### PR TITLE
Implement TestRecorder stub and wire up IntegTestSuite, LocalTestCluster, and test.py

### DIFF
--- a/bundle-workflow/python/paths/tree_walker.py
+++ b/bundle-workflow/python/paths/tree_walker.py
@@ -1,0 +1,9 @@
+import os
+
+def walk(root):
+    print(f'Walking tree from {root}')
+    for dir, dirs, files in os.walk(root):
+        for file_name in files:
+            absolute_path = os.path.join(dir, file_name)
+            relative_path = os.path.relpath(absolute_path, root)
+            yield (os.path.realpath(absolute_path), relative_path)

--- a/bundle-workflow/python/system/execute.py
+++ b/bundle-workflow/python/system/execute.py
@@ -1,0 +1,14 @@
+import subprocess
+
+def execute(command, dir, capture = True, raise_on_failure = True):
+    '''
+    Execute a shell command inside a directory.
+    :param command: The shell command to execute.
+    :param dir: The full path to the directory that the command should be executed in.
+    :returns a tuple containing the exit code, stdout, and stderr.
+    '''
+    print(f'Executing "{command}" in {dir}')
+    result = subprocess.run(command, cwd = dir, shell = True, capture_output = capture, text = True)
+    if raise_on_failure:
+        result.check_returncode()
+    return (result.returncode, result.stdout, result.stderr)

--- a/bundle-workflow/python/test.py
+++ b/bundle-workflow/python/test.py
@@ -6,6 +6,7 @@ from manifests.bundle_manifest import BundleManifest
 from git.git_repository import GitRepository
 from test_workflow.local_test_cluster import LocalTestCluster
 from test_workflow.integ_test_suite import IntegTestSuite
+from test_workflow.test_recorder import TestRecorder
 from paths.script_finder import ScriptFinder
 from system.temporary_directory import TemporaryDirectory
 
@@ -16,6 +17,7 @@ args = parser.parse_args()
 
 manifest = BundleManifest.from_file(args.manifest)
 script_finder = ScriptFinder()
+test_recorder = TestRecorder(os.path.dirname(args.manifest.name))
 
 with TemporaryDirectory(keep = args.keep) as work_dir:
     os.chdir(work_dir)
@@ -28,11 +30,11 @@ with TemporaryDirectory(keep = args.keep) as work_dir:
 
         # For each component, check out the git repo and run `integtest.sh`
         for component in manifest.components:
-            print(component.name)
+            print(f'Testing {component.name}')
             repo = GitRepository(component.repository, component.commit_id, os.path.join(work_dir, component.name))
-            test_suite = IntegTestSuite(component.name, repo, script_finder)
+            test_suite = IntegTestSuite(component.name, repo, script_finder, test_recorder)
             test_suite.execute(cluster, True)
     finally:
-        cluster.destroy()
+        cluster.destroy(test_recorder)
 
     # TODO: Store test results, send notification.

--- a/bundle-workflow/python/test_workflow/integ_test_suite.py
+++ b/bundle-workflow/python/test_workflow/integ_test_suite.py
@@ -1,14 +1,26 @@
 import os
+import glob
+from system.execute import execute
+from paths.tree_walker import walk
 
 class IntegTestSuite:
-    def __init__(self, name, repo, script_finder):
+    def __init__(self, name, repo, script_finder, test_recorder):
         self.name = name
         self.repo = repo
         self.script_finder = script_finder
+        self.test_recorder = test_recorder
 
     def execute(self, cluster, security):
         script = self.script_finder.find_integ_test_script(self.name, self.repo.dir)
         if (os.path.exists(script)):
-            self.repo.execute(f'sh {script} -b {cluster.endpoint()} -p {cluster.port()} -s {str(security).lower()}')
+            cmd = f'sh {script} -b {cluster.endpoint()} -p {cluster.port()} -s {str(security).lower()}'
+            (status, stdout, stderr) = execute(cmd, self.repo.dir, True, False)
+            results_dir = os.path.join(self.repo.dir,
+                                       'integ-test',
+                                       'build',
+                                       'reports',
+                                       'tests',
+                                       'integTest')
+            self.test_recorder.record_integ_test_outcome(self.name, status, stdout, stderr, walk(results_dir))
         else:
             print(f'{script} does not exist. Skipping integ tests for {self.name}')

--- a/bundle-workflow/python/test_workflow/local_test_cluster.py
+++ b/bundle-workflow/python/test_workflow/local_test_cluster.py
@@ -4,7 +4,9 @@ import subprocess
 import time
 import ssl
 import requests
+import itertools
 from test_workflow.test_cluster import TestCluster, ClusterCreationException
