### PR TITLE
Add notifications to 1.0 maven release.

### DIFF
--- a/bundle-workflow/scripts/components/alerting/build.sh
+++ b/bundle-workflow/scripts/components/alerting/build.sh
@@ -69,3 +69,7 @@ echo "COPY ${distributions}/*.zip"
 cp ${distributions}/*.zip ./$OUTPUT/plugins
 
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x ktlint
+
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ~/.m2/repository/org/opensearch/notification $OUTPUT/maven/org/opensearch/notification
+

--- a/manifests/opensearch-1.0.0-maven.yml
+++ b/manifests/opensearch-1.0.0-maven.yml
@@ -6,10 +6,13 @@ build:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: 1.0
+    ref: tags/1.0.0
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: 1.0
+    ref: tags/1.0.0.0
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: 1.0.0.0
+    ref: tags/1.0.0.0
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: tags/1.0.0.0


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Adding notifications to 1.0 maven release.
Updated to build tags and a specific sha of common-utils.
 
### Issues Resolved
Follow up on https://github.com/opensearch-project/opensearch-build/pull/307
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
