### PR TITLE
Change opensearch-tar-install.sh to use 'exec' rather than 'bash' to start up the OpenSearch process

### DIFF
--- a/release/tar/linux/opensearch-tar-install.sh
+++ b/release/tar/linux/opensearch-tar-install.sh
@@ -20,7 +20,6 @@ bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configurati
 
 ##Perf Plugin
 chmod 755 $OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/pa_bin/performance-analyzer-agent
-chmod -R 755 /dev/shm
 chmod 755 $OPENSEARCH_HOME/bin/performance-analyzer-agent-cli
 echo "done security"
 PA_AGENT_JAVA_OPTS="-Dlog4j.configurationFile=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/pa_config/log4j2.xml \
@@ -70,4 +69,4 @@ else
 fi
 
 ##Start OpenSearch
-bash $OPENSEARCH_HOME/bin/opensearch "$@"
+exec $OPENSEARCH_HOME/bin/opensearch "$@"


### PR DESCRIPTION
### Description
Currently, the opensearch-tar-install.sh script does not correctly pass SIGTERM and SIGKILL down to the child process, which means that even after a CTRL-C there can be a leftover Java process running. Since starting OpenSearch is the last line in this script, the easiest solution is to use 'exec' so that the current process gets replaced by the OpenSearch Java process.

This change also removes the `chmod /dev/shm` because that has to be run as root. This script should not be run as root.

### Testing
Before the change:
```
> ./opensearch-tar-install.sh >& /dev/null &
[1] <some pid>
> ps
<some pid> opensearch-tar-install
<some other pid> java
> fg
> ctrl-c
> ps
<some other pid> java
```

After the change:
```
> ./opensearch-tar-install.sh >& /dev/null &
[1] <some pid>
> ps
<some pid> java
> fg
> ctrl-c
> ps
```

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