+from paths.tree_walker import walk
 
 class LocalTestCluster(TestCluster):
     '''
@@ -22,10 +24,10 @@ class LocalTestCluster(TestCluster):
         self.download()
         self.stdout = open('stdout.txt', 'w')
         self.stderr = open('stderr.txt', 'w')
-        dir = f'opensearch-{self.manifest.build.version}'
+        self.install_dir = f'opensearch-{self.manifest.build.version}'
         if not self.security_enabled:
-            self.disable_security(dir)
-        self.process = subprocess.Popen('./opensearch-tar-install.sh', cwd = dir, shell = True, stdout = self.stdout, stderr = self.stderr)
+            self.disable_security(self.install_dir)
+        self.process = subprocess.Popen('./opensearch-tar-install.sh', cwd = self.install_dir, shell = True, stdout = self.stdout, stderr = self.stderr)
         print(f'Started OpenSearch with PID {self.process.pid}')
         self.wait_for_service()
 
@@ -35,29 +37,12 @@ class LocalTestCluster(TestCluster):
     def port(self):
         return 9200
 
-    def destroy(self):
+    def destroy(self, test_recorder):
         if self.process is None:
             print('Local test cluster is not started')
             return
-        print(f'Sending SIGTERM to PID {self.process.pid}')
-        self.process.terminate()
-        try:
-            print('Waiting for process to terminate')
-            self.process.wait(10)
-        except TimeoutExpired:
-            print('Process did not terminate after 10 seconds. Sending SIGKILL')
-            self.process.kill()
-            try:
-                print('Waiting for process to terminate')
-                self.process.wait(10)
-            except TimeoutExpired:
-                print('Process failed to terminate even after SIGKILL')
-                raise
-        finally:
-            print(f'Process terminated with exit code {self.process.returncode}')
-            self.stdout.close()
-            self.stderr.close()
-            self.process = None
+        self.terminate_process()
+        test_recorder.record_cluster_logs(itertools.chain([(os.path.realpath(self.stdout.name), 'stdout'), (os.path.realpath(self.stderr.name), 'stderr')], walk(os.path.join(self.install_dir, 'logs'))))
 
     def url(self, path=''):
         return f'{"https" if self.security_enabled else "http"}://{self.endpoint()}:{self.port()}{path}'
@@ -92,3 +77,24 @@ class LocalTestCluster(TestCluster):
                 print(f'Service not available yet')
             time.sleep(10)
         raise ClusterCreationException('Cluster is not green after 10 attempts')
+
+    def terminate_process(self):
+        print(f'Sending SIGTERM to PID {self.process.pid}')
+        self.process.terminate()
+        try:
+            print('Waiting for process to terminate')
+            self.process.wait(10)
+        except TimeoutExpired:
+            print('Process did not terminate after 10 seconds. Sending SIGKILL')
+            self.process.kill()
+            try:
+                print('Waiting for process to terminate')
+                self.process.wait(10)
+            except TimeoutExpired:
+                print('Process failed to terminate even after SIGKILL')
+                raise
+        finally:
+            print(f'Process terminated with exit code {self.process.returncode}')
+            self.stdout.close()
+            self.stderr.close()
+            self.process = None

--- a/bundle-workflow/python/test_workflow/test_cluster.py
+++ b/bundle-workflow/python/test_workflow/test_cluster.py
@@ -14,9 +14,10 @@ class TestCluster(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def destroy(self):
+    def destroy(self, test_recorder):
         '''
