### PR TITLE
Add build workflow entry point

### DIFF
--- a/bundle-workflow/python/build.py
+++ b/bundle-workflow/python/build.py
@@ -3,31 +3,57 @@
 
 import os
 import sys
+import subprocess
 import tempfile
-import urllib.request
-from lib.build_manifest import BuildManifest
-from lib.build_output import BuildOutput
+import yaml
+from manifests.input_manifest import InputManifest
+from build_workflow.build_recorder import BuildRecorder
+from build_workflow.builder import Builder
+from build_workflow.git_repository import GitRepository
 
 if (len(sys.argv) < 2):
     print("Build an OpenSearch Bundle")
     print("usage: build.sh /path/to/manifest")
     exit(1)
 
-with tempfile.TemporaryDirectory() as work_dir:
-    manifest = BuildManifest.from_file(sys.argv[1])
-    build = manifest.build
-    output = BuildOutput()
+component_scripts_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/components')
+default_build_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/standard-gradle-build/build.sh')
 
-    print(f'Building {build.name} ({output.arch}) into {output.dest} ...')
+def get_arch():
+    arch = subprocess.check_output(['uname', '-m']).decode().strip()
+    if arch == 'x86_64':
+        return 'x64'
+    elif arch == 'aarch64' or arch == 'arm64':
+        return  'arm64'
+    else:
+        raise ValueError(f'Unsupported architecture: {arch}')
+
+arch = get_arch()
+manifest = InputManifest.from_file(sys.argv[1])
+output_dir = os.path.join(os.getcwd(), 'artifacts')
+os.makedirs(output_dir, exist_ok = True)
+
+with tempfile.TemporaryDirectory() as work_dir:
+    print(f'Building in {work_dir}')
 
     os.chdir(work_dir)
 
-    for component in manifest.components:
-        print(f'=== Building {component.name} ...')
-        component.checkout()
-        component.build(build.version, output.arch)
-        component.export(output.dest)
+    build_recorder = BuildRecorder(output_dir, manifest.build.name, manifest.build.version, arch)
 
-    manifest_path = os.path.join(output.dest, 'manifest.yml')
-    manifest.save_to(manifest_path)
-    print(f'Done.')
+    print(f'Building {manifest.build.name} ({arch}) into {output_dir}')
+
+    for component in manifest.components:
+        print(f'Building {component.name}')
+        repo = GitRepository(component.repository, component.ref)
+        builder = Builder(component.name,
+                          repo,
+                          component_scripts_path,
+                          default_build_path,
+                          build_recorder)
+        builder.build(manifest.build.version, arch)
+        builder.export_artifacts()
+
+    output_manifest = build_recorder.get_manifest()
+    manifest_path = os.path.join(output_dir, 'manifest.yml')
+    with open(manifest_path, 'w') as file:
+        yaml.dump(output_manifest.to_dict(), file)


### PR DESCRIPTION
### Description
`build.py` is the entry point to execute the build workflow. It takes in an input manifest and outputs build artifacts + an output manifest to the `artifacts` directory.

This change depends on https://github.com/opensearch-project/opensearch-build/pull/165 and https://github.com/opensearch-project/opensearch-build/pull/166. See those PRs for details of the manifests and build_workflow packages.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/157
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
