### PR TITLE
Manually flushing maven cache during cleanup

### DIFF
--- a/bundle-workflow/Jenkinsfile
+++ b/bundle-workflow/Jenkinsfile
@@ -46,6 +46,7 @@ pipeline {
                     post() {
                         always {
                             cleanWs disableDeferredWipeout: true, deleteDirs: true
+                            sh "rm -rf ~/.m2/"
                         }
                     }
                 }
@@ -63,6 +64,7 @@ pipeline {
                     post() {
                         always {
                             cleanWs disableDeferredWipeout: true, deleteDirs: true
+                            sh "rm -rf ~/.m2/"
                         }
                     }
                 }
@@ -80,6 +82,7 @@ pipeline {
                     post() {
                         always {
                             cleanWs disableDeferredWipeout: true, deleteDirs: true
+                            sh "rm -rf ~/.m2/"
                         }
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Previous clean up did clean up the workspace, but the shared maven local repository was not cleaned 
 
### Issues Resolved
#392
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
