### PR TITLE
Fix build.

### DIFF
--- a/bundle-workflow/src/manifests/test_manifest.py
+++ b/bundle-workflow/src/manifests/test_manifest.py
@@ -60,5 +60,5 @@ class TestManifest:
             return {
                 "name": self.name,
                 "integ-test": self.integ_test,
-                "bwc-test": self.bwc_test
+                "bwc-test": self.bwc_test,
             }

--- a/bundle-workflow/src/run_integ_test.py
+++ b/bundle-workflow/src/run_integ_test.py
@@ -68,19 +68,19 @@ def pull_common_dependencies(work_dir, build_manifest):
 # TODO: replace with DependencyProvider - https://github.com/opensearch-project/opensearch-build/issues/283
 def sync_dependencies_to_maven_local(work_dir, manifest_build_ver):
     os.chdir(work_dir + "/OpenSearch")
+    deps_script = os.path.join(
+        work_dir,
+        "opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh",
+    )
     subprocess.run(
-        work_dir
-        + "/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh opensearch "
-        + manifest_build_ver,
+        f"{deps_script} opensearch {manifest_build_ver}",
         shell=True,
         check=True,
         capture_output=True,
     )
     os.chdir(work_dir + "/common-utils")
     subprocess.run(
-        work_dir
-        + "/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh common-utils "
-        + manifest_build_ver,
+        f"{deps_script} common-utils {manifest_build_ver}",
         shell=True,
         check=True,
         capture_output=True,

--- a/bundle-workflow/src/run_integ_test.py
+++ b/bundle-workflow/src/run_integ_test.py
@@ -21,21 +21,26 @@ from test_workflow.integ_test_suite import IntegTestSuite
 # TODO: 2. Move common functions to utils.py
 
 
-COMMON_DEPENDENCIES = [
-    'OpenSearch',
-    'common-utils',
-    'job-scheduler',
-    'alerting'
-]
+COMMON_DEPENDENCIES = ["OpenSearch", "common-utils", "job-scheduler", "alerting"]
 
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
-    parser.add_argument('--bundle-manifest', type=argparse.FileType('r'), help="Bundle Manifest file.")
-    parser.add_argument('--build-manifest', type=argparse.FileType('r'), help="Build Manifest file.")
-    parser.add_argument('--test-manifest', type=argparse.FileType('r'), help="Test Manifest file.")
-    parser.add_argument('--keep', dest='keep', action='store_true',
-                        help="Do not delete the working temporary directory.")
+    parser.add_argument(
+        "--bundle-manifest", type=argparse.FileType("r"), help="Bundle Manifest file."
+    )
+    parser.add_argument(
+        "--build-manifest", type=argparse.FileType("r"), help="Build Manifest file."
+    )
+    parser.add_argument(
+        "--test-manifest", type=argparse.FileType("r"), help="Test Manifest file."
+    )
+    parser.add_argument(
+        "--keep",
+        dest="keep",
+        action="store_true",
+        help="Do not delete the working temporary directory.",
+    )
     args = parser.parse_args()
     return args
 
@@ -45,22 +50,41 @@ def pull_common_dependencies(work_dir, build_manifest):
     print("Pulling common dependencies for integration tests")
     print("Pulling opensearch-build")
     os.chdir(work_dir)
-    GitRepository('https://github.com/opensearch-project/opensearch-build.git', 'main',
-                  os.path.join(work_dir, 'opensearch-build'))
+    GitRepository(
+        "https://github.com/opensearch-project/opensearch-build.git",
+        "main",
+        os.path.join(work_dir, "opensearch-build"),
+    )
     for component in build_manifest.components:
         if component.name in COMMON_DEPENDENCIES:
             print("Pulling " + component.name)
-            GitRepository(component.repository, component.commit_id, os.path.join(work_dir, component.name))
+            GitRepository(
+                component.repository,
+                component.commit_id,
+                os.path.join(work_dir, component.name),
+            )
 
 
 # TODO: replace with DependencyProvider - https://github.com/opensearch-project/opensearch-build/issues/283
 def sync_dependencies_to_maven_local(work_dir, manifest_build_ver):
     os.chdir(work_dir + "/OpenSearch")
-    subprocess.run(work_dir + '/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh opensearch ' + manifest_build_ver,
-                   shell=True, check=True, capture_output=True)
-    os.chdir(work_dir + '/common-utils')
-    subprocess.run(work_dir + '/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh common-utils ' + manifest_build_ver,
-                   shell=True, check=True, capture_output=True)
+    subprocess.run(
+        work_dir
+        + "/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh opensearch "
+        + manifest_build_ver,
+        shell=True,
+        check=True,
+        capture_output=True,
+    )
+    os.chdir(work_dir + "/common-utils")
+    subprocess.run(
+        work_dir
+        + "/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh common-utils "
+        + manifest_build_ver,
+        shell=True,
+        check=True,
+        capture_output=True,
+    )
 
 
 def main():
@@ -79,11 +103,19 @@ def main():
         sync_dependencies_to_maven_local(work_dir, build_manifest.build.version)
         for component in bundle_manifest.components:
             if component.name in integ_test_config.keys():
-                test_suite = IntegTestSuite(component, integ_test_config[component.name], bundle_manifest, work_dir)
+                test_suite = IntegTestSuite(
+                    component,
+                    integ_test_config[component.name],
+                    bundle_manifest,
+                    work_dir,
+                )
                 test_suite.execute()
             else:
-                print('Skipping tests for %s, as it is currently not supported' % component.name)
+                print(
+                    "Skipping tests for %s, as it is currently not supported"
+                    % component.name
+                )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/bundle-workflow/src/test_workflow/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test_suite.py
@@ -20,6 +20,7 @@ class IntegTestSuite:
     Kicks of integration tests for a component based on test configurations provided in
     test_support_matrix.yml
     """
+
     def __init__(self, component, test_config, bundle_manifest, work_dir):
         self.component = component
         self.bundle_manifest = bundle_manifest
@@ -27,32 +28,48 @@ class IntegTestSuite:
         self.test_config = test_config
         self.script_finder = ScriptFinder()
         self.test_recorder = TestRecorder(os.path.dirname(bundle_manifest.name))
-        self.repo = GitRepository(self.component.repository, self.component.commit_id, os.path.join(self.work_dir, self.component.name))
+        self.repo = GitRepository(
+            self.component.repository,
+            self.component.commit_id,
+            os.path.join(self.work_dir, self.component.name),
+        )
 
     def execute(self):
         self._fetch_plugin_specific_dependencies()
-        for config in self.test_config.integ_test['test-configs']:
+        for config in self.test_config.integ_test["test-configs"]:
             self._setup_cluster_and_execute_test_config(config)
 
     # TODO: fetch pre-built dependencies from s3
     def _fetch_plugin_specific_dependencies(self):
         os.chdir(self.work_dir)
-        subprocess.run('mv -v job-scheduler ' + self.component.name, shell=True, check=True)
-        os.chdir(self.work_dir + '/' + self.component.name + '/job-scheduler')
-        subprocess.run(self.work_dir
-                       + '/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh job-scheduler '
-                       + self.bundle_manifest.build.version, shell=True, check=True, capture_output=True)
+        subprocess.run(
+            "mv -v job-scheduler " + self.component.name, shell=True, check=True
+        )
+        os.chdir(self.work_dir + "/" + self.component.name + "/job-scheduler")
+        subprocess.run(
+            self.work_dir
+            + "/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh job-scheduler "
+            + self.bundle_manifest.build.version,
+            shell=True,
+            check=True,
+            capture_output=True,
+        )
         os.chdir(self.work_dir)
-        subprocess.run('mv alerting notifications', shell=True, check=True)
-        os.chdir(self.work_dir + '/' + '/notifications')
-        subprocess.run(self.work_dir
-                       + '/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh alerting '
-                       + self.bundle_manifest.build.version, shell=True, check=True, capture_output=True)
+        subprocess.run("mv alerting notifications", shell=True, check=True)
+        os.chdir(self.work_dir + "/" + "/notifications")
+        subprocess.run(
+            self.work_dir
+            + "/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh alerting "
+            + self.bundle_manifest.build.version,
+            shell=True,
+            check=True,
+            capture_output=True,
+        )
 
     # TODO: revisit this once the test_manifest.yml is finalized
     def _is_security_enabled(self, config):
         # TODO: Separate this logic in function once we have test-configs defined
-        if config == 'with-security':
+        if config == "with-security":
             return True
         else:
             return False
@@ -71,7 +88,9 @@ class IntegTestSuite:
             cluster.destroy()
 
     def _execute_integtest_sh(self, cluster, security):
-        script = self.script_finder.find_integ_test_script(self.component.name, self.repo.dir)
+        script = self.script_finder.find_integ_test_script(
+            self.component.name, self.repo.dir
+        )
         if os.path.exists(script):
             cmd = f"sh {script} -b {cluster.endpoint()} -p {cluster.port()} -s {str(security).lower()}"
             (status, stdout, stderr) = execute(cmd, self.repo.dir, True, False)

--- a/bundle-workflow/src/test_workflow/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test_suite.py
@@ -46,10 +46,12 @@ class IntegTestSuite:
             "mv -v job-scheduler " + self.component.name, shell=True, check=True
         )
         os.chdir(self.work_dir + "/" + self.component.name + "/job-scheduler")
+        deps_script = os.path.join(
+            self.work_dir,
+            "opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh",
+        )
         subprocess.run(
-            self.work_dir
-            + "/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh job-scheduler "
-            + self.bundle_manifest.build.version,
+            f"{deps_script} job-scheduler {self.bundle_manifest.build.version}",
             shell=True,
             check=True,
             capture_output=True,
@@ -58,9 +60,7 @@ class IntegTestSuite:
         subprocess.run("mv alerting notifications", shell=True, check=True)
         os.chdir(self.work_dir + "/" + "/notifications")
         subprocess.run(
-            self.work_dir
-            + "/opensearch-build/tools/standard-test/integtest_dependencies_opensearch.sh alerting "
-            + self.bundle_manifest.build.version,
+            f"{deps_script} alerting {self.bundle_manifest.build.version}",
             shell=True,
             check=True,
             capture_output=True,

--- a/bundle-workflow/tests/tests_build_workflow/test_builder.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_builder.py
@@ -15,9 +15,7 @@ from paths.script_finder import ScriptFinder
 class TestBuilder(unittest.TestCase):
     def setUp(self):
         self.builder = Builder(
-            "component",
-            MagicMock(dir="/tmp/checked-out-component"),
-            MagicMock(),
+            "component", MagicMock(dir="/tmp/checked-out-component"), MagicMock()
         )
 
     def test_builder(self):


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Fixes build from #338 by running `pipenv run black .` in bundle-workflow.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
