### PR TITLE
Add ScriptFinder to abstract away the logic for finding build.sh and integtest.sh scripts

### DIFF
--- a/bundle-workflow/python/build.py
+++ b/bundle-workflow/python/build.py
@@ -11,6 +11,7 @@ from manifests.input_manifest import InputManifest
 from build_workflow.build_recorder import BuildRecorder
 from build_workflow.builder import Builder
 from build_workflow.git_repository import GitRepository
+from paths.script_finder import ScriptFinder
 
 if (len(sys.argv) < 2):
     print("Build an OpenSearch Bundle")
@@ -18,7 +19,8 @@ if (len(sys.argv) < 2):
     exit(1)
 
 component_scripts_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/components')
-default_build_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/standard-gradle-build/build.sh')
+default_scripts_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/standard-gradle-build')
+script_finder = ScriptFinder(component_scripts_path, default_scripts_path)
 
 def get_arch():
     arch = subprocess.check_output(['uname', '-m']).decode().strip()
@@ -48,8 +50,7 @@ with tempfile.TemporaryDirectory() as work_dir:
         repo = GitRepository(component.repository, component.ref)
         builder = Builder(component.name,
                           repo,
-                          component_scripts_path,
-                          default_build_path,
+                          script_finder,
                           build_recorder)
         builder.build(manifest.build.version, arch)
         builder.export_artifacts()

--- a/bundle-workflow/python/paths/script_finder.py
+++ b/bundle-workflow/python/paths/script_finder.py
@@ -1,0 +1,43 @@
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from dataclasses import dataclass
+
+@dataclass
+class ScriptFinder:
+    '''
+    ScriptFinder is a helper that abstracts away the details of where to look for build and test scripts.
+    Given a component name and a checked-out Git repository, it will look in the following locations, in order, for either "build.sh" or "integtest.sh", depending on the use case:
+      * Root of the Git repository
+      * /scripts/<script-name> in the Git repository
+      * <component_scripts_path>/<component_name>/<script-name>
+      * <default_scripts_path>/<script-name>
+    '''
+
+    component_scripts_path: str
+    default_scripts_path: str
+
+    def find_build_script(self, component_name, git_dir):
+        paths = [os.path.realpath(os.path.join(git_dir, 'build.sh')),
+                 os.path.realpath(os.path.join(git_dir, 'scripts/build.sh')),
+                 os.path.realpath(os.path.join(self.component_scripts_path, component_name, 'build.sh')),
+                 os.path.realpath(os.path.join(self.default_scripts_path, 'build.sh'))
+                 ]
+
+        build_script = next(filter(lambda path: os.path.exists(path), paths), None)
+        if build_script is None:
+            raise RuntimeError(f'Could not find build.sh script. Looked in {paths}')
+        return build_script
+
+    def find_integ_test_script(self, component_name, git_dir):
+        paths = [os.path.realpath(os.path.join(git_dir, 'integtest.sh')),
+                 os.path.realpath(os.path.join(git_dir, 'scripts/integtest.sh')),
+                 os.path.realpath(os.path.join(self.component_scripts_path, component_name, 'integtest.sh')),
+                 os.path.realpath(os.path.join(self.default_scripts_path, 'integtest.sh'))
+                 ]
+
+        test_script = next(filter(lambda path: os.path.exists(path), paths), None)
+        if test_script is None:
+            raise RuntimeError(f'Could not find integtest.sh script. Looked in {paths}')
+        return test_script


### PR DESCRIPTION
Also refactor builder.py to use ScriptFinder

### Testing
Manually verified that build.py works correctly
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
