### PR TITLE
[FIX] multiarch build checker loop

### DIFF
--- a/release/docker/build-image-multi-arch.sh
+++ b/release/docker/build-image-multi-arch.sh
@@ -84,7 +84,7 @@ if [ -z "$VERSION" ] || [ -z "$DOCKERFILE" ] || [ -z "$PRODUCT" ] || [ -z "$ARCH
   exit 1
 else
   echo $VERSION $DOCKERFILE $PRODUCT $ARCHITECTURE
-  IFS=', ' read -r -a ARCHITECTURE_ARRAY <<< "$ARCHITECTURE"
+  IFS=',' read -r -a ARCHITECTURE_ARRAY <<< "$ARCHITECTURE"
   IFS=', ' read -r -a TARBALL_ARRAY <<< "$TARBALL"
 fi
 
@@ -94,11 +94,15 @@ then
     exit 1
 fi
 
-if [ "$ARCHITECTURE" != "x64" ] && [ "$ARCHITECTURE" != "arm64" ]
-then
-    echo "We only support 'x64' and 'arm64' as architecture name for -a parameter"
-    exit 1
-fi
+for ARCH in $ARCHITECTURE_ARRAY
+do
+  echo $ARCH      #Executed for all values of ''I'', up to a disaster-condition if any.
+  if [ "$ARCH" != "x64" ] && [ "$ARCH" != "arm64" ]
+  then
+	echo "We only support 'x64' and 'arm64' as architecture name for -a parameter"
+    	exit 1       	   #Abandon the loop.
+  fi
+done
 
 # Warning docker desktop
 if (! docker buildx version)

--- a/release/docker/build-image-multi-arch.sh
+++ b/release/docker/build-image-multi-arch.sh
@@ -84,7 +84,7 @@ if [ -z "$VERSION" ] || [ -z "$DOCKERFILE" ] || [ -z "$PRODUCT" ] || [ -z "$ARCH
   exit 1
 else
   echo $VERSION $DOCKERFILE $PRODUCT $ARCHITECTURE
-  IFS=',' read -r -a ARCHITECTURE_ARRAY <<< "$ARCHITECTURE"
+  IFS=', ' read -r -a ARCHITECTURE_ARRAY <<< "$ARCHITECTURE"
   IFS=', ' read -r -a TARBALL_ARRAY <<< "$TARBALL"
 fi
 
@@ -99,7 +99,7 @@ do
   if [ "$ARCH" != "x64" ] && [ "$ARCH" != "arm64" ]
   then
 	echo "We only support 'x64' and 'arm64' as architecture name for -a parameter"
-    	exit 1       	   #Abandon the loop.
+    	exit 1
   fi
 done
 

--- a/release/docker/build-image-multi-arch.sh
+++ b/release/docker/build-image-multi-arch.sh
@@ -96,7 +96,6 @@ fi
 
 for ARCH in $ARCHITECTURE_ARRAY
 do
-  echo $ARCH      #Executed for all values of ''I'', up to a disaster-condition if any.
   if [ "$ARCH" != "x64" ] && [ "$ARCH" != "arm64" ]
   then
 	echo "We only support 'x64' and 'arm64' as architecture name for -a parameter"


### PR DESCRIPTION
### Description
[Describe what this change achieves]
build-image-multi-arch.sh only checked first input from -a argument.
### Issues Resolved
[List any issues this PR will resolve]
 #389 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
