### PR TITLE
Misc nits for test_perf_tests

### DIFF
--- a/bundle-workflow/src/test_workflow/perf_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/perf_test_cluster.py
@@ -1,5 +1,5 @@
-import logging
 import json
+import logging
 import os
 import subprocess
 

--- a/bundle-workflow/src/test_workflow/perf_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/perf_test_cluster.py
@@ -1,3 +1,4 @@
+import logging
 import json
 import os
 import subprocess
@@ -39,12 +40,12 @@ class PerfTestCluster(TestCluster):
     def create_cluster(self):
         os.chdir(self.work_dir)
         command = f'cdk deploy {self.params} --outputs-file {self.output_file}'
-        print(f'Executing "{command}" in {os.getcwd()}')
+        logging.info(f'Executing "{command}" in {os.getcwd()}')
         subprocess.check_call(command, cwd=os.getcwd(), shell=True)
         with open(self.output_file, 'r') as read_file:
             load_output = json.load(read_file)
         self.ip_address = load_output[self.stack_name]['PrivateIp']
-        print('Private IP:', self.ip_address)
+        logging.info('Private IP:', self.ip_address)
 
     def endpoint(self):
         self.cluster_endpoint = self.ip_address
@@ -57,5 +58,5 @@ class PerfTestCluster(TestCluster):
     def destroy(self):
         os.chdir(self.work_dir)
         command = f'cdk destroy {self.params} --force'
-        print(f'Executing "{command}" in {os.getcwd()}')
+        logging.info(f'Executing "{command}" in {os.getcwd()}')
         subprocess.check_call(command, cwd=os.getcwd(), shell=True)

--- a/bundle-workflow/tests/test_perf_workflow/__init__.py
+++ b/bundle-workflow/tests/test_perf_workflow/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))


### PR DESCRIPTION
### Description

- Adds a module init so you can do `pipenv run pytest tests/test_perf_workflow/` without depending on inserting `src` from other places.
- Replaces `print` with `logging`.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
