### PR TITLE
Build index-management that requires artifacts from previous components.

### DIFF
--- a/bundle-workflow/python/build_workflow/builder.py
+++ b/bundle-workflow/python/build_workflow/builder.py
@@ -26,7 +26,7 @@ class Builder:
 
     def build(self, version, arch, snapshot):
         build_script = self.script_finder.find_build_script(self.component_name, self.git_repo.dir)
-        build_command = f'{build_script} -v {version} -a {arch} -s {str(snapshot).lower()} -o {self.output_path}'
+        build_command = f'{build_script} -v {version} -a {arch} -s {str(snapshot).lower()} -o {self.output_path} -d {self.build_recorder.output_dir}'
         self.git_repo.execute(build_command)
         self.build_recorder.record_component(self.component_name, self.git_repo)
 

--- a/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
@@ -16,7 +16,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +30,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/OpenSearch/build.sh
@@ -10,6 +10,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-o DEST\t[Ignored] Full destination path from which to pickup dependent artifacts."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."

--- a/bundle-workflow/scripts/bundle-build/components/alerting/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/alerting/build.sh
@@ -16,7 +16,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +30,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/bundle-workflow/scripts/bundle-build/components/alerting/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/alerting/build.sh
@@ -10,6 +10,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-o DEST\t[Ignored] Full destination path from which to pickup dependent artifacts."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."

--- a/bundle-workflow/scripts/bundle-build/components/common-utils/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/common-utils/build.sh
@@ -16,7 +16,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +30,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/bundle-workflow/scripts/bundle-build/components/common-utils/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/common-utils/build.sh
@@ -10,6 +10,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-o DEST\t[Ignored] Full destination path from which to pickup dependent artifacts."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."

--- a/bundle-workflow/scripts/bundle-build/components/dashboards-notebooks/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/dashboards-notebooks/build.sh
@@ -16,7 +16,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +30,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/bundle-workflow/scripts/bundle-build/components/dashboards-notebooks/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/dashboards-notebooks/build.sh
@@ -10,6 +10,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-o DEST\t[Ignored] Full destination path from which to pickup dependent artifacts."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."

--- a/bundle-workflow/scripts/bundle-build/components/dashboards-reports/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/dashboards-reports/build.sh
@@ -16,7 +16,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +30,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/bundle-workflow/scripts/bundle-build/components/dashboards-reports/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/dashboards-reports/build.sh
@@ -10,6 +10,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-o DEST\t[Ignored] Full destination path from which to pickup dependent artifacts."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."

--- a/bundle-workflow/scripts/bundle-build/components/index-management/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/index-management/build.sh
@@ -10,6 +10,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-o DEST\t[Required] Full destination path from which to pickup dependent artifacts."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."

--- a/bundle-workflow/scripts/bundle-build/components/job-scheduler/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/job-scheduler/build.sh
@@ -16,7 +16,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +30,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG
@@ -53,15 +56,15 @@ if [ -z "$VERSION" ]; then
 fi
 
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
-[ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-mkdir -p $OUTPUT
-./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-
-mkdir -p $OUTPUT/plugins
-cp ./build/distributions/*.zip $OUTPUT/plugins
+./gradlew build --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 mkdir -p $OUTPUT/maven
 cp -r ~/.m2/repository/org/opensearch/opensearch-job-scheduler $OUTPUT/maven
 cp -r ~/.m2/repository/org/opensearch/opensearch-job-scheduler-spi $OUTPUT/maven
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+mkdir -p $OUTPUT/plugins
+cp ./build/distributions/*.zip $OUTPUT/plugins

--- a/bundle-workflow/scripts/bundle-build/components/job-scheduler/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/job-scheduler/build.sh
@@ -10,6 +10,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-o DEST\t[Ignored] Full destination path from which to pickup dependent artifacts."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."

--- a/bundle-workflow/scripts/bundle-build/components/k-NN/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/k-NN/build.sh
@@ -10,13 +10,14 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-o DEST\t[Ignored] Full destination path from which to pickup dependent artifacts."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +31,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/bundle-workflow/scripts/bundle-build/components/notifications/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/notifications/build.sh
@@ -16,7 +16,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +30,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG
@@ -55,9 +58,16 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-outputDir=$OUTPUT
-mkdir -p $outputDir/maven
+mkdir -p $OUTPUT/maven
+mkdir -p $OUTPUT/plugins
+
 cd notifications
-
 ./gradlew publishToMavenLocal -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+cd ..
 
+zipPath=$(find . -path \*notifications/build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+echo "COPY ${distributions}/*.zip"
+mkdir -p $OUTPUT/plugins
+cp ${distributions}/*.zip ./$OUTPUT/plugins

--- a/bundle-workflow/scripts/bundle-build/components/notifications/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/notifications/build.sh
@@ -10,6 +10,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-o DEST\t[Ignored] Full destination path from which to pickup dependent artifacts."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."

--- a/bundle-workflow/scripts/bundle-build/components/performance-analyzer/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/performance-analyzer/build.sh
@@ -16,7 +16,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +30,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/bundle-workflow/scripts/bundle-build/components/security/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/security/build.sh
@@ -16,7 +16,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +30,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/bundle-workflow/scripts/bundle-build/standard-gradle-build/build.sh
+++ b/bundle-workflow/scripts/bundle-build/standard-gradle-build/build.sh
@@ -16,7 +16,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +30,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        d)
+            DEST=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Adds the capability for a script to consume previously built components. This is needed for index-management that needs a job-scheduler and notifications plugin to build. 

If you know a way to disable certain tests in that one to avoid needing these, I'd probably prefer that.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
