### PR TITLE
Fix tests on OSX.

### DIFF
--- a/.github/workflows/bundle-workflow.yml
+++ b/.github/workflows/bundle-workflow.yml
@@ -10,16 +10,17 @@ on:
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     env:
       PYTHON_VERSION: 3.7
-
     defaults:
       run:
         working-directory: ./bundle-workflow
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ env.PYTHON_VERSION }}

--- a/bundle-workflow/src/build_workflow/builder.py
+++ b/bundle-workflow/src/build_workflow/builder.py
@@ -28,6 +28,7 @@ class Builder:
         self.git_repo = git_repo
         self.build_recorder = build_recorder
         self.output_path = "artifacts"
+        self.artifacts_path = os.path.join(self.git_repo.working_directory, self.output_path)
 
     def build(self, target):
         build_script = ScriptFinder.find_build_script(
@@ -38,14 +39,11 @@ class Builder:
         self.build_recorder.record_component(self.component_name, self.git_repo)
 
     def export_artifacts(self):
-        artifacts_dir = os.path.realpath(
-            os.path.join(self.git_repo.working_directory, self.output_path)
-        )
         for artifact_type in ["maven", "bundle", "plugins", "libs", "core-plugins"]:
-            for dir, dirs, files in os.walk(os.path.join(artifacts_dir, artifact_type)):
+            for dir, dirs, files in os.walk(os.path.join(self.artifacts_path, artifact_type)):
                 for file_name in files:
                     absolute_path = os.path.join(dir, file_name)
-                    relative_path = os.path.relpath(absolute_path, artifacts_dir)
+                    relative_path = os.path.relpath(absolute_path, self.artifacts_path)
                     self.build_recorder.record_artifact(
                         self.component_name, artifact_type, relative_path, absolute_path
                     )

--- a/bundle-workflow/src/git/git_repository.py
+++ b/bundle-workflow/src/git/git_repository.py
@@ -23,7 +23,7 @@ class GitRepository:
         self.ref = ref
         if directory is None:
             self.temp_dir = tempfile.TemporaryDirectory()
-            self.dir = self.temp_dir.name
+            self.dir = os.path.realpath(self.temp_dir.name)
         else:
             self.temp_dir = None
             self.dir = directory

--- a/bundle-workflow/tests/tests_build_workflow/test_builder.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_builder.py
@@ -75,19 +75,17 @@ class TestBuilder(unittest.TestCase):
         mock_walk.side_effect = self.mock_os_walk
         self.builder.export_artifacts()
         self.assertEqual(self.builder.build_recorder.record_artifact.call_count, 2)
-        self.builder.build_recorder.record_artifact.assert_has_calls(
-            [
-                call(
-                    "component",
-                    "maven",
-                    "../../../maven/artifact1.jar",
-                    "/maven/artifact1.jar",
-                ),
-                call(
-                    "component",
-                    "core-plugins",
-                    "../../../core-plugins/plugin1.zip",
-                    "/core-plugins/plugin1.zip",
-                ),
-            ]
-        )
+        self.builder.build_recorder.record_artifact.assert_has_calls([
+            call(
+                "component",
+                "maven",
+                os.path.relpath("/maven/artifact1.jar", self.builder.artifacts_path),
+                "/maven/artifact1.jar",
+            ),
+            call(
+                "component",
+                "core-plugins",
+                os.path.relpath("/core-plugins/plugin1.zip", self.builder.artifacts_path),
+                "/core-plugins/plugin1.zip",
+            ),
+        ])

--- a/bundle-workflow/tests/tests_git/test_git_repository.py
+++ b/bundle-workflow/tests/tests_git/test_git_repository.py
@@ -25,7 +25,7 @@ class TestGitRepository(unittest.TestCase):
         self.assertEqual(self.repo.ref, "8ac515431bf24caf92fea9d9b0af3b8f10b88453")
         self.assertEqual(self.repo.sha, "8ac515431bf24caf92fea9d9b0af3b8f10b88453")
         self.assertIs(type(self.repo.temp_dir), tempfile.TemporaryDirectory)
-        self.assertEqual(self.repo.dir, self.repo.temp_dir.name)
+        self.assertEqual(self.repo.dir, os.path.realpath(self.repo.temp_dir.name))
         self.assertTrue(
             os.path.isfile(os.path.join(self.repo.dir, "CODE_OF_CONDUCT.md"))
         )


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

The `/tmp` location is a symlink to `/private/tmp`. Using `os.path.realpath` we can get the actual location. Relative paths differ by one `../` because of this as well. 

https://apple.stackexchange.com/questions/1043/why-is-tmp-a-symlink-to-private-tmp
https://stackoverflow.com/questions/58719364/tempfile-mkdtemp-difference-on-osx/69151922#69151922

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/452

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
