### PR TITLE
Fix OpenSearch build output for snapshot builds.

### DIFF
--- a/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
@@ -66,18 +66,28 @@ mkdir -p "${outputDir}/maven"
 # Copy maven publications to be promoted
 cp -r ./build/local-test-repo/org/opensearch "${outputDir}"/maven
 
-if [ "${ARCHITECTURE}" = "x64" ]; then
-  ./gradlew :distribution:archives:linux-tar:assemble -Dbuild.snapshot=false
-  cp -r distribution/archives/linux-tar/build/distributions/. "${outputDir}"/bundle
-elif [ "${ARCHITECTURE}" == "arm64" ]; then
-  ./gradlew :distribution:archives:linux-arm64-tar:assemble -Dbuild.snapshot=false
-  cp -r distribution/archives/linux-arm64-tar/build/distributions/ "${outputDir}"/bundle
-fi
+# Assemble distribution artifact
+# see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
+case $ARCHITECTURE in
+    x86)
+        TARGET="linux-tar"
+        QUALIFIER="linux-x86"
+        ;;
+    x64)
+        TARGET="linux-arm64-tar"
+        QUALIFIER="linux-arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: ${ARCHITECTURE}"
+        exit 1
+        ;;
+esac
 
-cd $outputDir/bundle
+./gradlew :distribution:archives:$TARGET:assemble -Dbuild.snapshot=$SNAPSHOT
 
-#rename included bundle to -min.
-ARTIFACT_FULL_NAME=`ls  | grep -E 'tar.gz$' | tail -n 1`
-ARTIFACT_BASE_NAME=`basename -s .tar.gz $ARTIFACT_FULL_NAME | sed "s/opensearch/opensearch-min/g"`
-ARTIFACT_NEW_NAME="${ARTIFACT_BASE_NAME}${IDENTIFIER}.tar.gz"
-mv $ARTIFACT_FULL_NAME $ARTIFACT_NEW_NAME || true
+# Copy artifact to bundle output with -min in the name
+[[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
+ARTIFACT_BUILD_NAME=opensearch-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
+ARTIFACT_TARGET_NAME=opensearch-min-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
+mkdir -p "${outputDir}/bundle"
+cp distribution/archives/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${outputDir}"/bundle/$ARTIFACT_TARGET_NAME


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

The build doesn't correctly name the -min artifact with `-SNAPSHOT`. The script is also trying to be a bit too smart, we know exactly what the name of the artifact is and we only need to add `-min` to it. 

Made the script a bit more future proof when we decide to build other targets such as Windows.

Finally, I opened https://github.com/opensearch-project/OpenSearch/issues/1094 because there's no reason why the output of OpenSearch repo build shouldn't just be called `-min`, we can take care of it when merging this script into it.

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-build/issues/179
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
