### PR TITLE
Copy install script permissions during assembly

### DIFF
--- a/bundle-workflow/src/assemble.py
+++ b/bundle-workflow/src/assemble.py
@@ -58,7 +58,7 @@ with tempfile.TemporaryDirectory() as work_dir:
     logging.info(f"Installed plugins: {bundle.installed_plugins}")
 
     # Copy the tar installation script into the bundle
-    shutil.copyfile(
+    shutil.copy2(
         tarball_installation_script,
         os.path.join(
             bundle.archive_path, os.path.basename(tarball_installation_script)


### PR DESCRIPTION
Fixes
- https://github.com/opensearch-project/opensearch-build/issues/432

Testing
* Used the build workflow to make build locally
* Triggered assembly via `./build-workflow/assembly.sh ./artifacts/manifest.yml`
* Cracked open the bundle from `./bundle/opensearch-1.1.0-linux-x64.tar.gz` and then checked the permissions with `ls -al`
* Has execution permissons now

Signed-off-by: Peter Nied <petern@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
