### PR TITLE
Adding bwc_test.py as a single entry point for bwc tests and cleanup

### DIFF
--- a/bundle-workflow/src/bwc_test.py
+++ b/bundle-workflow/src/bwc_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+from manifests.bundle_manifest import BundleManifest
+from system.temporary_directory import TemporaryDirectory
+from test_workflow.bwc_test_suite import BwcTestSuite
+from test_workflow.test_args import TestArgs
+
+
+def main():
+    args = TestArgs()
+    manifest = BundleManifest.from_file(args.manifest)
+    with TemporaryDirectory(keep=args.keep) as work_dir:
+        os.chdir(work_dir)
+        # For each component, check out the git repo and run `bwctest.sh`
+        for component in manifest.components:
+            if args.component is None or args.component == component.name:
+                # TODO: Store and report test results, send notification via {console_output}
+                BwcTestSuite(manifest, component, work_dir).component_bwc_tests()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bundle-workflow/src/test.py
+++ b/bundle-workflow/src/test.py
@@ -6,21 +6,11 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import os
+import sys
+import bwc_test
 
-from manifests.bundle_manifest import BundleManifest
-from test_workflow.bwc_test_suite import BwcTestSuite
-from test_workflow.test_args import TestArgs
-from test_workflow.test_recorder import TestRecorder
+def main():
+    bwc_test.main()
 
-args = TestArgs()
-manifest = BundleManifest.from_file(args.manifest)
-test_recorder = TestRecorder(os.path.dirname(manifest.name))
-
-
-def bwc_test_suite():
-    test_suite = BwcTestSuite(manifest, args.component, args.keep)
-    test_suite.execute()
-
-
-bwc_test_suite()
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bundle-workflow/src/test.py
+++ b/bundle-workflow/src/test.py
@@ -7,10 +7,13 @@
 # compatible open source license.
 
 import sys
+
 import bwc_test
+
 
 def main():
     bwc_test.main()
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/bundle-workflow/src/test_workflow/bwc_test_suite.py
+++ b/bundle-workflow/src/test_workflow/bwc_test_suite.py
@@ -10,42 +10,32 @@
 import os
 import subprocess
 
-from system.temporary_directory import TemporaryDirectory
 from test_workflow.test_component import TestComponent
 
 
 class BwcTestSuite:
     manifest: str
     component: str
-    keep: bool
+    work_dir: str
 
-    def __init__(self, manifest, component, keep):
+    def __init__(self, manifest, component, work_dir):
         self.manifest = manifest
         self.component = component
-        self.keep = keep
+        self.work_dir = work_dir
 
     def run_tests(self, work_dir):
-        bwc_script = "bwctest.sh"
-        run_bwctests = f"./{bwc_script}"
+        run_bwctests = f"./bwctest.sh"
         output = subprocess.check_output(run_bwctests, cwd=work_dir, shell=True)
         return output
 
-    def component_bwc_tests(self, component, work_dir):
-        test_component = TestComponent(component.repository, component.commit_id)
-        test_component.checkout(os.path.join(work_dir, component.name))
+    def component_bwc_tests(self):
+        test_component = TestComponent(
+            self.component.repository, self.component.commit_id
+        )
+        test_component.checkout(os.path.join(self.work_dir, self.component.name))
         try:
-            console_output = self.run_tests(work_dir + "/" + component.name)
+            console_output = self.run_tests(self.work_dir + "/" + self.component.name)
             return console_output
         except:
             # TODO: Store and report test failures for {component}
-            print(f"Exception while running BWC tests for {component.name}")
-
-    def execute(self):
-        # TODO copy all maven dependencies from S3 to local
-        with TemporaryDirectory(keep=self.keep) as work_dir:
-            os.chdir(work_dir)
-            # For each component, check out the git repo and run `bwctest.sh`
-            for component in self.manifest.components:
-                if self.component is None or self.component == component.name:
-                    # TODO: Store and report test results, send notification via {console_output}
-                    self.component_bwc_tests(component, work_dir)
+            print(f"Exception while running BWC tests for {self.component.name}")

--- a/bundle-workflow/src/test_workflow/bwc_test_suite.py
+++ b/bundle-workflow/src/test_workflow/bwc_test_suite.py
@@ -24,7 +24,7 @@ class BwcTestSuite:
         self.work_dir = work_dir
 
     def run_tests(self, work_dir):
-        run_bwctests = f"./bwctest.sh"
+        run_bwctests = "./bwctest.sh"
         output = subprocess.check_output(run_bwctests, cwd=work_dir, shell=True)
         return output
 

--- a/bundle-workflow/tests/test_bwc_workflow/test_bwc_suite.py
+++ b/bundle-workflow/tests/test_bwc_workflow/test_bwc_suite.py
@@ -19,19 +19,8 @@ class TestBwcSuite(unittest.TestCase):
         manifest_file_handle = open("data/test_manifest.yaml", "r")
         self.manifest = BundleManifest.from_file(manifest_file_handle)
         self.bwc_test_suite = BwcTestSuite(
-            manifest=self.manifest, component=None, keep=False
-        )
+            manifest=self.manifest, component=self.manifest.components[1], work_dir=".")
         manifest_file_handle.close()
-
-    def test_execute(self):
-        expected = []
-        for component in self.manifest.components:
-            expected.append(call(component, ANY))
-        self.bwc_test_suite.component_bwc_tests = MagicMock()
-        self.bwc_test_suite.execute()
-        self.assertEqual(
-            self.bwc_test_suite.component_bwc_tests.call_args_list, expected
-        )
 
     def test_run_bwctest(self):
         with self.assertRaises(subprocess.CalledProcessError) as process_ret:
@@ -46,7 +35,7 @@ class TestBwcSuite(unittest.TestCase):
         self.bwc_test_suite.run_tests = MagicMock()
         expected = [call("./" + self.manifest.components[1].name)]
 
-        self.bwc_test_suite.component_bwc_tests(component, ".")
+        self.bwc_test_suite.component_bwc_tests()
         test_component_mock.return_value.checkout.assert_called_with(
             "./" + component.name
         )

--- a/bundle-workflow/tests/test_bwc_workflow/test_bwc_suite.py
+++ b/bundle-workflow/tests/test_bwc_workflow/test_bwc_suite.py
@@ -7,7 +7,7 @@
 import os
 import subprocess
 import unittest
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import MagicMock, call, patch
 
 from manifests.bundle_manifest import BundleManifest
 from test_workflow.bwc_test_suite import BwcTestSuite
@@ -19,7 +19,8 @@ class TestBwcSuite(unittest.TestCase):
         manifest_file_handle = open("data/test_manifest.yaml", "r")
         self.manifest = BundleManifest.from_file(manifest_file_handle)
         self.bwc_test_suite = BwcTestSuite(
-            manifest=self.manifest, component=self.manifest.components[1], work_dir=".")
+            manifest=self.manifest, component=self.manifest.components[1], work_dir="."
+        )
         manifest_file_handle.close()
 
     def test_run_bwctest(self):


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Adding bwc_test.py as a single entry point for bwc tests and cleanup
 
### Issues Resolved
Closes #275 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
