### PR TITLE
Refactor manifest writing.

### DIFF
--- a/bundle-workflow/src/assemble_workflow/bundle_recorder.py
+++ b/bundle-workflow/src/assemble_workflow/bundle_recorder.py
@@ -7,8 +7,6 @@
 import os
 from urllib.parse import urljoin
 
-import yaml
-
 from manifests.bundle_manifest import BundleManifest
 
 
@@ -67,10 +65,8 @@ class BundleRecorder:
         return self.bundle_manifest.to_manifest()
 
     def write_manifest(self, folder):
-        output_manifest = self.get_manifest()
         manifest_path = os.path.join(folder, "manifest.yml")
-        with open(manifest_path, "w") as file:
-            yaml.dump(output_manifest.to_dict(), file)
+        self.get_manifest().to_file(manifest_path)
 
     class BundleManifestBuilder:
         def __init__(self, build_id, name, version, arch, location):

--- a/bundle-workflow/src/build_workflow/build_recorder.py
+++ b/bundle-workflow/src/build_workflow/build_recorder.py
@@ -9,8 +9,6 @@ import os
 import shutil
 from zipfile import ZipFile
 
-import yaml
-
 from manifests.build_manifest import BuildManifest
 from system.properties_file import PropertiesFile
 
@@ -57,10 +55,8 @@ class BuildRecorder:
         return self.build_manifest.to_manifest()
 
     def write_manifest(self):
-        output_manifest = self.get_manifest()
         manifest_path = os.path.join(self.target.output_dir, "manifest.yml")
-        with open(manifest_path, "w") as file:
-            yaml.dump(output_manifest.to_dict(), file)
+        self.get_manifest().to_file(manifest_path)
         logging.info(f'Created build manifest {manifest_path}')
 
     def __check_artifact(self, artifact_type, artifact_file):

