### PR TITLE
Allow GitRepository to check out into a named directory

### DIFF
--- a/bundle-workflow/python/build_workflow/builder.py
+++ b/bundle-workflow/python/build_workflow/builder.py
@@ -25,13 +25,13 @@ class Builder:
         self.output_path = 'artifacts'
 
     def build(self, version, arch, snapshot):
-        build_script = self.script_finder.find_build_script(self.component_name, self.git_repo.dir.name)
+        build_script = self.script_finder.find_build_script(self.component_name, self.git_repo.dir)
         build_command = f'{build_script} -v {version} -a {arch} -s {str(snapshot).lower()} -o {self.output_path}'
         self.git_repo.execute(build_command)
         self.build_recorder.record_component(self.component_name, self.git_repo)
 
     def export_artifacts(self):
-        artifacts_dir = os.path.realpath(os.path.join(self.git_repo.dir.name, self.output_path))
+        artifacts_dir = os.path.realpath(os.path.join(self.git_repo.dir, self.output_path))
         for artifact_type in ["maven", "bundle", "plugins", "libs"]:
             for dir, dirs, files in os.walk(os.path.join(artifacts_dir, artifact_type)):
                 for file_name in files:

--- a/bundle-workflow/python/git/git_repository.py
+++ b/bundle-workflow/python/git/git_repository.py
@@ -1,30 +1,39 @@
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import subprocess
 import tempfile
-from dataclasses import dataclass
+import shutil
 
-'''
-This class checks out a Git repository at a particular ref into a temporary directory.
-Clients can obtain the actual commit ID by querying the "sha" attribute, and the temp directory name with "dir.name".
-'''
-@dataclass
 class GitRepository:
-    url: str
-    ref: str
-    sha: str = None
-    dir: tempfile.TemporaryDirectory = None
+    '''
+    This class checks out a Git repository at a particular ref into a named directory (or temporary a directory if no named directory is given). Temporary directories will be automatically deleted when the GitRepository object goes out of scope; named directories will be deleted and recreated when the GitRepository is constructed.
+    Clients can obtain the actual commit ID by querying the "sha" attribute, and the temp directory name with "dir".
+    '''
+    def __init__(self, url, ref, directory = None):
+        self.url = url
+        self.ref = ref
+        if directory is None:
+            self.temp_dir = tempfile.TemporaryDirectory()
+            self.dir = self.temp_dir.name
+        else:
+            self.dir = directory
+            print(f'Deleting {self.dir}')
+            shutil.rmtree(self.dir, ignore_errors = True)
+            os.makedirs(self.dir, exist_ok = True)
 
-    def __post_init__(self):
-        self.dir = tempfile.TemporaryDirectory()
-        self.execute(f'git init')
-        self.execute(f'git remote add origin {self.url}')
-        self.execute(f'git fetch --depth 1 origin {self.ref}')
-        self.execute(f'git checkout FETCH_HEAD')
-        self.sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd = self.dir.name).decode().strip()
-        print(f'Checked out {self.url}@{self.ref} into {self.dir.name} at {self.sha}')
+        # Check out the repository
+        self.execute(f'git init', True)
+        self.execute(f'git remote add origin {self.url}', True)
+        self.execute(f'git fetch --depth 1 origin {self.ref}', True)
+        self.execute(f'git checkout FETCH_HEAD', True)
+        self.sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd = self.dir).decode().strip()
+        print(f'Checked out {self.url}@{self.ref} into {self.dir} at {self.sha}')
 
-    def execute(self, command):
-        print(f'Executing "{command}" in {self.dir.name}')
-        subprocess.check_call(command, cwd = self.dir.name, shell = True)
+    def execute(self, command, silent = False):
+        print(f'Executing "{command}" in {self.dir}')
+        if silent:
+            subprocess.check_call(command, cwd = self.dir, shell = True, stdout = subprocess.DEVNULL, stderr = subprocess.DEVNULL)
+        else:
+            subprocess.check_call(command, cwd = self.dir, shell = True)

--- a/bundle-workflow/python/test.py
+++ b/bundle-workflow/python/test.py
@@ -3,6 +3,7 @@
 import os
 import tempfile
 import argparse
+import pathlib
 from manifests.bundle_manifest import BundleManifest
 from git.git_repository import GitRepository
 from test_workflow.test_cluster import LocalTestCluster
@@ -10,20 +11,26 @@ from test_workflow.integ_test_suite import IntegTestSuite
 
 parser = argparse.ArgumentParser(description = "Test an OpenSearch Bundle")
 parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
+parser.add_argument('--workdir', type = pathlib.Path, help="Specify a working directory. If this is not specified then a temporary directory will be used. This option is mostly useful for debugging - it will leave the contents of the directory after the tool finishes, whereas a temporary directory will be automatically deleted.")
 args = parser.parse_args()
 
 manifest = BundleManifest.from_file(args.manifest)
+with tempfile.TemporaryDirectory() as temp_work_dir:
+    if args.workdir is None:
+        work_dir = temp_work_dir
+    else:
+        work_dir = args.workdir
+        os.makedirs(work_dir, exist_ok = True)
 
-with tempfile.TemporaryDirectory() as work_dir:
     os.chdir(work_dir)
 
     # Spin up a test cluster
-    cluster = LocalTestCluster(manifest.bundle_location)
+    cluster = LocalTestCluster(manifest.build.location)
 
     # For each component, check out the git repo and run `integtest.sh`
     for component in manifest.components:
         print(component.name)
-        repo = GitRepository(component.repository_url, component.commit_id)
+        repo = GitRepository(component.repository, component.commit_id, os.path.join(work_dir, component.name))
         test_suite = IntegTestSuite(component.name, repo)
         test_suite.execute(cluster)
 

--- a/bundle-workflow/python/test_workflow/integ_test_suite.py
+++ b/bundle-workflow/python/test_workflow/integ_test_suite.py
@@ -6,9 +6,9 @@ class IntegTestSuite:
         self.repo = repo
 
     def execute(self, cluster):
-        script = self.repo.dir.name + "/integtest.sh"
+        script = self.repo.dir + "/integtest.sh"
         if (os.path.exists(script)):
-            print(f'sh integtest.sh -b {cluster.endpoint()} -p {cluster.port()}')
-#            repo.execute(f'sh integtest.sh -b {cluster.endpoint()} -p {cluster.port()}')
+            print(f'sh {script} -b {cluster.endpoint()} -p {cluster.port()}')
+            self.repo.execute(f'sh {script} -b {cluster.endpoint()} -p {cluster.port()}')
         else:
             print(f'{script} does not exist. Skipping integ tests for {self.name}')


### PR DESCRIPTION
### Description
Add a command-line parameter to "test.py" to allow for a fixed working directory. This makes debugging test script failures easier.

Fix typo in looking up the bundle tarball location.

### Testing
Manually verified that test.py and build.py still work correctly.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
