### PR TITLE
Added unit tests for build_workflow.

### DIFF
--- a/bundle-workflow/src/build_workflow/build_args.py
+++ b/bundle-workflow/src/build_workflow/build_args.py
@@ -40,16 +40,14 @@ class BuildArgs:
         self.snapshot = args.snapshot
         self.component = args.component
         self.keep = args.keep
-
-    def script_path(self):
-        return sys.argv[0].replace("/src/build.py", "/build.sh")
+        self.script_path = sys.argv[0].replace("/src/build.py", "/build.sh")
 
     def component_command(self, name):
         return " ".join(
             filter(
                 None,
                 [
-                    self.script_path(),
+                    self.script_path,
                     self.manifest.name,
                     f"--component {name}",
                     "--snapshot" if self.snapshot else None,

--- a/bundle-workflow/src/build_workflow/build_recorder.py
+++ b/bundle-workflow/src/build_workflow/build_recorder.py
@@ -44,9 +44,9 @@ class BuildRecorder:
     def get_manifest(self):
         return self.build_manifest.to_manifest()
 
-    def write_manifest(self, folder):
+    def write_manifest(self, dest_dir):
         output_manifest = self.get_manifest()
-        manifest_path = os.path.join(folder, "manifest.yml")
+        manifest_path = os.path.join(dest_dir, "manifest.yml")
         with open(manifest_path, "w") as file:
             yaml.dump(output_manifest.to_dict(), file)
 

--- a/bundle-workflow/src/sign_workflow/signer.py
+++ b/bundle-workflow/src/sign_workflow/signer.py
@@ -36,7 +36,14 @@ class Signer:
             self.verify(location + ".asc")
 
     def is_valid_file_type(self, file_name):
-        return any(x in [pathlib.Path(file_name).suffix, "".join(pathlib.Path(file_name).suffixes)] for x in Signer.ACCEPTED_FILE_TYPES)
+        return any(
+            x
+            in [
+                pathlib.Path(file_name).suffix,
+                "".join(pathlib.Path(file_name).suffixes),
+            ]
+            for x in Signer.ACCEPTED_FILE_TYPES
+        )
 
     def get_repo_url(self):
         if "GITHUB_TOKEN" in os.environ:

--- a/bundle-workflow/tests/tests_build_workflow/__init__.py
+++ b/bundle-workflow/tests/tests_build_workflow/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))

--- a/bundle-workflow/tests/tests_build_workflow/test_build_args.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_build_args.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import unittest
+from unittest.mock import patch
+
+from build_workflow.build_args import BuildArgs
+
+
+class TestBuildArgs(unittest.TestCase):
+
+    BUILD_PY = os.path.realpath(
+        os.path.join(os.path.dirname(__file__), "../../src/build.py")
+    )
+
+    BUILD_SH = os.path.realpath(
+        os.path.join(os.path.dirname(__file__), "../../build.sh")
+    )
+
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__), "../../../manifests/opensearch-1.1.0.yml"
+        )
+    )
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_manifest(self):
+        self.assertEqual(BuildArgs().manifest.name, TestBuildArgs.OPENSEARCH_MANIFEST)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_keep_default(self):
+        self.assertFalse(BuildArgs().keep)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--keep"])
+    def test_keep_true(self):
+        self.assertTrue(BuildArgs().keep)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_snapshot_default(self):
+        self.assertFalse(BuildArgs().snapshot)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--snapshot"])
+    def test_snapshot_true(self):
+        self.assertTrue(BuildArgs().snapshot)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_component_default(self):
+        self.assertIsNone(BuildArgs().component)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
+    def test_component(self):
+        self.assertEqual(BuildArgs().component, "xyz")
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
+    def test_script_path(self):
+        self.assertTrue(os.path.isfile(self.BUILD_PY))
+        self.assertTrue(os.path.isfile(self.BUILD_SH))
+        self.assertEqual(BuildArgs().script_path, self.BUILD_SH)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_component_command(self):
+        self.assertEqual(
+            BuildArgs().component_command("component"),
+            f"{self.BUILD_SH} {self.OPENSEARCH_MANIFEST} --component component",
+        )
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--snapshot"])
+    def test_component_command_with_snapshot(self):
+        self.assertEqual(
+            BuildArgs().component_command("component"),
+            f"{self.BUILD_SH} {self.OPENSEARCH_MANIFEST} --component component --snapshot",
+        )

