### PR TITLE
Re-generate Pipfile.lock using Python 3.7.

### DIFF
--- a/bundle-workflow/Pipfile.lock
+++ b/bundle-workflow/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dd3023db0a194f3dd63bd4a91cebd388767d817e24bc8f99daaaf49987a3a10a"
+            "sha256": "aa8ff3f731dfae0464f2e052dccd660375d0492a74ada70832581568ae4462d7"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.7"
         },
         "sources": [
             {


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

We lowered the python version in https://github.com/opensearch-project/opensearch-build/pull/203, but forgot to re-generate a Pipfile.lock.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
