### PR TITLE
BugFix - Fix OpenSearch build.sh script to correctly build for arm64.

### DIFF
--- a/bundle-workflow/scripts/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch/build.sh
@@ -72,7 +72,7 @@ case $ARCHITECTURE in
         TARGET="linux-tar"
         QUALIFIER="linux-x86"
         ;;
-    x64)
+    arm64)
         TARGET="linux-arm64-tar"
         QUALIFIER="linux-arm64"
         ;;


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Fix OpenSearch build.sh script to correctly build for arm64.  The architecture string passed to each build.sh script resolves to 'arm64', not 'x64'.

From CI:
```
Executing "/var/jenkins/workspace/bundle-build-1.x/bundle-workflow/scripts/components/OpenSearch/build.sh -v 1.1.0 -a arm64 -s false -o artifacts" in /tmp/tmpsvcx9qr5/OpenSearch
+ case $ARCHITECTURE in
+ echo 'Unsupported architecture: arm64'
Unsupported architecture: arm64
+ exit 1
```

 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
