### PR TITLE
Use Alerting 1.1 branch for OpenSearch 1.1

### DIFF
--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -18,7 +18,7 @@ components:
     ref: "1.1"
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: main
+    ref: "1.1"
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: main


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <qreshi@amazon.com>

### Description
Change to use the 1.1 branch of Alerting in the 1.1 manifest file.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
