### PR TITLE
[Build] bundle OpenSearch Dashboards

### DIFF
--- a/bundle-workflow/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch-Dashboards/build.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch Dashboards version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch Dashboards version"
+    usage
+    exit 1
+fi
+
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+# Assemble distribution artifact
+# see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
+case $ARCHITECTURE in
+    x64)
+        TARGET="linux-tar"
+        QUALIFIER="linux-x64"
+        ;;
+    arm64)
+        TARGET="linux-arm64-tar"
+        QUALIFIER="linux-arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: ${ARCHITECTURE}"
+        exit 1
+        ;;
+esac
+
+echo "Building node modules for core"
+yarn osd bootstrap
+
+echo "Building artifact"
+yarn build --skip-os-packages --release
+
+# Copy artifact to bundle output with -min in the name
+[[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
+#ARTIFACT_BUILD_NAME=opensearch-dashboards-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
+ARTIFACT_BUILD_NAME=opensearch-dashboards-$VERSION-$QUALIFIER.tar.gz
+ARTIFACT_TARGET_NAME=opensearch-dashboards-min-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
+mkdir -p "${OUTPUT}/bundle"
+
+# Release gets built to /target, regular non-tarball gets built to /build
+cp target/$ARTIFACT_BUILD_NAME $OUTPUT/bundle/$ARTIFACT_TARGET_NAME
+mkdir -p "${OUTPUT}/bundle/opensearch-dashboards"
+
+# Untar for the plugins
+tar -xzf "${OUTPUT}"/bundle/$ARTIFACT_TARGET_NAME --strip-components=1 --directory "${OUTPUT}"/bundle/opensearch-dashboards
+
+echo "Building node modules for plugins"
+cp -r ~/"${OUTPUT}"/dashboards-plugins/. ./plugins
+yarn osd bootstrap
+for plugin in ./plugins/*; do
+    PLUGIN_NAME="$(basename "${plugin}")"
+    cd plugins/$PLUGIN_NAME
+    yarn plugin-helpers build
+    cd ../..
+    ./"${OUTPUT}"/bundle/opensearch-dashboards/bin/opensearch-dashboards-plugin --allow-root install file:./plugins/$PLUGIN_NAME/build/$PLUGIN_NAME-$VERSION.zip
+done
+
+
+
+
+
+#chmod u+x artifacts/bundle/opensearch-dashboards/bin/opensearch-dashboards && chmod u+x artifacts/bundle/opensearch-dashboards/node/bin/node 

--- a/bundle-workflow/scripts/components/alertingDashboards/build.sh
+++ b/bundle-workflow/scripts/components/alertingDashboards/build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch Dashboards version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch Dashboards version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+PLUGIN_NAME=$(basename "$PWD")
+mkdir -p ~/$OUTPUT/dashboards-plugins
+echo "COPY $PLUGIN_NAME"
+cp -r ../$PLUGIN_NAME/ ~/$OUTPUT/dashboards-plugins
+ls ~/$OUTPUT/dashboards-plugins

--- a/manifests/opensearch-dashboards-1.0.0.yml
+++ b/manifests/opensearch-dashboards-1.0.0.yml
@@ -1,0 +1,43 @@
+---
+schema-version: 1.0
+build:
+  name: OpenSearch Dashboards
+  version: 1.0.0
+components:
+  - name: OpenSearch-Dashboards
+    repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+    ref: 1.x
+  # hybrid repo (workbench)
+  - name: queryWorkbench
+    repository: https://github.com/opensearch-project/sql.git
+    ref: main
+  - name: alertingDashboards
+    repository: https://github.com/opensearch-project/alerting-dashboards-plugin
+    ref: main
+  # hybrid repo (dashboards-notifications)
+  - name: notificationsDashboards
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: main
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin
+    ref: main
+  - name: indexManagementDashboards
+    repository: https://github.com/opensearch-project/index-management-dashboards-plugin
+    ref: main
+  - name: anomalyDetectionDashboards
+    repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
+    ref: main
+  # hybrid repo (dashboards-reports)
+  - name: reportsDashboards
+    repository: https://github.com/opensearch-project/dashboards-reports.git
+    ref: main
+  # hybrid repo (dashboards-notebooks)
+  - name: notebooksDashboards
+    repository: https://github.com/opensearch-project/dashboards-notebooks.git
+    ref: main
+  - name: traceAnalyticsDashboards
+    repository: https://github.com/opensearch-project/trace-analytics.git
+    ref: main
+  # - name: ganttChartDashboards
+  #   repository: ????????
+  #   ref: main

--- a/manifests/opensearch-dashboards-1.1.0.yml
+++ b/manifests/opensearch-dashboards-1.1.0.yml
@@ -1,0 +1,43 @@
+---
+schema-version: 1.0
+build:
+  name: OpenSearch Dashboards
+  version: 1.1.0
+components:
+  # hybrid repo (workbench)
+  # - name: queryWorkbench
+  #   repository: https://github.com/opensearch-project/sql.git
+  #   ref: main
+  - name: alertingDashboards
+    repository: https://github.com/opensearch-project/alerting-dashboards-plugin
+    ref: main
+  # hybrid repo (dashboards-notifications)
+  # - name: notificationsDashboards
+  #   repository: https://github.com/opensearch-project/notifications.git
+  #   ref: main
+  # - name: securityDashboards
+  #   repository: https://github.com/opensearch-project/security-dashboards-plugin
+  #   ref: main
+  # - name: indexManagementDashboards
+  #   repository: https://github.com/opensearch-project/index-management-dashboards-plugin
+  #   ref: main
+  # - name: anomalyDetectionDashboards
+  #   repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
+  #   ref: main
+  # # hybrid repo (dashboards-reports)
+  # - name: reportsDashboards
+  #   repository: https://github.com/opensearch-project/dashboards-reports.git
+  #   ref: main
+  # # hybrid repo (dashboards-notebooks)
+  # - name: notebooksDashboards
+  #   repository: https://github.com/opensearch-project/dashboards-notebooks.git
+  #   ref: main
+  # - name: traceAnalyticsDashboards
+  #   repository: https://github.com/opensearch-project/trace-analytics.git
+  #   ref: main
+  # - name: ganttChartDashboards
+  #   repository: ????????
+  #   ref: main
+  - name: OpenSearch-Dashboards
+    repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+    ref: 1.x


### PR DESCRIPTION
### Description
Produce an OpenSearch Dashboards bundle with plugins provided by a manifest.

This requires the manifest to be in order with plugins first and then Dashboards
being last. The plugins will need to pulled down and placed in the plugins
folder. Then we need to bootstrap to generate the modules so that we can actually
install the plugins to the release build.

What is missing?
* Environment setup, this requires nvm and yarn to be already set up.
We will need to set that up.
* Signing of the artifact
* Diff between release and snapshot
* Default script for plugins, this will need more information on how we want this to
look like.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/158
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
