### PR TITLE
Fix maven artifact paths to correctly be in maven/org/opensearch

### DIFF
--- a/bundle-workflow/scripts/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch/build.sh
@@ -54,8 +54,7 @@ fi
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-outputDir=$OUTPUT
-mkdir -p "${outputDir}/maven"
+mkdir -p $OUTPUT/maven/org/opensearch
 
 # Build project and publish to maven local.
 ./gradlew publishToMavenLocal -Dbuild.snapshot=$SNAPSHOT
@@ -64,7 +63,7 @@ mkdir -p "${outputDir}/maven"
 ./gradlew publishNebulaPublicationToTestRepository -Dbuild.snapshot=$SNAPSHOT
 
 # Copy maven publications to be promoted
-cp -r ./build/local-test-repo/org/opensearch "${outputDir}"/maven
+cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org/opensearch
 
 # Assemble distribution artifact
 # see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
@@ -89,5 +88,5 @@ esac
 [[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
 ARTIFACT_BUILD_NAME=opensearch-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
 ARTIFACT_TARGET_NAME=opensearch-min-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
-mkdir -p "${outputDir}/bundle"
-cp distribution/archives/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${outputDir}"/bundle/$ARTIFACT_TARGET_NAME
+mkdir -p "${OUTPUT}/bundle"
+cp distribution/archives/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/bundle/$ARTIFACT_TARGET_NAME

--- a/bundle-workflow/scripts/components/common-utils/build.sh
+++ b/bundle-workflow/scripts/components/common-utils/build.sh
@@ -57,5 +57,5 @@ fi
 
 ./gradlew build -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-mkdir -p artifacts/maven
-cp -r ~/.m2/repository/org/opensearch/common-utils $OUTPUT/maven
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ~/.m2/repository/org/opensearch/common-utils $OUTPUT/maven/org/opensearch/common-utils

--- a/bundle-workflow/scripts/components/job-scheduler/build.sh
+++ b/bundle-workflow/scripts/components/job-scheduler/build.sh
@@ -56,9 +56,9 @@ fi
 ./gradlew build --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-mkdir -p $OUTPUT/maven
-cp -r ~/.m2/repository/org/opensearch/opensearch-job-scheduler $OUTPUT/maven
-cp -r ~/.m2/repository/org/opensearch/opensearch-job-scheduler-spi $OUTPUT/maven
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ~/.m2/repository/org/opensearch/opensearch-job-scheduler $OUTPUT/maven/org/opensearch
+cp -r ~/.m2/repository/org/opensearch/opensearch-job-scheduler-spi $OUTPUT/maven/org/opensearch
 
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This PR fixes the path in which maven artifacts are copied under artifacts/maven.  These paths need to match the group ID of the publication, which in our case is always org/opensearch.
 
### Issues Resolved
closes #271
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
