### PR TITLE
Add CloudFormation template for creating AWS resources needed by the build-bundle-test workflows

### DIFF
--- a/cloudformation/build-bundle-test-workflow.yml
+++ b/cloudformation/build-bundle-test-workflow.yml
@@ -1,0 +1,101 @@
+Description: Template for setting up resources for the build-bundle-test workflows
+Resources:
+  BuildBucket:
+    Type: "AWS::S3::Bucket"
+  WorkflowUser:
+    Type: "AWS::IAM::User"
+    Properties:
+      UserName: buildworkflow
+      Policies:
+        - PolicyName: AssumeRole
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              Effect: Allow
+              Action: "sts:AssumeRole"
+              Resource:
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/opensearch-build"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/opensearch-bundle"
+                - !Sub "arn:aws:iam::${AWS::AccountId}:role/opensearch-test"
+  BuildRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: opensearch-build
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !GetAtt WorkflowUser.Arn
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: S3_Build_Write_Access
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              Effect: Allow
+              Action: "s3:PutObject"
+              Resource:
+                - !Sub "arn:aws:s3:::${BuildBucket}/builds/*"
+  BundleRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: opensearch-bundle
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !GetAtt WorkflowUser.Arn
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: S3_Build_Read_Access
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              Effect: Allow
+              Action: "s3:GetObject"
+              Resource:
+                - !Sub "arn:aws:s3:::${BuildBucket}/builds/*"
+        - PolicyName: S3_Bundle_Write_Access
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              Effect: Allow
+              Action: "s3:PutObject"
+              Resource:
+                - !Sub "arn:aws:s3:::${BuildBucket}/bundles/*"
+  TestRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: opensearch-test
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !GetAtt WorkflowUser.Arn
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: S3_Bundle_Read_Access
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              Effect: Allow
+              Action: "s3:GetObject"
+              Resource:
+                - !Sub "arn:aws:s3:::${BuildBucket}/bundles/*"
+        - PolicyName: S3_TestResults_Write_Access
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              Effect: Allow
+              Action: "s3:PutObject"
+              Resource:
+                - !Sub "arn:aws:s3:::${BuildBucket}/bundles/*/tests/*"


### PR DESCRIPTION
### Description
CloudFormation stack for managing the S3 bucket used by the build-bundle-test workflows and IAM users for each of the three stages.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/143
 
### Testing
Manually verified that the bucket and IAM users are created. Tested in the IAM policy simulator to verify that the users have the correct access to folders within the bucket.

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
