### PR TITLE
Add replication plugin to Opensearch 1.1 build manifest

### DIFF
--- a/bundle-workflow/tests/test_run_build.py
+++ b/bundle-workflow/tests/test_run_build.py
@@ -68,7 +68,7 @@ class TestRunBuild(unittest.TestCase):
             any_order=True,
         )
 
-        self.assertEqual(mock_repo.call_count, 14)
+        self.assertEqual(mock_repo.call_count, 15)
 
         # each component is built and its artifacts exported
         mock_builder.assert_has_calls(
@@ -86,9 +86,9 @@ class TestRunBuild(unittest.TestCase):
             any_order=True,
         )
 
-        self.assertEqual(mock_builder.call_count, 14)
-        self.assertEqual(mock_builder.return_value.build.call_count, 14)
-        self.assertEqual(mock_builder.return_value.export_artifacts.call_count, 14)
+        self.assertEqual(mock_builder.call_count, 15)
+        self.assertEqual(mock_builder.return_value.build.call_count, 15)
+        self.assertEqual(mock_builder.return_value.export_artifacts.call_count, 15)
 
         # the output manifest is written
         mock_recorder.return_value.write_manifest.assert_called()

--- a/bundle-workflow/tests/test_run_checkout.py
+++ b/bundle-workflow/tests/test_run_checkout.py
@@ -68,4 +68,4 @@ class TestRunChecout(unittest.TestCase):
             any_order=True,
         )
 
-        self.assertEqual(mock_repo.call_count, 14)
+        self.assertEqual(mock_repo.call_count, 15)

--- a/bundle-workflow/tests/test_run_ci.py
+++ b/bundle-workflow/tests/test_run_ci.py
@@ -61,5 +61,5 @@ class TestRunCi(unittest.TestCase):
         )
 
         # each component gets checked out and checked
-        self.assertEqual(mock_repo.call_count, 14)
-        self.assertEqual(mock_ci.return_value.check.call_count, 14)
+        self.assertEqual(mock_repo.call_count, 15)
+        self.assertEqual(mock_ci.return_value.check.call_count, 15)

--- a/bundle-workflow/tests/tests_manifests/test_input_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_input_manifest.py
@@ -42,7 +42,7 @@ class TestInputManifest(unittest.TestCase):
         self.assertEqual(manifest.version, "1.0")
         self.assertEqual(manifest.build.name, "OpenSearch")
         self.assertEqual(manifest.build.version, "1.1.0")
-        self.assertEqual(len(manifest.components), 14)
+        self.assertEqual(len(manifest.components), 15)
         # opensearch component
         opensearch_component = manifest.components[0]
         self.assertEqual(opensearch_component.name, "OpenSearch")

--- a/manifests/1.1.0/opensearch-1.1.0.yml
+++ b/manifests/1.1.0/opensearch-1.1.0.yml
@@ -37,6 +37,9 @@ components:
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: "1.1"
+  - name: cross-cluster-replication
+    repository: https://github.com/opensearch-project/cross-cluster-replication.git
+    ref: "1.1"
   - name: performance-analyzer-rca
     repository: https://github.com/opensearch-project/performance-analyzer-rca.git
     ref: "1.1"
@@ -86,4 +89,3 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
-    


### PR DESCRIPTION
### Description
Add replication plugin to Opensearch 1.1 build manifest
PR on plugin side: https://github.com/opensearch-project/cross-cluster-replication/pull/119

Also, replication build depends on the following change on opensearch: https://github.com/opensearch-project/OpenSearch/pull/1038 . So the PR should be deployed for build to go through.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/266

### Testing done
`./bundle-workflow/build.sh manifests/opensearch-1.1.0.yml --snapshot --component cross-cluster-replication`
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
