### PR TITLE
Update Cloudformation Scripts to take role name as an input param

### DIFF
--- a/bundle-workflow/cloudformation/build-bundle-test-workflow.yml
+++ b/bundle-workflow/cloudformation/build-bundle-test-workflow.yml
@@ -1,22 +1,11 @@
 Description: Template for setting up resources for the build-bundle-test workflows
+Parameters:
+  InstanceRoleArn:
+    Type: String
+    Description: Cross account arn that is allowed to assume roles to publish/read from BuildBucket
 Resources:
   BuildBucket:
     Type: "AWS::S3::Bucket"
-  WorkflowUser:
-    Type: "AWS::IAM::User"
-    Properties:
-      UserName: buildworkflow
-      Policies:
-        - PolicyName: AssumeRole
-          PolicyDocument:
-            Version: 2012-10-17
-            Statement:
-              Effect: Allow
-              Action: "sts:AssumeRole"
-              Resource:
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/opensearch-build"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/opensearch-bundle"
-                - !Sub "arn:aws:iam::${AWS::AccountId}:role/opensearch-test"
   BuildRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -27,7 +16,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !GetAtt WorkflowUser.Arn
+                - Ref: InstanceRoleArn
             Action:
               - 'sts:AssumeRole'
       Policies:
@@ -49,7 +38,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !GetAtt WorkflowUser.Arn
+                - Ref: InstanceRoleArn
             Action:
               - 'sts:AssumeRole'
       Policies:
@@ -79,7 +68,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !GetAtt WorkflowUser.Arn
+                - Ref: InstanceRoleArn
             Action:
               - 'sts:AssumeRole'
       Policies:


### PR DESCRIPTION

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This commit updates build-bundle-test-workflow.yml
by taking in the arn given access to assume these roles as input.
The IAM User is no longer required so it has been removed.
 
### Check List
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
