### PR TITLE
Add security_enabled flag to LocalTestCluster

### DIFF
--- a/bundle-workflow/Pipfile
+++ b/bundle-workflow/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 pyyaml = "~=5.4"
+requests = "~=2.26"
 
 [dev-packages]
 

--- a/bundle-workflow/python/test_workflow/integ_test_suite.py
+++ b/bundle-workflow/python/test_workflow/integ_test_suite.py
@@ -6,10 +6,9 @@ class IntegTestSuite:
         self.repo = repo
         self.script_finder = script_finder
 
-    def execute(self, cluster):
+    def execute(self, cluster, security):
         script = self.script_finder.find_integ_test_script(self.name, self.repo.dir)
         if (os.path.exists(script)):
-            print(f'sh {script} -b {cluster.endpoint()} -p {cluster.port()}')
-            self.repo.execute(f'sh {script} -b {cluster.endpoint()} -p {cluster.port()}')
+            self.repo.execute(f'sh {script} -b {cluster.endpoint()} -p {cluster.port()} -s {str(security).lower()}')
         else:
             print(f'{script} does not exist. Skipping integ tests for {self.name}')

--- a/bundle-workflow/python/test_workflow/local_test_cluster.py
+++ b/bundle-workflow/python/test_workflow/local_test_cluster.py
@@ -1,29 +1,33 @@
 import os
-import tempfile
 import urllib.request
-import shutil
 import subprocess
-from test_workflow.test_cluster import TestCluster
+import time
+import ssl
+import requests
+from test_workflow.test_cluster import TestCluster, ClusterCreationException
 
 class LocalTestCluster(TestCluster):
-    def __init__(self, bundle_manifest):
+    '''
+    Represents an on-box test cluster. This class downloads a bundle (from a BundleManifest) and runs it as a background process.
+    '''
+
+    def __init__(self, work_dir, bundle_manifest, security_enabled):
         self.manifest = bundle_manifest
-        self.work_dir = tempfile.TemporaryDirectory()
+        self.work_dir = os.path.join(work_dir, 'local-test-cluster')
+        os.makedirs(self.work_dir, exist_ok = True)
+        self.security_enabled = security_enabled
+        self.process = None
 
     def create(self):
-        print(f'Creating local test cluster in {self.work_dir.name}')
-        os.chdir(self.work_dir.name)
-        print(f'Downloading bundle from {self.manifest.build.location}')
-        urllib.request.urlretrieve(self.manifest.build.location, 'bundle.tgz')
-        print(f'Downloaded bundle to {os.path.realpath("bundle.tgz")}')
-        print('Unpacking')
-        subprocess.check_call('tar -xzf bundle.tgz', shell = True)
-        print('Unpacked')
+        self.download()
         self.stdout = open('stdout.txt', 'w')
         self.stderr = open('stderr.txt', 'w')
         dir = f'opensearch-{self.manifest.build.version}'
+        if not self.security_enabled:
+            self.disable_security(dir)
         self.process = subprocess.Popen('./opensearch-tar-install.sh', cwd = dir, shell = True, stdout = self.stdout, stderr = self.stderr)
         print(f'Started OpenSearch with PID {self.process.pid}')
+        self.wait_for_service()
 
     def endpoint(self):
         return 'localhost'
@@ -32,6 +36,9 @@ class LocalTestCluster(TestCluster):
         return 9200
 
     def destroy(self):
+        if self.process is None:
+            print('Local test cluster is not started')
+            return
         print(f'Sending SIGTERM to PID {self.process.pid}')
         self.process.terminate()
         try:
@@ -51,3 +58,37 @@ class LocalTestCluster(TestCluster):
             self.stdout.close()
             self.stderr.close()
             self.process = None
+
+    def url(self, path=''):
+        return f'{"https" if self.security_enabled else "http"}://{self.endpoint()}:{self.port()}{path}'
+
+    def download(self):
+        print(f'Creating local test cluster in {self.work_dir}')
+        os.chdir(self.work_dir)
+        print(f'Downloading bundle from {self.manifest.build.location}')
+        urllib.request.urlretrieve(self.manifest.build.location, 'bundle.tgz')
+        print(f'Downloaded bundle to {os.path.realpath("bundle.tgz")}')
+
+        print('Unpacking')
+        subprocess.check_call('tar -xzf bundle.tgz', shell = True)
+        print('Unpacked')
+
+    def disable_security(self, dir):
+        subprocess.check_call(f'echo "plugins.security.disabled: true" >> {os.path.join(dir, "config", "opensearch.yml")}', shell = True)
+
+    def wait_for_service(self):
+        print('Waiting for service to become available')
+        url = self.url('/_cluster/health')
+
+        for attempt in range(10):
+            try:
+                print(f'Pinging {url} attempt {attempt}')
+                response = requests.get(url, verify = False, auth = ('admin', 'admin'))
+                print(f'{response.status_code}: {response.text}')
+                if response.status_code == 200 and '"status":"green"' in response.text:
+                    print('Cluster is green')
+                    return
+            except requests.exceptions.ConnectionError:
+                print(f'Service not available yet')
+            time.sleep(10)
+        raise ClusterCreationException('Cluster is not green after 10 attempts')


### PR DESCRIPTION
### Description
Add 'work_dir' argument to LocalTestCluster so that a top-level temp directory can be wired in and the keep-or-delete logic stays in one place.

Change LocalTestCluster so that calls to 'create' do not return until the cluster is ready to take requests.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/205
 
### Testing
Manually verified that `test.py` works correctly with and without security enabled, and that the `--keep` flag does the right thing.

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
