### PR TITLE
Implement LocalTestCluster

### DIFF
--- a/bundle-workflow/python/test.py
+++ b/bundle-workflow/python/test.py
@@ -25,15 +25,17 @@ with tempfile.TemporaryDirectory() as temp_work_dir:
     os.chdir(work_dir)
 
     # Spin up a test cluster
-    cluster = LocalTestCluster(manifest.build.location)
+    cluster = LocalTestCluster(manifest)
+    cluster.create()
 
     # For each component, check out the git repo and run `integtest.sh`
-    for component in manifest.components:
-        print(component.name)
-        repo = GitRepository(component.repository, component.commit_id, os.path.join(work_dir, component.name))
-        test_suite = IntegTestSuite(component.name, repo)
-        test_suite.execute(cluster)
-
-    cluster.destroy()
+    try:
+        for component in manifest.components:
+            print(component.name)
+            repo = GitRepository(component.repository, component.commit_id, os.path.join(work_dir, component.name))
+            test_suite = IntegTestSuite(component.name, repo)
+            test_suite.execute(cluster)
+    finally:
+        cluster.destroy()
 
     # TODO: Store test results, send notification.

--- a/bundle-workflow/python/test_workflow/test_cluster.py
+++ b/bundle-workflow/python/test_workflow/test_cluster.py
@@ -45,7 +45,8 @@ class LocalTestCluster:
             except TimeoutExpired:
                 print('Process failed to terminate even after SIGKILL')
                 raise
-        print(f'Process terminated with exit code {self.process.returncode}')
-        self.stdout.close()
-        self.stderr.close()
-        self.process = None
+        finally:
+            print(f'Process terminated with exit code {self.process.returncode}')
+            self.stdout.close()
+            self.stderr.close()
+            self.process = None

--- a/bundle-workflow/python/test_workflow/test_cluster.py
+++ b/bundle-workflow/python/test_workflow/test_cluster.py
@@ -1,6 +1,28 @@
+import os
+import tempfile
+import urllib.request
+import shutil
+import subprocess
+
 class LocalTestCluster:
-    def __init__(self, bundle_location):
-        pass
+    def __init__(self, bundle_manifest):
+        self.manifest = bundle_manifest
+        self.work_dir = tempfile.TemporaryDirectory()
+
+    def create(self):
+        print(f'Creating local test cluster in {self.work_dir.name}')
+        os.chdir(self.work_dir.name)
+        print(f'Downloading bundle from {self.manifest.build.location}')
+        urllib.request.urlretrieve(self.manifest.build.location, 'bundle.tgz')
+        print(f'Downloaded bundle to {os.path.realpath("bundle.tgz")}')
+        print('Unpacking')
+        subprocess.check_call('tar -xzf bundle.tgz', shell = True)
+        print('Unpacked')
+        self.stdout = open('stdout.txt', 'w')
+        self.stderr = open('stderr.txt', 'w')
+        dir = f'opensearch-{self.manifest.build.version}'
+        self.process = subprocess.Popen('./opensearch-tar-install.sh', cwd = dir, shell = True, stdout = self.stdout, stderr = self.stderr)
+        print(f'Started OpenSearch with PID {self.process.pid}')
 
     def endpoint(self):
         return 'localhost'
@@ -9,4 +31,21 @@ class LocalTestCluster:
         return 9200
 
     def destroy(self):
-        pass
+        print(f'Sending SIGTERM to PID {self.process.pid}')
+        self.process.terminate()
+        try:
+            print('Waiting for process to terminate')
+            self.process.wait(10)
+        except TimeoutExpired:
+            print('Process did not terminate after 10 seconds. Sending SIGKILL')
+            self.process.kill()
+            try:
+                print('Waiting for process to terminate')
+                self.process.wait(10)
+            except TimeoutExpired:
+                print('Process failed to terminate even after SIGKILL')
+                raise
+        print(f'Process terminated with exit code {self.process.returncode}')
+        self.stdout.close()
+        self.stderr.close()
+        self.process = None


### PR DESCRIPTION
### Description
Implements LocalTestCluster that downloads, unpacks, and starts a local OpenSearch node (via opensearch-tar-install.sh), and tears it down again when the tests are finished.

### Testing
Manual testing. I was able to run the SQL plugin integ tests.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/205
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
