### PR TITLE
Integ tests: Logic to read arguments from pipeline, and pull artifact…

### DIFF
--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -120,6 +120,15 @@ The following options are available.
 
 This step runs integration tests invoking `integtest.sh` in each component from bundle manifest.
 
+To run integration tests locally, use below command. It pulls down the built bundle and its manifest file from S3,
+reads all components of the bundle and runs integration tests against each component.
+ 
+```
+cd opensearch-build/bundle-workflow
+pipenv install
+pipenv shell
+python src/run_integ_test.py --s3-bucket <bucket_name> --opensearch-version <version> --build-id <id> --architecture <arch>
+```
 #### Backwards Compatibility Tests
 
 This step run backward compatibility invoking `bwctest.sh` in each component from bundle manifest.

--- a/bundle-workflow/src/run_integ_test.py
+++ b/bundle-workflow/src/run_integ_test.py
@@ -18,6 +18,8 @@ from manifests.test_manifest import TestManifest
 from system import console
 from system.temporary_directory import TemporaryDirectory
 from test_workflow.integ_test.integ_test_suite import IntegTestSuite
+from test_workflow.utils.bundle_manifest_provider import BundleManifestProvider
+from test_workflow.utils.build_manifest_provider import BuildManifestProvider
 
 # TODO: 1. log test related logging into a log file. Output only workflow logs on shell.
 # TODO: 2. Move common functions to utils.py
