### PR TITLE
Extract common loading of manifests into base class.

### DIFF
--- a/bundle-workflow/src/manifests/build_manifest.py
+++ b/bundle-workflow/src/manifests/build_manifest.py
@@ -4,7 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import yaml
+from manifests.manifest import Manifest
 
 """
 A BuildManifest is an immutable view of the outputs from a build step
@@ -36,15 +36,10 @@ components:
 """
 
 
-class BuildManifest:
-    @staticmethod
-    def from_file(file):
-        return BuildManifest(yaml.safe_load(file))
-
+class BuildManifest(Manifest):
     def __init__(self, data):
-        self.version = str(data["schema-version"])
-        if self.version != "1.0":
-            raise ValueError(f"Unsupported schema version: {self.version}")
+        super().__init__(data)
+
         self.build = self.Build(data["build"])
         self.components = list(
             map(lambda entry: self.Component(entry), data["components"])

--- a/bundle-workflow/src/manifests/bundle_manifest.py
+++ b/bundle-workflow/src/manifests/bundle_manifest.py
@@ -4,10 +4,10 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import yaml
+from manifests.manifest import Manifest
 
 
-class BundleManifest:
+class BundleManifest(Manifest):
     """
     A BundleManifest is an immutable view of the outputs from a assemble step
     The manifest contains information about the bundle that was built (in the `assemble` section),
@@ -28,14 +28,9 @@ class BundleManifest:
             location: /relative/path/to/artifact
     """
 
-    @staticmethod
-    def from_file(file):
-        return BundleManifest(yaml.safe_load(file))
-
     def __init__(self, data):
-        self.version = str(data["schema-version"])
-        if self.version != "1.0":
-            raise ValueError(f"Unsupported schema version: {self.version}")
+        super().__init__(data)
+
         self.build = self.Build(data["build"])
         self.components = list(
             map(lambda entry: self.Component(entry), data["components"])

--- a/bundle-workflow/src/manifests/input_manifest.py
+++ b/bundle-workflow/src/manifests/input_manifest.py
@@ -4,8 +4,6 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import yaml
-
 """
 An InputManifest is an immutable view of the input manifest for the build system.
 The manifest contains information about the product that is being built (in the `build` section),
@@ -23,16 +21,13 @@ components:
   - ...
 """
 
+from manifests.manifest import Manifest
 
-class InputManifest:
-    @staticmethod
-    def from_file(file):
-        return InputManifest(yaml.safe_load(file))
 
+class InputManifest(Manifest):
     def __init__(self, data):
-        self.version = str(data["schema-version"])
-        if self.version != "1.0":
-            raise ValueError(f"Unsupported schema version: {self.version}")
+        super().__init__(data)
+
         self.build = self.Build(data["build"])
         self.components = list(
             map(lambda entry: self.Component(entry), data["components"])

--- a/bundle-workflow/src/manifests/manifest.py
+++ b/bundle-workflow/src/manifests/manifest.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+from abc import ABC, abstractmethod
+
+import yaml
+
+
+class Manifest(ABC):
+    @classmethod
+    def from_file(cls, file):
+        return cls(yaml.safe_load(file))
+
+    @classmethod
+    def from_path(cls, path):
+        with open(path, "r") as f:
+            return cls.from_file(f)
+
+    @abstractmethod
+    def __init__(self, data):
+        self.version = str(data["schema-version"])
+        if self.version != "1.0":
+            raise ValueError(f"Unsupported schema version: {self.version}")

--- a/bundle-workflow/tests/tests_manifests/data/invalid-schema-version.yml
+++ b/bundle-workflow/tests/tests_manifests/data/invalid-schema-version.yml
@@ -1,0 +1,1 @@
+schema-version: 'invalid'

--- a/bundle-workflow/tests/tests_manifests/test_build_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_build_manifest.py
@@ -20,8 +20,7 @@ class TestBuildManifest(unittest.TestCase):
         self.manifest_filename = os.path.join(
             self.data_path, "opensearch-build-1.1.0.yml"
         )
-        with open(self.manifest_filename) as f:
-            self.manifest = BuildManifest.from_file(f)
+        self.manifest = BuildManifest.from_path(self.manifest_filename)
 
     def test_build(self):
         self.assertEqual(self.manifest.version, "1.0")

--- a/bundle-workflow/tests/tests_manifests/test_bundle_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_bundle_manifest.py
@@ -20,8 +20,7 @@ class TestBundleManifest(unittest.TestCase):
         self.manifest_filename = os.path.join(
             self.data_path, "opensearch-bundle-1.1.0.yml"
         )
-        with open(self.manifest_filename) as f:
-            self.manifest = BundleManifest.from_file(f)
+        self.manifest = BundleManifest.from_path(self.manifest_filename)
 
     def test_build(self):
         self.assertEqual(self.manifest.version, "1.0")

--- a/bundle-workflow/tests/tests_manifests/test_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_manifest.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import unittest
+
+from manifests.manifest import Manifest
+
+
+class TestManifest(unittest.TestCase):
+    def setUp(self):
+        self.data_path = os.path.join(os.path.dirname(__file__), "data")
+
+    def test_manifest_is_abstract(self):
+        with self.assertRaises(TypeError) as context:
+            Manifest(None)
+            self.assertEqual(
+                "Can't instantiate abstract class Manifest with abstract methods __init__",
+                context.exception.__str__(),
+            )
+
+    def test_invalid_version(self):
+        class TestManifest(Manifest):
+            def __init__(self, data):
+                super().__init__(data)
+
+        manifest_path = os.path.join(self.data_path, "invalid-schema-version.yml")
+
+        with self.assertRaises(ValueError) as context:
+            TestManifest.from_path(manifest_path)
+            self.assertEqual(
+                "Unsupported schema version: invalid", context.exception.__str__()
+            )


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

- Refactored common parts of manifest loading into a base class.
- Added `Manifest.from_path` to load manifests without having to `open()` in tests.
- Added unit tests for invalid schema version.
- Fixed up `test/` directory that should have been `tests/` to match others. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
