### PR TITLE
Prevent node reuse to ensure stability

### DIFF
--- a/bundle-workflow/Jenkinsfile
+++ b/bundle-workflow/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
             }
         }
         stage('build') {
-            parallel {
+            stages {
                 stage('build-snapshots') {
                     environment {
                         SNAPSHOT_REPO_URL = "https://aws.oss.sonatype.org/content/repositories/snapshots/"
@@ -43,6 +43,11 @@ pipeline {
                             }
                         }
                     }
+                    post() {
+                        always {
+                            cleanWs disableDeferredWipeout: true, deleteDirs: true
+                        }
+                    }
                 }
                 stage('build-x86') {
                     agent {
@@ -55,6 +60,11 @@ pipeline {
                             build()
                         }
                     }
+                    post() {
+                        always {
+                            cleanWs disableDeferredWipeout: true, deleteDirs: true
+                        }
+                    }
                 }
                 stage('build-arm64') {
                     agent {
@@ -65,6 +75,11 @@ pipeline {
                     steps {
                         script {
                             build()
+                        }
+                    }
+                    post() {
+                        always {
+                            cleanWs disableDeferredWipeout: true, deleteDirs: true
                         }
                     }
                 }


### PR DESCRIPTION
The parallel configuration was causing build nodes to be reused, leading to build failures.  Cleaning the workspace between actions and removing the parallel execution.  Tested the premise on a local jenkins instance, will need to validate on the build node.

Signed-off-by: Peter Nied <petern@amazon.com>

### Issues Resolved
* #392
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