@@ -29,13 +31,16 @@ COMMON_DEPENDENCIES = ["OpenSearch", "common-utils", "job-scheduler", "alerting"
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
     parser.add_argument(
-        "--bundle-manifest", type=argparse.FileType("r"), help="Bundle Manifest file."
+        "--s3-bucket", type=str, help="S3 bucket name"
     )
     parser.add_argument(
-        "--build-manifest", type=argparse.FileType("r"), help="Build Manifest file."
+        "--opensearch-version", type=str, help="OpenSearch version to test"
     )
     parser.add_argument(
-        "--test-manifest", type=argparse.FileType("r"), help="Test Manifest file."
+        "--build-id", type=str, help="The build id for the built artifact"
+    )
+    parser.add_argument(
+        "--architecture", type=str, help="The os architecture e.g. x64, arm64"
     )
     parser.add_argument(
         "--keep",
@@ -101,9 +106,10 @@ def sync_dependencies_to_maven_local(work_dir, manifest_build_ver):
 def main():
     args = parse_arguments()
     console.configure(level=args.logging_level)
-    bundle_manifest = BundleManifest.from_file(args.bundle_manifest)
-    build_manifest = BuildManifest.from_file(args.build_manifest)
-    test_manifest = TestManifest.from_file(args.test_manifest)
+    script_dir = str(os.getcwd())
+    test_manifest_path = ("%s%s" % (script_dir, '/src/test_workflow/config/test_manifest.yml'))
+    with open(test_manifest_path, 'r') as file:
+        test_manifest = TestManifest.from_file(file)
     integ_test_config = dict()
     for component in test_manifest.components:
         if component.integ_test is not None:
@@ -111,6 +117,10 @@ def main():
     with TemporaryDirectory(keep=args.keep) as work_dir:
         logging.info("Switching to temporary work_dir: " + work_dir)
         os.chdir(work_dir)
+        bundle_manifest = BundleManifestProvider.load_manifest(
+            args.s3_bucket, args.build_id, args.opensearch_version, args.architecture)
+        build_manifest = BuildManifestProvider.load_manifest(
+            args.s3_bucket, args.build_id, args.opensearch_version, args.architecture)
         pull_common_dependencies(work_dir, build_manifest)
         sync_dependencies_to_maven_local(work_dir, build_manifest.build.version)
         for component in bundle_manifest.components:
@@ -120,6 +130,7 @@ def main():
                     integ_test_config[component.name],
                     bundle_manifest,
                     work_dir,
+                    args.s3_bucket
                 )
                 test_suite.execute()
             else:

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -20,11 +20,12 @@ class IntegTestSuite:
     test_support_matrix.yml
     """
 
-    def __init__(self, component, test_config, bundle_manifest, work_dir):
+    def __init__(self, component, test_config, bundle_manifest, work_dir, s3_bucket_name):
         self.component = component
         self.bundle_manifest = bundle_manifest
         self.work_dir = work_dir
         self.test_config = test_config
+        self.s3_bucket_name = s3_bucket_name
         self.script_finder = ScriptFinder()
         self.repo = GitRepository(
             self.component.repository,
@@ -74,7 +75,7 @@ class IntegTestSuite:
 
     def _setup_cluster_and_execute_test_config(self, config):
         security = self._is_security_enabled(config)
-        with LocalTestCluster.create(self.work_dir, self.bundle_manifest, security) as (test_cluster_endpoint, test_cluster_port):
+        with LocalTestCluster.create(self.work_dir, self.bundle_manifest, security, self.s3_bucket_name) as (test_cluster_endpoint, test_cluster_port):
             logging.info("component name: " + self.component.name)
             os.chdir(self.work_dir)
             # TODO: (Create issue) Since plugins don't have integtest.sh in version branch, hardcoded it to main

--- a/bundle-workflow/src/test_workflow/utils/build_manifest_provider.py
+++ b/bundle-workflow/src/test_workflow/utils/build_manifest_provider.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+import os
+from manifests.build_manifest import BuildManifest
+from aws.s3_bucket import S3Bucket
+
+
+class BuildManifestProvider:
+    @staticmethod
+    def get_build_manifest_relative_location(build_id, opensearch_version, architecture):
+        return f"builds/{opensearch_version}/{build_id}/{architecture}/manifest.yml"
+
+    @staticmethod
+    def load_manifest(bucket_name, build_id, opensearch_version, architecture):
+        local_path = str(os.getcwd())
+        manifest_s3_path = BuildManifestProvider.get_build_manifest_relative_location(build_id, opensearch_version, architecture)
+        S3Bucket(bucket_name).download_file(manifest_s3_path, local_path)
+        with open('manifest.yml', 'r') as file:
+            return BuildManifest.from_file(file)

--- a/bundle-workflow/src/test_workflow/utils/bundle_manifest_provider.py
+++ b/bundle-workflow/src/test_workflow/utils/bundle_manifest_provider.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+import os
+from manifests.bundle_manifest import BundleManifest
+from aws.s3_bucket import S3Bucket
+
+
+class BundleManifestProvider:
+    @staticmethod
+    def get_tarball_relative_location(build_id, opensearch_version, architecture):
+        return f"bundles/{opensearch_version}/{build_id}/{architecture}/opensearch-{opensearch_version}-linux-{architecture}.tar.gz"
+
+    @staticmethod
+    def get_tarball_name(opensearch_version, architecture):
+        return f"opensearch-{opensearch_version}-linux-{architecture}.tar.gz"
+
+    @staticmethod
+    def get_bundle_manifest_relative_location(build_id, opensearch_version, architecture):
+        return f"bundles/{opensearch_version}/{build_id}/{architecture}/manifest.yml"
+
+    @staticmethod
+    def load_manifest(bucket_name, build_id, opensearch_version, architecture):
+        local_path = str(os.getcwd())
+        manifest_s3_path = BundleManifestProvider.get_bundle_manifest_relative_location(build_id, opensearch_version, architecture)
+        S3Bucket(bucket_name).download_file(manifest_s3_path, local_path)
+        with open('manifest.yml', 'r') as file:
+            return BundleManifest.from_file(file)
+
+
+

--- a/bundle-workflow/tests/tests_test_workflow/test_build_manifest_provider.py
+++ b/bundle-workflow/tests/tests_test_workflow/test_build_manifest_provider.py
@@ -1,0 +1,12 @@
+import unittest
+
+from test_workflow.utils.build_manifest_provider import BuildManifestProvider
+
+
+class TestBuildManifestProvider(unittest.TestCase):
+    def test_get_manifest_relative_location(self):
+        actual = BuildManifestProvider.get_build_manifest_relative_location(
+            '25', '1.1.0', 'x64'
+        )
+        expected = 'builds/1.1.0/25/x64/manifest.yml'
+        self.assertEqual(actual, expected, "the manifest relative location is not as expected")

--- a/bundle-workflow/tests/tests_test_workflow/test_bundle_manifest_provider.py
+++ b/bundle-workflow/tests/tests_test_workflow/test_bundle_manifest_provider.py
@@ -1,0 +1,22 @@
+import unittest
+
+from test_workflow.utils.bundle_manifest_provider import BundleManifestProvider
+
+
+class TestBundleManifestProvider(unittest.TestCase):
+    def test_get_manifest_relative_location(self):
+        actual = BundleManifestProvider.get_bundle_manifest_relative_location(
+            '25', '1.1.0', 'x64'
+        )
+        expected = 'bundles/1.1.0/25/x64/manifest.yml'
+        self.assertEqual(actual, expected, "the manifest relative location is not as expected")
+
+    def test_get_tarball_relative_location(self):
+        actual = BundleManifestProvider.get_tarball_relative_location('25', '1.1.0', 'x64')
+        expected = 'bundles/1.1.0/25/x64/opensearch-1.1.0-linux-x64.tar.gz'
+        self.assertEqual(actual, expected, "the tarball relative location is not as expected")
+
+    def test_get_tarball_name(self):
+        actual = BundleManifestProvider.get_tarball_name('1.1.0', 'x64')
+        expected = f"opensearch-1.1.0-linux-x64.tar.gz"
+        self.assertEqual(actual, expected, "the tarball name is not as expected")


### PR DESCRIPTION
…s from s3

Signed-off-by: Himanshu Setia <setiah@amazon.com>

### Description
1. This change reworks the input arguments to the integ test tool to align them with what is passed by the pipeline
2. It adds logic to read the bundle manifest, build manifest from S3 and spin up local cluster from the tarball in S3
 
### Issues Resolved
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
