### PR TITLE
Cleanup for Integ Test

### DIFF
--- a/bundle-workflow/src/perf_test.py
+++ b/bundle-workflow/src/perf_test.py
@@ -39,7 +39,7 @@ for component in manifest.components:
         security = True
 
 with WorkingDirectory(current_workspace) as curdir:
-    with PerfTestCluster.create(manifest, config, args.stack, security) as test_cluster_endpoint:
+    with PerfTestCluster.create(manifest, config, args.stack, security) as (test_cluster_endpoint, test_cluster_port):
         os.chdir(current_workspace)
         perf_test_suite = PerfTestSuite(manifest, test_cluster_endpoint, security, current_workspace)
         perf_test_suite.execute()

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -10,10 +10,8 @@ import subprocess
 
 from git.git_repository import GitRepository
 from paths.script_finder import ScriptFinder
-from paths.tree_walker import walk
 from system.execute import execute
 from test_workflow.integ_test.local_test_cluster import LocalTestCluster
-from test_workflow.test_recorder import TestRecorder
 
 
 class IntegTestSuite:
@@ -28,7 +26,6 @@ class IntegTestSuite:
         self.work_dir = work_dir
         self.test_config = test_config
         self.script_finder = ScriptFinder()
-        self.test_recorder = TestRecorder(os.path.dirname(bundle_manifest.name))
         self.repo = GitRepository(
             self.component.repository,
             self.component.commit_id,
@@ -77,30 +74,19 @@ class IntegTestSuite:
 
     def _setup_cluster_and_execute_test_config(self, config):
         security = self._is_security_enabled(config)
-        try:
-            # Spin up a test cluster
-            cluster = LocalTestCluster(self.work_dir, self.bundle_manifest, security)
-            cluster.create()
+        with LocalTestCluster.create(self.work_dir, self.bundle_manifest, security) as (test_cluster_endpoint, test_cluster_port):
             logging.info("component name: " + self.component.name)
             os.chdir(self.work_dir)
             # TODO: (Create issue) Since plugins don't have integtest.sh in version branch, hardcoded it to main
-            self._execute_integtest_sh(cluster, security)
-        finally:
-            cluster.destroy()
+            self._execute_integtest_sh(test_cluster_endpoint, test_cluster_port, security)
 
-    def _execute_integtest_sh(self, cluster, security):
+    def _execute_integtest_sh(self, endpoint, port, security):
         script = self.script_finder.find_integ_test_script(
             self.component.name, self.repo.dir
         )
         if os.path.exists(script):
-            cmd = f"sh {script} -b {cluster.endpoint()} -p {cluster.port()} -s {str(security).lower()}"
+            cmd = f"sh {script} -b {endpoint} -p {port} -s {str(security).lower()}"
             (status, stdout, stderr) = execute(cmd, self.repo.dir, True, False)
-            results_dir = os.path.join(
-                self.repo.dir, "integ-test", "build", "reports", "tests", "integTest"
-            )
-            self.test_recorder.record_integ_test_outcome(
-                self.name, status, stdout, stderr, walk(results_dir)
-            )
         else:
             logging.info(
                 f"{script} does not exist. Skipping integ tests for {self.name}"

--- a/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
@@ -4,7 +4,6 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import itertools
 import logging
 import os
 import subprocess
@@ -13,7 +12,6 @@ import urllib.request
 
 import requests
 
-from paths.tree_walker import walk
 from test_workflow.test_cluster import ClusterCreationException, TestCluster
 
 
@@ -29,7 +27,7 @@ class LocalTestCluster(TestCluster):
         self.security_enabled = security_enabled
         self.process = None
 
-    def create(self):
+    def create_cluster(self):
         self.download()
         self.stdout = open("stdout.txt", "w")
         self.stderr = open("stderr.txt", "w")
@@ -52,20 +50,11 @@ class LocalTestCluster(TestCluster):
     def port(self):
         return 9200
 
-    def destroy(self, test_recorder):
+    def destroy(self):
         if self.process is None:
             logging.info("Local test cluster is not started")
             return
         self.terminate_process()
-        test_recorder.record_cluster_logs(
-            itertools.chain(
-                [
-                    (os.path.realpath(self.stdout.name), "stdout"),
-                    (os.path.realpath(self.stderr.name), "stderr"),
-                ],
-                walk(os.path.join(self.install_dir, "logs")),
-            )
-        )
 
     def url(self, path=""):
         return f'{"https" if self.security_enabled else "http"}://{self.endpoint()}:{self.port()}{path}'

--- a/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
@@ -41,7 +41,7 @@ class LocalTestCluster(TestCluster):
             stdout=self.stdout,
             stderr=self.stderr,
         )
-        logging.info(f"Started OpenSearch with parentPID {self.process.pid}")
+        logging.info(f"Started OpenSearch with parent PID {self.process.pid}")
         self.wait_for_service()
 
     def endpoint(self):

--- a/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
@@ -41,7 +41,7 @@ class LocalTestCluster(TestCluster):
             stdout=self.stdout,
             stderr=self.stderr,
         )
-        logging.info(f"Started OpenSearch with PID {self.process.pid}")
+        logging.info(f"Started OpenSearch with parentPID {self.process.pid}")
         self.wait_for_service()
 
     def endpoint(self):

--- a/bundle-workflow/src/test_workflow/test_cluster.py
+++ b/bundle-workflow/src/test_workflow/test_cluster.py
@@ -22,7 +22,7 @@ class TestCluster(abc.ABC):
         cluster = cls(*args)
         try:
             cluster.create_cluster()
-            yield cluster.endpoint()
+            yield cluster.endpoint(), cluster.port()
         finally:
             cluster.destroy()
 


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
1. Added generator pattern for LocalTestCluster to handle creating and destroying the cluster.
2. Removed partial TestRecorder logic from IntegTestSuite. It will be added as a part of https://github.com/opensearch-project/opensearch-build/issues/340 
 
### Issues Resolved
Partially resolves https://github.com/opensearch-project/opensearch-build/issues/429
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
