### PR TITLE
Use set -ex to dispay commands being run.

### DIFF
--- a/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/bundle-workflow/scripts/bundle-build/components/alerting/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/alerting/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/bundle-workflow/scripts/bundle-build/components/common-utils/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/common-utils/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/bundle-workflow/scripts/bundle-build/components/dashboards-notebooks/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/dashboards-notebooks/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/bundle-workflow/scripts/bundle-build/components/dashboards-reports/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/dashboards-reports/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/bundle-workflow/scripts/bundle-build/components/job-scheduler/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/job-scheduler/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/bundle-workflow/scripts/bundle-build/components/notifications/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/notifications/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/bundle-workflow/scripts/bundle-build/components/performance-analyzer-rca/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/performance-analyzer-rca/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/bundle-workflow/scripts/bundle-build/components/performance-analyzer/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/performance-analyzer/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/bundle-workflow/scripts/bundle-build/components/security/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/security/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/bundle-workflow/scripts/bundle-build/standard-gradle-build/build.sh
+++ b/bundle-workflow/scripts/bundle-build/standard-gradle-build/build.sh
@@ -3,7 +3,7 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 function usage() {
     echo "Usage: $0 [args]"
@@ -56,7 +56,6 @@ fi
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
 mkdir -p $OUTPUT
-echo ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 zipPath=$(find . -path \*build/distributions/*.zip)


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Coming from https://github.com/opensearch-project/opensearch-build/pull/189#discussion_r687931080, use `set -ex` to display the command being executed to ease debugging.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
