### PR TITLE
Added missing tests for tree_walker#walk.

### DIFF
--- a/bundle-workflow/tests/tests_paths/test_tree_walker.py
+++ b/bundle-workflow/tests/tests_paths/test_tree_walker.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import itertools
+import os
+import unittest
+
+from paths.tree_walker import walk
+
+
+class TestTreeWalker(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+        self.data_path = os.path.realpath(
+            os.path.join(os.path.dirname(__file__), "data")
+        )
+
+    def test_walk(self):
+        paths = sorted(
+            list(itertools.chain(walk(self.data_path))), key=lambda path: path[0]
+        )
+        self.assertTrue(len(paths), 7)
+        self.assertEqual(
+            paths[0][1], "git/component-with-scripts-folder/scripts/build.sh"
+        )
+        self.assertEqual(
+            paths[0][0],
+            os.path.realpath(
+                os.path.join(
+                    self.data_path, "git/component-with-scripts-folder/scripts/build.sh"
+                )
+            ),
+        )


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Added missing tests for tree_walker#walk.
  
Part of #264.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
