### PR TITLE
Add core plugins zips to published artifacts

### DIFF
--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -23,6 +23,7 @@ Artifacts will contain the following folders.
   bundle/ <- contains opensearch min tarball 
   maven/ <- all built maven artifacts
   plugins/ <- all built plugin zips
+  core-plugins/ <- all built core plugins zip
   manifest.yml <- build manifest describing all built components and their artifacts
 ```
 
@@ -44,7 +45,7 @@ Each component build relies on a `build.sh` script that is used to prepare bundl
 ./bundle-workflow/assemble.sh artifacts/manifest.yml
 ```
 
-The bundling step takes output from the build step, installs plugins, and assembles a full bundle into a `bundle` folder. The input requires a path to the build manifest and is expected to be inside the `artifacts` directory that contains `bundle`, `maven` and `plugins` subdirectories from the build step.
+The bundling step takes output from the build step, installs plugins, and assembles a full bundle into a `bundle` folder. The input requires a path to the build manifest and is expected to be inside the `artifacts` directory that contains `bundle`, `maven`, `plugins` and `core-plugins` subdirectories from the build step.
 
 Artifacts will be updated as follows.
 

--- a/bundle-workflow/python/build_workflow/builder.py
+++ b/bundle-workflow/python/build_workflow/builder.py
@@ -32,7 +32,7 @@ class Builder:
 
     def export_artifacts(self):
         artifacts_dir = os.path.realpath(os.path.join(self.git_repo.dir, self.output_path))
-        for artifact_type in ["maven", "bundle", "plugins", "libs"]:
+        for artifact_type in ["maven", "bundle", "plugins", "libs", "core-plugins"]:
             for dir, dirs, files in os.walk(os.path.join(artifacts_dir, artifact_type)):
                 for file_name in files:
                     absolute_path = os.path.join(dir, file_name)

--- a/bundle-workflow/scripts/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch/build.sh
@@ -90,3 +90,16 @@ ARTIFACT_BUILD_NAME=opensearch-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
 ARTIFACT_TARGET_NAME=opensearch-min-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
 mkdir -p "${OUTPUT}/bundle"
 cp distribution/archives/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/bundle/$ARTIFACT_TARGET_NAME
+
+echo "Building core plugins..."
+mkdir -p "${OUTPUT}/core-plugins"
+cd plugins
+../gradlew assemble -Dbuild.snapshot="$SNAPSHOT"
+cd ..
+for plugin in plugins/*; do
+  PLUGIN_NAME=$(basename "$plugin")
+  if [ -d "$plugin" ] && [ "examples" != "$PLUGIN_NAME" ]; then
+    PLUGIN_ARTIFACT_BUILD_NAME=$PLUGIN_NAME-$VERSION$IDENTIFIER.zip
+    cp "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
+  fi
+done


### PR DESCRIPTION
### Description
Create build artifacts (zips) for core plugins and copy those into `artifacts/core-plugins` directory.
 
### Issues Resolved
Closes #200 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Rabi Panda <adnapibar@gmail.com>