### PR TITLE
Add opensearch-min Dockerfile and config

### DIFF
--- a/release/docker/config/opensearch-min/log4j2.properties
+++ b/release/docker/config/opensearch-min/log4j2.properties
@@ -1,0 +1,9 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/release/docker/config/opensearch-min/opensearch-min-docker-entrypoint.sh
+++ b/release/docker/config/opensearch-min/opensearch-min-docker-entrypoint.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# This script specify the entrypoint startup actions for opensearch
+# It will start both opensearch and performance analyzer plugin cli
+# If either process failed, the entire docker container will be removed
+# in favor of a newly started container
+
+# Files created by OpenSearch should always be group writable too
+umask 0002
+
+if [[ "$(id -u)" == "0" ]]; then
+    echo "OpenSearch cannot run as root. Please start your container as another user."
+    exit 1
+fi
+
+# Parse Docker env vars to customize OpenSearch
+#
+# e.g. Setting the env var cluster.name=testcluster
+#
+# will cause OpenSearch to be invoked with -Ecluster.name=testcluster
+
+declare -a opensearch_opts
+
+while IFS='=' read -r envvar_key envvar_value
+do
+    # OpenSearch settings need to have at least two dot separated lowercase
+    # words, e.g. `cluster.name`, except for `processors` which we handle
+    # specially
+    if [[ "$envvar_key" =~ ^[a-z0-9_]+\.[a-z0-9_]+ || "$envvar_key" == "processors" ]]; then
+        if [[ ! -z $envvar_value ]]; then
+          opensearch_opt="-E${envvar_key}=${envvar_value}"
+          opensearch_opts+=("${opensearch_opt}")
+        fi
+    fi
+done < <(env)
+
+# The virtual file /proc/self/cgroup should list the current cgroup
+# membership. For each hierarchy, you can follow the cgroup path from
+# this file to the cgroup filesystem (usually /sys/fs/cgroup/) and
+# introspect the statistics for the cgroup for the given
+# hierarchy. Alas, Docker breaks this by mounting the container
+# statistics at the root while leaving the cgroup paths as the actual
+# paths. Therefore, OpenSearch provides a mechanism to override
+# reading the cgroup path from /proc/self/cgroup and instead uses the
+# cgroup path defined the JVM system property
+# opensearch.cgroups.hierarchy.override. Therefore, we set this value here so
+# that cgroup statistics are available for the container this process
+# will run in.
+export OPENSEARCH_JAVA_OPTS="-Dopensearch.cgroups.hierarchy.override=/ $OPENSEARCH_JAVA_OPTS"
+
+# Export OpenSearch Home
+export OPENSEARCH_HOME=/usr/share/opensearch
+
+# Start opensearch
+exec $OPENSEARCH_HOME/bin/opensearch "${opensearch_opts[@]}"

--- a/release/docker/config/opensearch-min/opensearch.yml
+++ b/release/docker/config/opensearch-min/opensearch.yml
@@ -1,0 +1,11 @@
+cluster.name: docker-cluster
+
+# Bind to all interfaces because we don't know what IP address Docker will assign to us.
+network.host: 0.0.0.0
+
+# # minimum_master_nodes need to be explicitly set when bound on a public IP
+# # set to 1 to allow single node clusters
+discovery.zen.minimum_master_nodes: 1
+
+# Setting network.host to a non-loopback address enables the annoying bootstrap checks. "Single-node" mode disables them again.
+discovery.type: single-node

--- a/release/docker/dockerfiles/opensearch-min.dockerfile
+++ b/release/docker/dockerfiles/opensearch-min.dockerfile
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+
+# This dockerfile generates an AmazonLinux-based image containing an OpenSearch installation.
+# It assumes that the working directory contains the following files:
+#   opensearch-min.tgz
+#   log4j2.properties
+#   opensearch.yml
+#   opensearch-min-docker-entrypoint.sh
+# Build arguments:
+#   VERSION: Required. Used to label the image.
+#   BUILD_DATE: Required. Used to label the image. Should be in the form 'yyyy-mm-ddThh:mm:ssZ', i.e. a date-time from https://tools.ietf.org/html/rfc3339. The timestamp must be in UTC.
+#   UID: Optional. Specify the opensearch userid. Defaults to 1000.
+#   GID: Optional. Specify the opensearch groupid. Defaults to 1000.
+#   OPENSEARCH_HOME: Optional. Specify the opensearch root directory. Defaults to /usr/share/opensearch.
+
+
+########################### Stage 0 ########################
+FROM amazonlinux:2 AS linux_x64_stage_0
+
+ARG UID=1000
+ARG GID=1000
+ARG OPENSEARCH_HOME=/usr/share/opensearch
+
+# Update packages
+# Install the tools we need: tar and gzip to unpack the OpenSearch tarball, and shadow-utils to give us `groupadd` and `useradd`.
+RUN yum update -y && yum install -y tar gzip shadow-utils && yum clean all
+
+# Create an opensearch user, group, and directory
+RUN groupadd -g $GID opensearch && \
+    adduser -u $UID -g $GID -d $OPENSEARCH_HOME opensearch && \
+    mkdir /tmp/opensearch
+
+# Prepare working directory
+COPY opensearch-min.tgz /tmp/opensearch/opensearch-min.tgz
+RUN tar -xzf /tmp/opensearch/opensearch-min.tgz -C $OPENSEARCH_HOME --strip-components=1
+COPY opensearch-min-docker-entrypoint.sh $OPENSEARCH_HOME/
+COPY log4j2.properties opensearch.yml $OPENSEARCH_HOME/config/
+
+
+########################### Stage 1 ########################
+# Copy working directory to the actual release docker images
+FROM amazonlinux:2
+
+ARG UID=1000
+ARG GID=1000
+ARG OPENSEARCH_HOME=/usr/share/opensearch
+
+# Update packages
+# Install the tools we need: tar and gzip to unpack the OpenSearch tarball, and shadow-utils to give us `groupadd` and `useradd`.
+RUN yum update -y && yum install -y tar gzip shadow-utils && yum clean all
+
+# Create an opensearch user, group
+RUN groupadd -g $GID opensearch && \
+    adduser -u $UID -g $GID -d $OPENSEARCH_HOME opensearch
+
+# Copy from Stage0
+COPY --from=linux_x64_stage_0 $OPENSEARCH_HOME $OPENSEARCH_HOME
+WORKDIR $OPENSEARCH_HOME
+
+RUN chown -R $UID:$GID $OPENSEARCH_HOME
+
+# Change user
+USER $UID
+
+# Expose ports for the opensearch service (9200 for HTTP and 9300 for internal transport)
+EXPOSE 9200 9300
+
+ARG VERSION
+ARG BUILD_DATE
+
+# Label
+LABEL org.label-schema.schema-version="1.0" \
+  org.label-schema.name="opensearch-min" \
+  org.label-schema.version="$VERSION" \
+  org.label-schema.url="https://opensearch.org" \
+  org.label-schema.vcs-url="https://github.com/OpenSearch" \
+  org.label-schema.license="Apache-2.0" \
+  org.label-schema.vendor="Amazon" \
+  org.label-schema.build-date="$BUILD_DATE"
+
+# CMD to run
+CMD ["./opensearch-min-docker-entrypoint.sh"]


### PR DESCRIPTION
### Description
Adds opensearch-min Dockerfile and runtime configuration necessary to stand up a working OpenSearch node.
 
Tested by running `docker run -P opensearchproject/opensearch-min:1.0.0` and manually creating an index and adding a few documents to it.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
