### PR TITLE
Add publish snapshot script

### DIFF
--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
+
 ###### Information ############################################################################
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  The OpenSearch Contributors require contributions made to
+#  this file be licensed under the Apache-2.0 license or a
+#  compatible open source license.
+#
 # Name:          publish-snapshot.sh
 # Language:      Shell
 #

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -11,8 +11,7 @@
 # Language:      Shell
 #
 # About:         Deploy opensearch artifacts to a sonatype snapshot repository.
-#                The given directory is intended to be the root directory of a maven repository containing ./org/opensearch artifacts.
-#                This script will search POM files under ./org/opensearch.
+#                This script will search POM files under the passed in directory.
 #                If found, pom, jar, and signature files will be deployed to the org/opensearch namespace.
 #
 # Prerequisites: The given directory must be the parent directory of org/opensearch artifacts.
@@ -27,9 +26,29 @@
 set -e
 
 [ -z "${1:-}" ] && {
-  echo "Usage: ($basename $0) dir"
-  exit 1
+  usage
 }
+
+usage() {
+    echo "usage: $0 dir [-h]"
+    echo "  dir     parent directory of artifacts to be published to org/opensearch namespace."
+    echo "          example: dir = ~/.m2/repository/org/opensearch where dir contains artifacts of a path:"
+    echo "                   /plugin/reindex-client/1.0.0-SNAPSHOT/reindex-client-1.0.0-SNAPSHOT.jar"
+    echo "  -h      display help"
+    echo "Required environment variables:"
+    echo "SONATYPE_ID - username with publish rights to a sonatype repository"
+    echo "SONATYPE_ID - password for sonatype"
+    echo "REPO_URL    - repository URL without path, ex. https://aws.oss.sonatype.org/"
+    exit 1
+}
+
+while getopts ":h" option; do
+  case $option in
+    h)
+       usage
+       exit;
+  esac
+done
 
 [ -z "${SONATYPE_ID}" ] && {
   echo "SONATYPE_ID is required"
@@ -41,12 +60,12 @@ set -e
   exit 1
 }
 
-[ -z "${SNAPSHOT_HOST}" ] && {
-  echo "SNAPSHOT_HOST is required"
+[ -z "${REPO_URL}" ] && {
+  echo "REPO_URL is required"
   exit 1
 }
 
-snapshot_url="${SNAPSHOT_HOST}/nexus/content/repositories/snapshots/"
+snapshot_url="${REPO_URL%/}/nexus/content/repositories/snapshots/org/opensearch"
 
 # Import Opensearch GPG key
 curl -S https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import
@@ -56,7 +75,7 @@ i=0
 
 echo "searching for poms under $PWD"
 
-pomFiles="$(find "./org/opensearch" -name '*.pom')"
+pomFiles="$(find "." -name '*.pom')"
 if [ -z "${pomFiles}" ]; then
   echo "No artifacts found under $PWD"
   exit 1

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -89,7 +89,6 @@ if [ -z "${pomFiles}" ]; then
 fi
 
 artifacts=()
-count=0
 for pom in ${pomFiles}; do
   jar=${pom/.pom/.jar}
 
@@ -115,11 +114,10 @@ for pom in ${pomFiles}; do
     exit 1
   fi
   artifacts+=("${pom}" "${pomsig}" "${jar}" "${jarsig}")
-  ((count+=4))
 done
 
 echo "==========================================="
-echo "Found ${count} artifacts to upload"
+echo "Found ${#artifacts[@]} artifacts to upload"
 echo "==========================================="
 
 success_count=0

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -30,7 +30,7 @@ set -e
 }
 
 usage() {
-    echo "usage: $0 dir [-h]"
+    echo "usage: $0 [-h] [dir]"
     echo "  dir     parent directory of artifacts to be published to org/opensearch namespace."
     echo "          example: dir = ~/.m2/repository/org/opensearch where dir contains artifacts of a path:"
     echo "                   /plugin/reindex-client/1.0.0-SNAPSHOT/reindex-client-1.0.0-SNAPSHOT.jar"
@@ -46,7 +46,10 @@ while getopts ":h" option; do
   case $option in
     h)
        usage
-       exit;
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+       usage
+    ;;
   esac
 done
 
@@ -65,13 +68,18 @@ done
   exit 1
 }
 
-snapshot_url="${REPO_URL%/}/nexus/content/repositories/snapshots/org/opensearch"
+if [ ! -d "$1" ]; then
+  echo "Invalid directory $1 does not exist"
+  usage
+fi
 
-# Import Opensearch GPG key
-curl -S https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import
+snapshot_url="${REPO_URL%/}/nexus/content/repositories/snapshots/org/opensearch"
 
 cd "$1"
 i=0
+
+# Import Opensearch GPG key
+curl -S https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import
 
 echo "searching for poms under $PWD"
 

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -122,10 +122,17 @@ echo "==========================================="
 echo "Found ${count} artifacts to upload"
 echo "==========================================="
 
-for i in "${artifacts[@]}"; do
-    curl -v -u "${SONATYPE_ID}":"${SONATYPE_PASSWORD}" --upload-file "${pom}" "$snapshot_url${pom}"
+success_count=0
+for artifact in "${artifacts[@]}"; do
+    response=$(curl -s -w "%{http_code}" -v -u "${SONATYPE_ID}":"${SONATYPE_PASSWORD}" --upload-file "${artifact}" "$snapshot_url${artifact}")
+    http_code=$(tail -n1 <<< "$response")
+    if [[ "${http_code}" != 2* ]]; then
+     echo "Failed to upload ${artifact}"
+     continue;
+    fi
+    ((success_count++))
 done
 
 echo "==========================================="
