### PR TITLE
Update OpenSearch build.sh script to properly set QUALIFIER for x64 builds

### DIFF
--- a/bundle-workflow/scripts/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch/build.sh
@@ -70,7 +70,7 @@ cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org/opensearch
 case $ARCHITECTURE in
     x64)
         TARGET="linux-tar"
-        QUALIFIER="linux-x86"
+        QUALIFIER="linux-x64"
         ;;
     arm64)
         TARGET="linux-arm64-tar"


### PR DESCRIPTION
Update OpenSearch build.sh script to properly set QUALIFIER for x64 builds.

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This change updates the QUALIFIER to 'x64' instead of 'x86' to be consistent with our [existing](https://opensearch.org/artifacts/opensearch/opensearch-1-0-0-min-linux-x64.html) min names and what is currently built by the core repo.

This renaming will go away when [this issue ](https://github.com/opensearch-project/OpenSearch/issues/1094) is taken.
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
