### PR TITLE
Fix security building snapshot by default.

### DIFF
--- a/bundle-workflow/scripts/components/security/build.sh
+++ b/bundle-workflow/scripts/components/security/build.sh
@@ -55,7 +55,7 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-mvn -B clean package -Padvanced -DskipTests -Dopensearch.version=$VERSION
+mvn -B clean package -Padvanced -DskipTests -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 artifact_zip=$(ls $(pwd)/target/releases/opensearch-security-*.zip | grep -v admin-standalone)
 ./gradlew assemble --no-daemon -ParchivePath=$artifact_zip -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Maven needs to know whether we're building a snapshot or not.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
