### PR TITLE
Extract TestCluster interface

### DIFF
--- a/bundle-workflow/python/test.py
+++ b/bundle-workflow/python/test.py
@@ -4,7 +4,7 @@ import os
 import argparse
 from manifests.bundle_manifest import BundleManifest
 from git.git_repository import GitRepository
-from test_workflow.test_cluster import LocalTestCluster
+from test_workflow.local_test_cluster import LocalTestCluster
 from test_workflow.integ_test_suite import IntegTestSuite
 from paths.script_finder import ScriptFinder
 from system.temporary_directory import TemporaryDirectory

--- a/bundle-workflow/python/test_workflow/local_test_cluster.py
+++ b/bundle-workflow/python/test_workflow/local_test_cluster.py
@@ -1,0 +1,53 @@
+import os
+import tempfile
+import urllib.request
+import shutil
+import subprocess
+from test_workflow.test_cluster import TestCluster
+
+class LocalTestCluster(TestCluster):
+    def __init__(self, bundle_manifest):
+        self.manifest = bundle_manifest
+        self.work_dir = tempfile.TemporaryDirectory()
+
+    def create(self):
+        print(f'Creating local test cluster in {self.work_dir.name}')
+        os.chdir(self.work_dir.name)
+        print(f'Downloading bundle from {self.manifest.build.location}')
+        urllib.request.urlretrieve(self.manifest.build.location, 'bundle.tgz')
+        print(f'Downloaded bundle to {os.path.realpath("bundle.tgz")}')
+        print('Unpacking')
+        subprocess.check_call('tar -xzf bundle.tgz', shell = True)
+        print('Unpacked')
+        self.stdout = open('stdout.txt', 'w')
+        self.stderr = open('stderr.txt', 'w')
+        dir = f'opensearch-{self.manifest.build.version}'
+        self.process = subprocess.Popen('./opensearch-tar-install.sh', cwd = dir, shell = True, stdout = self.stdout, stderr = self.stderr)
+        print(f'Started OpenSearch with PID {self.process.pid}')
+
+    def endpoint(self):
+        return 'localhost'
+
+    def port(self):
+        return 9200
+
+    def destroy(self):
+        print(f'Sending SIGTERM to PID {self.process.pid}')
+        self.process.terminate()
+        try:
+            print('Waiting for process to terminate')
+            self.process.wait(10)
+        except TimeoutExpired:
+            print('Process did not terminate after 10 seconds. Sending SIGKILL')
+            self.process.kill()
+            try:
+                print('Waiting for process to terminate')
+                self.process.wait(10)
+            except TimeoutExpired:
+                print('Process failed to terminate even after SIGKILL')
+                raise
+        finally:
+            print(f'Process terminated with exit code {self.process.returncode}')
+            self.stdout.close()
+            self.stderr.close()
+            self.process = None

--- a/bundle-workflow/python/test_workflow/test_cluster.py
+++ b/bundle-workflow/python/test_workflow/test_cluster.py
@@ -1,52 +1,41 @@
-import os
-import tempfile
-import urllib.request
-import shutil
-import subprocess
+import abc
 
-class LocalTestCluster:
-    def __init__(self, bundle_manifest):
-        self.manifest = bundle_manifest
-        self.work_dir = tempfile.TemporaryDirectory()
+class TestCluster(abc.ABC):
+    '''
+    Abstract base class for all types of test clusters.
+    '''
 
+    @abc.abstractmethod
     def create(self):
-        print(f'Creating local test cluster in {self.work_dir.name}')
-        os.chdir(self.work_dir.name)
-        print(f'Downloading bundle from {self.manifest.build.location}')
-        urllib.request.urlretrieve(self.manifest.build.location, 'bundle.tgz')
-        print(f'Downloaded bundle to {os.path.realpath("bundle.tgz")}')
-        print('Unpacking')
-        subprocess.check_call('tar -xzf bundle.tgz', shell = True)
-        print('Unpacked')
-        self.stdout = open('stdout.txt', 'w')
-        self.stderr = open('stderr.txt', 'w')
-        dir = f'opensearch-{self.manifest.build.version}'
-        self.process = subprocess.Popen('./opensearch-tar-install.sh', cwd = dir, shell = True, stdout = self.stdout, stderr = self.stderr)
-        print(f'Started OpenSearch with PID {self.process.pid}')
+        '''
+        Set up the cluster. When this method returns, the cluster must be available to take requests.
+        Throws ClusterCreationException if the cluster could not start for some reason. If this exception is thrown, the caller does not need to call "destroy".
+        '''
+        pass
 
-    def endpoint(self):
-        return 'localhost'
-
-    def port(self):
-        return 9200
-
+    @abc.abstractmethod
     def destroy(self):
-        print(f'Sending SIGTERM to PID {self.process.pid}')
-        self.process.terminate()
-        try:
-            print('Waiting for process to terminate')
-            self.process.wait(10)
-        except TimeoutExpired:
-            print('Process did not terminate after 10 seconds. Sending SIGKILL')
-            self.process.kill()
-            try:
-                print('Waiting for process to terminate')
-                self.process.wait(10)
-            except TimeoutExpired:
-                print('Process failed to terminate even after SIGKILL')
-                raise
-        finally:
-            print(f'Process terminated with exit code {self.process.returncode}')
-            self.stdout.close()
-            self.stderr.close()
-            self.process = None
+        '''
+        Tear down the cluster. If the cluster is already destroyed or has not yet been created then this is a no-op.
+        '''
+        pass
+
+    @abc.abstractmethod
+    def endpoint(self):
+        '''
+        Get the endpoint that this cluster is listening on, e.g. 'localhost' or 'some.ip.address'.
+        '''
+        pass
+
+    @abc.abstractmethod
+    def port(self):
+        '''
+        Get the port that this cluster is listening on.
+        '''
+        pass
+
+class ClusterCreationException(Exception):
+    '''
+    Indicates that cluster creation failed for some reason.
+    '''
+    pass


### PR DESCRIPTION
Formalizing the TestCluster interface now that we have multiple people working on TestCluster implementations.

### Testing
Manually verified that `test.py` still works.

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
