### PR TITLE
Add k-nn build script and configure knnlib during bundle step.

### DIFF
--- a/bundle-workflow/python/assemble_workflow/bundle.py
+++ b/bundle-workflow/python/assemble_workflow/bundle.py
@@ -38,6 +38,8 @@ class Bundle:
         for plugin in self.plugins:
             print(f'Installing {plugin.name}')
             self.install_plugin(plugin)
+            if plugin.name == 'k-NN':
+                self.copy_knnlib(plugin)
         self.installed_plugins = os.listdir(os.path.join(self.archive_path, 'plugins'))
 
     def install_plugin(self, plugin):
@@ -83,3 +85,12 @@ class Bundle:
 
     def get_min_bundle(self, build_components):
         return next(iter([c for c in build_components if "bundle" in c.artifacts]), None)
+
+    def copy_knnlib(self, component):
+        local_path = self.get_rel_path(component, 'libs')
+        if local_path:
+            knnlib = os.path.join(self.artifacts_dir, local_path)
+            dest_path = os.path.join(self.archive_path, 'plugins/opensearch-knn/knnlib')
+            os.makedirs(dest_path, exist_ok=True)
+            dest = os.path.join(dest_path, os.path.basename(knnlib))
+            shutil.copyfile(knnlib, dest)

--- a/bundle-workflow/scripts/bundle-build/components/k-NN/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/k-NN/build.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+work_dir=$PWD
+mkdir -p $OUTPUT/libs
+
+# Build knnlib and copy it to libs
+cd jni
+cmake .
+make
+
+cd $work_dir
+cp ./jni/release/libKNNIndexV2_0_11* ./$OUTPUT/libs
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+
+echo "COPY ${distributions}/*.zip"
+mkdir -p $OUTPUT/plugins
+cp ${distributions}/*.zip ./$OUTPUT/plugins


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Add a build.sh script for k-nn.  This is so that knnlib is properly built and placed into /libs.
Updates bundle step to configure this lib if knn is included as a plugin.

Tested this by executing the build & assembly steps and unpacking the built tarball.
lib is placed at the correct location and ./opensearch-tar-install.sh can find it.
 
### Issues Resolved
closes 149
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
