### PR TITLE
Fix sign.py to properly parse basepath

### DIFF
--- a/bundle-workflow/src/sign.py
+++ b/bundle-workflow/src/sign.py
@@ -21,7 +21,7 @@ parser.add_argument("--type", nargs="?", help="Artifact type")
 args = parser.parse_args()
 
 manifest = BuildManifest.from_file(args.manifest)
-basepath = os.path.dirname(os.path.abspath(manifest.name))
+basepath = os.path.dirname(os.path.abspath(args.manifest.name))
 signer = Signer()
 
 for component in manifest.components:


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This [PR](https://github.com/opensearch-project/opensearch-build/commit/a05acc3a68fad518cecbaf9a08494b6f4b8daada) incorrectly used the manifest name of 'OpenSearch' when it needs to be using the manifest arg name.
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