--- a/bundle-workflow/tests/tests_build_workflow/test_build_recorder.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_build_recorder.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from build_workflow.build_recorder import BuildRecorder
+from manifests.build_manifest import BuildManifest
+
+
+class TestBuildRecorder(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+        self.build_recorder = BuildRecorder(
+            "1", "output_dir", "OpenSearch", "1.1", "x64", False
+        )
+
+    @patch("shutil.copyfile")
+    @patch("os.makedirs")
+    def test_record_component_and_artifact(self, mock_makedirs, mock_copyfile):
+        self.build_recorder.record_component(
+            "common-utils",
+            MagicMock(
+                url="https://github.com/opensearch-project/common-utils",
+                ref="main",
+                sha="3913d7097934cbfe1fdcf919347f22a597d00b76",
+            ),
+        )
+
+        self.build_recorder.record_artifact(
+            "common-utils", "/files", "../file1.jar", __file__
+        )
+
+        self.build_recorder.record_artifact(
+            "common-utils", "/files", "../file2.jar", __file__
+        )
+
+        self.assertEqual(
+            self.build_recorder.get_manifest().to_dict(),
+            {
+                "build": {
+                    "architecture": "x64",
+                    "id": "1",
+                    "name": "OpenSearch",
+                    "version": "1.1",
+                },
+                "components": [
+                    {
+                        "artifacts": {"/files": ["../file1.jar", "../file2.jar"]},
+                        "commit_id": "3913d7097934cbfe1fdcf919347f22a597d00b76",
+                        "name": "common-utils",
+                        "ref": "main",
+                        "repository": "https://github.com/opensearch-project/common-utils",
+                    }
+                ],
+                "schema-version": "1.0",
+            },
+        )
+
+        mock_copyfile.assert_called()
+        mock_makedirs.assert_called()
+
+    @patch("shutil.copyfile")
+    @patch("os.makedirs")
+    def test_record_artifact(self, mock_makedirs, mock_copyfile):
+        self.build_recorder.record_component(
+            "common-utils",
+            MagicMock(
+                url="https://github.com/opensearch-project/common-utils",
+                ref="main",
+                sha="3913d7097934cbfe1fdcf919347f22a597d00b76",
+            ),
+        )
+
+        self.build_recorder.record_artifact(
+            "common-utils", "/files", "../file1.jar", __file__
+        )
+
+        mock_makedirs.assert_called_with("output_dir/..", exist_ok=True)
+        mock_copyfile.assert_called_with(__file__, "output_dir/../file1.jar")
+
+    def test_get_manifest(self):
+        manifest = self.build_recorder.get_manifest()
+        self.assertIs(type(manifest), BuildManifest)
+        self.assertEqual(
+            manifest.to_dict(),
+            {
+                "build": {
+                    "architecture": "x64",
+                    "id": "1",
+                    "name": "OpenSearch",
+                    "version": "1.1",
+                },
+                "components": [],
+                "schema-version": "1.0",
+            },
+        )
+
+    def test_write_manifest(self):
+        with tempfile.TemporaryDirectory() as dest_dir:
+            self.build_recorder.write_manifest(dest_dir)
+            manifest_path = os.path.join(dest_dir, "manifest.yml")
+            self.assertTrue(os.path.isfile(manifest_path))
+            data = self.build_recorder.get_manifest().to_dict()
+            with open(manifest_path) as f:
+                self.assertEqual(yaml.safe_load(f), data)

--- a/bundle-workflow/tests/tests_build_workflow/test_builder.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_builder.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from build_workflow.builder import Builder
+from paths.script_finder import ScriptFinder
+
+
+class TestBuilder(unittest.TestCase):
+    def setUp(self):
+        self.builder = Builder(
+            "component",
+            MagicMock(dir="/tmp/checked-out-component"),
+            ScriptFinder(),
+            MagicMock(),
+        )
+
+    def test_builder(self):
+        self.assertEqual(self.builder.component_name, "component")
+        self.assertEqual(self.builder.output_path, "artifacts")
+
+    def test_build(self):
+        self.builder.build("1.0.0", "x64", False)
+        self.builder.git_repo.execute.assert_called_with(
+            " ".join(
+                [
+                    os.path.realpath(
+                        os.path.join(
+                            self.builder.script_finder.default_scripts_path, "build.sh"
+                        )
+                    ),
+                    "-v 1.0.0",
+                    "-a x64",
+                    "-s false",
+                    "-o artifacts",
+                ]
+            )
+        )
+        self.builder.build_recorder.record_component.assert_called_with(
+            "component", self.builder.git_repo
+        )
+
+    def test_build_snapshot(self):
+        self.builder.build("1.0.0", "x64", True)
+        self.builder.git_repo.execute.assert_called_with(
+            " ".join(
+                [
+                    os.path.realpath(
+                        os.path.join(
+                            self.builder.script_finder.default_scripts_path, "build.sh"
+                        )
+                    ),
+                    "-v 1.0.0",
+                    "-a x64",
+                    "-s true",
+                    "-o artifacts",
+                ]
+            )
+        )
+        self.builder.build_recorder.record_component.assert_called_with(
+            "component", self.builder.git_repo
+        )
+
+    def mock_os_walk(self, artifact_type):
+        if artifact_type == "/tmp/checked-out-component/artifacts/core-plugins":
+            return [["/core-plugins", [], ["plugin1.zip"]]]
+        if artifact_type == "/tmp/checked-out-component/artifacts/maven":
+            return [("/maven", [], ["artifact1.jar"])]
+        else:
+            return []
+
+    @patch("os.walk")
+    def test_export_artifacts(self, mock_walk):
+        mock_walk.side_effect = self.mock_os_walk
+        self.builder.export_artifacts()
+        self.assertEqual(self.builder.build_recorder.record_artifact.call_count, 2)
+        self.builder.build_recorder.record_artifact.has_calls(
+            [
+                "component",
+                "maven",
+                "../../../maven/artifact1.jar",
+                "/maven/artifact1.jar",
+            ],
+            [
+                "component",
+                "core-plugins",
+                "../../../core-plugins/plugin1.zip",
+                "/core-plugins/plugin1.zip",
+            ],
+        )

--- a/bundle-workflow/tests/tests_sign_workflow/test_signer.py
+++ b/bundle-workflow/tests/tests_sign_workflow/test_signer.py
@@ -17,7 +17,7 @@ class TestSigner(unittest.TestCase):
             "the-module.module",
             "the-tar.tar.gz",
             "random-file.txt",
-            "something-1.0.0.0.jar"
+            "something-1.0.0.0.jar",
         ]
         expected = [
             call("/path/the-jar.jar"),


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Adds tests for build workflow. Part of #264. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
