### PR TITLE
Build and publish Snapshot maven artifacts with build pipeline.

### DIFF
--- a/bundle-workflow/Jenkinsfile
+++ b/bundle-workflow/Jenkinsfile
@@ -4,8 +4,8 @@ pipeline {
         OPENSEARCH_BUILD_ID = "${BUILD_NUMBER}"
     }
     tools {
-      jdk "JDK14"
-      maven "maven-3.8.2"
+        jdk "JDK14"
+        maven "maven-3.8.2"
     }
     stages {
         stage('parameters') {
@@ -25,6 +25,25 @@ pipeline {
         }
         stage('build') {
             parallel {
+                stage('build-snapshots') {
+                    environment {
+                        SNAPSHOT_REPO_URL = "https://aws.oss.sonatype.org/content/repositories/snapshots/"
+                    }
+                    agent {
+                        node {
+                            label 'Jenkins-Agent-al2-x64-m5xlarge'
+                        }
+                    }
+                    steps {
+                        script {
+                            git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
+                            sh "./bundle-workflow/build.sh manifests/$BUILD_MANIFEST --snapshot"
+                            withCredentials([usernamePassword(credentialsId: 'Sonatype', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD')]) {
+                                sh('$WORKSPACE/publish/publish-snapshot.sh $WORKSPACE/artifacts/$ARTIFACT_PATH/maven')
+                            }
+                        }
+                    }
+                }
                 stage('build-x86') {
                     agent {
                         node {

--- a/publish/publish-snapshot.sh
+++ b/publish/publish-snapshot.sh
@@ -79,8 +79,8 @@ create_maven_settings() {
   <servers>
     <server>
       <id>nexus</id>
-      <username>${MAVEN_USERNAME}</username>
-      <password>${MAVEN_PASSWORD}</password>
+      <username>${SONATYPE_USERNAME}</username>
+      <password>${SONATYPE_PASSWORD}</password>
     </server>
   </servers>
 </settings>
@@ -118,7 +118,7 @@ for pom in ${pomFiles}; do
          mvn --settings="${mvn_settings}" deploy:deploy-file \
          -DgeneratePom=false \
          -DrepositoryId=nexus \
-         -Durl="${SNAPSHOT_URL}" \
+         -Durl="${SNAPSHOT_REPO_URL}" \
          -DpomFile="${pom}" \
          -Dfile="${FILE}" || echo "Failed to upload ${FILE}"
        ;;


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Add a parallel step to the nightly build job to build and publish snapshots to https://aws.oss.sonatype.org/content/repositories/snapshots/
Corrected publish-snapshot script to use the correct URL and credential variables.

Ran this and verified artifacts are present.
 
### Issues Resolved
closes #349 
 
### Check List
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
