### PR TITLE
Enable performance-analyzer build and bundle steps

### DIFF
--- a/bundle-workflow/scripts/components/performance-analyzer-rca/build.sh
+++ b/bundle-workflow/scripts/components/performance-analyzer-rca/build.sh
@@ -56,4 +56,7 @@ fi
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
 ./gradlew build -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x test
+
+mkdir -p $OUTPUT/maven/org/opensearch
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+cp -r ~/.m2/repository/org/opensearch/performanceanalyzer-rca $OUTPUT/maven/org/opensearch

--- a/bundle-workflow/scripts/components/performance-analyzer/build.sh
+++ b/bundle-workflow/scripts/components/performance-analyzer/build.sh
@@ -55,9 +55,10 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-# remove this script when https://github.com/opensearch-project/performance-analyzer/issues/44 is fixed
-git fetch origin main
-git checkout main
-
 ./gradlew build -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x test
+mkdir -p $OUTPUT/plugins
+cp ./build/distributions/*.zip $OUTPUT/plugins
+
+mkdir -p $OUTPUT/maven/org/opensearch
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+cp -r ~/.m2/repository/org/opensearch/opensearch-performance-analyzer $OUTPUT/maven/org/opensearch

--- a/bundle-workflow/scripts/components/performance-analyzer/install.sh
+++ b/bundle-workflow/scripts/components/performance-analyzer/install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-a ARTIFACTS\t[Required] Location of build artifacts."
+    echo -e "-o OUTPUT\t[Required] Output path."
+    echo -e "-h help"
+}
+
+while getopts ":h:a:o:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARTIFACTS=$OPTARG
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+## Setup Performance Analyzer Agent
+cp -r $OUTPUT/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OUTPUT/
+mv $OUTPUT/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli $OUTPUT/bin
+rm -rf $OUTPUT/bin/opensearch-performance-analyzer

--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -26,15 +26,12 @@ components:
     # https://github.com/opensearch-project/security/issues/1403
     repository: https://github.com/dblock/security.git
     ref: fix-snapshot-build
-  #
-  # https://github.com/opensearch-project/opensearch-build/issues/148
-  #
-  # - name: performance-analyzer-rca
-  #   repository: https://github.com/opensearch-project/performance-analyzer-rca.git
-  #   ref: main
-  # - name: performance-analyzer
-  #   repository: https://github.com/opensearch-project/performance-analyzer.git
-  #   ref: main
+  - name: performance-analyzer-rca
+    repository: https://github.com/opensearch-project/performance-analyzer-rca.git
+    ref: main
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
+    ref: main
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
     ref: main

--- a/release/tar/linux/opensearch-tar-install.sh
+++ b/release/tar/linux/opensearch-tar-install.sh
@@ -26,7 +26,7 @@ PA_AGENT_JAVA_OPTS="-Dlog4j.configurationFile=$OPENSEARCH_HOME/plugins/opensearc
               -Xms64M -Xmx64M -XX:+UseSerialGC -XX:CICompilerCount=1 -XX:-TieredCompilation -XX:InitialCodeCacheSize=4096 \
               -XX:InitialBootClassLoaderMetaspaceSize=30720 -XX:MaxRAM=400m"
 
-OPENSEARCH_MAIN_CLASS="com.amazon.opendistro.opensearch.performanceanalyzer.PerformanceAnalyzerApp" \
+OPENSEARCH_MAIN_CLASS="org.opensearch.performanceanalyzer.PerformanceAnalyzerApp" \
 OPENSEARCH_ADDITIONAL_CLASSPATH_DIRECTORIES=plugins/opensearch-performance-analyzer \
 OPENSEARCH_JAVA_OPTS=$PA_AGENT_JAVA_OPTS
 


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Enable performance-analyzer build and bundle steps.

Perf analyzer is currently building from a fork until https://github.com/opensearch-project/performance-analyzer/pull/52 is merged.

Tested by fully assembling and running the bundle.
 
### Issues Resolved
closes #148 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
