### PR TITLE
Update Index Management branch from main to 1.1

### DIFF
--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -30,7 +30,7 @@ components:
     ref: main
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: main
+    ref: "1.1"
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
     ref: main


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn bowenlan23@gmail.com

### Description
Change to use the 1.1 branch of Index Management in the 1.1 manifest file.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
