### PR TITLE
Update OpenSearch build.sh to properly build and tag for x64

### DIFF
--- a/bundle-workflow/scripts/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch/build.sh
@@ -68,7 +68,7 @@ cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org/opensearch
 # Assemble distribution artifact
 # see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
 case $ARCHITECTURE in
-    x86)
+    x64)
         TARGET="linux-tar"
         QUALIFIER="linux-x86"
         ;;


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Fix OpenSearch build.sh to properly build for x64 by matching what is returned from [arch.py](https://github.com/opensearch-project/opensearch-build/blob/main/bundle-workflow/python/system/arch.py)



### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
