### PR TITLE
Improve the comments to rename es to opensearch in docker entrypoint

### DIFF
--- a/release/docker/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/release/docker/config/opensearch/opensearch-docker-entrypoint.sh
@@ -66,7 +66,7 @@ done < <(env)
 # paths. Therefore, OpenSearch provides a mechanism to override
 # reading the cgroup path from /proc/self/cgroup and instead uses the
 # cgroup path defined the JVM system property
-# es.cgroups.hierarchy.override. Therefore, we set this value here so
+# opensearch.cgroups.hierarchy.override. Therefore, we set this value here so
 # that cgroup statistics are available for the container this process
 # will run in.
 export OPENSEARCH_JAVA_OPTS="-Dopensearch.cgroups.hierarchy.override=/ $OPENSEARCH_JAVA_OPTS"


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Improve the comments to rename es to opensearch in docker entrypoint #40 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
