### PR TITLE
Add Scripts to publish maven snapshots and stage maven releases.

### DIFF
--- a/publish/publish-snapshot.sh
+++ b/publish/publish-snapshot.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+###### Information ############################################################################
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  The OpenSearch Contributors require contributions made to
+#  this file be licensed under the Apache-2.0 license or a
+#  compatible open source license.
+#
+# Name:          publish-snapshot.sh
+# Language:      Shell
+#
+# About:         Deploy opensearch artifacts to a sonatype snapshot repository.
+#                This script will search POM files under the passed in directory and publish artifacts to
+#                a snapshot repository using the mvn deploy plugin.
+#
+# Usage:         ./publish-snapshot.sh <directory>
+#
+###############################################################################################
+set -e
+
+[ -z "${1:-}" ] && {
+  usage
+}
+
+usage() {
+    echo "usage: $0 [-h] [dir]"
+    echo "  dir     parent directory of artifacts to be published to org/opensearch namespace."
+    echo "          example: dir = ~/.m2/repository/org/opensearch where dir contains artifacts of a path:"
+    echo "                   /maven/reindex-client/1.0.0-SNAPSHOT/reindex-client-1.0.0-SNAPSHOT.jar"
+    echo "  -h      display help"
+    echo "Required environment variables:"
+    echo "SONATYPE_USERNAME - username with publish rights to a sonatype repository"
+    echo "SONATYPE_PASSWORD - password for sonatype"
+    echo "SNAPSHOT_REPO_URL - repository URL ex. http://localhost:8081/nexus/content/repositories/snapshots/"
+    exit 1
+}
+
+while getopts ":h" option; do
+  case $option in
+    h)
+       usage
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+       usage
+    ;;
+  esac
+done
+
+[ -z "${SONATYPE_USERNAME}" ] && {
+  echo "SONATYPE_USERNAME is required"
+  exit 1
+}
+
+[ -z "${SONATYPE_PASSWORD}" ] && {
+  echo "SONATYPE_PASSWORD is required"
+  exit 1
+}
+
+[ -z "${SNAPSHOT_REPO_URL}" ] && {
+  echo "REPO_URL is required"
+  exit 1
+}
+
+if [ ! -d "$1" ]; then
+  echo "Invalid directory $1 does not exist"
+  usage
+fi
+
+create_maven_settings() {
+    # Create a settings.xml file with the user+password for maven
+    mvn_settings="${workdir}/mvn-settings.xml"
+    cat > ${mvn_settings} <<-EOF
+<?xml version="1.0" encoding="UTF-8" ?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                            http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>nexus</id>
+      <username>${MAVEN_USERNAME}</username>
+      <password>${MAVEN_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>
+EOF
+}
+
+url="${SNAPSHOT_REPO_URL}"
+workdir=$(mktemp -d)
+
+function cleanup() {
+  rm -rf "${workdir}"
+}
+
+trap cleanup TERM INT EXIT
+
+create_maven_settings
+
+cd "$1"
+
+echo "searching for poms under $PWD"
+
+pomFiles="$(find "." -name '*.pom')"
+if [ -z "${pomFiles}" ]; then
+  echo "No artifacts found under $PWD"
+  exit 1
+fi
+
+for pom in ${pomFiles}; do
+  pom_dir="$(dirname "${pom}")"
+  for FILE in "${pom_dir}"/*;  do
+    if [[ ! $FILE == *"-javadoc.jar"* ]] && [[ ! $FILE == *"-sources.jar"* ]]; then
+    extension="${FILE##*.}"
+      case $extension in jar|war|zip)
+        echo "Uploading: ${FILE} to ${url}"
+         mvn --settings="${mvn_settings}" deploy:deploy-file \
+         -DgeneratePom=false \
+         -DrepositoryId=nexus \
+         -Durl="${SNAPSHOT_URL}" \
+         -DpomFile="${pom}" \
+         -Dfile="${FILE}" || echo "Failed to upload ${FILE}"
+       ;;
+           *) echo "Skipping upload for ${FILE}"
+      esac
+    fi
+  done
+
+  echo "Finished uploading ${pom_dir}"
+done
+
+echo "==========================================="
+echo "Done."
+echo "==========================================="

--- a/publish/stage-maven-release.sh
+++ b/publish/stage-maven-release.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+###### Information ############################################################################
+#  SPDX-License-Identifier: Apache-2.0
+#
+#  The OpenSearch Contributors require contributions made to
+#  this file be licensed under the Apache-2.0 license or a
+#  compatible open source license.
+#
+# Name:          stage-maven-release.sh
+# Language:      Shell
+#
+# About:         Deploy opensearch artifacts to a sonatype staging repository.
+#                This script will create a new staging repository in Sonatype and stage
+#                all artifacts in the passed in directory. The folder passed as input should contain
+#                subfolders org/opensearch to ensure artifacts are deployed under the correct groupId.
+#                Example: ./stage-maven-release.sh /maven
+#                - where maven contains /maven/org/opensearch
+#
+# Usage:         ./stage-maven-release.sh <directory>
+#
+###############################################################################################
+set -e
+
+[ -z "${1:-}" ] && {
+  usage
+}
+
+usage() {
+  echo "usage: $0 [-h] [dir]"
+  echo "  dir     parent directory containing artifacts to org/opensearch namespace."
+  echo "          example: dir = ~/.m2/repository where repository contains /org/opensearch"
+  echo "  -h      display help"
+  echo "Required environment variables:"
+  echo "SONATYPE_USERNAME - username with publish rights to a sonatype repository"
+  echo "SONATYPE_PASSWORD - password for sonatype"
+  echo "BUILD_ID - Build ID from CI so we can trace where the artifacts were built"
+  echo "STAGING_PROFILE_ID - Sonatype Staging profile ID"
+  echo "REPO_URL - repository URL without path, ex. https://aws.oss.sonatype.org/"
+  exit 1
+}
+
+while getopts ":h" option; do
+  case $option in
+  h)
+    usage
+    ;;
+  \?)
+    echo "Invalid option -$OPTARG" >&2
+    usage
+    ;;
+  esac
+done
+
+[ -z "${SONATYPE_USERNAME}" ] && {
+  echo "SONATYPE_USERNAME is required"
+  exit 1
+}
+
+[ -z "${SONATYPE_PASSWORD}" ] && {
+  echo "SONATYPE_PASSWORD is required"
+  exit 1
+}
+
+[ -z "${REPO_URL}" ] && {
+  echo "REPO_URL is required"
+  exit 1
+}
+
+[ -z "${BUILD_ID}" ] && {
+  echo "BUILD_ID is required"
+  exit 1
+}
+
+[ -z "${STAGING_PROFILE_ID}" ] && {
+  echo "STAGING_PROFILE_ID is required"
+  exit 1
+}
+
+if [ ! -d "$1" ]; then
+  echo "Invalid directory $1 does not exist"
+  usage
+fi
+
+[ ! -d "$1"/org/opensearch ] && {
+  echo "Given directory does not contain opensearch artifacts"
+  usage
+}
+
+staged_repo=$1
+
+workdir=$(mktemp -d)
+
+function cleanup() {
+  rm -rf "${workdir}"
+}
+trap cleanup TERM INT EXIT
+
+function create_maven_settings() {
+  # Create a settings.xml file with the user+password for maven
+  mvn_settings="${workdir}/mvn-settings.xml"
+  cat >"${mvn_settings}" <<-EOF
+<?xml version="1.0" encoding="UTF-8" ?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                            http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>nexus</id>
+      <username>${SONATYPE_USERNAME}</username>
+      <password>${SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+</settings>
+EOF
+}
+
+function create_staging_repository() {
+  staging_repo_id=$(mvn --settings="${mvn_settings}" \
+    org.sonatype.plugins:nexus-staging-maven-plugin:rc-open \
+    -DnexusUrl="${NEXUS_URL}" \
+    -DserverId=nexus \
+    -DstagingProfileId="${STAGING_PROFILE_ID}" \
+    -DstagingDescription="Staging artifacts for build ${BUILD_ID}" \
+    -DopenedRepositoryMessageFormat="opensearch-staging-repo-id=%s" |
+    grep -E -o 'opensearch-staging-repo-id=.*$' | cut -d'=' -f2)
+  echo "Opened staging repository ID $staging_repo_id"
+}
+
+
+url="${REPO_URL}"
+create_maven_settings
+create_staging_repository
+
+echo "==========================================="
+echo "Deploying artifacts under ${artifact_path} to Staging Repository ${staging_repo_id}."
+echo "==========================================="
+
+mvn --settings="${mvn_settings}" \
+  org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy-staged-repository \
+  -DrepositoryDirectory="${staged_repo}" \
+  -DnexusUrl="${url}" \
+  -DserverId=nexus \
+  -DautoReleaseAfterClose=false \
+  -DstagingProgressTimeoutMinutes=30 \
+  -DstagingProfileId="${STAGING_PROFILE_ID}" \
+  -DstagingRepositoryId="${staging_repo_id}"
+
+echo "==========================================="
+echo "Done."
+echo "==========================================="


### PR DESCRIPTION

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This PR introduces two scripts to publish to maven.

publish-snapshot.sh will publish /maven output to a snapshot repository.  It will publish only jars, zips, and wars and their poms.

stage-maven-release.sh will open a staging repo inside Sonatype and deploy the contents of a passed in directory to the staged repository.  Publishing the staged repository will require a human to approve its contents.

### Issues Resolved
closes #190 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
