### PR TITLE
Lock Python dependencies using pipenv.

### DIFF
--- a/bundle-workflow/Pipfile
+++ b/bundle-workflow/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+pyyaml = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/bundle-workflow/Pipfile
+++ b/bundle-workflow/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pyyaml = "*"
+pyyaml = "~=5.4"
 
 [dev-packages]
 

--- a/bundle-workflow/Pipfile.lock
+++ b/bundle-workflow/Pipfile.lock
@@ -1,0 +1,56 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "64ea0b1cc667d3f6700806541c5165eb4fb1081a3d0747b6240ab5a214dc1c24"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        }
+    },
+    "develop": {}
+}

--- a/bundle-workflow/Pipfile.lock
+++ b/bundle-workflow/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "64ea0b1cc667d3f6700806541c5165eb4fb1081a3d0747b6240ab5a214dc1c24"
+            "sha256": "dd3023db0a194f3dd63bd4a91cebd388767d817e24bc8f99daaaf49987a3a10a"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -7,7 +7,7 @@ The OpenSearch repo is built first, followed by common-utils. These dependencies
 ### Usage
 
 ```bash
-./tools/bundle-build/build.sh manifests/opensearch-bundle.1.0.yml
+./bundle-workflow/build.sh manifests/opensearch-1.0.0.yml
 ```
 
 ### Scripts

--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -12,4 +12,4 @@ The OpenSearch repo is built first, followed by common-utils. These dependencies
 
 ### Scripts
 
-Each component build relies on a `build.sh` script that is used to prepare bundle artifacts for a particular bundle version that takes two arguments: version and target architecture. By default the tool will look for a script in [scripts/bundle-build/components](../../scripts/bundle-build/components), then in the checked-out repository in `build/build.sh`, then default to a Gradle build implemented in [scripts/bundle-build/standard-gradle-build](../../scripts/bundle-build/standard-gradle-build).
+Each component build relies on a `build.sh` script that is used to prepare bundle artifacts for a particular bundle version that takes two arguments: version and target architecture. By default the tool will look for a script in [scripts/bundle-build/components](scripts/bundle-build/components), then in the checked-out repository in `build/build.sh`, then default to a Gradle build implemented in [scripts/bundle-build/standard-gradle-build](scripts/bundle-build/standard-gradle-build).

--- a/bundle-workflow/build.sh
+++ b/bundle-workflow/build.sh
@@ -6,4 +6,4 @@
 set -e
 
 DIR="$(dirname "$0")"
-python3 "$DIR/python/build.py" $@
+"$DIR/run.sh" "$DIR/python/build.py" $@

--- a/bundle-workflow/python/build.py
+++ b/bundle-workflow/python/build.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/bundle-workflow/python/test.py
+++ b/bundle-workflow/python/test.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import os
 import sys
 import tempfile

--- a/bundle-workflow/run.sh
+++ b/bundle-workflow/run.sh
@@ -5,12 +5,16 @@
 
 set -e
 
-DIR="$(dirname "$0")"
-
 if [ -z "$1" ]; then (echo "syntax: run.sh [workflow.py]"; exit -1); fi
 command -v python3 >/dev/null 2>&1 || (echo "missing python3"; exit -1)
 command -v pip >/dev/null 2>&1 || (echo "missing python3-pip"; exit -1)
 command -v pipenv >/dev/null 2>&1 || (echo "missing pipenv"; exit -1)
 
+DIR="$(dirname "$0")"
+
+echo "Installing dependencies in $DIR ..."
+export PIPENV_PIPFILE="$DIR/Pipfile"
 python3 -m pipenv install
+
+echo "Running "$1" ${@:2} ..."
 python3 -m pipenv run "$1" ${@:2}

--- a/bundle-workflow/run.sh
+++ b/bundle-workflow/run.sh
@@ -8,9 +8,9 @@ set -e
 DIR="$(dirname "$0")"
 
 if [ -z "$1" ]; then (echo "syntax: run.sh [workflow.py]"; exit -1); fi
-command -v python3 >/dev/null 2>&1 || (echo "missing python3, try 'sudo apt install python3'"; exit -1)
-command -v pip >/dev/null 2>&1 || (echo "missing pip, try 'sudo apt install python3-pip'"; exit -1)
-command -v pipenv >/dev/null 2>&1 || (echo "missing pipenv, try 'sudo apt install pipenv'"; exit -1)
+command -v python3 >/dev/null 2>&1 || (echo "missing python3"; exit -1)
+command -v pip >/dev/null 2>&1 || (echo "missing python3-pip"; exit -1)
+command -v pipenv >/dev/null 2>&1 || (echo "missing pipenv"; exit -1)
 
 python3 -m pipenv install
 python3 -m pipenv run "$1" ${@:2}

--- a/bundle-workflow/run.sh
+++ b/bundle-workflow/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+DIR="$(dirname "$0")"
+
+if [ -z "$1" ]; then (echo "syntax: run.sh [workflow.py]"; exit -1); fi
+command -v python3 >/dev/null 2>&1 || (echo "missing python3, try 'sudo apt install python3'"; exit -1)
+command -v pip >/dev/null 2>&1 || (echo "missing pip, try 'sudo apt install python3-pip'"; exit -1)
+command -v pipenv >/dev/null 2>&1 || (echo "missing pipenv, try 'sudo apt install pipenv'"; exit -1)
+
+python3 -m pipenv install
+python3 -m pipenv run "$1" ${@:2}

--- a/bundle-workflow/scripts/bundle-build/README.md
+++ b/bundle-workflow/scripts/bundle-build/README.md
@@ -1,1 +1,1 @@
-Scripts invoked by [bundle-build](../tools/bundle-build).
+Scripts invoked by [bundle-workflow](../..).

--- a/bundle-workflow/test.sh
+++ b/bundle-workflow/test.sh
@@ -6,4 +6,4 @@
 set -e
 
 DIR="$(dirname "$0")"
-python3 "$DIR/python/test.py" $@
+"$DIR/run.sh" "$DIR/python/test.py" $@

--- a/tools/bundle-build/__init__.py
+++ b/tools/bundle-build/__init__.py
@@ -1,2 +1,0 @@
-# Copyright OpenSearch Contributors.
-# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Instead of documenting dependencies as suggested in https://github.com/opensearch-project/opensearch-build/pull/159 introduce a Pipfile that lists them along with auto-failure and suggestions of what to install when `python3`, `pip` or `pipenv` may be missing. 

Extract common parts of `build.sh` and `test.sh` into `run.sh` that takes an argument of what to run.
 
### Issues Resolved

Closes  https://github.com/opensearch-project/opensearch-build/issues/160.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
