### PR TITLE
Disable WhiteSource scan till the plugin builds are stable

### DIFF
--- a/.github/workflows/check-vulnerability-whitesource.yml
+++ b/.github/workflows/check-vulnerability-whitesource.yml
@@ -1,8 +1,8 @@
 name: WhiteSource Vulnerability Scan
 
 on:
-  schedule:
-    - cron: '30 10 * * *'
+#  schedule:
+#    - cron: '30 10 * * *'
   repository_dispatch:
     types: [check-vulnerability-whitesource]
 


### PR DESCRIPTION
### Description
Disable WhiteSource scan till the plugin builds are stable
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
