### PR TITLE
Add --component to build a single component.

### DIFF
--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -38,10 +38,10 @@ Build Step:
 
 The following options are available.
 
-| name               | description                                                         |
-|--------------------|---------------------------------------------------------------------|
-| --snapshot         | Build a snapshot instead of a release artifact, default is `false`. |
-| --component [name] | Build a single component by name, e.g. `--component common-utils`.  |
+| name               | description                                                           |
+|--------------------|-----------------------------------------------------------------------|
+| --snapshot         | Build a snapshot instead of a release artifact, default is `false`.   |
+| --component [name] | Rebuild a single component by name, e.g. `--component common-utils`.  |
 
 Bundle step:
 ```bash

--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -38,9 +38,10 @@ Build Step:
 
 The following options are available.
 
-| name       | description                                                         |
-|------------|---------------------------------------------------------------------|
-| --snapshot | Build a snapshot instead of a release artifact, default is `false`. |
+| name               | description                                                         |
+|--------------------|---------------------------------------------------------------------|
+| --snapshot         | Build a snapshot instead of a release artifact, default is `false`. |
+| --component [name] | Build a single component by name, e.g. `--component common-utils`.  |
 
 Bundle step:
 ```bash

--- a/bundle-workflow/python/build_workflow/build_args.py
+++ b/bundle-workflow/python/build_workflow/build_args.py
@@ -13,7 +13,7 @@ class BuildArgs():
         parser = argparse.ArgumentParser(description = "Build an OpenSearch Bundle")
         parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
         parser.add_argument('-s', '--snapshot', action = 'store_true', default = False, help="Build snapshot.")
-        parser.add_argument('-c', '--component', type = str, help="Build a single component.")
+        parser.add_argument('-c', '--component', type = str, help="Rebuild a single component.")
         args = parser.parse_args()
         self.manifest = args.manifest
         self.snapshot = args.snapshot

--- a/bundle-workflow/python/build_workflow/build_args.py
+++ b/bundle-workflow/python/build_workflow/build_args.py
@@ -1,0 +1,31 @@
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import argparse
+
+class BuildArgs():
+    manifest: str
+    snapshot: bool
+    component: str
+    
+    def __init__(self):
+        parser = argparse.ArgumentParser(description = "Build an OpenSearch Bundle")
+        parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
+        parser.add_argument('-s', '--snapshot', action = 'store_true', default = False, help="Build snapshot.")
+        parser.add_argument('-c', '--component', type = str, help="Build a single component.")
+        args = parser.parse_args()
+        self.manifest = args.manifest
+        self.snapshot = args.snapshot
+        self.component = args.component
+
+    def script_path(self):
+        return sys.argv[0].replace('/python/build.py', '/build.sh')
+
+    def component_command(self, name):
+        return ' '.join(filter(None, [
+            self.script_path(),
+            self.manifest.name,
+            f'--component {name}',
+            f'--snapshot' if self.snapshot else None
+        ]))


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Got a bit tired of constantly commenting out components in the manifest while fixing individual components. You can now pass in `--component` and it will build just that component, skipping all the others. The build output also shows the last failure and gives a copy-paste to rebuild the last component that failed. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
