### PR TITLE
Fix a typo error in opensearch.al2.dockerfile

### DIFF
--- a/release/docker/dockerfiles/opensearch.al2.dockerfile
+++ b/release/docker/dockerfiles/opensearch.al2.dockerfile
@@ -23,7 +23,7 @@
 
 
 # This dockerfile generates an AmazonLinux-based image containing an OpenSearch installation.
-# It assumes that the working directory contains four files: an OpenSearch tarball (opensearch.tgz), log4j2.properties, opensearch.yml, opensearch-docker-entrypoint.sh, opensearch-onetime-setup.sh.
+# It assumes that the working directory contains these files: an OpenSearch tarball (opensearch.tgz), log4j2.properties, opensearch.yml, opensearch-docker-entrypoint.sh, opensearch-onetime-setup.sh.
 # Build arguments:
 #   VERSION: Required. Used to label the image.
 #   BUILD_DATE: Required. Used to label the image. Should be in the form 'yyyy-mm-ddThh:mm:ssZ', i.e. a date-time from https://tools.ietf.org/html/rfc3339. The timestamp must be in UTC.


### PR DESCRIPTION
### Description
Change the incorrect number of files listed in comment. 
 
### Issues Resolved
Correct a typo error in opensearch.al2.dockerfile comment part.
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
