### PR TITLE
Add Bundle assembly script to bundle-workflow

### DIFF
--- a/bundle-workflow/assemble.sh
+++ b/bundle-workflow/assemble.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+DIR="$(dirname "$0")"
+python3 "$DIR/python/assemble.py" $@

--- a/bundle-workflow/python/assemble.py
+++ b/bundle-workflow/python/assemble.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import tempfile
+from assemble_workflow.bundle import Bundle
+from assemble_workflow.bundle_recorder import BundleRecorder
+from manifests.build_manifest import BuildManifest
+
+if (len(sys.argv) < 2):
+    print("Build an OpenSearch Bundle")
+    print("usage: assemble.sh /path/to/build_manifest")
+    exit(1)
+
+
+build_manifest_path = sys.argv[1]
+build_manifest = BuildManifest.from_file(build_manifest_path)
+build = build_manifest.build
+artifacts_dir = os.path.dirname(os.path.realpath(build_manifest_path))
+output_dir = os.path.join(os.getcwd(), 'bundle')
+os.makedirs(output_dir, exist_ok=True)
+
+with tempfile.TemporaryDirectory() as work_dir:
+    print(f'Bundling {build.name} ({build.architecture}) into {output_dir} ...')
+
+    os.chdir(work_dir)
+
+    bundle_recorder = BundleRecorder(build, output_dir, artifacts_dir)
+    bundle = Bundle(build_manifest, artifacts_dir, bundle_recorder)
+
+    bundle.install_plugins()
+    print(f'Installed plugins: {bundle.installed_plugins}')
+
+    #  Save a copy of the manifest inside of the tar
+    bundle_recorder.write_manifest(bundle.archive_path)
+    bundle.build_tar(output_dir)
+
+    bundle_recorder.write_manifest(output_dir)
+
+print(f'Done.')

--- a/bundle-workflow/python/assemble_workflow/bundle.py
+++ b/bundle-workflow/python/assemble_workflow/bundle.py
@@ -1,0 +1,85 @@
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import tarfile
+import tempfile
+import shutil
+import subprocess
+
+'''
+This class is responsible for executing the build of the full bundle and passing results to a bundle recorder.
+It requires a min tarball distribution where plugins will be installed and the path to an artifacts directory where 
+plugins can be found.
+'''
+
+
+class Bundle:
+
+    def __init__(self, build_manifest, artifacts_dir, bundle_recorder):
+        """
+        Construct a new Bundle instance.
+        :param build_manifest: A BuildManifest created from the build workflow.
+        :param artifacts_dir: Dir location where build artifacts can be found locally
+        :param bundle_recorder: The bundle recorder that will capture and build a BundleManifest
+        """
+        self.min_tarball = self.get_min_bundle(build_manifest.components)
+        self.plugins = self.get_plugins(build_manifest.components)
+        self.artifacts_dir = artifacts_dir
+        self.bundle_recorder = bundle_recorder
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.installed_plugins = []
+        tmp_path = self.add_component(self.min_tarball, "bundle")
+        self.unpack(tmp_path, self.tmp_dir.name)
+        # OpenSearch & Dashboard tars will include only a single folder at the top level of the tar
+        self.archive_path = next(iter([file.path for file in os.scandir(self.tmp_dir.name) if file.is_dir()]))
+
+    def install_plugins(self):
+        for plugin in self.plugins:
+            print(f'Installing {plugin.name}')
+            self.install_plugin(plugin)
+        self.installed_plugins = os.listdir(os.path.join(self.archive_path, 'plugins'))
+
+    def install_plugin(self, plugin):
+        tmp_path = self.add_component(plugin, "plugins")
+        cli_path = os.path.join(self.archive_path, 'bin/opensearch-plugin')
+        self.execute(f'{cli_path} install --batch file:{tmp_path}')
+
+    def add_component(self, component, component_type):
+        rel_path = self.get_rel_path(component, component_type)
+        tmp_path = self.copy_component(rel_path, self.tmp_dir.name)
+        self.bundle_recorder.record_component(component, rel_path)
+        return tmp_path
+
+    def execute(self, command):
+        print(f'Executing "{command}" in {self.archive_path}')
+        subprocess.check_call(command, cwd=self.archive_path, shell=True)
+
+    def unpack(self, tar_path, dest):
+        with tarfile.open(tar_path) as tar:
+            tar.extractall(dest)
+
+    def build_tar(self, dest):
+        tar_name = self.bundle_recorder.tar_name
+        with tarfile.open(tar_name, "w:gz") as tar:
+            tar.add(self.archive_path, arcname=os.path.basename(self.archive_path))
+        shutil.copyfile(tar_name, os.path.join(dest, tar_name))
+
+    def get_rel_path(self, component, component_type):
+        return next(iter(component.artifacts.get(component_type, [])), None)
+
+    def copy_component(self, rel_path, dest):
+        local_path = os.path.join(self.artifacts_dir, rel_path)
+        dest_path = os.path.join(dest, os.path.basename(local_path))
+        if os.path.isfile(local_path):
+            # rel path provided, in this case we copy it into dest
+            shutil.copyfile(local_path, dest_path)
+            return os.path.join(dest, os.path.basename(local_path))
+        else:
+            raise ValueError(f'No file found at path: {local_path}')
+
+    def get_plugins(self, build_components):
+        return [c for c in build_components if "plugins" in c.artifacts]
+
+    def get_min_bundle(self, build_components):
+        return next(iter([c for c in build_components if "bundle" in c.artifacts]), None)

