### PR TITLE
Remove notifications from opensearch 1.1 manifest file

### DIFF
--- a/bundle-workflow/tests/tests_manifests/test_input_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_input_manifest.py
@@ -39,7 +39,7 @@ class TestInputManifest(unittest.TestCase):
             self.assertEqual(manifest.version, "1.0")
             self.assertEqual(manifest.build.name, "OpenSearch")
             self.assertEqual(manifest.build.version, "1.1.0")
-            self.assertEqual(len(manifest.components), 15)
+            self.assertEqual(len(manifest.components), 14)
             opensearch_component = manifest.components[0]
             self.assertEqual(opensearch_component.name, "OpenSearch")
             self.assertEqual(

--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -19,9 +19,6 @@ components:
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
     ref: main
-  - name: notifications
-    repository: https://github.com/opensearch-project/notifications.git
-    ref: main
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: main


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Remove notifications from the `1.1` release manifest file since it is delayed to `1.2`. Please let me know if I should create a `1.2` or `2.0` manifest as @dblock mentioned in https://github.com/opensearch-project/opensearch-build/issues/343#issue-981859350, thanks.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/343
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
