### PR TITLE
Remove demo certificates when DISABLE_INSTALL_DEMO_CONFIG is set to true

### DIFF
--- a/release/docker/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/release/docker/config/opensearch/opensearch-docker-entrypoint.sh
@@ -71,6 +71,9 @@ done < <(env)
 # will run in.
 export OPENSEARCH_JAVA_OPTS="-Dopensearch.cgroups.hierarchy.override=/ $OPENSEARCH_JAVA_OPTS"
 
+if [[ "${DISABLE_INSTALL_DEMO_CONFIG}" =~ [tT]rue ]]; then
+    rm /usr/share/opensearch/config/{esnode-key.pem,esnode.pem,kirk-key.pem,kirk.pem,root-ca.pem}
+fi
 
 # Start up the opensearch and performance analyzer agent processes.
 # When either of them halts, this script exits, or we receive a SIGTERM or SIGINT signal then we want to kill both these processes.


### PR DESCRIPTION
### Description
The demo certificates exists in official Opensearch container images.
Sometimes it may raise an issue to start properly the opensearch
service. In that case, if DISABLE_INSTALL_DEMO_CONFIG variable is set to
true, demo certificates will be removed before opensearch will start.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/254
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