-echo "Finished deploying ${count} artifacts to $snapshot_url"
+echo "Finished deploying ${success_count} artifacts to $snapshot_url"
 echo "==========================================="

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+###### Information ############################################################################
+# Name:          publish-snapshot.sh
+# Language:      Shell
+#
+# About:         Deploy opensearch artifacts to a sonatype snapshot repository.
+#                The given directory is intended to be the root directory of a maven repository containing ./org/opensearch artifacts.
+#                This script will search POM files under ./org/opensearch.
+#                If found, pom, jar, and signature files will be deployed to the org/opensearch namespace.
+#
+# Prerequisites: The given directory must be the parent directory of org/opensearch artifacts.
+#                Environment variables must be set:
+#                SONATYPE_ID/SONATYPE_PASSWORD - repository credentials
+#                SNAPSHOT_HOST - repository host
+#
+#
+# Usage:         ./publish-snapshot.sh <directory>
+#
+###############################################################################################
+set -e
+
+[ -z "${1:-}" ] && {
+  echo "Usage: ($basename $0) dir"
+  exit 1
+}
+
+[ -z "${SONATYPE_ID}" ] && {
+  echo "SONATYPE_ID is required"
+  exit 1
+}
+
+[ -z "${SONATYPE_PASSWORD}" ] && {
+  echo "SONATYPE_PASSWORD is required"
+  exit 1
+}
+
+[ -z "${SNAPSHOT_HOST}" ] && {
+  echo "SNAPSHOT_HOST is required"
+  exit 1
+}
+
+snapshot_url="${SNAPSHOT_HOST}/nexus/content/repositories/snapshots/"
+
+# Import Opensearch GPG key
+curl -S https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import
+
+cd "$1"
+i=0
+
+echo "searching for poms under $PWD"
+
+pomFiles="$(find "./org/opensearch" -name '*.pom')"
+if [ -z "${pomFiles}" ]; then
+  echo "No artifacts found under $PWD"
+  exit 1
+fi
+
+for pom in ${pomFiles}; do
+  jar=${pom/.pom/.jar}
+
+  pomsig=${pom/.pom/.pom.asc}
+  jarsig=${pom/.pom/.jar.asc}
+
+  if [ -z "${pomsig}" ]; then
+    echo "No signature file found for pom, skipping ${jar}..."
+    continue
+  fi
+
+  if [ -z "${jarsig}" ]; then
+    echo "No signature file found for jar, skipping ${jar}..."
+    continue
+  fi
+
+  echo "Validating signatures for - ${pomsig} and ${jarsig}"
+
+  gpg --verify-files "${pomsig}" "${jarsig}"
+
+  if [ $? -ne 0 ]; then
+    echo "Invalid signature on artifacts, skipping ${pom}"
+  else
+    echo "Uploading artifacts for ${pom}"
+  fi
+
+  curl -v -u "${SONATYPE_ID}":"${SONATYPE_PASSWORD}" --upload-file "${pom}" "$snapshot_url${pom}"
+  curl -v -u "${SONATYPE_ID}":"${SONATYPE_PASSWORD}" --upload-file "${jar}" "$snapshot_url${jar}"
+  curl -v -u "${SONATYPE_ID}":"${SONATYPE_PASSWORD}" --upload-file "${pomsig}" "$snapshot_url${pomsig}"
+  curl -v -u "${SONATYPE_ID}":"${SONATYPE_PASSWORD}" --upload-file "${jarsig}" "$snapshot_url${jarsig}"
+  ((i++))
+done
+
+echo "==========================================="
+echo "Finished deploying ${i} projects to $snapshot_url"
+echo "==========================================="

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -12,7 +12,9 @@
 #
 # About:         Deploy opensearch artifacts to a sonatype snapshot repository.
 #                This script will search POM files under the passed in directory.
-#                If found, pom, jar, and signature files will be deployed to the org/opensearch namespace.
+#                If found, a signature check is performed and if successful pom, jar, and signature files will be deployed to the
+#                org/opensearch namespace. If any artifact fails signature check, nothing will be published.
+#                This script is intended to be run once per repository built.
 #
 # Prerequisites: The given directory must be the parent directory of org/opensearch artifacts.
 #                Environment variables must be set:

--- a/scripts/publish-snapshot.sh
+++ b/scripts/publish-snapshot.sh
@@ -77,7 +77,7 @@ snapshot_url="${REPO_URL%/}/nexus/content/repositories/snapshots/org/opensearch"
 
 cd "$1"
 
-# Import Opensearch GPG key
+# Import Opensearch PUBLIC GPG key
 curl -S https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import
 
 echo "searching for poms under $PWD"


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Add a simple publish script to push pre-built/signed artifacts to a sonatype nexus repository.
This is intended do be used with https://aws.oss.sonatype.org/content/repositories/snapshots.

The script takes in a directory that should contain org/opensearch projects to publish.  It intentionally searches only for poms in this namespace and pushes only to a snapshot repository.

Tested with a local instance of nexus running at localhost:8081 and prebuilt/signed dummy artifacts.

note - this uses curl instead of the maven-deploy plugin to deploy.  The maven-deploy plugin auto generates a timestamp for each artifact, but it does not deploy signature files.  So that signatures match the artifact/pom names, any timestamp/build id should be appended during packaging.
 
### Issues Resolved
Partial - https://github.com/opensearch-project/opensearch-build/issues/20
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
