### PR TITLE
Fail with a better error if bundle is missing from the output manifest.

### DIFF
--- a/bundle-workflow/python/assemble_workflow/bundle.py
+++ b/bundle-workflow/python/assemble_workflow/bundle.py
@@ -84,7 +84,10 @@ class Bundle:
         return [c for c in build_components if "plugins" in c.artifacts]
 
     def get_min_bundle(self, build_components):
-        return next(iter([c for c in build_components if "bundle" in c.artifacts]), None)
+        min_bundle = next(iter([c for c in build_components if "bundle" in c.artifacts]), None)
+        if min_bundle == None:
+            raise ValueError(f'Missing min "bundle" in input artifacts.')
+        return min_bundle
 
     def copy_knnlib(self, component):
         local_path = self.get_rel_path(component, 'libs')


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I had a partial manifest and got a weird error because the min bundle wasn't in it.
Fail with a better error if bundle is missing from the output manifest.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
