### PR TITLE
Check versions and file names in plugin and maven artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ coverage.xml
 .settings/
 out.txt
 
-./artifacts/
-./bundle/
-./bundle-workflow/artifacts/
-./bundle-workflow/bundle/
+/artifacts/
+/bundle/
+/bundle-workflow/artifacts/
+/bundle-workflow/bundle/

--- a/bundle-workflow/Pipfile
+++ b/bundle-workflow/Pipfile
@@ -14,6 +14,7 @@ mypy = "~=0.9"
 pytest = "*"
 coverage = "~=4.5.4"
 pytest-cov = "~=2.10.0"
+jproperties = "~=2.1.1"
 
 [dev-packages]
 

--- a/bundle-workflow/Pipfile.lock
+++ b/bundle-workflow/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b4840c9424722e9642781af29b98e7d256bb399aa9052f3eccb7849f7f7c2291"
+            "sha256": "07e4a8897c8984329cf5ca621b60f9b63593b2326439f3695311f46fa6b080ae"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -95,11 +95,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:9e04bf59076a15a9b6dd9c27806e8fcdf15280ba529c6a8cc3f4d5b4875bdd61",
-                "sha256:c4eb3dec5f697682e383a39701a7de11cd5c02daf8dd93534b69e3e6473f6b1b"
+                "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
+                "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==4.7.1"
+            "version": "==4.8.1"
         },
         "iniconfig": {
             "hashes": [
@@ -115,6 +115,14 @@
             ],
             "index": "pypi",
             "version": "==5.9.3"
+        },
+        "jproperties": {
+            "hashes": [
+                "sha256:40b71124e8d257e8954899a91cd2d5c0f72e0f67f1b72048a5ba264567604f29",
+                "sha256:4dfcd7cab56d9c79bce4453f7ca9ffbe0ff0574ddcf1c2a99a8646df60634664"
+            ],
+            "index": "pypi",
+            "version": "==2.1.1"
         },
         "mccabe": {
             "hashes": [
@@ -169,11 +177,11 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.13.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
         },
         "py": {
             "hashes": [
@@ -209,11 +217,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
-                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
+                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
             ],
             "index": "pypi",
-            "version": "==6.2.4"
+            "version": "==6.2.5"
         },
         "pytest-cov": {
             "hashes": [
@@ -266,6 +274,14 @@
             "index": "pypi",
             "version": "==2.26.0"
         },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
@@ -312,11 +328,11 @@
         },
         "types-pyyaml": {
             "hashes": [
-                "sha256:e084cfc878c8c8b1d4e89011ae5d65ea962fc5745c3d08b931df2aaaa665de96",
-                "sha256:f00ad122a78a7d41b0ad4e3fa481751c2b9bc3f34b8f71ea35232211057dd50f"
+                "sha256:1d9e431e9f1f78a65ea957c558535a3b15ad67ea4912bce48a6c1b613dcf81ad",
+                "sha256:f1d1357168988e45fa20c65aecb3911462246a84809015dd889ebf8b1db74124"
             ],
             "index": "pypi",
-            "version": "==5.4.8"
+            "version": "==5.4.10"
         },
         "types-requests": {
             "hashes": [
@@ -328,12 +344,12 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497",
-                "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342",
-                "sha256:779383f6086d90c99ae41cf0ff39aac8a7937a9283ce0a414e5dd782f4c94a84"
+                "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e",
+                "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
+                "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==3.10.0.0"
+            "version": "==3.10.0.2"
         },
         "urllib3": {
             "hashes": [

--- a/bundle-workflow/src/build_workflow/build_recorder.py
+++ b/bundle-workflow/src/build_workflow/build_recorder.py
@@ -5,7 +5,9 @@
 # compatible open source license.
 
 import os
+import re
 import shutil
+from zipfile import ZipFile
 
 import yaml
 
@@ -13,15 +15,56 @@ from manifests.build_manifest import BuildManifest
 
 
 class BuildRecorder:
+    class ArtifactInvalidError(Exception):
+        def __init__(self, path, message):
+            self.path = path
+            super().__init__(
+                f"Artifact {os.path.basename(path)} is invalid: {message}."
+            )
+
+    class PropertiesFile:
+        def __init__(self, filename, data):
+            self.filename = filename
+            self.data = data
+
+        def get_value(self, key):
+            result = re.findall(f"^{key}=(.*)$", self.data, re.MULTILINE)
+            return result[0] if result else None
+
+        def check_value(self, key, expected_value):
+            value = self.get_value(key)
+            if not value:
+                raise BuildRecorder.ArtifactInvalidError(
+                    self.filename,
+                    f"expected to have {key}={expected_value}, but none was found",
+                )
+            elif value != expected_value:
+                raise BuildRecorder.ArtifactInvalidError(
+                    self.filename,
+                    f"expected to have {key}={expected_value}, but was {value}",
+                )
+
     def __init__(self, build_id, output_dir, name, version, arch, snapshot):
         self.output_dir = output_dir
+        self.version = str(version)
+        self.opensearch_version = (
+            self.version + "-SNAPSHOT" if snapshot else self.version
+        )
+        # BUG: the 4th digit is dictated by the component, it's not .0, this will break for 1.1.0.1
+        self.component_version = (
+            self.version + ".0-SNAPSHOT" if snapshot else f"{self.version}.0"
+        )
         self.build_manifest = self.BuildManifestBuilder(
-            build_id, name, version, arch, snapshot
+            build_id, name, self.opensearch_version, arch, snapshot
         )
 
     def record_component(self, component_name, git_repo):
         self.build_manifest.append_component(
-            component_name, git_repo.url, git_repo.ref, git_repo.sha
+            component_name,
+            self.component_version,
+            git_repo.url,
+            git_repo.ref,
+            git_repo.sha,
         )
 
     def record_artifact(
@@ -34,6 +77,8 @@ class BuildRecorder:
         dest_file = os.path.join(self.output_dir, artifact_path)
         dest_dir = os.path.dirname(dest_file)
         os.makedirs(dest_dir, exist_ok=True)
+        # Check artifact
+        self.__check_artifact(artifact_type, artifact_file)
         # Copy the file
         shutil.copyfile(artifact_file, dest_file)
         # Notify the recorder
@@ -50,15 +95,35 @@ class BuildRecorder:
         with open(manifest_path, "w") as file:
             yaml.dump(output_manifest.to_dict(), file)
 
+    def __check_artifact(self, artifact_type, artifact_file):
+        if artifact_type == "plugins":
+            self.__check_plugin_artifact(artifact_file)
+        elif artifact_type == "maven":
+            self.__check_maven_artifact(artifact_file)
+
+    def __check_plugin_artifact(self, artifact_file):
+        if os.path.splitext(artifact_file)[1] != ".zip":
+            raise BuildRecorder.ArtifactInvalidError(artifact_file, "not a zip file")
+        if not artifact_file.endswith(f"-{self.component_version}.zip"):
+            raise BuildRecorder.ArtifactInvalidError(
+                artifact_file, f"expected filename to include {self.component_version}"
+            )
+        with ZipFile(artifact_file, "r") as zip:
+            data = zip.read("plugin-descriptor.properties").decode("UTF-8")
+            properties = BuildRecorder.PropertiesFile(artifact_file, data)
+            properties.check_value("version", self.component_version)
+            properties.check_value("opensearch.version", self.version)
+
+    def __check_maven_artifact(self, artifact_file):
+        pass
+
     class BuildManifestBuilder:
         def __init__(self, build_id, name, version, arch, snapshot):
             self.data = {}
             self.data["build"] = {}
             self.data["build"]["id"] = build_id
             self.data["build"]["name"] = name
-            self.data["build"]["version"] = (
-                str(version) + "-SNAPSHOT" if snapshot else str(version)
-            )
+            self.data["build"]["version"] = version
             self.data["build"]["architecture"] = arch
             self.data["build"]["snapshot"] = str(snapshot).lower()
             self.data["schema-version"] = "1.0"
@@ -66,13 +131,14 @@ class BuildRecorder:
             # When we convert to a BuildManifest this will get converted back into a list
             self.data["components_hash"] = {}
 
-        def append_component(self, name, repository_url, ref, commit_id):
+        def append_component(self, name, version, repository_url, ref, commit_id):
             component = {
                 "name": name,
                 "repository": repository_url,
                 "ref": ref,
                 "commit_id": commit_id,
                 "artifacts": {},
+                "version": version,
             }
             self.data["components_hash"][name] = component
 

--- a/bundle-workflow/src/manifests/build_manifest.py
+++ b/bundle-workflow/src/manifests/build_manifest.py
@@ -76,6 +76,7 @@ class BuildManifest(Manifest):
             self.ref = data["ref"]
             self.commit_id = data["commit_id"]
             self.artifacts = data["artifacts"]
+            self.version = data["version"]
 
         def to_dict(self):
             return {
@@ -84,4 +85,5 @@ class BuildManifest(Manifest):
                 "ref": self.ref,
                 "commit_id": self.commit_id,
                 "artifacts": self.artifacts,
+                "version": self.version,
             }

--- a/bundle-workflow/tests/tests_assemble_workflow/data/opensearch-build-1.1.0.yml
+++ b/bundle-workflow/tests/tests_assemble_workflow/data/opensearch-build-1.1.0.yml
@@ -1,6 +1,6 @@
 build:
   architecture: x64
-  id: f39b2d68f8b74389a0037f3e8d6ba0b0
+  id: c3ff7a232d25403fa8cc14c97799c323
   name: OpenSearch
   version: 1.1.0
 components:
@@ -2329,10 +2329,11 @@ components:
     - maven/org/opensearch/script-expert-scoring/1.1.0/script-expert-scoring-1.1.0.jar.sha256
     - maven/org/opensearch/script-expert-scoring/1.1.0/script-expert-scoring-1.1.0.jar
     - maven/org/opensearch/script-expert-scoring/1.1.0/script-expert-scoring-1.1.0.module.sha256
-  commit_id: 07a57d9bbb3922079b7bb1be83a01252f57f81ec
+  commit_id: b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583
   name: OpenSearch
   ref: 1.x
   repository: https://github.com/opensearch-project/OpenSearch.git
+  version: 1.1.0.0
 - artifacts:
     maven:
     - maven/org/opensearch/common-utils/maven-metadata-local.xml
@@ -2344,6 +2345,7 @@ components:
   name: common-utils
   ref: main
   repository: https://github.com/opensearch-project/common-utils.git
+  version: 1.1.0.0
 - artifacts:
     maven:
     - maven/org/opensearch/opensearch-job-scheduler/maven-metadata-local.xml
@@ -2363,34 +2365,45 @@ components:
   name: job-scheduler
   ref: main
   repository: https://github.com/opensearch-project/job-scheduler.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-sql-1.1.0.0.zip
-  commit_id: 9ada74383a812baf534af8984a276303e4619574
+  commit_id: d68547d585092af1e053d01e1b834259723cd304
   name: sql
   ref: main
   repository: https://github.com/opensearch-project/sql.git
+  version: 1.1.0.0
 - artifacts:
+    maven:
+    - maven/org/opensearch/notification/maven-metadata-local.xml
+    - maven/org/opensearch/notification/1.1.0.0/notification-1.1.0.0-sources.jar
+    - maven/org/opensearch/notification/1.1.0.0/notification-1.1.0.0.pom
+    - maven/org/opensearch/notification/1.1.0.0/notification-1.1.0.0.jar
+    - maven/org/opensearch/notification/1.1.0.0/notification-1.1.0.0-javadoc.jar
     plugins:
     - plugins/opensearch-alerting-1.1.0.0.zip
-  commit_id: ecd283f5c7eac51902a43ef577e44fdccdc0e5ae
+  commit_id: 8024b8b9195f837e49e5bebd7f4a31dfc333eb4d
   name: alerting
   ref: main
   repository: https://github.com/opensearch-project/alerting.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-notifications-1.1.0.0.zip
-  commit_id: 7efc43a0a2f6829b170909ede56d70434d32ab1d
+  commit_id: d0d3e485c4a850f73652a989eeec795b7347fbb6
   name: notifications
   ref: main
   repository: https://github.com/opensearch-project/notifications.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-security-1.1.0.0.zip
-  commit_id: 25383effb9b7eeb3718e1fd7288e388a074568bf
+  commit_id: 534fffe0e6cf2b33b9abcbc6508e98fc2d077a3d
   name: security
-  ref: fix-snapshot-build
-  repository: https://github.com/dblock/security.git
+  ref: main
+  repository: https://github.com/opensearch-project/security.git
+  version: 1.1.0.0
 - artifacts:
     maven:
     - maven/org/opensearch/performanceanalyzer-rca/maven-metadata-local.xml
@@ -2401,6 +2414,7 @@ components:
   name: performance-analyzer-rca
   ref: main
   repository: https://github.com/opensearch-project/performance-analyzer-rca.git
+  version: 1.1.0.0
 - artifacts:
     maven:
     - maven/org/opensearch/opensearch-performance-analyzer/maven-metadata-local.xml
@@ -2411,17 +2425,19 @@ components:
     - maven/org/opensearch/opensearch-performance-analyzer/1.1.0.0/opensearch-performance-analyzer-1.1.0.0-sources.jar
     plugins:
     - plugins/opensearch-performance-analyzer-1.1.0.0.zip
-  commit_id: 95c2b6c7054f3e52df5d31d7859515b19bc95b59
+  commit_id: f184f0bc39302ac38af2585c663d619048f6cffe
   name: performance-analyzer
   ref: main
   repository: https://github.com/opensearch-project/performance-analyzer.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-index-management-1.1.0.0.zip
-  commit_id: ec0578934bae1fdee31ead07500ae8cee633c6d7
+  commit_id: 7897e9ae9cd5b49535e6a8bbf4c2f73cb458af24
   name: index-management
   ref: main
   repository: https://github.com/opensearch-project/index-management.git
+  version: 1.1.0.0
 - artifacts:
     libs:
     - libs/libKNNIndexV2_0_11.so
@@ -2431,13 +2447,15 @@ components:
   name: k-NN
   ref: main
   repository: https://github.com/opensearch-project/k-NN.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-anomaly-detection-1.1.0.0.zip
-  commit_id: b5d02ebfffab35a3918c3b603da328584497b589
+  commit_id: bedc5b620384163abe272e913705fa23cfd3b3a3
   name: anomaly-detection
   ref: main
   repository: https://github.com/opensearch-project/anomaly-detection.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-asynchronous-search-1.1.0.0.zip
@@ -2445,18 +2463,21 @@ components:
   name: asynchronous-search
   ref: main
   repository: https://github.com/opensearch-project/asynchronous-search.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-reports-scheduler-1.1.0.0.zip
-  commit_id: edc55c09fc337117c04adeef51f5d2ddc54bd9df
+  commit_id: 622f334b0724e47f7ffd21cf7e7d521a9f6c949e
   name: dashboards-reports
   ref: main
   repository: https://github.com/opensearch-project/dashboards-reports.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-notebooks-1.1.0.0.zip
-  commit_id: 0016edddcb670b9ae93693623d37af5944921794
+  commit_id: 5a996eb8ec8c92e7469cd5e5f87b237352f60f61
   name: dashboards-notebooks
   ref: main
   repository: https://github.com/opensearch-project/dashboards-notebooks.git
+  version: 1.1.0.0
 schema-version: '1.0'

--- a/bundle-workflow/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/bundle-workflow/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -41,7 +41,7 @@ class TestBundleRecorder(unittest.TestCase):
             {
                 "build": {
                     "architecture": "x64",
-                    "id": "f39b2d68f8b74389a0037f3e8d6ba0b0",
+                    "id": "c3ff7a232d25403fa8cc14c97799c323",
                     "location": "output_dir/opensearch-1.1.0-linux-x64.tar.gz",
                     "name": "OpenSearch",
                     "version": "1.1.0",
@@ -67,7 +67,7 @@ class TestBundleRecorder(unittest.TestCase):
             {
                 "build": {
                     "architecture": "x64",
-                    "id": "f39b2d68f8b74389a0037f3e8d6ba0b0",
+                    "id": "c3ff7a232d25403fa8cc14c97799c323",
                     "location": "output_dir/opensearch-1.1.0-linux-x64.tar.gz",
                     "name": "OpenSearch",
                     "version": "1.1.0",

--- a/bundle-workflow/tests/tests_build_workflow/test_build_recorder_snapshot.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_build_recorder_snapshot.py
@@ -112,4 +112,6 @@ class TestBuildRecorderSnapshot(unittest.TestCase):
             )
             manifest_dict = self.build_recorder.get_manifest().to_dict()
             self.assertEqual(manifest_dict["build"]["version"], "1.1.0-SNAPSHOT")
-            self.assertEqual(manifest_dict["components"][0]["version"], "1.1.0.0-SNAPSHOT")
+            self.assertEqual(
+                manifest_dict["components"][0]["version"], "1.1.0.0-SNAPSHOT"
+            )

--- a/bundle-workflow/tests/tests_manifests/data/opensearch-build-1.1.0.yml
+++ b/bundle-workflow/tests/tests_manifests/data/opensearch-build-1.1.0.yml
@@ -1,6 +1,6 @@
 build:
   architecture: x64
-  id: f39b2d68f8b74389a0037f3e8d6ba0b0
+  id: c3ff7a232d25403fa8cc14c97799c323
   name: OpenSearch
   version: 1.1.0
 components:
@@ -2329,10 +2329,11 @@ components:
     - maven/org/opensearch/script-expert-scoring/1.1.0/script-expert-scoring-1.1.0.jar.sha256
     - maven/org/opensearch/script-expert-scoring/1.1.0/script-expert-scoring-1.1.0.jar
     - maven/org/opensearch/script-expert-scoring/1.1.0/script-expert-scoring-1.1.0.module.sha256
-  commit_id: 07a57d9bbb3922079b7bb1be83a01252f57f81ec
+  commit_id: b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583
   name: OpenSearch
   ref: 1.x
   repository: https://github.com/opensearch-project/OpenSearch.git
+  version: 1.1.0.0
 - artifacts:
     maven:
     - maven/org/opensearch/common-utils/maven-metadata-local.xml
@@ -2344,6 +2345,7 @@ components:
   name: common-utils
   ref: main
   repository: https://github.com/opensearch-project/common-utils.git
+  version: 1.1.0.0
 - artifacts:
     maven:
     - maven/org/opensearch/opensearch-job-scheduler/maven-metadata-local.xml
@@ -2363,34 +2365,45 @@ components:
   name: job-scheduler
   ref: main
   repository: https://github.com/opensearch-project/job-scheduler.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-sql-1.1.0.0.zip
-  commit_id: 9ada74383a812baf534af8984a276303e4619574
+  commit_id: d68547d585092af1e053d01e1b834259723cd304
   name: sql
   ref: main
   repository: https://github.com/opensearch-project/sql.git
+  version: 1.1.0.0
 - artifacts:
+    maven:
+    - maven/org/opensearch/notification/maven-metadata-local.xml
+    - maven/org/opensearch/notification/1.1.0.0/notification-1.1.0.0-sources.jar
+    - maven/org/opensearch/notification/1.1.0.0/notification-1.1.0.0.pom
+    - maven/org/opensearch/notification/1.1.0.0/notification-1.1.0.0.jar
+    - maven/org/opensearch/notification/1.1.0.0/notification-1.1.0.0-javadoc.jar
     plugins:
     - plugins/opensearch-alerting-1.1.0.0.zip
-  commit_id: ecd283f5c7eac51902a43ef577e44fdccdc0e5ae
+  commit_id: 8024b8b9195f837e49e5bebd7f4a31dfc333eb4d
   name: alerting
   ref: main
   repository: https://github.com/opensearch-project/alerting.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-notifications-1.1.0.0.zip
-  commit_id: 7efc43a0a2f6829b170909ede56d70434d32ab1d
+  commit_id: d0d3e485c4a850f73652a989eeec795b7347fbb6
   name: notifications
   ref: main
   repository: https://github.com/opensearch-project/notifications.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-security-1.1.0.0.zip
-  commit_id: 25383effb9b7eeb3718e1fd7288e388a074568bf
+  commit_id: 534fffe0e6cf2b33b9abcbc6508e98fc2d077a3d
   name: security
-  ref: fix-snapshot-build
-  repository: https://github.com/dblock/security.git
+  ref: main
+  repository: https://github.com/opensearch-project/security.git
+  version: 1.1.0.0
 - artifacts:
     maven:
     - maven/org/opensearch/performanceanalyzer-rca/maven-metadata-local.xml
@@ -2401,6 +2414,7 @@ components:
   name: performance-analyzer-rca
   ref: main
   repository: https://github.com/opensearch-project/performance-analyzer-rca.git
+  version: 1.1.0.0
 - artifacts:
     maven:
     - maven/org/opensearch/opensearch-performance-analyzer/maven-metadata-local.xml
@@ -2411,17 +2425,19 @@ components:
     - maven/org/opensearch/opensearch-performance-analyzer/1.1.0.0/opensearch-performance-analyzer-1.1.0.0-sources.jar
     plugins:
     - plugins/opensearch-performance-analyzer-1.1.0.0.zip
-  commit_id: 95c2b6c7054f3e52df5d31d7859515b19bc95b59
+  commit_id: f184f0bc39302ac38af2585c663d619048f6cffe
   name: performance-analyzer
   ref: main
   repository: https://github.com/opensearch-project/performance-analyzer.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-index-management-1.1.0.0.zip
-  commit_id: ec0578934bae1fdee31ead07500ae8cee633c6d7
+  commit_id: 7897e9ae9cd5b49535e6a8bbf4c2f73cb458af24
   name: index-management
   ref: main
   repository: https://github.com/opensearch-project/index-management.git
+  version: 1.1.0.0
 - artifacts:
     libs:
     - libs/libKNNIndexV2_0_11.so
@@ -2431,13 +2447,15 @@ components:
   name: k-NN
   ref: main
   repository: https://github.com/opensearch-project/k-NN.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-anomaly-detection-1.1.0.0.zip
-  commit_id: b5d02ebfffab35a3918c3b603da328584497b589
+  commit_id: bedc5b620384163abe272e913705fa23cfd3b3a3
   name: anomaly-detection
   ref: main
   repository: https://github.com/opensearch-project/anomaly-detection.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-asynchronous-search-1.1.0.0.zip
@@ -2445,18 +2463,21 @@ components:
   name: asynchronous-search
   ref: main
   repository: https://github.com/opensearch-project/asynchronous-search.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-reports-scheduler-1.1.0.0.zip
-  commit_id: edc55c09fc337117c04adeef51f5d2ddc54bd9df
+  commit_id: 622f334b0724e47f7ffd21cf7e7d521a9f6c949e
   name: dashboards-reports
   ref: main
   repository: https://github.com/opensearch-project/dashboards-reports.git
+  version: 1.1.0.0
 - artifacts:
     plugins:
     - plugins/opensearch-notebooks-1.1.0.0.zip
-  commit_id: 0016edddcb670b9ae93693623d37af5944921794
+  commit_id: 5a996eb8ec8c92e7469cd5e5f87b237352f60f61
   name: dashboards-notebooks
   ref: main
   repository: https://github.com/opensearch-project/dashboards-notebooks.git
+  version: 1.1.0.0
 schema-version: '1.0'

--- a/bundle-workflow/tests/tests_manifests/data/opensearch-bundle-1.1.0.yml
+++ b/bundle-workflow/tests/tests_manifests/data/opensearch-bundle-1.1.0.yml
@@ -1,11 +1,11 @@
 build:
   architecture: x64
-  id: f39b2d68f8b74389a0037f3e8d6ba0b0
+  id: c3ff7a232d25403fa8cc14c97799c323
   location: bundle/opensearch-1.1.0-linux-x64.tar.gz
   name: OpenSearch
   version: 1.1.0
 components:
-- commit_id: 07a57d9bbb3922079b7bb1be83a01252f57f81ec
+- commit_id: b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583
   location: artifacts/bundle/opensearch-min-1.1.0-linux-x64.tar.gz
   name: OpenSearch
   ref: 1.x

--- a/bundle-workflow/tests/tests_manifests/test_build_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_build_manifest.py
@@ -36,7 +36,7 @@ class TestBuildManifest(unittest.TestCase):
             "https://github.com/opensearch-project/OpenSearch.git",
         )
         self.assertEqual(
-            opensearch_component.commit_id, "07a57d9bbb3922079b7bb1be83a01252f57f81ec"
+            opensearch_component.commit_id, "b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583"
         )
         self.assertEqual(opensearch_component.ref, "1.x")
         self.assertEqual(

--- a/bundle-workflow/tests/tests_manifests/test_bundle_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_bundle_manifest.py
@@ -45,7 +45,7 @@ class TestBundleManifest(unittest.TestCase):
         )
         self.assertEqual(
             opensearch_min_component.commit_id,
-            "07a57d9bbb3922079b7bb1be83a01252f57f81ec",
+            "b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583",
         )
         self.assertEqual(opensearch_min_component.ref, "1.x")
 

--- a/bundle-workflow/tests/tests_manifests/test_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_manifest.py
@@ -17,10 +17,10 @@ class TestManifest(unittest.TestCase):
     def test_manifest_is_abstract(self):
         with self.assertRaises(TypeError) as context:
             Manifest(None)
-            self.assertEqual(
-                "Can't instantiate abstract class Manifest with abstract methods __init__",
-                context.exception.__str__(),
-            )
+        self.assertEqual(
+            "Can't instantiate abstract class Manifest with abstract methods __init__",
+            context.exception.__str__(),
+        )
 
     def test_invalid_version(self):
         class TestManifest(Manifest):
@@ -31,6 +31,6 @@ class TestManifest(unittest.TestCase):
 
         with self.assertRaises(ValueError) as context:
             TestManifest.from_path(manifest_path)
-            self.assertEqual(
-                "Unsupported schema version: invalid", context.exception.__str__()
-            )
+        self.assertEqual(
+            "Unsupported schema version: invalid", context.exception.__str__()
+        )


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

1. Adds component versions to the build manifest.
2. Checks versions and file names in plugin artifacts. Ensures that the plugin-descriptor.properties is built against the OpenSearch version being built, and that its own version matches the filename. 
3. Checks versions and file extensions in maven artifacts. Ensures that the MANIFEST.mf contains the correct `Implementation-Version`, if any. Some components like common-utils do not have this at all, will open an issue whether we need all of them to have it.

### Issues Resolved

Closes #137. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
