### PR TITLE
Signing artifacts from manifest

### DIFF
--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -57,3 +57,24 @@ Artifacts will be updated as follows.
 #### Custom Install Scripts
 
 You can perform additional plugin install steps by adding an `install.sh` script. By default the tool will look for a script in [scripts/bundle-build/components](scripts/bundle-build/components), then default to a noop version implemented in [scripts/bundle-build/standard-gradle-build/install.sh](scripts/bundle-build/standard-gradle-build/install.sh).
+
+Step 3: Signing [optional]
+
+The signing step takes the manifest file created from the build step and signs all its component artifacts using the opensearch-signer-client. The input requires a path to the build manifest and is expected to be inside the artifacts directory with the same directories mentioned in the build step. 
+
+The following options are available. 
+
+| name        | description                                                         |
+|-------------|---------------------------------------------------------------------|
+| --component | The component name of the component whose artifacts will be signed  |
+| --type      | The artifact type to be signed. Currently one of 3 options:         |
+|             | 	1. plugins                                                  |
+|             |         2. maven                                                    |
+|             |         3. bundle                                                   |
+
+The signed artifacts (<artifact>.asc) will be found in the same location as the original artifact. 
+
+Signing step (to sign all artifacts):
+```bash
+./bundle_workflow/sign.sh artifacts/manifest.yml
+```