--- a/bundle-workflow/python/assemble_workflow/bundle_recorder.py
+++ b/bundle-workflow/python/assemble_workflow/bundle_recorder.py
@@ -1,0 +1,82 @@
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import yaml
+from manifests.bundle_manifest import BundleManifest
+from urllib.parse import urljoin
+
+
+class BundleRecorder:
+    def __init__(self, build, output_dir, artifacts_dir):
+        self.output_dir = output_dir
+        self.build_id = build.id
+        self.public_url = os.getenv('PUBLIC_ARTIFACT_URL', None)
+        self.version = build.version
+        self.tar_name = self.get_tar_name(build)
+        self.artifacts_dir = artifacts_dir
+        self.bundle_manifest = self.BundleManifestBuilder(build.id, build.name, build.version, build.architecture, self.get_tar_location())
+
+    def get_tar_name(self, build):
+        return "-".join([build.name.lower(), build.version, 'linux', build.architecture]) + '.tar.gz'
+
+    def get_public_url_path(self, folder, rel_path):
+        path = "{}/{}/{}/{}".format(folder, self.version, self.build_id, rel_path)
+        return urljoin(self.public_url, path)
+
+    def get_location(self, folder_name, rel_path, abs_path):
+        if self.public_url:
+            return self.get_public_url_path(folder_name, rel_path)
+        return abs_path
+
+    # Assembled bundles are expected to be served from a separate "bundles" folder
+    # Example: https://artifacts.opensearch.org/bundles/1.0.0/<build-id
+    def get_tar_location(self):
+        return self.get_location("bundles", self.tar_name, os.path.join(self.output_dir, self.tar_name))
+
+    # Build artifacts are expected to be served from a "builds" folder
+    # Example: https://artifacts.opensearch.org/builds/1.0.0/<build-id>
+    def get_component_location(self, component_rel_path):
+        abs_path = os.path.join(self.artifacts_dir, component_rel_path)
+        return self.get_location("builds", component_rel_path, abs_path)
+
+    def record_component(self, component, rel_path):
+        abs_path = os.path.join(self.artifacts_dir, rel_path)
+        self.bundle_manifest.append_component(component.name, component.repository, component.ref,
+                                              component.commit_id, self.get_component_location(rel_path))
+
+    def get_manifest(self):
+        return self.bundle_manifest.to_manifest()
+
+    def write_manifest(self, folder):
+        output_manifest = self.get_manifest()
+        manifest_path = os.path.join(folder, 'manifest.yml')
+        with open(manifest_path, 'w') as file:
+            yaml.dump(output_manifest.to_dict(), file)
+
+    class BundleManifestBuilder:
+        def __init__(self, build_id, name, version, arch, location):
+            self.data = {}
+            self.data['build'] = {}
+            self.data['build']['id'] = build_id
+            self.data['build']['name'] = name
+            self.data['build']['version'] = str(version)
+            self.data['build']['architecture'] = arch
+            self.data['build']['location'] = location
+            self.data['schema-version'] = '1.0'
+            # We need to store components as a hash so that we can append artifacts by component name
+            # When we convert to a BundleManifest this will get converted back into a list
+            self.data['components'] = []
+
+        def append_component(self, name, repository_url, ref, commit_id, location):
+            component = {
+                'name': name,
+                'repository': repository_url,
+                'ref': ref,
+                'commit_id': commit_id,
+                'location': location,
+            }
+            self.data['components'].append(component)
+
+        def to_manifest(self):
+            return BundleManifest(self.data)

