### PR TITLE
Added support for passing snapshot build options.

### DIFF
--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -10,6 +10,12 @@ The OpenSearch repo is built first, followed by common-utils. These dependencies
 ./bundle-workflow/build.sh manifests/opensearch-1.0.0.yml
 ```
 
+The following options are available.
+
+| name       | description                                                         |
+|------------|---------------------------------------------------------------------|
+| --snapshot | Build a snapshot instead of a release artifact, default is `false`. |
+
 ### Scripts
 
 Each component build relies on a `build.sh` script that is used to prepare bundle artifacts for a particular bundle version that takes two arguments: version and target architecture. By default the tool will look for a script in [scripts/bundle-build/components](scripts/bundle-build/components), then in the checked-out repository in `build/build.sh`, then default to a Gradle build implemented in [scripts/bundle-build/standard-gradle-build](scripts/bundle-build/standard-gradle-build).

--- a/bundle-workflow/python/assemble.py
+++ b/bundle-workflow/python/assemble.py
@@ -1,20 +1,17 @@
 import os
-import sys
 import tempfile
+import argparse
 from assemble_workflow.bundle import Bundle
 from assemble_workflow.bundle_recorder import BundleRecorder
 from manifests.build_manifest import BuildManifest
 
-if (len(sys.argv) < 2):
-    print("Build an OpenSearch Bundle")
-    print("usage: assemble.sh /path/to/build_manifest")
-    exit(1)
+parser = argparse.ArgumentParser(description = "Assembly an OpenSearch Bundle")
+parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
+args = parser.parse_args()
 
-
-build_manifest_path = sys.argv[1]
-build_manifest = BuildManifest.from_file(build_manifest_path)
+build_manifest = BuildManifest.from_file(args.manifest)
 build = build_manifest.build
-artifacts_dir = os.path.dirname(os.path.realpath(build_manifest_path))
+artifacts_dir = os.path.dirname(os.path.realpath(args.manifest))
 output_dir = os.path.join(os.getcwd(), 'bundle')
 os.makedirs(output_dir, exist_ok=True)
 

--- a/bundle-workflow/python/assemble.py
+++ b/bundle-workflow/python/assemble.py
@@ -5,7 +5,7 @@ from assemble_workflow.bundle import Bundle
 from assemble_workflow.bundle_recorder import BundleRecorder
 from manifests.build_manifest import BuildManifest
 
-parser = argparse.ArgumentParser(description = "Assembly an OpenSearch Bundle")
+parser = argparse.ArgumentParser(description = "Assemble an OpenSearch Bundle")
 parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
 args = parser.parse_args()
 

--- a/bundle-workflow/python/build.py
+++ b/bundle-workflow/python/build.py
@@ -16,6 +16,7 @@ from paths.script_finder import ScriptFinder
 
 parser = argparse.ArgumentParser(description = "Build an OpenSearch Bundle")
 parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
+parser.add_argument('-s', '--snapshot', action = 'store_true', default = False, help="Build snapshot.")
 args = parser.parse_args()
 
 component_scripts_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/components')
@@ -37,12 +38,12 @@ output_dir = os.path.join(os.getcwd(), 'artifacts')
 os.makedirs(output_dir, exist_ok = True)
 build_id = os.getenv('OPENSEARCH_BUILD_ID', uuid.uuid4().hex)
 
-with tempfile.TemporaryDirectory() as work_dir:
+with tempfile.TemporaryDirectory() as work_dir: 
     print(f'Building in {work_dir}')
 
     os.chdir(work_dir)
 
-    build_recorder = BuildRecorder(build_id, output_dir, manifest.build.name, manifest.build.version, arch)
+    build_recorder = BuildRecorder(build_id, output_dir, manifest.build.name, manifest.build.version, arch, args.snapshot)
 
     print(f'Building {manifest.build.name} ({arch}) into {output_dir}')
 
@@ -53,9 +54,9 @@ with tempfile.TemporaryDirectory() as work_dir:
                           repo,
                           script_finder,
                           build_recorder)
-        builder.build(manifest.build.version, arch)
+        builder.build(manifest.build.version, arch, args.snapshot)
         builder.export_artifacts()
 
     build_recorder.write_manifest(output_dir)
 
-print('Done')
+print('Done.')

--- a/bundle-workflow/python/build.py
+++ b/bundle-workflow/python/build.py
@@ -4,20 +4,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import sys
 import subprocess
 import tempfile
 import uuid
+import argparse
 from manifests.input_manifest import InputManifest
 from build_workflow.build_recorder import BuildRecorder
 from build_workflow.builder import Builder
 from build_workflow.git_repository import GitRepository
 from paths.script_finder import ScriptFinder
 
-if (len(sys.argv) < 2):
-    print("Build an OpenSearch Bundle")
-    print("usage: build.sh /path/to/manifest")
-    exit(1)
+parser = argparse.ArgumentParser(description = "Build an OpenSearch Bundle")
+parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
+args = parser.parse_args()
 
 component_scripts_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/components')
 default_scripts_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/standard-gradle-build')
@@ -33,7 +32,7 @@ def get_arch():
         raise ValueError(f'Unsupported architecture: {arch}')
 
 arch = get_arch()
-manifest = InputManifest.from_file(sys.argv[1])
+manifest = InputManifest.from_file(args.manifest)
 output_dir = os.path.join(os.getcwd(), 'artifacts')
 os.makedirs(output_dir, exist_ok = True)
 build_id = os.getenv('OPENSEARCH_BUILD_ID', uuid.uuid4().hex)

--- a/bundle-workflow/python/build_workflow/build_recorder.py
+++ b/bundle-workflow/python/build_workflow/build_recorder.py
@@ -40,7 +40,7 @@ class BuildRecorder:
             self.data['build'] = {}
             self.data['build']['id'] = build_id
             self.data['build']['name'] = name
-            self.data['build']['version'] = str(version)
+            self.data['build']['version'] = (str(version) + '-SNAPSHOT' if snapshot else str(version))
             self.data['build']['architecture'] = arch
             self.data['build']['snapshot'] = str(snapshot).lower()
             self.data['schema-version'] = '1.0'

--- a/bundle-workflow/python/build_workflow/build_recorder.py
+++ b/bundle-workflow/python/build_workflow/build_recorder.py
@@ -7,9 +7,9 @@ import yaml
 from manifests.build_manifest import BuildManifest
 
 class BuildRecorder:
-    def __init__(self, build_id, output_dir, name, version, arch):
+    def __init__(self, build_id, output_dir, name, version, arch, snapshot):
         self.output_dir = output_dir
-        self.build_manifest = self.BuildManifestBuilder(build_id, name, version, arch)
+        self.build_manifest = self.BuildManifestBuilder(build_id, name, version, arch, snapshot)
 
     def record_component(self, component_name, git_repo):
         self.build_manifest.append_component(component_name, git_repo.url, git_repo.ref, git_repo.sha)
@@ -35,13 +35,14 @@ class BuildRecorder:
             yaml.dump(output_manifest.to_dict(), file)
 
     class BuildManifestBuilder:
-        def __init__(self, build_id, name, version, arch):
+        def __init__(self, build_id, name, version, arch, snapshot):
             self.data = {}
             self.data['build'] = {}
             self.data['build']['id'] = build_id
             self.data['build']['name'] = name
             self.data['build']['version'] = str(version)
             self.data['build']['architecture'] = arch
+            self.data['build']['snapshot'] = str(snapshot).lower()
             self.data['schema-version'] = '1.0'
             # We need to store components as a hash so that we can append artifacts by component name
             # When we convert to a BuildManifest this will get converted back into a list

--- a/bundle-workflow/python/build_workflow/builder.py
+++ b/bundle-workflow/python/build_workflow/builder.py
@@ -22,15 +22,16 @@ class Builder:
         self.git_repo = git_repo
         self.script_finder = script_finder
         self.build_recorder = build_recorder
+        self.output_path = 'artifacts'
 
-    def build(self, version, arch):
+    def build(self, version, arch, snapshot):
         build_script = self.script_finder.find_build_script(self.component_name, self.git_repo.dir.name)
-        build_command = f'{build_script} {version} {arch}'
+        build_command = f'{build_script} -v {version} -a {arch} -s {str(snapshot).lower()} -o {self.output_path}'
         self.git_repo.execute(build_command)
         self.build_recorder.record_component(self.component_name, self.git_repo)
 
     def export_artifacts(self):
-        artifacts_dir = os.path.realpath(os.path.join(self.git_repo.dir.name, 'artifacts'))
+        artifacts_dir = os.path.realpath(os.path.join(self.git_repo.dir.name, self.output_path))
         for artifact_type in ["maven", "bundle", "plugins", "libs"]:
             for dir, dirs, files in os.walk(os.path.join(artifacts_dir, artifact_type)):
                 for file_name in files:

--- a/bundle-workflow/python/manifests/build_manifest.py
+++ b/bundle-workflow/python/manifests/build_manifest.py
@@ -33,9 +33,8 @@ components:
 '''
 class BuildManifest:
     @staticmethod
-    def from_file(path):
-        with open(path, 'r') as file:
-            return BuildManifest(yaml.safe_load(file))
+    def from_file(file):
+        return BuildManifest(yaml.safe_load(file))
 
     def __init__(self, data):
         self.version = str(data['schema-version'])

--- a/bundle-workflow/python/manifests/bundle_manifest.py
+++ b/bundle-workflow/python/manifests/bundle_manifest.py
@@ -26,9 +26,8 @@ components:
 
 class BundleManifest:
     @staticmethod
-    def from_file(path):
-        with open(path, 'r') as file:
-            return BundleManifest(yaml.safe_load(file))
+    def from_file(file):
+        return BundleManifest(yaml.safe_load(file))
 
     def __init__(self, data):
         self.version = str(data['schema-version'])

--- a/bundle-workflow/python/manifests/input_manifest.py
+++ b/bundle-workflow/python/manifests/input_manifest.py
@@ -21,9 +21,8 @@ components:
 '''
 class InputManifest:
     @staticmethod
-    def from_file(path):
-        with open(path, 'r') as file:
-            return InputManifest(yaml.safe_load(file))
+    def from_file(file):
+      return InputManifest(yaml.safe_load(file))
 
     def __init__(self, data):
         self.version = str(data['schema-version'])

--- a/bundle-workflow/python/test.py
+++ b/bundle-workflow/python/test.py
@@ -1,25 +1,21 @@
 #!/usr/bin/env python
 
 import os
-import sys
 import tempfile
-import urllib.request
-from test_workflow.manifest import BundleManifest
+import argparse
+from manifests.bundle_manifest import BundleManifest
 from test_workflow.test_cluster import LocalTestCluster
 from test_workflow.git import GitRepository
 from test_workflow.integ_test import IntegTestSuite
 
-if (len(sys.argv) < 2):
-    print("Usage: tester.py /path/to/manifest")
-    exit(1)
+parser = argparse.ArgumentParser(description = "Test an OpenSearch Bundle")
+parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
+args = parser.parse_args()
+
+manifest = BundleManifest.from_file(args.manifest)
 
 with tempfile.TemporaryDirectory() as work_dir:
     os.chdir(work_dir)
-
-    # Download the manifest
-    with urllib.request.urlopen(sys.argv[1]) as response:
-        text = response.read()
-        manifest = BundleManifest.from_text(text)
 
     # Spin up a test cluster
     cluster = LocalTestCluster(manifest.bundle_location)

--- a/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
@@ -5,27 +5,71 @@
 
 set -e
 
-version="$1"
-ARCHITECTURE="$2"
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
 
-outputDir=artifacts
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+outputDir=$OUTPUT
 mkdir -p "${outputDir}/maven"
 
 # Build project and publish to maven local.
-./gradlew publishToMavenLocal -Dbuild.snapshot=false
+./gradlew publishToMavenLocal -Dbuild.snapshot=$SNAPSHOT
 
 # Publish to existing test repo, using this to stage release versions of the artifacts that can be released from the same build.
-./gradlew publishNebulaPublicationToTestRepository -Dbuild.snapshot=false
+./gradlew publishNebulaPublicationToTestRepository -Dbuild.snapshot=$SNAPSHOT
 
 # Copy maven publications to be promoted
 cp -r ./build/local-test-repo/org/opensearch "${outputDir}"/maven
 
-if [ "${ARCHITECTURE}" = "x64" ]
-then
+if [ "${ARCHITECTURE}" = "x64" ]; then
   ./gradlew :distribution:archives:linux-tar:assemble -Dbuild.snapshot=false
   cp -r distribution/archives/linux-tar/build/distributions/. "${outputDir}"/bundle
-elif [ "${ARCHITECTURE}" == "arm64" ]
-then
+elif [ "${ARCHITECTURE}" == "arm64" ]; then
   ./gradlew :distribution:archives:linux-arm64-tar:assemble -Dbuild.snapshot=false
   cp -r distribution/archives/linux-arm64-tar/build/distributions/ "${outputDir}"/bundle
 fi

--- a/bundle-workflow/scripts/bundle-build/components/alerting/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/alerting/build.sh
@@ -5,16 +5,64 @@
 
 set -e
 
-echo ${PWD}
-outputDir=artifacts
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
 
-mkdir -p $outputDir/plugins
-./gradlew assemble --no-daemon --refresh-dependencies -Dbuild.snapshot=false -DskipTests=true -Dopensearch.version=$1
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+mkdir -p $OUTPUT/plugins
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 zipPath=$(find . -path \*build/distributions/*.zip)
 distributions="$(dirname "${zipPath}")"
 
 echo "COPY ${distributions}/*.zip"
-cp ${distributions}/*.zip ./$outputDir/plugins
+cp ${distributions}/*.zip ./$OUTPUT/plugins
 
-./gradlew publishToMavenLocal -Dopensearch.version=$1 -Dbuild.snapshot=false
+./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT

--- a/bundle-workflow/scripts/bundle-build/components/common-utils/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/common-utils/build.sh
@@ -55,7 +55,6 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-echo ./gradlew build -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 ./gradlew build -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 mkdir -p artifacts/maven

--- a/bundle-workflow/scripts/bundle-build/components/dashboards-notebooks/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/dashboards-notebooks/build.sh
@@ -5,10 +5,60 @@
 
 set -e
 
-cd opensearch-notebooks
-./gradlew assemble --no-daemon --refresh-dependencies -Dbuild.snapshot=false -DskipTests=true -Dopensearch.version=$1
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
 
-outputDir=../artifacts
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+cd opensearch-notebooks
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+
+outputDir=../$OUTPUT
 mkdir -p $outputDir
 
 zipPath=$(find . -path \*build/distributions/*.zip)

--- a/bundle-workflow/scripts/bundle-build/components/dashboards-reports/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/dashboards-reports/build.sh
@@ -5,10 +5,60 @@
 
 set -e
 
-cd reports-scheduler
-./gradlew assemble --no-daemon --refresh-dependencies -Dbuild.snapshot=false -DskipTests=true -Dopensearch.version=$1
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
 
-outputDir=../artifacts
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+cd reports-scheduler
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+
+outputDir=../$OUTPUT
 mkdir -p $outputDir
 
 zipPath=$(find . -path \*build/distributions/*.zip)

--- a/bundle-workflow/scripts/bundle-build/components/notifications/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/notifications/build.sh
@@ -5,9 +5,59 @@
 
 set -e
 
-outputDir=artifacts
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+outputDir=$OUTPUT
 mkdir -p $outputDir/maven
 cd notifications
 
-./gradlew publishToMavenLocal -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=$1
+./gradlew publishToMavenLocal -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 

--- a/bundle-workflow/scripts/bundle-build/components/performance-analyzer-rca/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/performance-analyzer-rca/build.sh
@@ -5,5 +5,55 @@
 
 set -e
 
-./gradlew build -x test
-./gradlew publishToMavenLocal
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+./gradlew build -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x test
+./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT

--- a/bundle-workflow/scripts/bundle-build/components/performance-analyzer/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/performance-analyzer/build.sh
@@ -5,9 +5,59 @@
 
 set -e
 
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
 # remove this script when https://github.com/opensearch-project/performance-analyzer/issues/44 is fixed
 git fetch origin main
 git checkout main
 
-./gradlew build -x test
-./gradlew publishToMavenLocal
+./gradlew build -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x test
+./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT

--- a/bundle-workflow/scripts/bundle-build/components/security/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/security/build.sh
@@ -5,9 +5,59 @@
 
 set -e
 
-mvn -B clean package -Padvanced -DskipTests
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+mvn -B clean package -Padvanced -DskipTests -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 artifact_zip=$(ls $(pwd)/target/releases/opensearch-security-*.zip | grep -v admin-standalone)
-./gradlew assemble --no-daemon -ParchivePath=$artifact_zip -Dbuild.snapshot=false
-outputDir=artifacts
-mkdir -p $outputDir/plugins
-cp $artifact_zip $outputDir/plugins
+./gradlew assemble --no-daemon -ParchivePath=$artifact_zip -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+
+mkdir -p $OUTPUT/plugins
+cp $artifact_zip $OUTPUT/plugins

--- a/bundle-workflow/scripts/bundle-build/standard-gradle-build/build.sh
+++ b/bundle-workflow/scripts/bundle-build/standard-gradle-build/build.sh
@@ -5,13 +5,63 @@
 
 set -e
 
-outputDir=artifacts
-mkdir -p $outputDir
-./gradlew assemble --no-daemon --refresh-dependencies -Dbuild.snapshot=false -DskipTests=true -Dopensearch.version=$1
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+mkdir -p $OUTPUT
+echo ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 zipPath=$(find . -path \*build/distributions/*.zip)
 distributions="$(dirname "${zipPath}")"
 
 echo "COPY ${distributions}/*.zip"
-mkdir -p $outputDir/plugins
-cp ${distributions}/*.zip ./$outputDir/plugins
+mkdir -p $OUTPUT/plugins
+cp ${distributions}/*.zip ./$OUTPUT/plugins


### PR DESCRIPTION
### Description

Added support for passing `--snapshot` to the bundle build, which cascades `-s` which cascades into `-dbuild.snapshot=true` into gradle/maven builds. Opened some issues to fix the actual snapshot builds for a handful of plugins, but that doesn't need to hold up this PR. 

Making the custom override scripts actually parse arguments so that we can extend them in the future with additional parameters and not rely on the fact that arg1 is OpenSearch version and arg2 is the architecture.

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-build/issues/179
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
