### PR TITLE
Add JAVA_HOME fixes for the docker opensearch images

### DIFF
--- a/release/docker/dockerfiles/opensearch.al2.dockerfile
+++ b/release/docker/dockerfiles/opensearch.al2.dockerfile
@@ -78,7 +78,8 @@ RUN groupadd -g $GID opensearch && \
 
 # Setup OpenSearch
 RUN ./opensearch-onetime-setup.sh && \
-    chown -R $UID:$GID $OPENSEARCH_HOME
+    chown -R $UID:$GID $OPENSEARCH_HOME && \
+    echo "export JAVA_HOME=$OPENSEARCH_HOME/jdk" >> /etc/profile.d/java_home.sh
 
 # Copy KNN Lib
 RUN cp -v $OPENSEARCH_HOME/plugins/opensearch-knn/knnlib/libKNNIndex*.so /usr/lib


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add JAVA_HOME fixes for the docker opensearch images

Before:
```
$ docker exec -it 6d2ccc5226ec12704268e3a108a833d76126095e25c5533d0bba69f5e32b7bcb /bin/bash
[opensearch@6d2ccc5226ec ~]$ echo $JAVA_HOME
﻿
[opensearch@6d2ccc5226ec ~]$
```

After:
```
$ docker exec -it 48e84371f0a99be99f564e7ef8d884ee0257a7fd474e265dc357f12c435b3b5d /bin/bash
[opensearch@48e84371f0a9 ~]$ echo $JAVA_HOME
/usr/share/opensearch/jdk
[opensearch@48e84371f0a9 ~]$
```
 
### Issues Resolved
#49
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
