### PR TITLE
Fix OpenSearch build.sh to properly place maven artifacts into org/opensearch

### DIFF
--- a/bundle-workflow/scripts/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch/build.sh
@@ -63,7 +63,7 @@ mkdir -p $OUTPUT/maven/org/opensearch
 ./gradlew publishNebulaPublicationToTestRepository -Dbuild.snapshot=$SNAPSHOT
 
 # Copy maven publications to be promoted
-cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org/opensearch
+cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org
 
 # Assemble distribution artifact
 # see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
OpenSearch maven artifacts are incorrectly getting placed into org/opensearch/opensearch.  This removes the extra directory so that the group ID matches the path.
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
