### PR TITLE
Fix assemble.sh to correctly parse args.manifest

### DIFF
--- a/bundle-workflow/assemble.sh
+++ b/bundle-workflow/assemble.sh
@@ -6,4 +6,4 @@
 set -e
 
 DIR="$(dirname "$0")"
-python3 "$DIR/python/assemble.py" $@
+"$DIR/run.sh" "$DIR/python/assemble.py" $@

--- a/bundle-workflow/python/assemble.py
+++ b/bundle-workflow/python/assemble.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import tempfile
 import argparse
@@ -11,7 +16,7 @@ args = parser.parse_args()
 
 build_manifest = BuildManifest.from_file(args.manifest)
 build = build_manifest.build
-artifacts_dir = os.path.dirname(os.path.realpath(args.manifest))
+artifacts_dir = os.path.dirname(os.path.realpath(args.manifest.name))
 output_dir = os.path.join(os.getcwd(), 'bundle')
 os.makedirs(output_dir, exist_ok=True)
 


### PR DESCRIPTION


Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This PR fixes assemble.py to correctly fetch the name property from
args.manifest. It also updates assemble.sh to use run.sh
 
### Issues Resolved
Build fix
 
### Check List
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
