### PR TITLE
Fix OpenSearch component build script to not hardcode version

### DIFF
--- a/bundle-workflow/scripts/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch/build.sh
@@ -89,8 +89,8 @@ esac
 
 # Copy artifact to bundle output with -min in the name
 [[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
-ARTIFACT_BUILD_NAME=opensearch-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
-ARTIFACT_TARGET_NAME=opensearch-min-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
+ARTIFACT_BUILD_NAME=`ls distribution/archives/$TARGET/build/distributions/ | grep "opensearch.*$QUALIFIER.tar.gz"`
+ARTIFACT_TARGET_NAME=`echo $ARTIFACT_BUILD_NAME | sed 's/opensearch/opensearch-min/g'`
 mkdir -p "${OUTPUT}/bundle"
 cp distribution/archives/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/bundle/$ARTIFACT_TARGET_NAME
 
@@ -102,7 +102,7 @@ cd ..
 for plugin in plugins/*; do
   PLUGIN_NAME=$(basename "$plugin")
   if [ -d "$plugin" ] && [ "examples" != "$PLUGIN_NAME" ]; then
-    PLUGIN_ARTIFACT_BUILD_NAME=$PLUGIN_NAME-$VERSION$IDENTIFIER.zip
+    PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME.*$IDENTIFIER.zip"`
     cp "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
   fi
 done


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Fix OpenSearch component build script to not hardcode version.
We are trying to build 1.0.1 bundle with 1.0.0 min but failed due to script trying to find non-exist 1.0.1 min.
This decouples the version dependencies to allow creating a bundle without fixed to the bundle version on min and core plugins. This also unblock the 1.0.1 patch release artifacts generation.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
