### PR TITLE
Added support for custom install scripts.

### DIFF
--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -48,6 +48,10 @@ Bundle step:
 ```bash
 ./bundle-workflow/assemble.sh artifacts/manifest.yml
 ```
-### Scripts
+### Custom Build Scripts
 
-Each component build relies on a `build.sh` script that is used to prepare bundle artifacts for a particular bundle version that takes two arguments: version and target architecture. By default the tool will look for a script in [scripts/bundle-build/components](scripts/bundle-build/components), then in the checked-out repository in `build/build.sh`, then default to a Gradle build implemented in [scripts/bundle-build/standard-gradle-build](scripts/bundle-build/standard-gradle-build).
+Each component build relies on a `build.sh` script that is used to prepare bundle artifacts for a particular bundle version that takes two arguments: version and target architecture. By default the tool will look for a script in [scripts/bundle-build/components](scripts/bundle-build/components), then in the checked-out repository in `build/build.sh`, then default to a Gradle build implemented in [scripts/bundle-build/standard-gradle-build/build.sh](scripts/bundle-build/standard-gradle-build/build.sh).
+
+#### Custom Install Scripts
+
+You can perform additional plugin install steps by adding an `install.sh` script. By default the tool will look for a script in [scripts/bundle-build/components](scripts/bundle-build/components), then default to a noop version implemented in [scripts/bundle-build/standard-gradle-build/install.sh](scripts/bundle-build/standard-gradle-build/install.sh).

--- a/bundle-workflow/python/assemble.py
+++ b/bundle-workflow/python/assemble.py
@@ -10,12 +10,17 @@ import shutil
 from assemble_workflow.bundle import Bundle
 from assemble_workflow.bundle_recorder import BundleRecorder
 from manifests.build_manifest import BuildManifest
+from paths.script_finder import ScriptFinder
 
 parser = argparse.ArgumentParser(description = "Assemble an OpenSearch Bundle")
 parser.add_argument('manifest', type = argparse.FileType('r'), help="Manifest file.")
 args = parser.parse_args()
 
 tarball_installation_script = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../release/tar/linux/opensearch-tar-install.sh')
+
+component_scripts_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/components')
+default_scripts_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../scripts/bundle-build/standard-gradle-build')
+script_finder = ScriptFinder(component_scripts_path, default_scripts_path)
 
 if not os.path.isfile(tarball_installation_script):
     print(f'No installation script found at path: {tarball_installation_script}')
@@ -33,7 +38,7 @@ with tempfile.TemporaryDirectory() as work_dir:
     os.chdir(work_dir)
 
     bundle_recorder = BundleRecorder(build, output_dir, artifacts_dir)
-    bundle = Bundle(build_manifest, artifacts_dir, bundle_recorder)
+    bundle = Bundle(build_manifest, artifacts_dir, bundle_recorder, script_finder)
 
     bundle.install_plugins()
     print(f'Installed plugins: {bundle.installed_plugins}')

--- a/bundle-workflow/python/paths/script_finder.py
+++ b/bundle-workflow/python/paths/script_finder.py
@@ -19,11 +19,12 @@ class ScriptFinder:
     default_scripts_path: str
 
     def find_build_script(self, component_name, git_dir):
-        paths = [os.path.realpath(os.path.join(git_dir, 'build.sh')),
-                 os.path.realpath(os.path.join(git_dir, 'scripts/build.sh')),
-                 os.path.realpath(os.path.join(self.component_scripts_path, component_name, 'build.sh')),
-                 os.path.realpath(os.path.join(self.default_scripts_path, 'build.sh'))
-                 ]
+        paths = [
+            os.path.realpath(os.path.join(git_dir, 'build.sh')),
+            os.path.realpath(os.path.join(git_dir, 'scripts/build.sh')),
+            os.path.realpath(os.path.join(self.component_scripts_path, component_name, 'build.sh')),
+            os.path.realpath(os.path.join(self.default_scripts_path, 'build.sh'))
+        ]
 
         build_script = next(filter(lambda path: os.path.exists(path), paths), None)
         if build_script is None:
@@ -31,13 +32,25 @@ class ScriptFinder:
         return build_script
 
     def find_integ_test_script(self, component_name, git_dir):
-        paths = [os.path.realpath(os.path.join(git_dir, 'integtest.sh')),
-                 os.path.realpath(os.path.join(git_dir, 'scripts/integtest.sh')),
-                 os.path.realpath(os.path.join(self.component_scripts_path, component_name, 'integtest.sh')),
-                 os.path.realpath(os.path.join(self.default_scripts_path, 'integtest.sh'))
-                 ]
+        paths = [
+            os.path.realpath(os.path.join(git_dir, 'integtest.sh')),
+            os.path.realpath(os.path.join(git_dir, 'scripts/integtest.sh')),
+            os.path.realpath(os.path.join(self.component_scripts_path, component_name, 'integtest.sh')),
+            os.path.realpath(os.path.join(self.default_scripts_path, 'integtest.sh'))
+        ]
 
         test_script = next(filter(lambda path: os.path.exists(path), paths), None)
         if test_script is None:
             raise RuntimeError(f'Could not find integtest.sh script. Looked in {paths}')
         return test_script
+
+    def find_install_script(self, component_name):
+        paths = [
+            os.path.realpath(os.path.join(self.component_scripts_path, component_name, 'install.sh')),
+            os.path.realpath(os.path.join(self.default_scripts_path, 'install.sh'))
+        ]
+
+        install_script = next(filter(lambda path: os.path.exists(path), paths), None)
+        if install_script is None:
+            raise RuntimeError(f'Could not find install.sh script. Looked in {paths}')
+        return install_script

--- a/bundle-workflow/scripts/bundle-build/components/k-NN/install.sh
+++ b/bundle-workflow/scripts/bundle-build/components/k-NN/install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-a ARTIFACTS\t[Required] Location of build artifacts."
+    echo -e "-o OUTPUT\t[Required] Output path."
+    echo -e "-h help"
+}
+
+while getopts ":h:a:o:" arg; do
+    case $arg in
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARTIFACTS=$OPTARG
+            ;;
+        h)
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+# see https://github.com/opensearch-project/k-NN/issues/80 to make this part of the plugin installer
+echo "Copying libKNN from $ARTIFACTS to $OUTPUT ..."
+mkdir -p "$OUTPUT/plugins/opensearch-knn/knnlib"
+cp "$ARTIFACTS"/libs/libKNN* "$OUTPUT/plugins/opensearch-knn/knnlib"

--- a/bundle-workflow/scripts/bundle-build/standard-gradle-build/install.sh
+++ b/bundle-workflow/scripts/bundle-build/standard-gradle-build/install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-a ARTIFACTS\t[Required] Location of build artifacts."
+    echo -e "-o OUTPUT\t[Required] Output path."
+    echo -e "-h help"
+}
+
+while getopts ":h:a:o:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARTIFACTS=$OPTARG
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Introduces `install.sh` that will run during installation of plugins.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/251
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
