### PR TITLE
Downgrade to python 3.7 to match CI

### DIFF
--- a/bundle-workflow/Pipfile
+++ b/bundle-workflow/Pipfile
@@ -9,4 +9,4 @@ pyyaml = "~=5.4"
 [dev-packages]
 
 [requires]
-python_version = "3.8"
+python_version = "3.7"


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Downgrade to python 3.7 to match installed version on Jenkins CI.
This is intended to be temporary until we are able to easily control python versions in CI or 
configure versions from a disposable container.

 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
