### PR TITLE
Publish plugin artifacts for job scheduler and notifications.

### DIFF
--- a/bundle-workflow/scripts/bundle-build/components/job-scheduler/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/job-scheduler/build.sh
@@ -53,15 +53,14 @@ if [ -z "$VERSION" ]; then
 fi
 
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
-[ -z "$OUTPUT" ] && OUTPUT=artifacts
-
-mkdir -p $OUTPUT
-./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-
-mkdir -p $OUTPUT/plugins
-cp ./build/distributions/*.zip $OUTPUT/plugins
+./gradlew build --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 mkdir -p $OUTPUT/maven
 cp -r ~/.m2/repository/org/opensearch/opensearch-job-scheduler $OUTPUT/maven
 cp -r ~/.m2/repository/org/opensearch/opensearch-job-scheduler-spi $OUTPUT/maven
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+mkdir -p $OUTPUT/plugins
+cp ./build/distributions/*.zip $OUTPUT/plugins

--- a/bundle-workflow/scripts/bundle-build/components/notifications/build.sh
+++ b/bundle-workflow/scripts/bundle-build/components/notifications/build.sh
@@ -55,9 +55,16 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-outputDir=$OUTPUT
-mkdir -p $outputDir/maven
+mkdir -p $OUTPUT/maven
+mkdir -p $OUTPUT/plugins
+
 cd notifications
-
 ./gradlew publishToMavenLocal -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+cd ..
 
+zipPath=$(find . -path \*notifications/build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+echo "COPY ${distributions}/*.zip"
+mkdir -p $OUTPUT/plugins
+cp ${distributions}/*.zip ./$OUTPUT/plugins


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

- Noop in job-scheduler, just first do maven, then artifact, a bit cleaner.
- Notifications is new, and needs to publish artifacts from a subfolder.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
