### PR TITLE
Add prototype for a component build system

### DIFF
--- a/bundle-build/build.rb
+++ b/bundle-build/build.rb
@@ -1,0 +1,41 @@
+#!/bin/ruby
+
+require 'yaml'
+require 'fileutils'
+require 'tmpdir'
+require_relative "config"
+require_relative "component_builder"
+
+if ARGV.length != 1
+	puts "Usage: ruby build.rb <path-to-config>"
+	exit
+end
+
+file = ARGV[0]
+
+config = Config.new(YAML.load_file(file))
+ARCHITECTURE=Config.getArchitecture()
+puts "Executing #{config.type} build for #{ARCHITECTURE}"
+
+FileUtils.mkdir_p('build')
+
+default_buildscripts=File.expand_path('./components')
+outputDir=File.expand_path('./build')
+workspace=Dir.pwd
+Dir.mktmpdir do |dir|
+  Dir.chdir(dir)
+  # Checkout all components
+  config.components.each{|component|
+   component.checkout()
+  }
+
+  # Build all components in order
+  builder=ComponentBuilder.new(default_buildscripts, outputDir)
+  config.components.each{|component|
+    builder.build_component(component, config.version, ARCHITECTURE)
+  }
+
+end
+Dir.chdir(workspace)
+
+# TODO: Pass components off for bundle assembly

--- a/bundle-build/component_builder.rb
+++ b/bundle-build/component_builder.rb
@@ -1,0 +1,57 @@
+require 'open3'
+require 'fileutils'
+
+##
+# This class is used to build components required for a bundle.
+# It will look for a build.sh script within a component's repository and if not present fall back to a default location specified.
+
+class ComponentBuilder
+  attr_reader :default_script_path, :output_path
+
+  ##
+  # Creates a new ComponentBuilder with the specified paths
+  # @param default_script_path - Path to a directory that contains a build.sh for a particular component.
+  # @param output_path - Path to a directory where all output artifacts will be placed.
+  def initialize(default_script_path, output_path)
+    @default_script_path=default_script_path
+    @output_path=output_path
+  end
+
+  def get_build_script(component)
+    script_path=File.expand_path("./#{component.name}/build/build.sh")
+    if File.exists?(script_path)
+      return script_path
+    else
+      default_path="#{default_script_path}/#{component.name}/build.sh"
+      if File.exists?(default_path)
+        return default_path
+      else
+        # default to standard gradle script
+        return "#{default_script_path}/standard-gradle-build/build.sh"
+      end
+    end
+  end
+
+  def build_component(component, opensearch_version, platform)
+    script_path=get_build_script(component)
+    puts "building #{component.name} with #{script_path}"
+    Dir.chdir(component.name) do
+         command="#{script_path} #{opensearch_version} #{platform}"
+         # Execute build and immediately flush any output to stdout
+         Open3.popen2e(command) do |stdin, stdout, wait|
+           Thread.new do
+              stdout.each {|line| puts line }
+           end
+           exit_status = wait.value
+           puts "EXIT STATUS #{exit_status}"
+         end
+         # copy component build output to ./build
+         outputDir="#{component.name}-artifacts"
+         puts File.expand_path("./#{outputDir}")
+         if Dir.exists?(File.expand_path("./#{outputDir}"))
+           FileUtils.cp_r("#{outputDir}/.", "#{output_path}", preserve: true)
+         end
+         puts "finished building #{component.name}"
+    end
+  end
+end

--- a/bundle-build/components/OpenSearch/build.sh
+++ b/bundle-build/components/OpenSearch/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+version="$1"
+ARCHITECTURE="$2"
+
+outputDir=$(basename $PWD)-artifacts
+mkdir -p "${outputDir}/maven"
+
+# Build project and publish to maven local.
+./gradlew publishToMavenLocal -Dbuild.snapshot=false
+
+# Publish to existing test repo, using this to stage release versions of the artifacts that can be released from the same build.
+./gradlew publishNebulaPublicationToTestRepository -Dbuild.snapshot=false
+
+# Copy maven publications to be promoted
+cp -r ./build/local-test-repo "${outputDir}"/maven
+
+if [ "${ARCHITECTURE}" = "x64" ]
+then
+  ./gradlew :distribution:archives:linux-tar:assemble -Dbuild.snapshot=false
+  cp -r distribution/archives/linux-tar/build/distributions/. $outputDir
+elif [ "${ARCHITECTURE}" == "arm64" ]
+then
+  ./gradlew :distribution:archives:linux-arm64-tar:assemble -Dbuild.snapshot=false
+  cp -r distribution/archives/linux-arm64-tar/build/distributions/ $outputDir
+fi
+
+cd $outputDir
+
+#rename included bundle to -min.
+ARTIFACT_FULL_NAME=`ls  | grep -E 'tar.gz$' | tail -n 1`
+ARTIFACT_BASE_NAME=`basename -s .tar.gz $ARTIFACT_FULL_NAME | sed "s/opensearch/opensearch-min/g"`
+ARTIFACT_NEW_NAME="${ARTIFACT_BASE_NAME}${IDENTIFIER}.tar.gz"
+mv $ARTIFACT_FULL_NAME $ARTIFACT_NEW_NAME || true

