### PR TITLE
Add 'manifests' package that contains immutable input and build manifest classes

### DIFF
--- a/bundle-workflow/python/manifests/__init__.py
+++ b/bundle-workflow/python/manifests/__init__.py
@@ -1,0 +1,1 @@
+# This page intentionally left blank

--- a/bundle-workflow/python/manifests/build_manifest.py
+++ b/bundle-workflow/python/manifests/build_manifest.py
@@ -1,0 +1,81 @@
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+import yaml
+
+'''
+A BuildManifest is an immutable view of the outputs from a build step
+The manifest contains information about the product that was built (in the `build` section),
+and the components that made up the build in the `components` section.
+
+The format for schema version 1.0 is:
+schema-version: 1.0
+build:
+  name: string
+  version: string
+components:
+  - name: string
+    repository: URL of git repository
+    ref: git ref that was built (sha, branch, or tag)
+    commitid: The actual git commit ID that was built (i.e. the resolved "ref")
+    artifacts:
+      maven:
+        - maven/relative/path/to/artifact
+        - ...
+      plugins:
+        - plugins/relative/path/to/artifact
+        - ...
+      libs:
+        - libs/relative/path/to/artifact
+        - ...
+  - ...
+'''
+class BuildManifest:
+    @staticmethod
+    def from_file(path):
+        with open(path, 'r') as file:
+            return BuildManifest(yaml.safe_load(file))
+
+    def __init__(self, data):
+        self.version = str(data['schema-version'])
+        if self.version != '1.0':
+            raise ValueError(f'Unsupported schema version: {self.version}')
+        self.build = self.Build(data['build'])
+        self.components = list(map(lambda entry: self.Component(entry),
+                                   data['components']))
+
+    def to_dict(self):
+        return {
+            'schema-version': '1.0',
+            'build': self.build.to_dict(),
+            'components': list(map(lambda component: component.to_dict(),
+                                   self.components))
+        }
+
+    class Build:
+        def __init__(self, data):
+            self.name = data['name']
+            self.version = data['version']
+
+        def to_dict(self):
+            return {
+                'name': self.name,
+                'version': self.version
+            }
+
+    class Component:
+        def __init__(self, data):
+            self.name = data['name']
+            self.repository = data['repository']
+            self.ref = data['ref']
+            self.commitid = data['commitid']
+            self.artifacts = data['artifacts']
+
+        def to_dict(self):
+            return {
+                'name': self.name,
+                'repository': self.repository,
+                'ref': self.ref,
+                'commitid': self.commitid,
+                'artifacts': self.artifacts
+            }

--- a/bundle-workflow/python/manifests/build_manifest.py
+++ b/bundle-workflow/python/manifests/build_manifest.py
@@ -13,6 +13,7 @@ schema-version: 1.0
 build:
   name: string
   version: string
+  architecture: x64 or arm64
 components:
   - name: string
     repository: URL of git repository
@@ -56,11 +57,13 @@ class BuildManifest:
         def __init__(self, data):
             self.name = data['name']
             self.version = data['version']
+            self.architecture = data['architecture']
 
         def to_dict(self):
             return {
                 'name': self.name,
-                'version': self.version
+                'version': self.version,
+                'architecture': self.architecture
             }
 
     class Component:

--- a/bundle-workflow/python/manifests/build_manifest.py
+++ b/bundle-workflow/python/manifests/build_manifest.py
@@ -18,7 +18,7 @@ components:
   - name: string
     repository: URL of git repository
     ref: git ref that was built (sha, branch, or tag)
-    commitid: The actual git commit ID that was built (i.e. the resolved "ref")
+    commit_id: The actual git commit ID that was built (i.e. the resolved "ref")
     artifacts:
       maven:
         - maven/relative/path/to/artifact
@@ -71,7 +71,7 @@ class BuildManifest:
             self.name = data['name']
             self.repository = data['repository']
             self.ref = data['ref']
-            self.commitid = data['commitid']
+            self.commit_id = data['commit_id']
             self.artifacts = data['artifacts']
 
         def to_dict(self):
@@ -79,6 +79,6 @@ class BuildManifest:
                 'name': self.name,
                 'repository': self.repository,
                 'ref': self.ref,
-                'commitid': self.commitid,
+                'commit_id': self.commit_id,
                 'artifacts': self.artifacts
             }

--- a/bundle-workflow/python/manifests/input_manifest.py
+++ b/bundle-workflow/python/manifests/input_manifest.py
@@ -1,0 +1,45 @@
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+import yaml
+
+'''
+An InputManifest is an immutable view of the input manifest for the build system.
+The manifest contains information about the product that is being built (in the `build` section),
+and the components that make up the product in the `components` section.
+
+The format for schema version 1.0 is:
+schema-version: 1.0
+build:
+  name: string
+  version: string
+components:
+  - name: string
+    repository: URL of git repository
+    ref: git ref to build (sha, branch, or tag)
+  - ...
+'''
+class InputManifest:
+    @staticmethod
+    def from_file(path):
+        with open(path, 'r') as file:
+            return InputManifest(yaml.safe_load(file))
+
+    def __init__(self, data):
+        self.version = str(data['schema-version'])
+        if self.version != '1.0':
+            raise ValueError(f'Unsupported schema version: {self.version}')
+        self.build = self.Build(data['build'])
+        self.components = list(map(lambda entry: self.Component(entry),
+                                   data['components']))
+
+    class Build:
+        def __init__(self, data):
+            self.name = data['name']
+            self.version = data['version']
+
+    class Component:
+        def __init__(self, data):
+            self.name = data['name']
+            self.repository = data['repository']
+            self.ref = data['ref']


### PR DESCRIPTION
### Description
Provides `InputManifest` and `BuildManifest` classes in the `manifests` package.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/157
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
