### PR TITLE
Wire up ScriptFinder into IntegTestSuite

### DIFF
--- a/bundle-workflow/python/test.py
+++ b/bundle-workflow/python/test.py
@@ -8,6 +8,7 @@ from manifests.bundle_manifest import BundleManifest
 from git.git_repository import GitRepository
 from test_workflow.test_cluster import LocalTestCluster
 from test_workflow.integ_test_suite import IntegTestSuite
+from paths.script_finder import ScriptFinder
 
 parser = argparse.ArgumentParser(description = "Test an OpenSearch Bundle")
 parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
@@ -15,6 +16,10 @@ parser.add_argument('--workdir', type = pathlib.Path, help="Specify a working di
 args = parser.parse_args()
 
 manifest = BundleManifest.from_file(args.manifest)
+component_scripts_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/components')
+default_scripts_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/standard-test')
+script_finder = ScriptFinder(component_scripts_path, default_scripts_path)
+
 with tempfile.TemporaryDirectory() as temp_work_dir:
     if args.workdir is None:
         work_dir = temp_work_dir
@@ -31,7 +36,7 @@ with tempfile.TemporaryDirectory() as temp_work_dir:
     for component in manifest.components:
         print(component.name)
         repo = GitRepository(component.repository, component.commit_id, os.path.join(work_dir, component.name))
-        test_suite = IntegTestSuite(component.name, repo)
+        test_suite = IntegTestSuite(component.name, repo, script_finder)
         test_suite.execute(cluster)
 
     cluster.destroy()

--- a/bundle-workflow/python/test_workflow/integ_test_suite.py
+++ b/bundle-workflow/python/test_workflow/integ_test_suite.py
@@ -1,12 +1,13 @@
 import os
 
 class IntegTestSuite:
-    def __init__(self, name, repo):
+    def __init__(self, name, repo, script_finder):
         self.name = name
         self.repo = repo
+        self.script_finder = script_finder
 
     def execute(self, cluster):
-        script = self.repo.dir + "/integtest.sh"
+        script = self.script_finder.find_integ_test_script(self.name, self.repo.dir)
         if (os.path.exists(script)):
             print(f'sh {script} -b {cluster.endpoint()} -p {cluster.port()}')
             self.repo.execute(f'sh {script} -b {cluster.endpoint()} -p {cluster.port()}')

--- a/bundle-workflow/scripts/bundle-build/standard-test/integtest.sh
+++ b/bundle-workflow/scripts/bundle-build/standard-test/integtest.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "WARNING: Dummy integtest.sh script invoked: $@"


### PR DESCRIPTION
### Testing
Manually verified that test.py still works

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
