### PR TITLE
Fix BundleManifest pydocs

### DIFF
--- a/bundle-workflow/python/manifests/bundle_manifest.py
+++ b/bundle-workflow/python/manifests/bundle_manifest.py
@@ -3,28 +3,27 @@
 
 import yaml
 
-'''
-A BundleManifest is an immutable view of the outputs from a assemble step
-The manifest contains information about the bundle that was built (in the `assemble` section),
-and the components that made up the bundle in the `components` section.
-
-The format for schema version 1.0 is:
-schema-version: 1.0
-build:
-  name: string
-  version: string
-  architecture: x64 or arm64
-  location: /relative/path/to/tarball
-components:
-  - name: string
-    repository: URL of git repository
-    ref: git ref that was built (sha, branch, or tag)
-    commit_id: The actual git commit ID that was built (i.e. the resolved "ref")
-    location: /relative/path/to/artifact
-'''
-
-
 class BundleManifest:
+    '''
+    A BundleManifest is an immutable view of the outputs from a assemble step
+    The manifest contains information about the bundle that was built (in the `assemble` section),
+    and the components that made up the bundle in the `components` section.
+
+    The format for schema version 1.0 is:
+        schema-version: 1.0
+        build:
+          name: string
+          version: string
+          architecture: x64 or arm64
+          location: /relative/path/to/tarball
+        components:
+          - name: string
+            repository: URL of git repository
+            ref: git ref that was built (sha, branch, or tag)
+            commit_id: The actual git commit ID that was built (i.e. the resolved "ref")
+            location: /relative/path/to/artifact
+    '''
+
     @staticmethod
     def from_file(file):
         return BundleManifest(yaml.safe_load(file))


### PR DESCRIPTION
Move the BundleManifest pydocs into the class instead of the module.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