--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -3,6 +3,7 @@
         - [Custom Build Scripts](#custom-build-scripts)
     - [Assemble the Bundle](#assemble-the-bundle)
         - [Custom Install Scripts](#custom-install-scripts)
+    - [Signing Artifacts](#signing-artifacts)
 
 ## OpenSearch Bundle Workflow
 
@@ -58,9 +59,9 @@ Artifacts will be updated as follows.
 
 You can perform additional plugin install steps by adding an `install.sh` script. By default the tool will look for a script in [scripts/bundle-build/components](scripts/bundle-build/components), then default to a noop version implemented in [scripts/bundle-build/standard-gradle-build/install.sh](scripts/bundle-build/standard-gradle-build/install.sh).
 
-Step 3: Signing [optional]
+### Signing Artifacts
 
-The signing step takes the manifest file created from the build step and signs all its component artifacts using the opensearch-signer-client. The input requires a path to the build manifest and is expected to be inside the artifacts directory with the same directories mentioned in the build step. 
+The signing step (optional) takes the manifest file created from the build step and signs all its component artifacts using the opensearch-signer-client. The input requires a path to the build manifest and is expected to be inside the artifacts directory with the same directories mentioned in the build step. 
 
 The following options are available. 
 
@@ -68,9 +69,9 @@ The following options are available.
 |-------------|---------------------------------------------------------------------|
 | --component | The component name of the component whose artifacts will be signed  |
 | --type      | The artifact type to be signed. Currently one of 3 options:         |
-|             | 	1. plugins                                                  |
-|             |         2. maven                                                    |
-|             |         3. bundle                                                   |
+|             | 	1. plugins                                                      |
+|             |     2. maven                                                        |
+|             |     3. bundle                                                       |
 
 The signed artifacts (<artifact>.asc) will be found in the same location as the original artifact. 
 

--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -65,13 +65,10 @@ The signing step (optional) takes the manifest file created from the build step 
 
 The following options are available. 
 
-| name        | description                                                         |
-|-------------|---------------------------------------------------------------------|
-| --component | The component name of the component whose artifacts will be signed  |
-| --type      | The artifact type to be signed. Currently one of 3 options:         |
-|             | 	1. plugins                                                      |
-|             |     2. maven                                                        |
-|             |     3. bundle                                                       |
+| name        | description                                                                         |
+|-------------|-------------------------------------------------------------------------------------|
+| --component | The component name of the component whose artifacts will be signed                  |
+| --type      | The artifact type to be signed. Currently one of 3 options: [plugins, maven, bundle]|
 
 The signed artifacts (<artifact>.asc) will be found in the same location as the original artifact. 
 

--- a/bundle-workflow/python/git/git_repository.py
+++ b/bundle-workflow/python/git/git_repository.py
@@ -4,7 +4,6 @@
 import os
 import subprocess
 import tempfile
-import shutil
 
 class GitRepository:
     '''
@@ -30,9 +29,13 @@ class GitRepository:
         self.sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd = self.dir).decode().strip()
         print(f'Checked out {self.url}@{self.ref} into {self.dir} at {self.sha}')
 
-    def execute(self, command, silent = False):
-        print(f'Executing "{command}" in {self.dir}')
+    def execute(self, command, silent = False, subdirname = None):
+        dirname = self.dir
+        if subdirname:
+            dirname = os.path.join(self.dir, subdirname)
+        print(f'Executing "{command}" in {dirname}')
         if silent:
-            subprocess.check_call(command, cwd = self.dir, shell = True, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
+            subprocess.check_call(command, cwd = dirname, shell = True, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
         else:
-            subprocess.check_call(command, cwd = self.dir, shell = True)
+            subprocess.check_call(command, cwd = dirname, shell = True)
+

--- a/bundle-workflow/python/sign.py
+++ b/bundle-workflow/python/sign.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import os
+import subprocess as sp
+import tempfile
+import uuid
+import argparse
+from manifests.bundle_manifest import BundleManifest
+
+parser = argparse.ArgumentParser(description = "Sign artifacts")
+parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
+args = parser.parse_args()
+
+def sign(filename):
+    signatureFile = filename + ".asc"
+    signing_cmd = './opensearch-signer-client -i ' + filename + ' -o ' + signatureFile + ' -p pgp'
+    sp.run(signing_cmd.split(),cwd='opensearch-signer-client/src')
+    verify_cmd = 'gpg --verify-files ' + signatureFile
+    sp.run(verify_cmd.split(),cwd='opensearch-signer-client/src')
+    sp.run(['mv',signatureFile,'signed_artifacts/'])
+
+manifest = BundleManifest.from_file(args.manifest)
+output_dir = os.path.join(os.getcwd(), 'signed_artifacts')
+os.makedirs(output_dir, exist_ok = True)
+build_id = os.getenv('OPENSEARCH_BUILD_ID', uuid.uuid4().hex)
+
+os.system('git clone https://github.com/opensearch-project/opensearch-signer-client.git')
+os.system('cp ./config.cfg ./opensearch-signer-client/src/')
+sp.run(['./bootstrap'],cwd='opensearch-signer-client/src')
+
+print(f'Signing {manifest.build.name} into {output_dir}')
+for component in manifest.components:
+        print(f'signing {component.name}')
+        sign(f'{component.location}')
+
+os.system('rm -rf opensearch-signer-client')
+print('Done.')

--- a/bundle-workflow/python/sign.py
+++ b/bundle-workflow/python/sign.py
@@ -11,20 +11,27 @@ from pathlib import Path
 from signing_workflow.signer import Signer
 
 parser = argparse.ArgumentParser(description = "Sign artifacts")
-parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
+parser.add_argument('manifest', type = argparse.FileType('r'), help="Absolute path of local manifest file.")
+parser.add_argument('--component',nargs='?',help="Component name")
+parser.add_argument('--type',nargs='?',help="Artifact type")
 args = parser.parse_args()
 
 manifest = BuildManifest.from_file(args.manifest)
-basepath = os.path.abspath(os.path.join(__file__ ,"../../..")) + '/artifacts/'
+basepath = os.path.dirname(args.manifest.name)
+print("hello",basepath)
+
 signer = Signer()
 for component in manifest.components:
+    if (not args.component) or ( args.component and component.name == args.component):
         print(f'signing {component.name}')
-        for key in component.artifacts:
-            artifact_list = component.artifacts[key]
-            for artifact in artifact_list:
-                location = basepath + artifact 
-                signer.sign(location)
-                signer.verify(location + ".asc")
+        for artifact_type in component.artifacts:
+            if (not args.type) or (args.type and artifact_type == args.type):
+                artifact_list = component.artifacts[artifact_type]
+                for artifact in artifact_list:
+                    location = os.path.join(basepath, artifact)
+                    print("LOCATION=", location)
+                    signer.sign(location)
+                    signer.verify(location + ".asc")
 signer.close()
 
 print('Done.')

--- a/bundle-workflow/python/sign.py
+++ b/bundle-workflow/python/sign.py
@@ -1,37 +1,30 @@
 #!/usr/bin/env python
 
 import os
-import subprocess as sp
+import subprocess
 import tempfile
 import uuid
 import argparse
-from manifests.bundle_manifest import BundleManifest
+from manifests.build_manifest import BuildManifest
+from pprint import pprint
+from pathlib import Path
+from signing_workflow.signer import Signer
 
 parser = argparse.ArgumentParser(description = "Sign artifacts")
 parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
 args = parser.parse_args()
 
-def sign(filename):
-    signatureFile = filename + ".asc"
-    signing_cmd = './opensearch-signer-client -i ' + filename + ' -o ' + signatureFile + ' -p pgp'
-    sp.run(signing_cmd.split(),cwd='opensearch-signer-client/src')
-    verify_cmd = 'gpg --verify-files ' + signatureFile
-    sp.run(verify_cmd.split(),cwd='opensearch-signer-client/src')
-    sp.run(['mv',signatureFile,'signed_artifacts/'])
-
-manifest = BundleManifest.from_file(args.manifest)
-output_dir = os.path.join(os.getcwd(), 'signed_artifacts')
-os.makedirs(output_dir, exist_ok = True)
-build_id = os.getenv('OPENSEARCH_BUILD_ID', uuid.uuid4().hex)
-
-os.system('git clone https://github.com/opensearch-project/opensearch-signer-client.git')
-os.system('cp ./config.cfg ./opensearch-signer-client/src/')
-sp.run(['./bootstrap'],cwd='opensearch-signer-client/src')
-
-print(f'Signing {manifest.build.name} into {output_dir}')
+manifest = BuildManifest.from_file(args.manifest)
+basepath = os.path.abspath(os.path.join(__file__ ,"../../..")) + '/artifacts/'
+signer = Signer()
 for component in manifest.components:
         print(f'signing {component.name}')
-        sign(f'{component.location}')
+        for key in component.artifacts:
+            artifact_list = component.artifacts[key]
+            for artifact in artifact_list:
+                location = basepath + artifact 
+                signer.sign(location)
+                signer.verify(location + ".asc")
+signer.close()
 
-os.system('rm -rf opensearch-signer-client')
 print('Done.')

--- a/bundle-workflow/python/sign.py
+++ b/bundle-workflow/python/sign.py
@@ -1,37 +1,37 @@
 #!/usr/bin/env python
 
 import os
-import subprocess
-import tempfile
-import uuid
 import argparse
 from manifests.build_manifest import BuildManifest
-from pprint import pprint
-from pathlib import Path
 from signing_workflow.signer import Signer
 
 parser = argparse.ArgumentParser(description = "Sign artifacts")
-parser.add_argument('manifest', type = argparse.FileType('r'), help="Absolute path of local manifest file.")
-parser.add_argument('--component',nargs='?',help="Component name")
-parser.add_argument('--type',nargs='?',help="Artifact type")
+parser.add_argument('manifest', type = argparse.FileType('r'), help = "Path to local manifest file.")
+parser.add_argument('--component', nargs = '?', help = "Component name")
+parser.add_argument('--type', nargs = '?', help = "Artifact type")
 args = parser.parse_args()
 
 manifest = BuildManifest.from_file(args.manifest)
-basepath = os.path.dirname(args.manifest.name)
-print("hello",basepath)
+basepath = os.path.dirname(os.path.abspath(args.manifest.name))
+signer = Signer()
 
 signer = Signer()
 for component in manifest.components:
-    if (not args.component) or ( args.component and component.name == args.component):
-        print(f'signing {component.name}')
-        for artifact_type in component.artifacts:
-            if (not args.type) or (args.type and artifact_type == args.type):
-                artifact_list = component.artifacts[artifact_type]
-                for artifact in artifact_list:
-                    location = os.path.join(basepath, artifact)
-                    print("LOCATION=", location)
-                    signer.sign(location)
-                    signer.verify(location + ".asc")
-signer.close()
+    
+    if args.component and args.component != component.name:
+        print(f'\nSkipping {component.name}')
+        continue
+    
+    print(f'\nSigning {component.name}')
+    for artifact_type in component.artifacts:
+        
+        if args.type and args.type != artifact_type:
+            continue
+        
+        artifact_list = component.artifacts[artifact_type]
+        for artifact in artifact_list:
+            location = os.path.join(basepath, artifact)
+            signer.sign(location)
+            signer.verify(location + ".asc")
 
 print('Done.')

--- a/bundle-workflow/python/signing_workflow/signer.py
+++ b/bundle-workflow/python/signing_workflow/signer.py
@@ -2,12 +2,11 @@
 
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
+import sys 
 
-import os
-import subprocess
-import tempfile
-import uuid
-import argparse
+sys.path.insert(0,"../git")
+from git.git_repository import GitRepository
+
 
 '''
 This class is responsible for signing an artifact using the OpenSearch-signer-client and verifying its signature.
@@ -15,20 +14,15 @@ The signed artifacts will be found in the same location as the original artifact
 '''
 class Signer:
     def __init__(self):
-        subprocess.check_output(["git","clone","https://github.com/opensearch-project/opensearch-signer-client.git"])
-        subprocess.check_output(["./bootstrap"],cwd='opensearch-signer-client/src')
-        subprocess.check_output(["rm","config.cfg"],cwd='opensearch-signer-client/src')
+        self.git_repo = GitRepository("https://github.com/opensearch-project/opensearch-signer-client.git", "HEAD")
+        self.git_repo.execute("./bootstrap", "src")
+        self.git_repo.execute("rm config.cfg", "src")
 
     def sign(self, filename):
-        signatureFile = filename + ".asc"
-        basepath = os.path.basename(filename)
-        signing_cmd=['./opensearch-signer-client', '-i', filename, '-o', signatureFile, '-p', 'pgp']
-        subprocess.check_output(signing_cmd,cwd="opensearch-signer-client/src")
+        signature_file = filename + ".asc"
+        signing_cmd = ['./opensearch-signer-client', '-i', filename, '-o', signature_file, '-p', 'pgp']
+        self.git_repo.execute(" ".join(signing_cmd), "src")
 
     def verify(self, filename):
-        verify_cmd = ['gpg', '--verify-files',filename]
-        subprocess.check_output(verify_cmd, cwd="opensearch-signer-client/src")
-
-    def close(self):
-        subprocess.run(["rm","-rf","opensearch-signer-client"])
-
+        verify_cmd = ['gpg', '--verify-files', filename]
+        self.git_repo.execute(" ".join(verify_cmd))

--- a/bundle-workflow/python/signing_workflow/signer.py
+++ b/bundle-workflow/python/signing_workflow/signer.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import tempfile
+import uuid
+import argparse
+
+'''
+This class is responsible for signing an artifact using the OpenSearch-signer-client and verifying its signature.
+The signed artifacts will be found in the same location as the original artifacts.
+'''
+class Signer:
+    def __init__(self):
+        subprocess.check_output(["git","clone","https://github.com/opensearch-project/opensearch-signer-client.git"])
+        subprocess.check_output(["./bootstrap"],cwd='opensearch-signer-client/src')
+        subprocess.check_output(["rm","config.cfg"],cwd='opensearch-signer-client/src')
+
+    def sign(self, filename):
+        signatureFile = filename + ".asc"
+        basepath = os.path.basename(filename)
+        signing_cmd=['./opensearch-signer-client', '-i', filename, '-o', signatureFile, '-p', 'pgp']
+        subprocess.check_output(signing_cmd,cwd="opensearch-signer-client/src")
+
+    def verify(self, filename):
+        verify_cmd = ['gpg', '--verify-files',filename]
+        subprocess.check_output(verify_cmd, cwd="opensearch-signer-client/src")
+
+    def close(self):
+        subprocess.run(["rm","-rf","opensearch-signer-client"])
+

--- a/bundle-workflow/python/signing_workflow/signer.py
+++ b/bundle-workflow/python/signing_workflow/signer.py
@@ -15,13 +15,13 @@ The signed artifacts will be found in the same location as the original artifact
 class Signer:
     def __init__(self):
         self.git_repo = GitRepository("https://github.com/opensearch-project/opensearch-signer-client.git", "HEAD")
-        self.git_repo.execute("./bootstrap", "src")
-        self.git_repo.execute("rm config.cfg", "src")
+        self.git_repo.execute("./bootstrap", subdirname = "src")
+        self.git_repo.execute("rm config.cfg", subdirname = "src")
 
     def sign(self, filename):
         signature_file = filename + ".asc"
         signing_cmd = ['./opensearch-signer-client', '-i', filename, '-o', signature_file, '-p', 'pgp']
-        self.git_repo.execute(" ".join(signing_cmd), "src")
+        self.git_repo.execute(" ".join(signing_cmd), subdirname = "src")
 
     def verify(self, filename):
         verify_cmd = ['gpg', '--verify-files', filename]

--- a/bundle-workflow/sign.sh
+++ b/bundle-workflow/sign.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+DIR="$(dirname "$0")"
+python3 "$DIR/python/sign.py" $@


### PR DESCRIPTION
Signed-off-by: Poojita-Raj <poojiraj@amazon.com>

### Description
As part of release workflow, we can now use a manifest file to sign the needed bundle artifacts with the signed artifacts residing in /signed_artifacts. 
 
### Issues Resolved
Related to #136 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
