### PR TITLE
Add notification during bundle builds

### DIFF
--- a/bundle-workflow/Jenkinsfile
+++ b/bundle-workflow/Jenkinsfile
@@ -119,6 +119,6 @@ void build() {
 
 void publishNotification(icon, msg) {
     withCredentials([string(credentialsId: 'BUILD_NOTICE_WEBHOOK', variable: 'TOKEN')]) {
-        sh """curl -XPOST --header "Content-Type: application/json" --data '{"result_text": "$icon ${env.JOB_NAME} [${env.BUILD_NUMBER}] $msg ${env.BUILD_URL}"}' $TOKEN"""
+        sh """curl -XPOST --header "Content-Type: application/json" --data '{"result_text": "$icon ${env.JOB_NAME} [${env.BUILD_NUMBER}] $msg ${env.BUILD_URL}\nManifest: ${BUILD_MANIFEST}"}' $TOKEN"""
     }
 }

--- a/bundle-workflow/Jenkinsfile
+++ b/bundle-workflow/Jenkinsfile
@@ -24,6 +24,11 @@ pipeline {
             }
         }
         stage('build') {
+            agent {
+                node {
+                    label 'Jenkins-Agent-al2-x64-m5xlarge'
+                }
+            }
             stages {
                 stage('build-snapshots') {
                     environment {
@@ -87,6 +92,14 @@ pipeline {
                     }
                 }
             }
+            post() {
+                success {
+                    publishNotificaiton(":white_check-mark:", "Successful Build")
+                }
+                failure {
+                    publishNotificaiton(":warning:", "Failed Build")
+                }
+            }
         }
     }
 }
@@ -101,5 +114,11 @@ void build() {
     withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
         s3Upload(file: 'artifacts', bucket: "${ARTIFACT_BUCKET_NAME}", path: "builds/${manifest.build.version}/${OPENSEARCH_BUILD_ID}/${manifest.build.architecture}")
         s3Upload(file: "bundle", bucket: "${ARTIFACT_BUCKET_NAME}", path: "bundles/${manifest.build.version}/${OPENSEARCH_BUILD_ID}/${manifest.build.architecture}")
+    }
+}
+
+void publishNotificaiton(icon, msg) {
+    withCredentials([string(credentialsId: 'BUILD_NOTICE_WEBHOOK', variable: 'TOKEN')]) {
+        sh """curl -XPOST --header "Content-Type: application/json" --data '{"result_text": "$icon ${env.JOB_NAME} [${env.BUILD_NUMBER}] $msg ${env.BUILD_URL}"}' $TOKEN"""
     }
 }

--- a/bundle-workflow/Jenkinsfile
+++ b/bundle-workflow/Jenkinsfile
@@ -94,10 +94,10 @@ pipeline {
             }
             post() {
                 success {
-                    publishNotificaiton(":white_check-mark:", "Successful Build")
+                    publishNotification(":white_check-mark:", "Successful Build")
                 }
                 failure {
-                    publishNotificaiton(":warning:", "Failed Build")
+                    publishNotification(":warning:", "Failed Build")
                 }
             }
         }
@@ -117,7 +117,7 @@ void build() {
     }
 }
 
-void publishNotificaiton(icon, msg) {
+void publishNotification(icon, msg) {
     withCredentials([string(credentialsId: 'BUILD_NOTICE_WEBHOOK', variable: 'TOKEN')]) {
         sh """curl -XPOST --header "Content-Type: application/json" --data '{"result_text": "$icon ${env.JOB_NAME} [${env.BUILD_NUMBER}] $msg ${env.BUILD_URL}"}' $TOKEN"""
     }


### PR DESCRIPTION
Wiring up a simple notification via Slack integration webhook to keep the team abreast of the builds.

![image](https://user-images.githubusercontent.com/2754967/133331669-a0cf3ea8-fa98-4912-a7c3-54cc96a4dc0c.png)
### Related Issue
* #211

Signed-off-by: Peter Nied <petern@amazon.com>

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