--- a/bundle-workflow/python/build.py
+++ b/bundle-workflow/python/build.py
@@ -5,6 +5,7 @@ import os
 import sys
 import subprocess
 import tempfile
+import uuid
 from manifests.input_manifest import InputManifest
 from build_workflow.build_recorder import BuildRecorder
 from build_workflow.builder import Builder
@@ -31,13 +32,14 @@ arch = get_arch()
 manifest = InputManifest.from_file(sys.argv[1])
 output_dir = os.path.join(os.getcwd(), 'artifacts')
 os.makedirs(output_dir, exist_ok = True)
+build_id = os.getenv('OPENSEARCH_BUILD_ID', uuid.uuid4().hex)
 
 with tempfile.TemporaryDirectory() as work_dir:
     print(f'Building in {work_dir}')
 
     os.chdir(work_dir)
 
-    build_recorder = BuildRecorder(output_dir, manifest.build.name, manifest.build.version, arch)
+    build_recorder = BuildRecorder(build_id, output_dir, manifest.build.name, manifest.build.version, arch)
 
     print(f'Building {manifest.build.name} ({arch}) into {output_dir}')
 

--- a/bundle-workflow/python/build_workflow/build_recorder.py
+++ b/bundle-workflow/python/build_workflow/build_recorder.py
@@ -7,9 +7,9 @@ import yaml
 from manifests.build_manifest import BuildManifest
 
 class BuildRecorder:
-    def __init__(self, output_dir, name, version, arch):
+    def __init__(self, build_id, output_dir, name, version, arch):
         self.output_dir = output_dir
-        self.build_manifest = self.BuildManifestBuilder(name, version, arch)
+        self.build_manifest = self.BuildManifestBuilder(build_id, name, version, arch)
 
     def record_component(self, component_name, git_repo):
         self.build_manifest.append_component(component_name, git_repo.url, git_repo.ref, git_repo.sha)
@@ -35,9 +35,10 @@ class BuildRecorder:
             yaml.dump(output_manifest.to_dict(), file)
 
     class BuildManifestBuilder:
-        def __init__(self, name, version, arch):
+        def __init__(self, build_id, name, version, arch):
             self.data = {}
             self.data['build'] = {}
+            self.data['build']['id'] = build_id
             self.data['build']['name'] = name
             self.data['build']['version'] = str(version)
             self.data['build']['architecture'] = arch

--- a/bundle-workflow/python/manifests/bundle_manifest.py
+++ b/bundle-workflow/python/manifests/bundle_manifest.py
@@ -4,9 +4,9 @@
 import yaml
 
 '''
-A BuildManifest is an immutable view of the outputs from a build step
-The manifest contains information about the product that was built (in the `build` section),
-and the components that made up the build in the `components` section.
+A BundleManifest is an immutable view of the outputs from a assemble step
+The manifest contains information about the bundle that was built (in the `assemble` section),
+and the components that made up the bundle in the `components` section.
 
 The format for schema version 1.0 is:
 schema-version: 1.0
@@ -14,28 +14,21 @@ build:
   name: string
   version: string
   architecture: x64 or arm64
+  location: /relative/path/to/tarball
 components:
   - name: string
     repository: URL of git repository
     ref: git ref that was built (sha, branch, or tag)
     commit_id: The actual git commit ID that was built (i.e. the resolved "ref")
-    artifacts:
-      maven:
-        - maven/relative/path/to/artifact
-        - ...
-      plugins:
-        - plugins/relative/path/to/artifact
-        - ...
-      libs:
-        - libs/relative/path/to/artifact
-        - ...
-  - ...
+    location: /relative/path/to/artifact
 '''
-class BuildManifest:
+
+
+class BundleManifest:
     @staticmethod
     def from_file(path):
         with open(path, 'r') as file:
-            return BuildManifest(yaml.safe_load(file))
+            return BundleManifest(yaml.safe_load(file))
 
     def __init__(self, data):
         self.version = str(data['schema-version'])
