### PR TITLE
Update sign entrypoint to use run.sh

### DIFF
--- a/bundle-workflow/sign.sh
+++ b/bundle-workflow/sign.sh
@@ -3,4 +3,4 @@
 set -e
 
 DIR="$(dirname "$0")"
-python3 "$DIR/python/sign.py" $@
+"$DIR/run.sh" "$DIR/python/sign.py" $@


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Update sign entrypoint to use run.sh for python env set up.
 
### Check List
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
