### PR TITLE
Fix trap handling on successful exits

### DIFF
--- a/release/tar/linux/opensearch-dashboards-tar-build.sh
+++ b/release/tar/linux/opensearch-dashboards-tar-build.sh
@@ -113,7 +113,10 @@ OPENSEARCH_DASHBOARDS_PLUGINS_URLS=`yq eval '.products.opensearch-dashboards.plu
 
 TRAP_SIG_LIST="TERM INT EXIT"
 function delete_temp_folders() {
-    rm -rf $WORKING_DIR $PLUGINS_TEMP $TARGET_DIR
+    if [ $? -ne 0 ]; then
+      echo "Deleting the temp folders"
+      rm -rf $WORKING_DIR $PLUGINS_TEMP $TARGET_DIR
+    fi
 }
 trap delete_temp_folders $TRAP_SIG_LIST
 

--- a/release/tar/linux/opensearch-tar-build.sh
+++ b/release/tar/linux/opensearch-tar-build.sh
@@ -113,7 +113,10 @@ LIBS=`yq eval '.products.opensearch.libs' $MANIFEST_FILE | sed s/^-// | sed -e '
 
 TRAP_SIG_LIST="TERM INT EXIT"
 function delete_temp_folders() {
-    rm -rf $WORKING_DIR $PLUGINS_TEMP $TARGET_DIR
+    if [ $? -ne 0 ]; then
+      echo "Deleting the temp folders"
+      rm -rf $WORKING_DIR $PLUGINS_TEMP $TARGET_DIR
+    fi
 }
 trap delete_temp_folders $TRAP_SIG_LIST
 


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Trap function should delete temporary folders only when there is an unsuccessful exit. This PR implements the same
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Tested locally with both successful and unsuccessful (exit 1) exits

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
