### PR TITLE
Revert "Use common-utils 1.1 branch for OpenSearch 1.1"

### DIFF
--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -9,7 +9,7 @@ components:
     ref: 1.x
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: "1.1"
+    ref: main
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
     ref: "1.1"


### PR DESCRIPTION
Reverting due to https://github.com/opensearch-project/opensearch-build/issues/410