### PR TITLE
Update signer repo url to require a github token.

### DIFF
--- a/bundle-workflow/python/signing_workflow/signer.py
+++ b/bundle-workflow/python/signing_workflow/signer.py
@@ -2,11 +2,11 @@
 
 # Copyright OpenSearch Contributors.
 # SPDX-License-Identifier: Apache-2.0
-import sys 
+import sys
+import os
 
 sys.path.insert(0,"../git")
 from git.git_repository import GitRepository
-
 
 '''
 This class is responsible for signing an artifact using the OpenSearch-signer-client and verifying its signature.
@@ -14,9 +14,14 @@ The signed artifacts will be found in the same location as the original artifact
 '''
 class Signer:
     def __init__(self):
-        self.git_repo = GitRepository("https://github.com/opensearch-project/opensearch-signer-client.git", "HEAD")
+        self.git_repo = GitRepository(self.get_repo_url(), "HEAD")
         self.git_repo.execute("./bootstrap", subdirname = "src")
         self.git_repo.execute("rm config.cfg", subdirname = "src")
+
+    def get_repo_url(self):
+        if "GITHUB_TOKEN" in os.environ:
+            return "https://${GITHUB_TOKEN}@github.com/opensearch-project/opensearch-signer-client.git"
+        return "https://github.com/opensearch-project/opensearch-signer-client.git"
 
     def sign(self, filename):
         signature_file = filename + ".asc"


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Update the signer url to take an access token so that it can be cloned from CI. The signer repo currently requires a github token to be cloned.
 
### Issues Resolved
related to setting up release workflow -  #136 
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