@@ -58,6 +51,7 @@ class BuildManifest:
             self.name = data['name']
             self.version = data['version']
             self.architecture = data['architecture']
+            self.location = data['location']
             self.id = data['id']
 
         def to_dict(self):
@@ -65,6 +59,7 @@ class BuildManifest:
                 'name': self.name,
                 'version': self.version,
                 'architecture': self.architecture,
+                'location': self.location,
                 'id': self.id
             }
 
@@ -74,7 +69,7 @@ class BuildManifest:
             self.repository = data['repository']
             self.ref = data['ref']
             self.commit_id = data['commit_id']
-            self.artifacts = data['artifacts']
+            self.location = data['location']
 
         def to_dict(self):
             return {
@@ -82,5 +77,5 @@ class BuildManifest:
                 'repository': self.repository,
                 'ref': self.ref,
                 'commit_id': self.commit_id,
-                'artifacts': self.artifacts
+                'location': self.location
             }

--- a/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
@@ -30,7 +30,7 @@ then
   cp -r distribution/archives/linux-arm64-tar/build/distributions/ "${outputDir}"/bundle
 fi
 
-cd $outputDir
+cd $outputDir/bundle
 
 #rename included bundle to -min.
 ARTIFACT_FULL_NAME=`ls  | grep -E 'tar.gz$' | tail -n 1`


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This commit introduces an assembly step to build a full bundle.
Given a build manifest created with the build step, it will
install all plugins, create a bundle manifest, and create the tarball.

Other notes:
- Fixes OpenSearch core's build.sh script to correctly rename the distro to -min. 
- Generates a build-id during the build step and re-uses the same build-id in the bundle manifest.
- It is expected that the manifest path passed as input lives inside a directory containing build output from the build workflow.
- Bundles are output to a separate /bundles folder.
- Adds support to reference a public location where artifacts are hosted in the build manifest.  If env variable PUBLIC_ARTIFACT_URL is set, it will construct a url in the format > PUBLIC_ARTIFACT_URL/bundles/version/build-id/...
- It is expected that bundles will be copied to a /bundles folder, and builds to a /builds folder.

Example manifest with env variable set:

```
build:
  architecture: x64
  id: 41d5ae25183d4e699e92debfbe3f83bd
  location: https://artifacts.opensearch.org/bundles/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/opensearch-1.0.0-linux-x64.tar.gz
  name: OpenSearch
  version: 1.0.0
components:
- commit_id: 8daa06f816a0a17694ff1c3b56977a9a18fdf1f9
  location: https://artifacts.opensearch.org/builds/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/bundle/opensearch-min-1.0.0-linux-x64.tar.gz
  name: OpenSearch
  ref: 1.0
  repository: https://github.com/opensearch-project/OpenSearch.git
- commit_id: 7fad9529358259de529763c1c923fd947817a3bd
  location: https://artifacts.opensearch.org/builds/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/plugins/opensearch-job-scheduler-1.0.0.0.zip
  name: job-scheduler
  ref: 1.0.0.0
  repository: https://github.com/opensearch-project/job-scheduler.git
```

if not set, absolute local paths are used:
```
build:
  architecture: x64
  id: 41d5ae25183d4e699e92debfbe3f83bd
  location: /Volumes/workplace/opensearch-build/bundles/opensearch-1.0.0-linux-x64.tar.gz
  name: OpenSearch
  version: 1.0.0
components:
- commit_id: 8daa06f816a0a17694ff1c3b56977a9a18fdf1f9
  location: /Volumes/workplace/opensearch-build/artifacts/bundle/opensearch-min-1.0.0-linux-x64.tar.gz
  name: OpenSearch
  ref: 1.0
  repository: https://github.com/opensearch-project/OpenSearch.git
- commit_id: 7fad9529358259de529763c1c923fd947817a3bd
  location: /Volumes/workplace/opensearch-build/artifacts/plugins/opensearch-job-scheduler-1.0.0.0.zip
  name: job-scheduler
  ref: 1.0.0.0
  repository: https://github.com/opensearch-project/job-scheduler.git
```

This script does not yet produce a fully functional bundle.  Knn and performance-analyzer require special configuration.  This should be done as part of  #148 and #149

 
### Issues Resolved
closes #133 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
