### PR TITLE
Update Build System to add artifacts list output build manifest.

### DIFF
--- a/scripts/bundle-build/components/OpenSearch/build.sh
+++ b/scripts/bundle-build/components/OpenSearch/build.sh
@@ -20,11 +20,11 @@ cp -r ./build/local-test-repo/org/opensearch "${outputDir}"/maven
 if [ "${ARCHITECTURE}" = "x64" ]
 then
   ./gradlew :distribution:archives:linux-tar:assemble -Dbuild.snapshot=false
-  cp -r distribution/archives/linux-tar/build/distributions/. $outputDir
+  cp -r distribution/archives/linux-tar/build/distributions/. "${outputDir}"/bundle
 elif [ "${ARCHITECTURE}" == "arm64" ]
 then
   ./gradlew :distribution:archives:linux-arm64-tar:assemble -Dbuild.snapshot=false
-  cp -r distribution/archives/linux-arm64-tar/build/distributions/ $outputDir
+  cp -r distribution/archives/linux-arm64-tar/build/distributions/ "${outputDir}"/bundle
 fi
 
 cd $outputDir

--- a/scripts/bundle-build/components/job-scheduler/build.sh
+++ b/scripts/bundle-build/components/job-scheduler/build.sh
@@ -6,12 +6,8 @@ outputDir=artifacts
 mkdir -p $outputDir
 ./gradlew assemble --no-daemon --refresh-dependencies -Dbuild.snapshot=false -DskipTests=true -Dopensearch.version=$1
 
-zipPath=$(find . -path \*build/distributions/*.zip)
-distributions="$(dirname "${zipPath}")"
-
-echo "COPY ${distributions}/*.zip"
 mkdir -p $outputDir/plugins
-cp ${distributions}/*.zip ./$outputDir/plugins
+cp ./build/distributions/*.zip ./$outputDir/plugins
 
 ./gradlew publishToMavenLocal -Dopensearch.version=$1 -Dbuild.snapshot=false
 mkdir -p $outputDir/maven


### PR DESCRIPTION
This change updates the output manifest to include artifacts.
artifacts will be in grouped into the following categories based on:
where they are placed inside a component's build.sh script.

bundles
plugins
libs
maven

This change also updates job-scheduler and OpenSearch core build scripts to correctly
place artifacts.

These components will be fed into a bundle build.  This change makes it easier to fetch plugin components that should be installed and ensures we can link the order of installation to what is defined in the input manifest.

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
With this change artifacts will be listed in the output manifest.
Example:
```
components:
- artifacts:
    bundle:
    - bundle/opensearch-1.0.0-linux-x64.tar.gz
    maven:
    - maven/opensearch/custom-suggester/maven-metadata.xml.sha256
    - maven/opensearch/custom-suggester/maven-metadata.xml
    - maven/opensearch/custom-suggester/maven-metadata.xml.sha512
    - maven/opensearch/custom-suggester/maven-metadata.xml.md5
    - maven/opensearch/custom-suggester/maven-metadata.xml.sha1
```
 
### Issues Resolved
#133 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
