### PR TITLE
Update 1.1.0 manifest to build k-NN from main

### DIFF
--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -36,9 +36,8 @@ components:
     repository: https://github.com/opensearch-project/index-management.git
     ref: main
   - name: k-NN
-    # https://github.com/opensearch-project/k-NN/issues/78
-    repository: https://github.com/VijayanB/k-NN-2.git
-    ref: update-workflow
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: main
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
     ref: main


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Issue https://github.com/opensearch-project/k-NN/issues/78 was closed with a fix.
Update 1.1.0 manifest to build k-NN from main

### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