--- a/bundle-workflow/src/manifests/build_manifest.py
+++ b/bundle-workflow/src/manifests/build_manifest.py
@@ -12,7 +12,7 @@ The manifest contains information about the product that was built (in the `buil
 and the components that made up the build in the `components` section.
 
 The format for schema version 1.0 is:
-schema-version: 1.0
+schema-version: "1.0"
 build:
   name: string
   version: string
@@ -45,12 +45,12 @@ class BuildManifest(Manifest):
             map(lambda entry: self.Component(entry), data["components"])
         )
 
-    def to_dict(self):
+    def __to_dict__(self):
         return {
             "schema-version": "1.0",
-            "build": self.build.to_dict(),
+            "build": self.build.__to_dict__(),
             "components": list(
-                map(lambda component: component.to_dict(), self.components)
+                map(lambda component: component.__to_dict__(), self.components)
             ),
         }
 
@@ -61,7 +61,7 @@ class BuildManifest(Manifest):
             self.architecture = data["architecture"]
             self.id = data["id"]
 
-        def to_dict(self):
+        def __to_dict__(self):
             return {
                 "name": self.name,
                 "version": self.version,
@@ -78,7 +78,7 @@ class BuildManifest(Manifest):
             self.artifacts = data["artifacts"]
             self.version = data["version"]
 
-        def to_dict(self):
+        def __to_dict__(self):
             return {
                 "name": self.name,
                 "repository": self.repository,

--- a/bundle-workflow/src/manifests/bundle_manifest.py
+++ b/bundle-workflow/src/manifests/bundle_manifest.py
@@ -14,7 +14,7 @@ class BundleManifest(Manifest):
     and the components that made up the bundle in the `components` section.
 
     The format for schema version 1.0 is:
-        schema-version: 1.0
+        schema-version: "1.0"
         build:
           name: string
           version: string
@@ -36,12 +36,12 @@ class BundleManifest(Manifest):
             map(lambda entry: self.Component(entry), data["components"])
         )
 
-    def to_dict(self):
+    def __to_dict__(self):
         return {
             "schema-version": "1.0",
-            "build": self.build.to_dict(),
+            "build": self.build.__to_dict__(),
             "components": list(
-                map(lambda component: component.to_dict(), self.components)
+                map(lambda component: component.__to_dict__(), self.components)
             ),
         }
 
@@ -53,7 +53,7 @@ class BundleManifest(Manifest):
             self.location = data["location"]
             self.id = data["id"]
 
-        def to_dict(self):
+        def __to_dict__(self):
             return {
                 "name": self.name,
                 "version": self.version,
@@ -70,7 +70,7 @@ class BundleManifest(Manifest):
             self.commit_id = data["commit_id"]
             self.location = data["location"]
 
-        def to_dict(self):
+        def __to_dict__(self):
             return {
                 "name": self.name,
                 "repository": self.repository,

--- a/bundle-workflow/src/manifests/input_manifest.py
+++ b/bundle-workflow/src/manifests/input_manifest.py
@@ -10,7 +10,7 @@ The manifest contains information about the product that is being built (in the 
 and the components that make up the product in the `components` section.
 
 The format for schema version 1.0 is:
-schema-version: 1.0
+schema-version: "1.0"
 build:
   name: string
   version: string
@@ -37,10 +37,22 @@ class InputManifest(Manifest):
             map(lambda entry: self.Component(entry), data["components"])
         )
 
+    def __to_dict__(self):
+        return {
+            "schema-version": "1.0",
+            "build": self.build.__to_dict__(),
+            "components": list(
+                map(lambda component: component.__to_dict__(), self.components)
+            ),
+        }
+
     class Build:
         def __init__(self, data):
             self.name = data["name"]
             self.version = data["version"]
+
+        def __to_dict__(self):
+            return {"name": self.name, "version": self.version}
 
     class Component:
         def __init__(self, data):
@@ -49,3 +61,14 @@ class InputManifest(Manifest):
             self.ref = data["ref"]
             self.working_directory = data.get("working_directory", None)
             self.checks = data.get("checks", [])
+
+        def __to_dict__(self):
+            return Manifest.compact(
+                {
+                    "name": self.name,
+                    "repository": self.repository,
+                    "ref": self.ref,
+                    "working_directory": self.working_directory,
+                    "checks": self.checks,
+                }
+            )

--- a/bundle-workflow/src/manifests/manifest.py
+++ b/bundle-workflow/src/manifests/manifest.py
@@ -21,15 +21,15 @@ class Manifest(ABC):
 
     @classmethod
     def compact(cls, d):
-        clean = {}
+        result = {}
         for k, v in d.items():
             if isinstance(v, dict):
                 nested = cls.compact(v)
-                if len(nested.keys()) > 0:
-                    clean[k] = nested
-            elif v is not None and v != []:
-                clean[k] = v
-        return clean
+                if nested:
+                    result[k] = nested
+            elif v and v != []:
+                result[k] = v
+        return result
 
     def __to_dict(self):
         return {}

--- a/bundle-workflow/src/manifests/manifest.py
+++ b/bundle-workflow/src/manifests/manifest.py
@@ -39,7 +39,7 @@ class Manifest(ABC):
 
     def to_file(self, path):
         with open(path, "w") as file:
-            yaml.dump(self.to_dict(), file)
+            yaml.safe_dump(self.to_dict(), file)
 
     @abstractmethod
     def __init__(self, data):

--- a/bundle-workflow/src/manifests/manifest.py
+++ b/bundle-workflow/src/manifests/manifest.py
@@ -19,6 +19,28 @@ class Manifest(ABC):
         with open(path, "r") as f:
             return cls.from_file(f)
 
+    @classmethod
+    def compact(cls, d):
+        clean = {}
+        for k, v in d.items():
+            if isinstance(v, dict):
+                nested = cls.compact(v)
+                if len(nested.keys()) > 0:
+                    clean[k] = nested
+            elif v is not None and v != []:
+                clean[k] = v
+        return clean
+
+    def __to_dict(self):
+        return {}
+
+    def to_dict(self):
+        return Manifest.compact(self.__to_dict__())
+
+    def to_file(self, path):
+        with open(path, "w") as file:
+            yaml.dump(self.to_dict(), file)
+
     @abstractmethod
     def __init__(self, data):
         self.version = str(data["schema-version"])

--- a/bundle-workflow/src/manifests/test_manifest.py
+++ b/bundle-workflow/src/manifests/test_manifest.py
@@ -42,11 +42,11 @@ class TestManifest:
             map(lambda entry: self.Component(entry), data["components"])
         )
 
-    def to_dict(self):
+    def __to_dict__(self):
         return {
             "schema-version": "1.0",
             "components": list(
-                map(lambda component: component.to_dict(), self.components)
+                map(lambda component: component.__to_dict__(), self.components)
             ),
         }
 
@@ -56,7 +56,7 @@ class TestManifest:
             self.integ_test = data["integ-test"]
             self.bwc_test = data["bwc-test"]
 
-        def to_dict(self):
+        def __to_dict__(self):
             return {
                 "name": self.name,
                 "integ-test": self.integ_test,

--- a/bundle-workflow/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/bundle-workflow/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -72,7 +72,6 @@ class TestBundleRecorder(unittest.TestCase):
                     "name": "OpenSearch",
                     "version": "1.1.0",
                 },
-                "components": [],
                 "schema-version": "1.0",
             },
         )

--- a/bundle-workflow/tests/tests_build_workflow/test_build_recorder.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_build_recorder.py
@@ -235,7 +235,6 @@ class TestBuildRecorder(unittest.TestCase):
                     "name": "OpenSearch",
                     "version": "1.1.0",
                 },
-                "components": [],
                 "schema-version": "1.0",
             },
         )

--- a/bundle-workflow/tests/tests_manifests/test_input_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_input_manifest.py
@@ -7,45 +7,55 @@
 import os
 import unittest
 
+import yaml
+
 from manifests.input_manifest import InputManifest
 
 
 class TestInputManifest(unittest.TestCase):
     def setUp(self):
+        self.maxDiff = None
         self.manifests_path = os.path.realpath(
             os.path.join(os.path.dirname(__file__), "../../../manifests")
         )
 
-    def test_from_file_1_0(self):
-        with open(os.path.join(self.manifests_path, "opensearch-1.0.0.yml")) as f:
-            manifest = InputManifest.from_file(f)
-            self.assertEqual(manifest.version, "1.0")
-            self.assertEqual(manifest.build.name, "OpenSearch")
-            self.assertEqual(manifest.build.version, "1.0.0")
-            self.assertEqual(len(manifest.components), 12)
-            opensearch_component = manifest.components[0]
-            self.assertEqual(opensearch_component.name, "OpenSearch")
-            self.assertEqual(
-                opensearch_component.repository,
-                "https://github.com/opensearch-project/OpenSearch.git",
-            )
-            self.assertEqual(opensearch_component.ref, "1.0")
-            for component in manifest.components:
-                self.assertIsInstance(component.ref, str)
+    def test_1_0(self):
+        path = os.path.join(self.manifests_path, "opensearch-1.0.0.yml")
+        manifest = InputManifest.from_path(path)
+        self.assertEqual(manifest.version, "1.0")
+        self.assertEqual(manifest.build.name, "OpenSearch")
+        self.assertEqual(manifest.build.version, "1.0.0")
+        self.assertEqual(len(manifest.components), 12)
+        opensearch_component = manifest.components[0]
+        self.assertEqual(opensearch_component.name, "OpenSearch")
+        self.assertEqual(
+            opensearch_component.repository,
+            "https://github.com/opensearch-project/OpenSearch.git",
+        )
+        self.assertEqual(opensearch_component.ref, "1.0")
+        for component in manifest.components:
+            self.assertIsInstance(component.ref, str)
 
-    def test_from_file_1_1(self):
-        with open(os.path.join(self.manifests_path, "opensearch-1.1.0.yml")) as f:
-            manifest = InputManifest.from_file(f)
-            self.assertEqual(manifest.version, "1.0")
-            self.assertEqual(manifest.build.name, "OpenSearch")
-            self.assertEqual(manifest.build.version, "1.1.0")
-            self.assertEqual(len(manifest.components), 14)
-            opensearch_component = manifest.components[0]
-            self.assertEqual(opensearch_component.name, "OpenSearch")
-            self.assertEqual(
-                opensearch_component.repository,
-                "https://github.com/opensearch-project/OpenSearch.git",
-            )
-            self.assertEqual(opensearch_component.ref, "1.x")
-            for component in manifest.components:
-                self.assertIsInstance(component.ref, str)
+    def test_1_1(self):
+        path = os.path.join(self.manifests_path, "opensearch-1.1.0.yml")
+        manifest = InputManifest.from_path(path)
+        self.assertEqual(manifest.version, "1.0")
+        self.assertEqual(manifest.build.name, "OpenSearch")
+        self.assertEqual(manifest.build.version, "1.1.0")
+        self.assertEqual(len(manifest.components), 14)
+        opensearch_component = manifest.components[0]
+        self.assertEqual(opensearch_component.name, "OpenSearch")
+        self.assertEqual(
+            opensearch_component.repository,
+            "https://github.com/opensearch-project/OpenSearch.git",
+        )
+        self.assertEqual(opensearch_component.ref, "1.x")
+        for component in manifest.components:
+            self.assertIsInstance(component.ref, str)
+
+    def test_to_dict(self):
+        path = os.path.join(self.manifests_path, "opensearch-1.1.0.yml")
+        manifest = InputManifest.from_path(path)
+        data = manifest.to_dict()
+        with open(path) as f:
+            self.assertEqual(yaml.safe_load(f), data)

--- a/manifests/1.0.1/manifest.linux.arm64.1.0.1.yml
+++ b/manifests/1.0.1/manifest.linux.arm64.1.0.1.yml
@@ -1,6 +1,6 @@
 ---
 manifest:
-  schema-version: 1.0
+  schema-version: "1.0"
 build:
   version: 1.0.1
   platform: linux

--- a/manifests/1.0.1/manifest.linux.x64.1.0.1.yml
+++ b/manifests/1.0.1/manifest.linux.x64.1.0.1.yml
@@ -1,6 +1,6 @@
 ---
 manifest:
-  schema-version: 1.0
+  schema-version: "1.0"
 build:
   version: 1.0.1
   platform: linux

--- a/manifests/1.0.1/opensearch-1.0.1.yml
+++ b/manifests/1.0.1/opensearch-1.0.1.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: 1.0
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.0.1

--- a/manifests/1.1.0/manifest.linux.arm64.1.1.0.yml
+++ b/manifests/1.1.0/manifest.linux.arm64.1.1.0.yml
@@ -1,6 +1,6 @@
 ---
 manifest:
-  schema-version: 1.0
+  schema-version: "1.0"
 build:
   version: 1.1.0
   platform: linux

--- a/manifests/1.1.0/manifest.linux.x64.1.1.0.yml
+++ b/manifests/1.1.0/manifest.linux.x64.1.1.0.yml
@@ -1,6 +1,6 @@
 ---
 manifest:
-  schema-version: 1.0
+  schema-version: "1.0"
 build:
   version: 1.1.0
   platform: linux

--- a/manifests/manifest.linux.arm64.example.yml
+++ b/manifests/manifest.linux.arm64.example.yml
@@ -1,6 +1,6 @@
 ---
 manifest:
-  schema-version: 1.0
+  schema-version: "1.0"
 build:
   version: 1.0.0
   platform: linux

--- a/manifests/manifest.linux.x64.example.yml
+++ b/manifests/manifest.linux.x64.example.yml
@@ -1,6 +1,6 @@
 ---
 manifest:
-  schema-version: 1.0
+  schema-version: "1.0"
 build:
   version: 1.0.0
   platform: linux

--- a/manifests/opensearch-1.0.0-maven.yml
+++ b/manifests/opensearch-1.0.0-maven.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: 1.0
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.0.0

--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: 1.0
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.1.0


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Extracted from #461.

- Added `Manifest#to_file`.
- Refactored `__to_dict__` into private methods and added a single `Manifest#to_dict`. 
- Added `Manifest#compact` that removes empty keys when writing manifests.
- Made sure `schema-version` is `str`.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
