### PR TITLE
Refactor workdir into --keep.

### DIFF
--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -38,10 +38,11 @@ Build Step:
 
 The following options are available.
 
-| name               | description                                                           |
-|--------------------|-----------------------------------------------------------------------|
-| --snapshot         | Build a snapshot instead of a release artifact, default is `false`.   |
-| --component [name] | Rebuild a single component by name, e.g. `--component common-utils`.  |
+| name               | description                                                             |
+|--------------------|-------------------------------------------------------------------------|
+| --snapshot         | Build a snapshot instead of a release artifact, default is `false`.     |
+| --component [name] | Rebuild a single component by name, e.g. `--component common-utils`.    |
+| --keep             | Do not delete the temporary working directory on both success or error. |
 
 Bundle step:
 ```bash

--- a/bundle-workflow/python/build.py
+++ b/bundle-workflow/python/build.py
@@ -4,10 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import tempfile
-import uuid
 import uuid
 from system.arch import current_arch
+from system.temporary_directory import TemporaryDirectory
 from manifests.input_manifest import InputManifest
 from build_workflow.build_recorder import BuildRecorder
 from build_workflow.builder import Builder
@@ -27,7 +26,7 @@ output_dir = os.path.join(os.getcwd(), 'artifacts')
 os.makedirs(output_dir, exist_ok = True)
 build_id = os.getenv('OPENSEARCH_BUILD_ID', uuid.uuid4().hex)
 
-with tempfile.TemporaryDirectory() as work_dir: 
+with TemporaryDirectory(keep = args.keep) as work_dir: 
     print(f'Building in {work_dir}')
 
     os.chdir(work_dir)

--- a/bundle-workflow/python/build_workflow/build_args.py
+++ b/bundle-workflow/python/build_workflow/build_args.py
@@ -8,16 +8,19 @@ class BuildArgs():
     manifest: str
     snapshot: bool
     component: str
+    keep: bool
     
     def __init__(self):
         parser = argparse.ArgumentParser(description = "Build an OpenSearch Bundle")
-        parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
-        parser.add_argument('-s', '--snapshot', action = 'store_true', default = False, help="Build snapshot.")
-        parser.add_argument('-c', '--component', type = str, help="Rebuild a single component.")
+        parser.add_argument('manifest', type = argparse.FileType('r'), help = "Manifest file.")
+        parser.add_argument('-s', '--snapshot', action = 'store_true', default = False, help = "Build snapshot.")
+        parser.add_argument('-c', '--component', type = str, help = "Rebuild a single component.")
+        parser.add_argument('--keep', dest = 'keep', action='store_true', help = "Do not delete the working temporary directory.")
         args = parser.parse_args()
         self.manifest = args.manifest
         self.snapshot = args.snapshot
         self.component = args.component
+        self.keep = args.keep
 
     def script_path(self):
         return sys.argv[0].replace('/python/build.py', '/build.sh')

--- a/bundle-workflow/python/manifests/__init__.py
+++ b/bundle-workflow/python/manifests/__init__.py
@@ -1,1 +1,1 @@
-# This page intentionally left blank
+# This page intentionally left blank.

--- a/bundle-workflow/python/system/temporary_directory.py
+++ b/bundle-workflow/python/system/temporary_directory.py
@@ -1,0 +1,14 @@
+from contextlib import contextmanager
+import tempfile
+import shutil
+
+@contextmanager
+def TemporaryDirectory(keep = False):
+    name = tempfile.mkdtemp()
+    try:
+        yield name
+    finally:
+        if keep:
+            print(f'Keeping {name}')
+        else:
+            shutil.rmtree(name)

--- a/bundle-workflow/python/test.py
+++ b/bundle-workflow/python/test.py
@@ -1,27 +1,20 @@
 #!/usr/bin/env python
 
 import os
-import tempfile
 import argparse
-import pathlib
 from manifests.bundle_manifest import BundleManifest
 from git.git_repository import GitRepository
 from test_workflow.test_cluster import LocalTestCluster
 from test_workflow.integ_test_suite import IntegTestSuite
+from system.temporary_directory import TemporaryDirectory
 
 parser = argparse.ArgumentParser(description = "Test an OpenSearch Bundle")
-parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
-parser.add_argument('--workdir', type = pathlib.Path, help="Specify a working directory. If this is not specified then a temporary directory will be used. This option is mostly useful for debugging - it will leave the contents of the directory after the tool finishes, whereas a temporary directory will be automatically deleted.")
+parser.add_argument('manifest', type = argparse.FileType('r'), help = "Manifest file.")
+parser.add_argument('--keep', dest = 'keep', action='store_true', help = "Do not delete the working temporary directory.")
 args = parser.parse_args()
 
 manifest = BundleManifest.from_file(args.manifest)
-with tempfile.TemporaryDirectory() as temp_work_dir:
-    if args.workdir is None:
-        work_dir = temp_work_dir
-    else:
-        work_dir = args.workdir
-        os.makedirs(work_dir, exist_ok = True)
-
+with TemporaryDirectory(keep = args.keep) as work_dir:
     os.chdir(work_dir)
 
     # Spin up a test cluster

--- a/bundle-workflow/python/test_workflow/__init__.py
+++ b/bundle-workflow/python/test_workflow/__init__.py
@@ -1,0 +1,1 @@
+# This page intentionally left blank.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Followup on #228 into a new `--keep` option to avoid overwriting files accidentally. Add it to build.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
