### PR TITLE
Update Jenkinsfile to build arm64 and x64 in parallel

### DIFF
--- a/bundle-workflow/Jenkinsfile
+++ b/bundle-workflow/Jenkinsfile
@@ -1,11 +1,11 @@
 pipeline {
-    agent {
-        node {
-            label 'Jenkins-Agent-al2-x64-m5xlarge'
-        }
-    }
+    agent none
     environment {
         OPENSEARCH_BUILD_ID = "${BUILD_NUMBER}"
+    }
+    tools {
+      jdk "JDK14"
+      maven "maven-3.8.2"
     }
     stages {
         stage('parameters') {
@@ -23,23 +23,46 @@ pipeline {
                 }
             }
         }
-        stage('build-x64') {
-            tools {
-                jdk "JDK14"
-                maven "maven-3.8.2"
-            }
-            steps {
-                git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
-                sh "./bundle-workflow/build.sh manifests/$BUILD_MANIFEST"
-                sh './bundle-workflow/assemble.sh artifacts/manifest.yml'
-
-                script { manifest = readYaml(file: 'artifacts/manifest.yml') }
-
-                withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
-                    s3Upload(file: 'artifacts', bucket: "${ARTIFACT_BUCKET_NAME}", path: "builds/${manifest.build.version}/${manifest.build.architecture}/${OPENSEARCH_BUILD_ID}")
-                    s3Upload(file: "bundle", bucket: "${ARTIFACT_BUCKET_NAME}", path: "bundles/${manifest.build.version}/${manifest.build.architecture}/${OPENSEARCH_BUILD_ID}")
+        stage('build') {
+            parallel {
+                stage('build-x86') {
+                    agent {
+                        node {
+                            label 'Jenkins-Agent-al2-x64-m5xlarge'
+                        }
+                    }
+                    steps {
+                        script {
+                            build()
+                        }
+                    }
+                }
+                stage('build-arm64') {
+                    agent {
+                        node {
+                            label 'Jenkins-Agent-al2-arm64-m6gxlarge'
+                        }
+                    }
+                    steps {
+                        script {
+                            build()
+                        }
+                    }
                 }
             }
         }
+    }
+}
+
+void build() {
+    git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
+    sh "./bundle-workflow/build.sh manifests/$BUILD_MANIFEST"
+    sh './bundle-workflow/assemble.sh artifacts/manifest.yml'
+
+    script { manifest = readYaml(file: 'artifacts/manifest.yml') }
+
+    withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
+        s3Upload(file: 'artifacts', bucket: "${ARTIFACT_BUCKET_NAME}", path: "builds/${manifest.build.version}/${OPENSEARCH_BUILD_ID}/${manifest.build.architecture}")
+        s3Upload(file: "bundle", bucket: "${ARTIFACT_BUCKET_NAME}", path: "bundles/${manifest.build.version}/${OPENSEARCH_BUILD_ID}/${manifest.build.architecture}")
     }
 }


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Updates the existing Jenkinsfile to build arm64 and x64 in parallel and upload to S3 under paths:
opensearch-version/build-id/arch
 
### Issues Resolved
closes #294 
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