--- a/bundle-build/components/alerting/build.sh
+++ b/bundle-build/components/alerting/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo ${PWD}
+outputDir=$(basename $PWD)-artifacts
+
+mkdir $outputDir
+./gradlew assemble --no-daemon --refresh-dependencies -Dbuild.snapshot=false -DskipTests=true -Dopensearch.version=$1
+
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+
+echo "COPY ${distributions}/*.zip"
+cp ${distributions}/*.zip ./$outputDir
+
+./gradlew publishToMavenLocal -Dopensearch.version=$1 -Dbuild.snapshot=false

--- a/bundle-build/components/common-utils/build.sh
+++ b/bundle-build/components/common-utils/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+opensearch_version=$1
+
+./gradlew build -Dopensearch.version=$1
+./gradlew publishToMavenLocal -Dopensearch.version=$1
+mkdir -p common-utils-artifacts/maven
+cp -r ~/.m2/repository/org/opensearch/common-utils common-utils-artifacts/maven

--- a/bundle-build/components/component.md
+++ b/bundle-build/components/component.md
@@ -1,0 +1,21 @@
+###Component Build.sh
+
+- Each component should have a corresponding ./build.sh script that is used to prepare their bundle artifacts for a particular
+ bundle version.
+
+- OpenSearch core repo will always be built first followed by common-utils. These dependencies will be made available via maven local so
+ projects can build against the bleeding edge of these repositories.
+ 
+- A component may depend on a different released version of OpenSearch for a particular build by creating/updating their corresponding
+ build.sh and setting the version passed to ./gradlew.
+ 
+- To publish Maven artifacts to central that correlate to a build, place the full path to your maven publications inside
+ <component-name>-artifacts/maven. <br>
+  Example: OpenSearch-artifacts/maven/org/opensearch/common-utils/1.0.0.0
+  <br>
+  These will be published as part of a separate release workflow to a staging maven repo.  If this bundle
+  build is released, the corresponding maven publications will be promoted to central.
+ 
+Usage: 
+- Inputs: build.sh -opensearch_version -architecture(x86/arm64)
+- Expected Outputs - a folder at <component-name>-artifacts containing all artifacts that should be included in the bundle

--- a/bundle-build/components/dashboards-notebooks/build.sh
+++ b/bundle-build/components/dashboards-notebooks/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+outputDir=$(basename $PWD)-artifacts
+mkdir $outputDir
+cd opensearch-notebooks
+./gradlew assemble --no-daemon --refresh-dependencies -Dbuild.snapshot=false -DskipTests=true -Dopensearch.version=$1
+
+distributions=$(find . -path \*build/distributions)
+
+cp ${distributions}/*.zip ../$outputDir

--- a/bundle-build/components/dashboards-reports/build.sh
+++ b/bundle-build/components/dashboards-reports/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+outputDir=$(basename $PWD)-artifacts
+mkdir $outputDir
+cd reports-scheduler
+./gradlew assemble --no-daemon --refresh-dependencies -Dbuild.snapshot=false -DskipTests=true -Dopensearch.version=$1
+
+distributions=$(find . -path \*build/distributions)
+
+cp ${distributions}/*.zip ../$outputDir
+

--- a/bundle-build/components/job-scheduler/build.sh
+++ b/bundle-build/components/job-scheduler/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+opensearch_version=$1
+
+outputDir=$(basename $PWD)-artifacts
+mkdir $outputDir
+./gradlew assemble --no-daemon --refresh-dependencies -Dbuild.snapshot=false -DskipTests=true -Dopensearch.version=$1
+
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+
+echo "COPY ${distributions}/*.zip"
+cp ${distributions}/*.zip ./$outputDir
+
+./gradlew publishToMavenLocal -Dopensearch.version=$1 -Dbuild.snapshot=false
+mkdir -p job-scheduler-artifacts/maven
+cp -r ~/.m2/repository/org/opensearch/opensearch-job-scheduler job-scheduler-artifacts/maven
+cp -r ~/.m2/repository/org/opensearch/opensearch-job-scheduler-spi job-scheduler-artifacts/maven

--- a/bundle-build/components/notifications/build.sh
+++ b/bundle-build/components/notifications/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+outputDir=$(basename $PWD)-artifacts
+mkdir -p $outputDir/maven
+cd notifications
+
+./gradlew publishToMavenLocal -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=$1
+

--- a/bundle-build/components/performance-analyzer-rca/build.sh
+++ b/bundle-build/components/performance-analyzer-rca/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./gradlew build -x test
+./gradlew publishToMavenLocal

--- a/bundle-build/components/security/build.sh
+++ b/bundle-build/components/security/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mvn -B clean package -Padvanced -DskipTests
+artifact_zip=$(ls $(pwd)/target/releases/opensearch-security-*.zip | grep -v admin-standalone)
+./gradlew assemble --no-daemon -ParchivePath=$artifact_zip -Dbuild.snapshot=false
+outputDir=$(basename $PWD)-artifacts
+mkdir $outputDir
+cp $artifact_zip $outputDir

--- a/bundle-build/components/standard-gradle-build/build.sh
+++ b/bundle-build/components/standard-gradle-build/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+outputDir=$(basename $PWD)-artifacts
+mkdir $outputDir
+./gradlew assemble --no-daemon --refresh-dependencies -Dbuild.snapshot=false -DskipTests=true -Dopensearch.version=$1
+
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+
+echo "COPY ${distributions}/*.zip"
+cp ${distributions}/*.zip ./$outputDir

--- a/bundle-build/config.rb
+++ b/bundle-build/config.rb
@@ -1,0 +1,40 @@
+##
+# This class is used to parse config used during a bundle build
+class Config
+    attr_reader :type, :version, :components
+    def initialize(hash)
+        @type = hash['type']
+        @version = hash['version']
+        @components = hash['components'].map{|component| Component.new(component)}
+    end
+
+    def self.getArchitecture()
+      arch=`uname -m`.strip
+      return case arch
+      when 'x86_64'
+          :'x64'
+      when 'aarch64', 'arm64'
+          :'arm64'
+      else
+          puts "Building on unsupported Architecture #{arch}, only x64 and arm64 are supported"
+          exit
+      end
+    end
+end
+
+class Component
+    attr_reader :name, :repository, :ref
+    def initialize(hash)
+        @name = hash['name']
+        @repository = hash['repository']
+        @ref = hash['ref']
+    end
+
+    def checkout()
+        `git clone #{repository} #{name}`
+        currentDir=Dir.pwd
+        Dir.chdir(name)
+        `git checkout #{ref}`
+        Dir.chdir(currentDir)
+    end
+end

--- a/bundle-build/configs/opensearch-1.0.0.yml
+++ b/bundle-build/configs/opensearch-1.0.0.yml
@@ -1,0 +1,48 @@
+type: opensearch
+version: 1.0.0
+components:
+  - name: OpenSearch
+    repository: https://github.com/opensearch-project/OpenSearch.git
+    ref: 1.0
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: tags/1.0
+  - name: notifications
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: develop
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: tags/1.0.0.0
+  - name: sql
+    repository: https://github.com/opensearch-project/sql.git
+    ref: tags/1.0.0.0
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: tags/1.0.0.0
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: tags/1.0.0.0
+  - name: performance-analyzer-rca
+    repository: https://github.com/opensearch-project/performance-analyzer-rca.git
+    ref: tags/1.0.0.0
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
+    ref: tags/1.0.0.0
+  - name: index-management
+    repository: https://github.com/opensearch-project/index-management.git
+    ref: tags/1.0.0.0
+  - name: k-NN
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: tags/1.0.0.0
+  - name: anomaly-detection
+    repository: https://github.com/opensearch-project/anomaly-detection.git
+    ref: 1.0
+  - name: asynchronous-search
+    repository: https://github.com/opensearch-project/asynchronous-search.git
+    ref: main
+  - name: dashboards-reports
+    repository: https://github.com/opensearch-project/dashboards-reports.git
+    ref: tags/1.0.0.0
+  - name: dashboards-notebooks
+    repository: https://github.com/opensearch-project/dashboards-notebooks.git
+    ref: tags/1.0.0.0


### PR DESCRIPTION
This is a first attempt at a central top-down build.

Given a config file for a particular bundle version, it clones each repository
and builds it with a given build script.

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
```
Usage: ruby build.rb ./configs/opensearch-1.0.0.yml
```

Component builds:
This PR includes a standard build script for projects using ./gradlew assemble and repo specific scripts for those that don't or have slightly different needs.
This PR is to get this started, the idea is that each repo would include a copy of this script under build/build.sh that tells us how to build their component.

Currently the order of components declared in Config matters because multiple repos depend on engine & common-utils and we do not yet have 1.0 in maven central.  These will be compiled first and the OpenSearch version passed along as a param to build.sh scripts.  The intention here is that repos will not depend on any unreleased version of a dependency. If they need to depend on the bleeding edge & compile against the version of those dependencies being built in this bundle build, they can do so.

Maven dependencies:
Each script can place their dependencies in <repo-name>-artifacts/maven to be picked up and published on their behalf.

### Issues Resolved
#133 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
