### PR TITLE
Sanity check the OpenSearch bundle.

### DIFF
--- a/.github/workflows/bundle-workflow.yml
+++ b/.github/workflows/bundle-workflow.yml
@@ -1,9 +1,9 @@
-name: test-bundle-workflow
+name: bundle-workflow
 
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -1,0 +1,24 @@
+name: manifests
+
+on: [push, pull_request]
+
+jobs:
+  check:
+
+    runs-on: ubuntu-latest
+
+    env:
+      PYTHON_VERSION: 3.7
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install Pipenv and Dependencies
+        run: |
+          python -m pip install --upgrade pipenv wheel
+      - name: OpenSearch 1.1
+        run: |
+          ./bundle-workflow/ci.sh manifests/opensearch-1.1.0.yml

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -1,6 +1,10 @@
 name: manifests
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
 

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -3,13 +3,24 @@ name: manifests
 on: [push, pull_request]
 
 jobs:
-  check:
 
+  list-manifests:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-matrix
+        run: echo "::set-output name=matrix::$(ls manifests/opensearch*.yml | jq -R -s -c 'split("\n")[:-1]')"
 
+  check:
+    needs: list-manifests
+    runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: 3.7
-
+    strategy:
+      matrix:
+        manifest: ${{ fromJson(needs.list-manifests.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}
@@ -19,6 +30,6 @@ jobs:
       - name: Install Pipenv and Dependencies
         run: |
           python -m pip install --upgrade pipenv wheel
-      - name: OpenSearch 1.1
+      - name: OpenSearch Manifests
         run: |
-          ./bundle-workflow/ci.sh manifests/opensearch-1.1.0.yml
+          ./bundle-workflow/ci.sh ${{ matrix.manifest }}

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -110,7 +110,7 @@ All done! ✨ 🍰 ✨
 23 files left unchanged.
 ```
 
-If your code isn't properly formatted, don't worry, [a CI workflow](./github/workflows/ci.yml) will make sure to remind you. 
+If your code isn't properly formatted, don't worry, [a CI workflow](./github/workflows/bundle-workflow.yml) will make sure to remind you. 
 
 ### Type Checking
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -110,7 +110,7 @@ All done! ✨ 🍰 ✨
 23 files left unchanged.
 ```
 
-If your code isn't properly formatted, don't worry, [a CI workflow](./github/workflows/test-bundle-workflow.yml) will make sure to remind you. 
+If your code isn't properly formatted, don't worry, [a CI workflow](./github/workflows/ci.yml) will make sure to remind you. 
 
 ### Type Checking
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <img src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg" height="64px"/>
 
-[![test-bundle-workflow](https://github.com/opensearch-project/opensearch-build/actions/workflows/test-bundle-workflow.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/test-bundle-workflow.yml)
+[![tests](https://github.com/opensearch-project/opensearch-build/actions/workflows/bundle-workflow.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/bundle-workflow.yml)
+[![manifests](https://github.com/opensearch-project/opensearch-build/actions/workflows/manifests.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/manifests.yml)
 [![codecov](https://codecov.io/gh/opensearch-project/opensearch-build/branch/main/graph/badge.svg?token=03S5XZ80UI)](https://codecov.io/gh/opensearch-project/opensearch-build)
 
 - [OpenSearch Build](#opensearch-build)

--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -7,6 +7,7 @@
   - [Test the Bundle](#test-the-bundle)
     - [Integration Tests](#integration-tests)
     - [Backwards Compatibility Tests](#backwards-compatibility-tests)
+  - [Sanity Check the Bundle](#sanity-check-the-bundle)
 
 ## OpenSearch Bundle Workflow
 
@@ -24,6 +25,7 @@ Each build requires a manifest to be passed as input.  We currently have the fol
 
 
 Usage:
+
 ```bash
 ./bundle-workflow/build.sh manifests/opensearch-1.1.0.yml --snapshot
 ```
@@ -94,14 +96,17 @@ Signing step (to sign all artifacts):
 ```
 
 ### Test the Bundle
+
 Tests the OpenSearch bundle.
 
 This workflow contains two sections: Integration Tests, Backwards Compatibility Tests.
 
 #### Integration Tests
+
 This step runs integration tests invoking `integtest.sh` in each component from bundle manifest.
 
 #### Backwards Compatibility Tests
+
 This step run backward compatibility invoking `bwctest.sh` in each component from bundle manifest.
 
 Usage:
@@ -109,6 +114,26 @@ Usage:
 Kick off all test suites on a manifest:
 ```bash
 ./bundle-workflow/test.sh manifests/opensearch-1.0.0.yml
+```
+
+The following options are available.
+
+| name               | description                                                             |
+|--------------------|-------------------------------------------------------------------------|
+| --component [name] | Test a single component by name, e.g. `--component common-utils`.       |
+| --keep             | Do not delete the temporary working directory on both success or error. |
+| -v, --verbose      | Show more verbose output.                                               |
+
+### Sanity Check the Bundle
+
+Runs basic sanity checks on the OpenSearch bundle.
+
+This workflow runs basic sanity checks on every component present in the bundle. For starters, it ensures that the component GitHub repositories are correct.
+
+Usage:
+
+```bash
+./bundle-workflow/ci.sh manifests/opensearch-1.1.0.yml
 ```
 
 The following options are available.

--- a/bundle-workflow/ci.sh
+++ b/bundle-workflow/ci.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -e
+
+DIR="$(dirname "$0")"
+"$DIR/run.sh" "$DIR/src/ci.py" $@

--- a/bundle-workflow/src/ci.py
+++ b/bundle-workflow/src/ci.py
@@ -8,41 +8,26 @@
 
 import logging
 import os
-import uuid
 
-from build_workflow.build_args import BuildArgs
-from build_workflow.build_recorder import BuildRecorder
-from build_workflow.builder import Builder
+from ci_workflow.ci import Ci
+from ci_workflow.ci_args import CiArgs
 from git.git_repository import GitRepository
 from manifests.input_manifest import InputManifest
 from system import console
 from system.arch import current_arch
 from system.temporary_directory import TemporaryDirectory
 
-args = BuildArgs()
+args = CiArgs()
 console.configure(level=args.logging_level)
-
 arch = current_arch()
 manifest = InputManifest.from_file(args.manifest)
-output_dir = os.path.join(os.getcwd(), "artifacts")
-os.makedirs(output_dir, exist_ok=True)
-build_id = os.getenv("OPENSEARCH_BUILD_ID", uuid.uuid4().hex)
 
 with TemporaryDirectory(keep=args.keep) as work_dir:
-    logging.info(f"Building in {work_dir}")
+    logging.info(f"Sanity-testing in {work_dir}")
 
     os.chdir(work_dir)
 
-    build_recorder = BuildRecorder(
-        build_id,
-        output_dir,
-        manifest.build.name,
-        manifest.build.version,
-        arch,
-        args.snapshot,
-    )
-
-    logging.info(f"Building {manifest.build.name} ({arch}) into {output_dir}")
+    logging.info(f"Sanity testing {manifest.build.name} ({arch})")
 
     for component in manifest.components:
 
@@ -50,21 +35,18 @@ with TemporaryDirectory(keep=args.keep) as work_dir:
             logging.info(f"Skipping {component.name}")
             continue
 
-        logging.info(f"Building {component.name}")
+        logging.info(f"Sanity checking {component.name}")
         repo = GitRepository(
             component.repository, component.ref, os.path.join(work_dir, component.name)
         )
 
         try:
-            builder = Builder(component.name, repo, build_recorder)
-            builder.build(manifest.build.version, arch, args.snapshot)
-            builder.export_artifacts()
+            ci = Ci(component.name, repo)
+            ci.check(manifest.build.version, arch, args.snapshot)
         except:
             logging.error(
-                f"Error building {component.name}, retry with: {args.component_command(component.name)}"
+                f"Error checking {component.name}, retry with: {args.component_command(component.name)}"
             )
             raise
-
-    build_recorder.write_manifest(output_dir)
 
 logging.info("Done.")

--- a/bundle-workflow/src/ci_workflow/__init__.py
+++ b/bundle-workflow/src/ci_workflow/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/bundle-workflow/src/ci_workflow/ci.py
+++ b/bundle-workflow/src/ci_workflow/ci.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+"""
+This class is responsible for sanity checking the OpenSearch bundle.
+"""
+
+
+class Ci:
+    def __init__(self, component_name, git_repo):
+        """
+        Construct a new instance of Ci.
+        :param component_name: The name of the component to sanity-check.
+        :param git_repo: A GitRepository instance containing the checked-out code.
+        """
+
+        self.component_name = component_name
+        self.git_repo = git_repo
+
+    def check(self, version, arch, snapshot):
+        pass

--- a/bundle-workflow/src/ci_workflow/ci_args.py
+++ b/bundle-workflow/src/ci_workflow/ci_args.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import argparse
+import logging
+import sys
+
+
+class CiArgs:
+    manifest: str
+    snapshot: bool
+
+    def __init__(self):
+        parser = argparse.ArgumentParser(
+            description="Sanity test the OpenSearch Bundle"
+        )
+        parser.add_argument(
+            "manifest", type=argparse.FileType("r"), help="Manifest file."
+        )
+        parser.add_argument(
+            "-s",
+            "--snapshot",
+            action="store_true",
+            default=False,
+            help="Build snapshot.",
+        )
+        parser.add_argument(
+            "-c", "--component", type=str, help="Rebuild a single component."
+        )
+        parser.add_argument(
+            "--keep",
+            dest="keep",
+            action="store_true",
+            help="Do not delete the working temporary directory.",
+        )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Show more verbose output.",
+            action="store_const",
+            default=logging.INFO,
+            const=logging.DEBUG,
+            dest="logging_level",
+        )
+        args = parser.parse_args()
+        self.manifest = args.manifest
+        self.snapshot = args.snapshot
+        self.component = args.component
+        self.keep = args.keep
+        self.logging_level = args.logging_level
+        self.script_path = sys.argv[0].replace("/src/ci.py", "/ci.sh")
+
+    def component_command(self, name):
+        return " ".join(
+            filter(
+                None,
+                [
+                    self.script_path,
+                    self.manifest.name,
+                    f"--component {name}",
+                    "--snapshot" if self.snapshot else None,
+                ],
+            )
+        )

--- a/bundle-workflow/tests/tests_ci_workflow/__init__.py
+++ b/bundle-workflow/tests/tests_ci_workflow/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))

--- a/bundle-workflow/tests/tests_ci_workflow/test_ci.py
+++ b/bundle-workflow/tests/tests_ci_workflow/test_ci.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from unittest.mock import MagicMock
+
+from ci_workflow.ci import Ci
+
+
+class TestCi(unittest.TestCase):
+    def setUp(self):
+        self.ci = Ci("component", MagicMock(dir="/tmp/checked-out-component"))
+
+    def test_ci(self):
+        self.assertEqual(self.ci.component_name, "component")
+
+    def test_check(self):
+        pass

--- a/bundle-workflow/tests/tests_ci_workflow/test_ci_args.py
+++ b/bundle-workflow/tests/tests_ci_workflow/test_ci_args.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import unittest
+from unittest.mock import patch
+
+from ci_workflow.ci_args import CiArgs
+
+
+class TestCiArgs(unittest.TestCase):
+
+    CI_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/ci.py"))
+
+    CI_SH = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../ci.sh"))
+
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__), "../../../manifests/opensearch-1.1.0.yml"
+        )
+    )
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST])
+    def test_manifest(self):
+        self.assertEqual(CiArgs().manifest.name, TestCiArgs.OPENSEARCH_MANIFEST)
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST])
+    def test_keep_default(self):
+        self.assertFalse(CiArgs().keep)
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST, "--keep"])
+    def test_keep_true(self):
+        self.assertTrue(CiArgs().keep)
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST])
+    def test_snapshot_default(self):
+        self.assertFalse(CiArgs().snapshot)
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST, "--snapshot"])
+    def test_snapshot_true(self):
+        self.assertTrue(CiArgs().snapshot)
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST])
+    def test_component_default(self):
+        self.assertIsNone(CiArgs().component)
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
+    def test_component(self):
+        self.assertEqual(CiArgs().component, "xyz")
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
+    def test_script_path(self):
+        self.assertTrue(os.path.isfile(self.CI_PY))
+        self.assertTrue(os.path.isfile(self.CI_SH))
+        self.assertEqual(CiArgs().script_path, self.CI_SH)
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST])
+    def test_component_command(self):
+        self.assertEqual(
+            CiArgs().component_command("component"),
+            f"{self.CI_SH} {self.OPENSEARCH_MANIFEST} --component component",
+        )
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST, "--snapshot"])
+    def test_component_command_with_snapshot(self):
+        self.assertEqual(
+            CiArgs().component_command("component"),
+            f"{self.CI_SH} {self.OPENSEARCH_MANIFEST} --component component --snapshot",
+        )


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Today it's possible to make a change to an OpenSearch bundle manifest and break everything. The simplest mistake is a typo in the GitHub URL. This PR adds a CI workflow and a GitHub action that runs it to ensure that the components are sane.  Future versions can get more crafty in terms of what's being checked (e.g. plugin versions). 

Originally I thought I'd add a dry run or a check option to the build workflow, but I think we're going to get more and more advanced with what we want to do in checks, so adding a new workflow for that.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
