### PR TITLE
Patch security plugin version at build time.

### DIFF
--- a/bundle-workflow/scripts/components/security/build.sh
+++ b/bundle-workflow/scripts/components/security/build.sh
@@ -58,7 +58,16 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-mvn -B clean package -Padvanced -DskipTests -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+# see https://github.com/opensearch-project/security/pull/1409
+PLUGIN_VERSION=$(cat plugin-descriptor.properties | grep ^version= | cut -d= -f2 | sed "s/-SNAPSHOT//")
+[[ "$SNAPSHOT" == "true" ]] && PLUGIN_VERSION=$PLUGIN_VERSION-SNAPSHOT
+
+sed -i "s/\(^opensearch\.version=\).*\$/\1${VERSION}/" plugin-descriptor.properties
+sed -i "s/\(^version=\).*\$/\1${PLUGIN_VERSION}/" plugin-descriptor.properties
+sed -i "s/\(<opensearch.version>\).*\(<\/opensearch.version>\)/\1${VERSION}\2/g" pom.xml
+sed -i -e "1,/<version>/s/\(<version>\).*\(<\/version>\)/\1${PLUGIN_VERSION}\2/g" pom.xml
+
+mvn -B clean package -Padvanced -DskipTests
 artifact_zip=$(ls $(pwd)/target/releases/opensearch-security-*.zip | grep -v admin-standalone)
 ./gradlew assemble --no-daemon -ParchivePath=$artifact_zip -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 

--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -23,9 +23,8 @@ components:
     repository: https://github.com/opensearch-project/notifications.git
     ref: main
   - name: security
-    # https://github.com/opensearch-project/security/issues/1403
-    repository: https://github.com/dblock/security.git
-    ref: fix-snapshot-build
+    repository: https://github.com/opensearch-project/security.git
+    ref: main
   - name: performance-analyzer-rca
     repository: https://github.com/opensearch-project/performance-analyzer-rca.git
     ref: main


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

An alternative to https://github.com/opensearch-project/security/pull/1409.

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-build/issues/179. 

### Testing

#### Regular Build

```
./bundle-workflow/build.sh manifests/opensearch-1.1.0.yml --component security
cd artifacts/plugins
unzip opensearch-security-1.1.0.0.zip

cat plugin-descriptor.properties | grep version=1.1
version=1.1.0.0
opensearch.version=1.1.0

unzip -p opensearch-security-1.1.0.0.jar META-INF/MANIFEST.MF | grep Implementation-Version
Implementation-Version: 1.1.0.0
```

#### Snapshot Build

```
./bundle-workflow/build.sh manifests/opensearch-1.1.0.yml --component security --snapshot
cd artifacts/plugins
unzip opensearch-security-1.1.0.0-SNAPSHOT.zip

cat plugin-descriptor.properties | grep version=1.1
version=1.1.0.0-SNAPSHOT
opensearch.version=1.1.0-SNAPSHOT

unzip -p opensearch-security-1.1.0.0-SNAPSHOT.jar META-INF/MANIFEST.MF | grep Implementation-Version
Implementation-Version: 1.1.0.0-SNAPSHOT
```
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
