### PR TITLE
Skip failing alerting ktlint step.

### DIFF
--- a/bundle-workflow/scripts/components/alerting/build.sh
+++ b/bundle-workflow/scripts/components/alerting/build.sh
@@ -57,7 +57,7 @@ fi
 
 mkdir -p $OUTPUT/plugins
 
-./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x ktlint
 
 zipPath=$(find . -path \*build/distributions/*.zip)
 distributions="$(dirname "${zipPath}")"
@@ -65,4 +65,4 @@ distributions="$(dirname "${zipPath}")"
 echo "COPY ${distributions}/*.zip"
 cp ${distributions}/*.zip ./$OUTPUT/plugins
 
-./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x ktlint


### PR DESCRIPTION
This commit skips the ktlint step that is currently failing.
The build system does not care about lint failures

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Ignore lint failures when building alerting repo.
 
### Issues Resolved
Circumvents failures. Issue in alerting repo https://github.com/opensearch-project/alerting/issues/146.
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
