### PR TITLE
Fix: unit test failure on OSX.

### DIFF
--- a/bundle-workflow/tests/tests_build_workflow/test_builder.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_builder.py
@@ -60,10 +60,10 @@ class TestBuilder(unittest.TestCase):
             "component", self.builder.git_repo
         )
 
-    def mock_os_walk(self, artifact_type):
-        if artifact_type == "/tmp/checked-out-component/artifacts/core-plugins":
+    def mock_os_walk(self, artifact_path):
+        if artifact_path.endswith("/checked-out-component/artifacts/core-plugins"):
             return [["/core-plugins", [], ["plugin1.zip"]]]
-        if artifact_type == "/tmp/checked-out-component/artifacts/maven":
+        if artifact_path.endswith("/checked-out-component/artifacts/maven"):
             return [("/maven", [], ["artifact1.jar"])]
         else:
             return []


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description
There was a hard-coded `/tmp` that is `/private/tmp` on OSX.
 
### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/355.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
