### PR TITLE
Prototype testing workflow skeleton

### DIFF
--- a/workflows/testing/test_workflow/git.py
+++ b/workflows/testing/test_workflow/git.py
@@ -1,0 +1,19 @@
+import subprocess
+import tempfile
+
+class GitRepository:
+    def __init__(self, url, ref):
+        self._url = url
+        self._dir = tempfile.TemporaryDirectory()
+        self.execute(f'git init')
+        self.execute(f'git remote add origin {url}')
+        self.execute(f'git fetch --depth 1 origin {ref}')
+        self.execute(f'git checkout {ref}')
+        print(f'Checked out {url}@{ref} into {self._dir.name}')
+
+    def dir(self):
+        return self._dir.name
+
+    def execute(self, command):
+        print(f'Executing "{command}" in {self._dir.name}')
+        subprocess.check_call(command, shell=True, cwd=self._dir.name)

--- a/workflows/testing/test_workflow/integ_test.py
+++ b/workflows/testing/test_workflow/integ_test.py
@@ -1,0 +1,13 @@
+import os
+
+class IntegTestSuite:
+    def __init__(self, name, repo):
+        self._name = name
+        self._repo = repo
+
+    def execute(self, cluster):
+        script = self._repo.dir() + "/integtest.sh"
+        if (os.path.exists(script)):
+            repo.execute(f'sh integtest.sh -b {cluster.endpoint()} -p {cluster.port()}')
+        else:
+            print(f'{script} does not exist. Skipping integ tests for {self._name}')

--- a/workflows/testing/test_workflow/manifest.py
+++ b/workflows/testing/test_workflow/manifest.py
@@ -1,0 +1,45 @@
+import yaml
+
+class BundleManifest:
+    @staticmethod
+    def from_file(path):
+        with open(path, 'r') as file:
+            data = yaml.safe_load(file)
+            return BundleManifest(data)
+
+    @staticmethod
+    def from_text(text):
+        data = yaml.safe_load(text)
+        return BundleManifest(data)
+
+    def __init__(self, data):
+        schema_version = str(data['schema-version'])
+        if schema_version != '1.0':
+            raise ValueError(f'Schema version must be 1.0; found {schema_version}')
+        self._build_id = data['build']['build-id']
+        self._bundle_location = data['build']['location']
+        self._components = list(map(lambda entry: Component(entry), data['components']))
+
+    def build_id(self):
+        return self._build_id
+
+    def bundle_location(self):
+        return self._bundle_location
+
+    def components(self):
+        return self._components
+
+class Component:
+    def __init__(self, data):
+        self._name = data['name']
+        self._repository = data['repository']
+        self._commit = data['commit']
+
+    def name(self):
+        return self._name
+
+    def repository_url(self):
+        return self._repository
+
+    def commit_id(self):
+        return self._commit

--- a/workflows/testing/test_workflow/test_cluster.py
+++ b/workflows/testing/test_workflow/test_cluster.py
@@ -1,0 +1,12 @@
+class LocalTestCluster:
+    def __init__(self, bundle_location):
+        pass
+
+    def endpoint(self):
+        return 'localhost'
+
+    def port(self):
+        return 9200
+
+    def destroy(self):
+        pass

--- a/workflows/testing/tester.py
+++ b/workflows/testing/tester.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import tempfile
+import urllib.request
+from test_workflow.manifest import BuildManifest
+from test_workflow.test_cluster import LocalTestCluster
+from test_workflow.git import GitRepository
+from test_workflow.integ_test import IntegTestSuite
+
+if (len(sys.argv) < 2):
+    print("Usage: tester.py /path/to/manifest")
+    exit(1)
+
+with tempfile.TemporaryDirectory() as work_dir:
+    os.chdir(work_dir)
+
+    # Download the manifest
+    with urllib.request.urlopen(sys.argv[1]) as response:
+        text = response.read()
+        manifest = BuildManifest.from_text(text)
+
+    # Spin up a test cluster
+    cluster = LocalTestCluster(manifest.bundle_location)
+
+    # For each component, check out the git repo and run `integtest.sh`
+    for component in manifest.components():
+        print(component.name())
+        repo = GitRepository(component.repository_url(), component.commit_id())
+        test_suite = IntegTestSuite(component.name(), repo)
+        test_suite.execute(cluster)
+
+    cluster.destroy()
+
+    # TODO: Store test results, send notification.


### PR DESCRIPTION
### Description
Prototype of the test workflow. This is mostly stubbed-out code, but it shows the overall flow of reading a manifest file, setting up a test cluster, running `integtest.sh` for each component, and reporting results.

You can run the tool on a demo manifest that contains the OpenSearch 1.0.0 release artifact:

`python tester.py https://artifacts.opensearch.org/builds/opensearch/1.0.0/manifest.yml`

Make sure you have `pyyaml` installed (with `pip install pyyaml` or whatever package manager you prefer to use if you don't like pip).

The goal of this PR is to get feedback on the general approach, and to highlight the subtasks we should add to https://github.com/opensearch-project/opensearch-build/issues/122 for the next few days. Assuming people agree with this approach, I suggest the following subtasks in rough order of priority:

* Implement LocalTestCluster to stand up / tear down a test cluster on the local host.
* Implement IntegTestSuite so that it can capture test results and logs.
* Implement a mechanism for storing test results, logs, and metadata.
* Add failure handling and make sure `tester.py` cleans up (especially remote test clusters) and returns a suitable exit code.
* Add `tester.py` to a Jenkins or GitHub Actions workflow that can accept a manifest URL as an argument.
* Create and implement RemoteSingleNodeCluster to set up a remote single-node cluster using CDK.
* Create and implement RemoteMultiNodeCluster.
* Create and implement PerformanceTestSuite.
* Change `tester.py` to execute integ test suites in parallel.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/122
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
