### PR TITLE
Fix stage-maven-release script to properly set url

### DIFF
--- a/publish/stage-maven-release.sh
+++ b/publish/stage-maven-release.sh
@@ -119,7 +119,7 @@ EOF
 function create_staging_repository() {
   staging_repo_id=$(mvn --settings="${mvn_settings}" \
     org.sonatype.plugins:nexus-staging-maven-plugin:rc-open \
-    -DnexusUrl="${NEXUS_URL}" \
+    -DnexusUrl="${REPO_URL}" \
     -DserverId=nexus \
     -DstagingProfileId="${STAGING_PROFILE_ID}" \
     -DstagingDescription="Staging artifacts for build ${BUILD_ID}" \
@@ -128,8 +128,6 @@ function create_staging_repository() {
   echo "Opened staging repository ID $staging_repo_id"
 }
 
-
-url="${REPO_URL}"
 create_maven_settings
 create_staging_repository
 
@@ -140,7 +138,7 @@ echo "==========================================="
 mvn --settings="${mvn_settings}" \
   org.sonatype.plugins:nexus-staging-maven-plugin:1.6.5:deploy-staged-repository \
   -DrepositoryDirectory="${staged_repo}" \
-  -DnexusUrl="${url}" \
+  -DnexusUrl="${REPO_URL}" \
   -DserverId=nexus \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Fixes the publish script to properly set URL.  This should be REPO_URL not NEXUS_URL.
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
