### PR TITLE
Include publish to maven local for the whitesource scan to mitigate build failures in the plugin repos. 

### DIFF
--- a/.github/workflows/check-vulnerability-whitesource.yml
+++ b/.github/workflows/check-vulnerability-whitesource.yml
@@ -70,7 +70,7 @@ jobs:
           export PATH=$PATH:/opt/gradle/gradle-6.7/bin
           gradle -v; mvn -v ; npm -v; yarn -v
           # This step is needed to avoid build failures in few plugins
-          # No ETA on when this depedency can be removed 
+          # No ETA on when this dependency can be removed 
           git clone https://github.com/opensearch-project/OpenSearch.git
           cd OpenSearch
           gradle publishToMavenLocal; cd ..


### PR DESCRIPTION
### Description
Include publish to maven local for the whitesource scan to mitigate build failures in the plugin repos. Also add additional plugins to the scan. 

### Tests 
https://github.com/opensearch-project/opensearch-build/actions/runs/775103481
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