-        Tear down the cluster. If the cluster is already destroyed or has not yet been created then this is a no-op.
+        Tear down the cluster and record server logs. If the cluster is already destroyed or has not yet been created then this is a no-op.
+        :param test_recorder: The test recorder to register server logs with.
         '''
         pass
 

--- a/bundle-workflow/python/test_workflow/test_recorder.py
+++ b/bundle-workflow/python/test_workflow/test_recorder.py
@@ -1,0 +1,22 @@
+class TestRecorder:
+    def __init__(self, location):
+        self.location = location
+        print(f'TestRecorder storing results in {location}')
+
+    def record_cluster_logs(self, log_files):
+        '''
+        Record the test cluster logs.
+        :param results: A generator that yields tuples containing test cluster log files, in the form (absolute_path, relative_path)
+        '''
+        print(f'Recording log files: {list(log_files)}')
+
+    def record_integ_test_outcome(self, component_name, exit_status, stdout, stderr, results):
+        '''
+        Record the outcome of a integration test run.
+        :param component_name: The name of the component that ran tests.
+        :param exit_code: One of SUCCESS, FAILED, ERROR. SUCCESS means the tests ran and all of them passed. FAILED means the tests ran and at least one failed. ERROR means the test suite did not run correctly.
+        :param stdout: A string containing the stdout stream from the test process.
+        :param stderr: A string containing the stderr stream from the test process.
+        :param results: A generator that yields tuples containing test results files, in the form (absolute_path, relative_path).
+        '''
+        print(f'Recording test results for {component_name}. Exit status: {exit_status}, stdout: {stdout}, stderr: {stderr}, results files: {results}')


### PR DESCRIPTION
Also add system.execute to make it easier to capture exit codes, stdout, and stderr from subprocesses.

This commit is just the first step in implementing https://github.com/opensearch-project/opensearch-build/issues/207 and is intended to illustrate how the test results recorder will interact with the rest of the system. The `TestRecorder` doesn't actually save anything right now - the next thing is to get it to upload everything to S3 (or store in a local folder) rather than just printing out the names of the files.

A couple of things I'm not too happy about:

`TestCluster.destroy` takes a `TestRecorder` as an argument. This feels pretty clunky, and maybe we should be passing the `TestRecorder` in to the constructor. It's good enough for now but if anyone has a better idea then I'm all ears.

In `IntegTestSuite`, the path to the test reports is based on what the SQL plugin currently emits (because SQL is the first plugin in the 1.0.0 manifest that actually runs integration tests, not because SQL is particularly special). This should be changed to a standardized location, similar to what the `Builder` does. Specifying that location and updating each component's integtest.sh is beyond the scope of this PR, so a hard-coded path is fine for now to get things moving.

Signed-off-by: Cameron Skinner <camerski@amazon.com>

### Testing
Command: `python bundle-workflow/python/test.py ../data/opensearch-1.0.0-bundle-manifest.yml`

Output:
```
...
Testing sql
Executing "git init" in /tmp/tmplhvx56b2/sql
Executing "git remote add origin https://github.com/opensearch-project/sql.git" in /tmp/tmplhvx56b2/sql
Executing "git fetch --depth 1 origin 65bb94fb7d46a88b07b61622585ed701918b19c5" in /tmp/tmplhvx56b2/sql
Executing "git checkout FETCH_HEAD" in /tmp/tmplhvx56b2/sql
Checked out https://github.com/opensearch-project/sql.git@65bb94fb7d46a88b07b61622585ed701918b19c5 into /tmp/tmplhvx56b2/sql at 65bb94fb7d46a88b07b61622585ed701918b19c5
Executing "sh /tmp/tmplhvx56b2/sql/integtest.sh -b localhost -p 9200 -s true" in /tmp/tmplhvx56b2/sql
Walking tree from /tmp/tmplhvx56b2/sql/integ-test/build/reports/tests/integTest
Recording test results for sql. Exit status: 0, stdout: ..., stderr: ..., results files: [('/tmp/tmplhvx56b2/sql/integ-test/build/reports/tests/integTest/index.html', 'index.html'), ('/tmp/tmplhvx56b2/sql/integ-test/build/reports/tests/integTest/classes/org.opensearch.sql.legacy.MultiQueryIT.html', ...
...
Sending SIGTERM to PID 29819
Waiting for process to terminate
Process terminated with exit code 143
Walking tree from opensearch-1.0.0/logs
Recording log files: [('/tmp/tmplhvx56b2/local-test-cluster/stdout.txt', 'stdout'), ('/tmp/tmplhvx56b2/local-test-cluster/stderr.txt', 'stderr'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/opensearch_server.json', 'opensearch_server.json'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/gc.log.00', 'gc.log.00'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/gc.log.01', 'gc.log.01'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/opensearch_index_search_slowlog.log', 'opensearch_index_search_slowlog.log'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/opensearch_index_search_slowlog.json', 'opensearch_index_search_slowlog.json'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/opensearch_index_indexing_slowlog.json', 'opensearch_index_indexing_slowlog.json'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/opensearch-2021-08-16-1.log.gz', 'opensearch-2021-08-16-1.log.gz'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/opensearch_index_indexing_slowlog.log', 'opensearch_index_indexing_slowlog.log'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/gc.log', 'gc.log'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/opensearch.log', 'opensearch.log'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/opensearch-2021-08-16-1.json.gz', 'opensearch-2021-08-16-1.json.gz'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/opensearch_deprecation.log', 'opensearch_deprecation.log'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/opensearch_deprecation.json', 'opensearch_deprecation.json'), ('/tmp/tmplhvx56b2/local-test-cluster/opensearch-1.0.0/logs/gc.log.02', 'gc.log.02')]
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/207
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
