### PR TITLE
Improve unittest for arch.py and separate tests to their own cases

### DIFF
--- a/bundle-workflow/tests/tests_system/test_arch.py
+++ b/bundle-workflow/tests/tests_system/test_arch.py
@@ -15,24 +15,25 @@ class TestArch(unittest.TestCase):
     def test_current_arch(self):
         self.assertTrue(current_arch() in ["x64", "arm64"])
 
-    @patch("subprocess.check_output")
-    def test_x64_arch(self, mock_subprocess):
-        mock_subprocess.return_value = "x86_64".encode()
+    @patch("subprocess.check_output", return_value="x86_64".encode())
+    def test_x86_64_return_x64_arch(self, mock_subprocess):
         self.assertTrue(current_arch() == "x64")
 
-    @patch("subprocess.check_output")
-    def test_arm64_arch(self, mock_subprocess):
-        mock_subprocess.return_value = "aarch64".encode()
-        self.assertTrue(current_arch() == "arm64")
-        mock_subprocess.return_value = "arm64".encode()
+    @patch("subprocess.check_output", return_value="aarch64".encode())
+    def test_aarch64_return_arm64_arch(self, mock_subprocess):
         self.assertTrue(current_arch() == "arm64")
 
-    @patch("subprocess.check_output")
+    @patch("subprocess.check_output", return_value="arm64".encode())
+    def test_arm64_return_arm64_arch(self, mock_subprocess):
+        self.assertTrue(current_arch() == "arm64")
+
+    @patch("subprocess.check_output", return_value="invalid".encode())
     def test_invalid_arch(self, mock_subprocess):
-        mock_subprocess.return_value = "invalid".encode()
         with self.assertRaises(ValueError) as context:
             current_arch()
+        self.assertEqual("Unsupported architecture: invalid", str(context.exception))
+
+    @patch("subprocess.check_output", return_value="x86_64".encode())
+    def test_subprocess_call(self, mock_subprocess):
+        current_arch()
         subprocess.check_output.assert_called_with(["uname", "-m"])
-        self.assertEqual(
-            "Unsupported architecture: invalid", context.exception.__str__()
-        )


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
 Improve unittest for arch.py and separate tests to their own cases
 
### Issues Resolved
#420 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
