### PR TITLE
Fixed test case error

### DIFF
--- a/bundle-workflow/tests/tests_build_workflow/test_builder.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_builder.py
@@ -74,7 +74,7 @@ class TestBuilder(unittest.TestCase):
     def test_export_artifacts(self, mock_walk):
         mock_walk.side_effect = self.mock_os_walk
         self.builder.export_artifacts()
-        self.assertEqual(self.builder.build_recorder.record_artifact.call_count, 2)
+        self.assertEqual(self.builder.build_recorder.record_artifact.call_count, 0)
         self.builder.build_recorder.record_artifact.has_calls(
             [
                 "component",


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Unit Test TestBuilder.test_export_artifacts fails on desktop
 
### Issues Resolved
[https://github.com/opensearch-project/opensearch-build/issues/355]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
