### PR TITLE
Fix: keep checked out git code in builds.

### DIFF
--- a/bundle-workflow/python/build.py
+++ b/bundle-workflow/python/build.py
@@ -42,7 +42,7 @@ with TemporaryDirectory(keep = args.keep) as work_dir:
             continue
 
         print(f'\nBuilding {component.name}')
-        repo = GitRepository(component.repository, component.ref)
+        repo = GitRepository(component.repository, component.ref, os.path.join(work_dir, component.name))
 
         try:
             builder = Builder(component.name, repo, script_finder, build_recorder)


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Works with `--keep`. Check out code under temp path, otherwise git repos are pruned on cleanup.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
