### PR TITLE
Created artifacts are put in the current local directory

### DIFF
--- a/bundle-workflow/src/build.py
+++ b/bundle-workflow/src/build.py
@@ -23,6 +23,8 @@ console.configure(level=args.logging_level)
 manifest = InputManifest.from_file(args.manifest)
 
 with TemporaryDirectory(keep=args.keep) as work_dir:
+    output_dir = os.path.join(os.getcwd(), "artifacts")
+
     logging.info(f"Building in {work_dir}")
 
     os.chdir(work_dir)
@@ -31,7 +33,7 @@ with TemporaryDirectory(keep=args.keep) as work_dir:
         name=manifest.build.name,
         version=manifest.build.version,
         snapshot=args.snapshot,
-        output_dir=os.path.join(os.getcwd(), "artifacts"),
+        output_dir=output_dir,
     )
 
     os.makedirs(target.output_dir, exist_ok=True)

--- a/bundle-workflow/src/build_workflow/build_recorder.py
+++ b/bundle-workflow/src/build_workflow/build_recorder.py
@@ -61,6 +61,7 @@ class BuildRecorder:
         manifest_path = os.path.join(self.target.output_dir, "manifest.yml")
         with open(manifest_path, "w") as file:
             yaml.dump(output_manifest.to_dict(), file)
+        logging.info(f'Created build manifest {manifest_path}')
 
     def __check_artifact(self, artifact_type, artifact_file):
         if artifact_type == "plugins":


### PR DESCRIPTION
Built artifacts were being placed into the tmp directory which was deleted, causing the publishing jobs to fail.

Signed-off-by: Peter Nied <petern@amazon.com>

### Testing
Built locally and confirmed the artifacts directory is created

### Issues Resolved
* #460 

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
