### PR TITLE
Fix: write OpenSearch version without -SNAPSHOT into security plugin descriptor.

### DIFF
--- a/bundle-workflow/scripts/components/security/build.sh
+++ b/bundle-workflow/scripts/components/security/build.sh
@@ -55,6 +55,7 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+OPENSEARCH_RELEASE=$VERSION
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
@@ -62,7 +63,7 @@ fi
 PLUGIN_VERSION=$(cat plugin-descriptor.properties | grep ^version= | cut -d= -f2 | sed "s/-SNAPSHOT//")
 [[ "$SNAPSHOT" == "true" ]] && PLUGIN_VERSION=$PLUGIN_VERSION-SNAPSHOT
 
-sed -i "s/\(^opensearch\.version=\).*\$/\1${VERSION}/" plugin-descriptor.properties
+sed -i "s/\(^opensearch\.version=\).*\$/\1${OPENSEARCH_RELEASE}/" plugin-descriptor.properties
 sed -i "s/\(^version=\).*\$/\1${PLUGIN_VERSION}/" plugin-descriptor.properties
 sed -i "s/\(<opensearch.version>\).*\(<\/opensearch.version>\)/\1${VERSION}\2/g" pom.xml
 sed -i -e "1,/<version>/s/\(<version>\).*\(<\/version>\)/\1${PLUGIN_VERSION}\2/g" pom.xml


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Always write a non-snapshot version of OpenSearch into the security plugin descriptor.
 
### Issues Resolved

Fixes https://github.com/opensearch-project/opensearch-build/issues/359.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
