### PR TITLE
Do not nuke existing folders in git checkout.

### DIFF
--- a/bundle-workflow/python/git/git_repository.py
+++ b/bundle-workflow/python/git/git_repository.py
@@ -19,9 +19,7 @@ class GitRepository:
             self.dir = self.temp_dir.name
         else:
             self.dir = directory
-            print(f'Deleting {self.dir}')
-            shutil.rmtree(self.dir, ignore_errors = True)
-            os.makedirs(self.dir, exist_ok = True)
+            os.makedirs(self.dir, exist_ok = False)
 
         # Check out the repository
         self.execute(f'git init', True)

--- a/bundle-workflow/python/git/git_repository.py
+++ b/bundle-workflow/python/git/git_repository.py
@@ -8,7 +8,8 @@ import shutil
 
 class GitRepository:
     '''
-    This class checks out a Git repository at a particular ref into a named directory (or temporary a directory if no named directory is given). Temporary directories will be automatically deleted when the GitRepository object goes out of scope; named directories will be deleted and recreated when the GitRepository is constructed.
+    This class checks out a Git repository at a particular ref into an empty named directory (or temporary a directory if no named directory is given).
+    Temporary directories will be automatically deleted when the GitRepository object goes out of scope; named directories will be left alone.
     Clients can obtain the actual commit ID by querying the "sha" attribute, and the temp directory name with "dir".
     '''
     def __init__(self, url, ref, directory = None):


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I did not enjoy accidentally using a path with files I cared about ;(
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
