### PR TITLE
Use Job Scheduler 1.1 branch for OpenSearch 1.1

### DIFF
--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -12,7 +12,7 @@ components:
     ref: main
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: main
+    ref: "1.1"
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
     ref: main


### PR DESCRIPTION
### Description
Change to use the 1.1 branch of Job Scheduler in the 1.1 manifest file.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
