### PR TITLE
Fix signer to correctly sign jars with '.' in filenames

### DIFF
--- a/bundle-workflow/src/sign.py
+++ b/bundle-workflow/src/sign.py
@@ -7,6 +7,7 @@
 # compatible open source license.
 
 import argparse
+import os
 
 from manifests.build_manifest import BuildManifest
 from signing_workflow.signer import Signer
@@ -20,6 +21,7 @@ parser.add_argument("--type", nargs="?", help="Artifact type")
 args = parser.parse_args()
 
 manifest = BuildManifest.from_file(args.manifest)
+basepath = os.path.dirname(os.path.abspath(manifest.name))
 signer = Signer()
 
 for component in manifest.components:
@@ -34,6 +36,6 @@ for component in manifest.components:
         if args.type and args.type != artifact_type:
             continue
 
-        signer.sign(component.artifacts[artifact_type])
+        signer.sign_artifacts(component.artifacts[artifact_type], basepath)
 
 print("Done.")

--- a/bundle-workflow/src/signing_workflow/signer.py
+++ b/bundle-workflow/src/signing_workflow/signer.py
@@ -28,17 +28,15 @@ class Signer:
 
     def sign_artifacts(self, artifacts, basepath):
         for artifact in artifacts:
-            if self.is_invalid_file_type(artifact):
+            if not self.is_valid_file_type(artifact):
                 print(f"Skipping signing of file ${artifact}")
                 continue
             location = os.path.join(basepath, artifact)
             self.sign(location)
             self.verify(location + ".asc")
 
-    def is_invalid_file_type(self, file_name):
-        return (
-            "".join(pathlib.Path(file_name).suffixes) not in Signer.ACCEPTED_FILE_TYPES
-        )
+    def is_valid_file_type(self, file_name):
+        return any(x in [pathlib.Path(file_name).suffix, "".join(pathlib.Path(file_name).suffixes)] for x in Signer.ACCEPTED_FILE_TYPES)
 
     def get_repo_url(self):
         if "GITHUB_TOKEN" in os.environ:

--- a/bundle-workflow/tests/tests_signing_workflow/test_signer.py
+++ b/bundle-workflow/tests/tests_signing_workflow/test_signer.py
@@ -17,6 +17,7 @@ class TestSigner(unittest.TestCase):
             "the-module.module",
             "the-tar.tar.gz",
             "random-file.txt",
+            "something-1.0.0.0.jar"
         ]
         expected = [
             call("/path/the-jar.jar"),
@@ -25,6 +26,7 @@ class TestSigner(unittest.TestCase):
             call("/path/the-pom.pom"),
             call("/path/the-module.module"),
             call("/path/the-tar.tar.gz"),
+            call("/path/something-1.0.0.0.jar"),
         ]
         signer = Signer()
         signer.sign = MagicMock()


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Currently we have jars that require signing with '.' in their filenames.
Example - `client-benchmarks-1.0.0-javadoc.jar`

This also fixes the entry-point of the signer to correctly sign the entire list of artifacts.

### Issues Resolved
closes #325 
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
