### PR TITLE
Replace print with a console logger

### DIFF
--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -1,12 +1,12 @@
 - [OpenSearch Bundle Workflow](#opensearch-bundle-workflow)
-    - [Build from Source](#build-from-source)
-        - [Custom Build Scripts](#custom-build-scripts)
-    - [Assemble the Bundle](#assemble-the-bundle)
-        - [Custom Install Scripts](#custom-install-scripts)
-    - [Signing Artifacts](#signing-artifacts)
-    - [Test the Bundle](#test-the-bundle)
-        - [Integration Tests](#integration-tests)
-        - [Backwards Compatibility Tests](#backward-compatibility-tests)
+  - [Build from Source](#build-from-source)
+    - [Custom Build Scripts](#custom-build-scripts)
+  - [Assemble the Bundle](#assemble-the-bundle)
+    - [Custom Install Scripts](#custom-install-scripts)
+  - [Signing Artifacts](#signing-artifacts)
+  - [Test the Bundle](#test-the-bundle)
+    - [Integration Tests](#integration-tests)
+    - [Backwards Compatibility Tests](#backwards-compatibility-tests)
 
 ## OpenSearch Bundle Workflow
 
@@ -48,6 +48,7 @@ The following options are available in `bundle-workflow/build.sh`.
 | --snapshot         | Build a snapshot instead of a release artifact, default is `false`.     |
 | --component [name] | Rebuild a single component by name, e.g. `--component common-utils`.    |
 | --keep             | Do not delete the temporary working directory on both success or error. |
+| -v, --verbose      | Show more verbose output.                                               |
 
 #### Custom Build Scripts
 
@@ -79,10 +80,11 @@ The signing step (optional) takes the manifest file created from the build step 
 
 The following options are available. 
 
-| name        | description                                                                         |
-|-------------|-------------------------------------------------------------------------------------|
-| --component | The component name of the component whose artifacts will be signed                  |
-| --type      | The artifact type to be signed. Currently one of 3 options: [plugins, maven, bundle]|
+| name          | description                                                                         |
+|---------------|-------------------------------------------------------------------------------------|
+| --component   | The component name of the component whose artifacts will be signed                  |
+| --type        | The artifact type to be signed. Currently one of 3 options: [plugins, maven, bundle]|
+| -v, --verbose | Show more verbose output.                                                           |
 
 The signed artifacts (<artifact>.asc) will be found in the same location as the original artifact. 
 
@@ -113,5 +115,6 @@ The following options are available.
 
 | name               | description                                                             |
 |--------------------|-------------------------------------------------------------------------|
-| --component [name] | Test a single component by name, e.g. `--component common-utils`.    |
+| --component [name] | Test a single component by name, e.g. `--component common-utils`.       |
 | --keep             | Do not delete the temporary working directory on both success or error. |
+| -v, --verbose      | Show more verbose output.                                               |

--- a/bundle-workflow/src/assemble_workflow/bundle.py
+++ b/bundle-workflow/src/assemble_workflow/bundle.py
@@ -5,6 +5,7 @@
 # compatible open source license.
 
 import errno
+import logging
 import os
 import shutil
 import subprocess
@@ -39,7 +40,7 @@ class Bundle:
 
     def install_plugins(self):
         for plugin in self.plugins:
-            print(f"Installing {plugin.name}")
+            logging.info(f"Installing {plugin.name}")
             self.install_plugin(plugin)
         plugins_path = os.path.join(self.archive_path, "plugins")
         if os.path.isdir(plugins_path):
@@ -61,7 +62,7 @@ class Bundle:
         shutil.copyfile(tar_name, os.path.join(dest, tar_name))
 
     def __execute(self, command):
-        print(f'Executing "{command}" in {self.archive_path}')
+        logging.info(f'Executing "{command}" in {self.archive_path}')
         subprocess.check_call(command, cwd=self.archive_path, shell=True)
 
     def __copy_component(self, component, component_type):

--- a/bundle-workflow/src/build_workflow/build_args.py
+++ b/bundle-workflow/src/build_workflow/build_args.py
@@ -5,6 +5,7 @@
 # compatible open source license.
 
 import argparse
+import logging
 import sys
 
 
@@ -35,7 +36,18 @@ class BuildArgs:
             action="store_true",
             help="Do not delete the working temporary directory.",
         )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Show more verbose output.",
+            action="store_const",
+            default=logging.INFO,
+            const=logging.DEBUG,
+            dest="logging_level",
+        )
+
         args = parser.parse_args()
+        self.logging_level = args.logging_level
         self.manifest = args.manifest
         self.snapshot = args.snapshot
         self.component = args.component

--- a/bundle-workflow/src/build_workflow/build_recorder.py
+++ b/bundle-workflow/src/build_workflow/build_recorder.py
@@ -4,6 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 import shutil
 from zipfile import ZipFile
@@ -89,7 +90,7 @@ class BuildRecorder:
     def record_artifact(
         self, component_name, artifact_type, artifact_path, artifact_file
     ):
-        print(
+        logging.info(
             f"Recording {artifact_type} artifact for {component_name}: {artifact_path} (from {artifact_file})"
         )
         # Ensure the target directory exists
@@ -132,7 +133,9 @@ class BuildRecorder:
             properties = BuildRecorder.PropertiesFile(artifact_file, data)
             properties.check_value("version", self.component_version)
             properties.check_value("opensearch.version", self.version)
-            print(f'Checked {artifact_file} ({properties.get_value("version", "N/A")})')
+            logging.info(
+                f'Checked {artifact_file} ({properties.get_value("version", "N/A")})'
+            )
 
     def __check_maven_artifact(self, artifact_file):
         ext = os.path.splitext(artifact_file)[1]
@@ -161,7 +164,7 @@ class BuildRecorder:
                     "Implementation-Version",
                     [self.component_version, self.opensearch_version, None],
                 )
-                print(
+                logging.info(
                     f'Checked {artifact_file} ({properties.get_value("Implementation-Version", "N/A")})'
                 )
 

--- a/bundle-workflow/src/git/git_repository.py
+++ b/bundle-workflow/src/git/git_repository.py
@@ -4,6 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 import subprocess
 import tempfile
@@ -37,13 +38,13 @@ class GitRepository:
             .decode()
             .strip()
         )
-        print(f"Checked out {self.url}@{self.ref} into {self.dir} at {self.sha}")
+        logging.info(f"Checked out {self.url}@{self.ref} into {self.dir} at {self.sha}")
 
     def execute(self, command, silent=False, subdirname=None):
         dirname = self.dir
         if subdirname:
             dirname = os.path.join(self.dir, subdirname)
-        print(f'Executing "{command}" in {dirname}')
+        logging.info(f'Executing "{command}" in {dirname}')
         if silent:
             subprocess.check_call(
                 command,

--- a/bundle-workflow/src/paths/tree_walker.py
+++ b/bundle-workflow/src/paths/tree_walker.py
@@ -4,11 +4,12 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 
 
 def walk(root):
-    print(f"Walking tree from {root}")
+    logging.info(f"Walking tree from {root}")
     for dir, dirs, files in os.walk(root):
         for file_name in files:
             absolute_path = os.path.join(dir, file_name)

--- a/bundle-workflow/src/sign.py
+++ b/bundle-workflow/src/sign.py
@@ -7,10 +7,12 @@
 # compatible open source license.
 
 import argparse
+import logging
 import os
 
 from manifests.build_manifest import BuildManifest
 from sign_workflow.signer import Signer
+from system import console
 
 parser = argparse.ArgumentParser(description="Sign artifacts")
 parser.add_argument(
@@ -18,7 +20,18 @@ parser.add_argument(
 )
 parser.add_argument("--component", nargs="?", help="Component name")
 parser.add_argument("--type", nargs="?", help="Artifact type")
+parser.add_argument(
+    "-v",
+    "--verbose",
+    help="Show more verbose output.",
+    action="store_const",
+    default=logging.INFO,
+    const=logging.DEBUG,
+    dest="logging_level",
+)
 args = parser.parse_args()
+
+console.configure(level=args.logging_level)
 
 manifest = BuildManifest.from_file(args.manifest)
 basepath = os.path.dirname(os.path.abspath(args.manifest.name))
@@ -27,10 +40,10 @@ signer = Signer()
 for component in manifest.components:
 
     if args.component and args.component != component.name:
-        print(f"\nSkipping {component.name}")
+        logging.info(f"Skipping {component.name}")
         continue
 
-    print(f"\nSigning {component.name}")
+    logging.info(f"Signing {component.name}")
     for artifact_type in component.artifacts:
 
         if args.type and args.type != artifact_type:
@@ -38,4 +51,4 @@ for component in manifest.components:
 
         signer.sign_artifacts(component.artifacts[artifact_type], basepath)
 
-print("Done.")
+logging.info("Done.")

--- a/bundle-workflow/src/sign_workflow/signer.py
+++ b/bundle-workflow/src/sign_workflow/signer.py
@@ -6,6 +6,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 import pathlib
 
@@ -29,7 +30,7 @@ class Signer:
     def sign_artifacts(self, artifacts, basepath):
         for artifact in artifacts:
             if not self.is_valid_file_type(artifact):
-                print(f"Skipping signing of file ${artifact}")
+                logging.info(f"Skipping signing of file ${artifact}")
                 continue
             location = os.path.join(basepath, artifact)
             self.sign(location)

--- a/bundle-workflow/src/system/console.py
+++ b/bundle-workflow/src/system/console.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import logging
+import sys
+
+
+def configure(level):
+    logging.basicConfig(
+        stream=sys.stdout,
+        level=level,
+        format="%(asctime)s %(levelname)-8s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )

--- a/bundle-workflow/src/system/execute.py
+++ b/bundle-workflow/src/system/execute.py
@@ -4,6 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import subprocess
 
 
@@ -14,7 +15,7 @@ def execute(command, dir, capture=True, raise_on_failure=True):
     :param dir: The full path to the directory that the command should be executed in.
     :returns a tuple containing the exit code, stdout, and stderr.
     """
-    print(f'Executing "{command}" in {dir}')
+    logging.info(f'Executing "{command}" in {dir}')
     result = subprocess.run(
         command, cwd=dir, shell=True, capture_output=capture, text=True
     )

--- a/bundle-workflow/src/system/temporary_directory.py
+++ b/bundle-workflow/src/system/temporary_directory.py
@@ -4,6 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import shutil
 import tempfile
 from contextlib import contextmanager
@@ -16,6 +17,6 @@ def TemporaryDirectory(keep=False):
         yield name
     finally:
         if keep:
-            print(f"Keeping {name}")
+            logging.info(f"Keeping {name}")
         else:
             shutil.rmtree(name)

--- a/bundle-workflow/src/test.py
+++ b/bundle-workflow/src/test.py
@@ -9,11 +9,14 @@
 import os
 
 from manifests.bundle_manifest import BundleManifest
+from system import console
 from test_workflow.bwc_test_suite import BwcTestSuite
 from test_workflow.test_args import TestArgs
 from test_workflow.test_recorder import TestRecorder
 
 args = TestArgs()
+console.configure(level=args.logging_level)
+
 manifest = BundleManifest.from_file(args.manifest)
 test_recorder = TestRecorder(os.path.dirname(manifest.name))
 

--- a/bundle-workflow/src/test_workflow/bwc_test_suite.py
+++ b/bundle-workflow/src/test_workflow/bwc_test_suite.py
@@ -7,6 +7,7 @@
 # Modifications Copyright OpenSearch Contributors. See
 # GitHub history for details.
 
+import logging
 import os
 import subprocess
 
@@ -38,7 +39,7 @@ class BwcTestSuite:
             return console_output
         except:
             # TODO: Store and report test failures for {component}
-            print(f"Exception while running BWC tests for {component.name}")
+            logging.info(f"Exception while running BWC tests for {component.name}")
 
     def execute(self):
         # TODO copy all maven dependencies from S3 to local

--- a/bundle-workflow/src/test_workflow/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test_suite.py
@@ -4,6 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 import subprocess
 
@@ -80,7 +81,7 @@ class IntegTestSuite:
             # Spin up a test cluster
             cluster = LocalTestCluster(self.work_dir, self.bundle_manifest, security)
             cluster.create()
-            print("component name: " + self.component.name)
+            logging.info("component name: " + self.component.name)
             os.chdir(self.work_dir)
             # TODO: (Create issue) Since plugins don't have integtest.sh in version branch, hardcoded it to main
             self._execute_integtest_sh(cluster, security)
@@ -101,4 +102,6 @@ class IntegTestSuite:
                 self.name, status, stdout, stderr, walk(results_dir)
             )
         else:
-            print(f"{script} does not exist. Skipping integ tests for {self.name}")
+            logging.info(
+                f"{script} does not exist. Skipping integ tests for {self.name}"
+            )

--- a/bundle-workflow/src/test_workflow/test_args.py
+++ b/bundle-workflow/src/test_workflow/test_args.py
@@ -8,6 +8,7 @@
 # GitHub history for details.
 
 import argparse
+import logging
 
 
 class TestArgs:
@@ -27,7 +28,17 @@ class TestArgs:
             action="store_true",
             help="Do not delete the working temporary directory.",
         )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Show more verbose output.",
+            action="store_const",
+            default=logging.INFO,
+            const=logging.DEBUG,
+            dest="logging_level",
+        )
         args = parser.parse_args()
+        self.logging_level = args.logging_level
         self.manifest = args.manifest
         self.component = args.component
         self.keep = args.keep

--- a/bundle-workflow/src/test_workflow/test_recorder.py
+++ b/bundle-workflow/src/test_workflow/test_recorder.py
@@ -4,18 +4,20 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
+
 
 class TestRecorder:
     def __init__(self, location):
         self.location = location
-        print(f"TestRecorder storing results in {location}")
+        logging.info(f"TestRecorder storing results in {location}")
 
     def record_cluster_logs(self, log_files):
         """
         Record the test cluster logs.
         :param results: A generator that yields tuples containing test cluster log files, in the form (absolute_path, relative_path)
         """
-        print(f"Recording log files: {list(log_files)}")
+        logging.info(f"Recording log files: {list(log_files)}")
 
     def record_integ_test_outcome(
         self, component_name, exit_status, stdout, stderr, results
@@ -29,6 +31,6 @@ class TestRecorder:
         :param stderr: A string containing the stderr stream from the test process.
         :param results: A generator that yields tuples containing test results files, in the form (absolute_path, relative_path).
         """
-        print(
+        logging.info(
             f"Recording test results for {component_name}. Exit status: {exit_status}, stdout: {stdout}, stderr: {stderr}, results files: {results}"
         )

--- a/bundle-workflow/tests/tests_build_workflow/test_build_args.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_build_args.py
@@ -4,6 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 import unittest
 from unittest.mock import patch
@@ -46,6 +47,14 @@ class TestBuildArgs(unittest.TestCase):
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--snapshot"])
     def test_snapshot_true(self):
         self.assertTrue(BuildArgs().snapshot)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_verbose_default(self):
+        self.assertEqual(BuildArgs().logging_level, logging.INFO)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--verbose"])
+    def test_verbose_true(self):
+        self.assertTrue(BuildArgs().logging_level, logging.DEBUG)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
     def test_component_default(self):


### PR DESCRIPTION
### Description

Replaces print output with a console logger that includes a timestamp.

```
2021-09-03 17:49:07 INFO     Building common-utils
2021-09-03 17:49:07 INFO     Executing "git init" in /tmp/tmpx4nnwkqe/common-utils
2021-09-03 17:49:07 INFO     Executing "git remote add origin https://github.com/opensearch-project/common-utils.git" in /tmp/tmpx4nnwkqe/common-utils
2021-09-03 17:49:07 INFO     Executing "git fetch --depth 1 origin main" in /tmp/tmpx4nnwkqe/common-utils
2021-09-03 17:49:07 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmpx4nnwkqe/common-utils
2021-09-03 17:49:07 INFO     Checked out https://github.com/opensearch-project/common-utils.git@main into /tmp/tmpx4nnwkqe/comm
```

Adds a `--verbose` option to switch to DEBUG logging level.

Currently on top of https://github.com/opensearch-project/opensearch-build/pull/372, will rebase.
 
### Issues Resolved

I didn't verify, but I think this fixes #280. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
