### PR TITLE
Add test_recorder implementation and integration with integ_test_suite

### DIFF
--- a/bundle-workflow/src/run_integ_test.py
+++ b/bundle-workflow/src/run_integ_test.py
@@ -104,7 +104,6 @@ def sync_dependencies_to_maven_local(work_dir, manifest_build_ver):
 
 def main():
     args = parse_arguments()
-    logging.getLogger('').handlers = []
     console.configure(level=args.logging_level)
     bundle_manifest = BundleManifest.from_file(args.bundle_manifest)
     build_manifest = BuildManifest.from_file(args.build_manifest)

--- a/bundle-workflow/src/run_integ_test.py
+++ b/bundle-workflow/src/run_integ_test.py
@@ -59,6 +59,7 @@ def parse_arguments():
     args = parser.parse_args()
     return args
 
+
 # TODO: replace with DependencyProvider - https://github.com/opensearch-project/opensearch-build/issues/283
 def pull_common_dependencies(work_dir, build_manifest):
     logging.info("Pulling common dependencies for integration tests")

--- a/bundle-workflow/src/test.py
+++ b/bundle-workflow/src/test.py
@@ -6,13 +6,10 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import os
-
 from manifests.bundle_manifest import BundleManifest
 from system import console
 from test_workflow.bwc_test.bwc_test_suite import BwcTestSuite
 from test_workflow.test_args import TestArgs
-from test_workflow.test_recorder import TestRecorder
 
 args = TestArgs()
 console.configure(level=args.logging_level)

--- a/bundle-workflow/src/test.py
+++ b/bundle-workflow/src/test.py
@@ -18,7 +18,6 @@ args = TestArgs()
 console.configure(level=args.logging_level)
 
 manifest = BundleManifest.from_file(args.manifest)
-test_recorder = TestRecorder(os.path.dirname(manifest.name))
 
 
 def bwc_test_suite():

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -33,12 +33,10 @@ class IntegTestSuite:
             self.component.commit_id,
             os.path.join(self.work_dir, self.component.name),
         )
-        self.individual_config = None
 
     def execute(self):
         self._fetch_plugin_specific_dependencies()
         for config in self.test_config.integ_test["test-configs"]:
-            self.individual_config = config
             self._setup_cluster_and_execute_test_config(config)
 
     # TODO: fetch pre-built dependencies from s3
@@ -83,9 +81,9 @@ class IntegTestSuite:
             os.chdir(self.work_dir)
             # TODO: (Create issue) Since plugins don't have integtest.sh in version branch, hardcoded it to main
             security = self._is_security_enabled(config)
-            self._execute_integtest_sh(test_cluster_endpoint, test_cluster_port, security)
+            self._execute_integtest_sh(test_cluster_endpoint, test_cluster_port, security, config)
 
-    def _execute_integtest_sh(self, endpoint, port, security):
+    def _execute_integtest_sh(self, endpoint, port, security, config):
         script = self.script_finder.find_integ_test_script(
             self.component.name, self.repo.dir
         )
@@ -95,9 +93,13 @@ class IntegTestSuite:
             results_dir = os.path.join(
                 self.repo.dir, "integ-test", "build", "reports", "tests", "integTest"
             )
-            self.test_recorder.record_test_outcome(
-                self.component.name, self.individual_config, status, stdout, stderr, walk(results_dir)
-            )
+            self.test_recorder.record_test_outcome(self.component.name,
+                                                   config,
+                                                   status,
+                                                   stdout,
+                                                   stderr,
+                                                   walk(results_dir)
+                                                   )
         else:
             logging.info(
                 f"{script} does not exist. Skipping integ tests for {self.component.name}"

--- a/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
@@ -61,7 +61,9 @@ class LocalTestCluster(TestCluster):
             return
         self.terminate_process()
         logs_files = walk(os.path.join(self.work_dir, self.install_dir, "logs"))
-        self.test_recorder.record_local_cluster_logs(self.component_name, self.component_config, self.local_cluster_stdout,
+        self.test_recorder.record_local_cluster_logs(self.component_name,
+                                                     self.component_config,
+                                                     self.local_cluster_stdout,
                                                      self.local_cluster_stderr,
                                                      logs_files)
 

--- a/bundle-workflow/src/test_workflow/test_recorder.py
+++ b/bundle-workflow/src/test_workflow/test_recorder.py
@@ -3,34 +3,143 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-
 import logging
+import os
+import shutil
+import tempfile
+
+import yaml
 
 
 class TestRecorder:
-    def __init__(self, location):
-        self.location = location
-        logging.info(f"TestRecorder storing results in {location}")
+    ACCEPTED_TEST_TYPES = ["integ-test", "bwc-test", "perf-test"]
 
-    def record_cluster_logs(self, log_files):
+    def __init__(self, test_run_id, test_type, location=None):
+        self.test_type = test_type
+        self.test_run_id = test_run_id
+
+        if self.test_type not in self.ACCEPTED_TEST_TYPES:
+            raise ValueError(f"test_type is invalid. Acceptable test_type are {self.ACCEPTED_TEST_TYPES}")
+
+        if location is None:
+            location = tempfile.TemporaryDirectory()
+            self.location = location.name
+        else:
+            self.location = location
+        logging.info(f'TestRecorder storing results in {os.path.realpath(self.location)}')
+
+    def record_local_cluster_logs(self, component_name, component_test_config, stdout, stderr, log_files):
         """
         Record the test cluster logs.
-        :param results: A generator that yields tuples containing test cluster log files, in the form (absolute_path, relative_path)
+        :param component_name: component that is under test right now.
+        :param component_test_config: component_config under consideration for test eg: with/without-security.
+        :param stdout: A string containing the stdout stream from the test process.
+        :param stderr: A string containing the stderr stream from the test process.
+        :param log_files: A generator that yields tuples containing test cluster log files, in the form (absolute_path, relative_path).
         """
-        logging.info(f"Recording log files: {list(log_files)}")
 
-    def record_integ_test_outcome(
-        self, component_name, exit_status, stdout, stderr, results
+        base = self.__create_base_folder_structure(component_name, component_test_config)
+        dest_directory = os.path.join(base, "local_cluster_logs")
+        os.makedirs(dest_directory, exist_ok=False)
+        logging.info(
+            f"Recording local cluster logs for {component_name} with {component_test_config} config in {os.path.realpath(dest_directory)}")
+        self.__generate_std_files(stdout, stderr, os.path.realpath(dest_directory))
+        local_cluster_log_files = list(log_files)
+        print(f"Log files are: {local_cluster_log_files}")
+        for log_file in local_cluster_log_files:
+            dest_file = os.path.join(dest_directory, os.path.basename(log_file[0]))
+            shutil.copyfile(log_file[0], dest_file)
+
+    def record_remote_cluster_logs(self, component_name, component_test_config, exit_code, stdout, stderr,
+                                   log_file_location, results):
+        """
+        Record the test cluster logs.
+        :param component_name: component that is under test right now.
+        :param exit_code: Integer value of the exit code.
+        :param stdout: A string containing the stdout stream from the test process.
+        :param stderr: A string containing the stderr stream from the test process.
+        :param component_test_config: component_config under consideration for test eg: with/without-security.
+        :param log_file_location: A string that gives log file location.
+        :param results: A generator that yields tuples containing test results files, in the form (absolute_path, relative_path).
+        """
+
+        base = self.__create_base_folder_structure(component_name, component_test_config)
+        dest_directory = os.path.join(base, "remote_cluster_logs")
+        os.makedirs(dest_directory, exist_ok=False)
+        logging.info(f"Recording remote cluster logs for {component_name} in {os.path.realpath(dest_directory)}")
+        self.__generate_std_files(stdout, stderr, os.path.realpath(dest_directory))
+        exit_status = self.__get_exit_status(exit_code)
+        component_yml = self.__generate_test_outcome_yml(component_name, component_test_config, exit_status,
+                                                         log_file_location)
+        shutil.copyfile(component_yml, os.path.join(dest_directory, os.path.basename(component_yml)))
+        results_dir = list(results)
+        for result in results_dir:
+            dest_file = os.path.join(dest_directory, os.path.basename(result[0]))
+            shutil.copyfile(result[0], dest_file)
+
+    def record_test_outcome(
+            self, component_name, component_test_config, exit_code, stdout, stderr, results
     ):
         """
         Record the outcome of a integration test run.
         :param component_name: The name of the component that ran tests.
-        :param exit_code: One of SUCCESS, FAILED, ERROR. SUCCESS means the tests ran and all of them passed.
-        FAILED means the tests ran and at least one failed. ERROR means the test suite did not run correctly.
+        :param component_test_config: component_config under consideration for test eg: with/without-security.
+        :param exit_code: Integer value of the exit code.
         :param stdout: A string containing the stdout stream from the test process.
         :param stderr: A string containing the stderr stream from the test process.
         :param results: A generator that yields tuples containing test results files, in the form (absolute_path, relative_path).
         """
+
+        base = self.__create_base_folder_structure(component_name, component_test_config)
+        dest_directory = os.path.join(base, "test_outcome")
+        os.makedirs(dest_directory, exist_ok=False)
         logging.info(
-            f"Recording test results for {component_name}. Exit status: {exit_status}, stdout: {stdout}, stderr: {stderr}, results files: {results}"
-        )
+            f"Recording component test results for {component_name} at {os.path.realpath(dest_directory)}")
+        self.__generate_std_files(stdout, stderr, dest_directory)
+        results_dir = list(results)
+        for result in results_dir:
+            dest_file = os.path.join(dest_directory, os.path.basename(result[0]))
+            shutil.copyfile(result[0], dest_file)
+        exit_status = self.__get_exit_status(exit_code)
+        component_yml = self.__generate_test_outcome_yml(component_name, component_test_config, exit_status, "S3")
+        shutil.copyfile(component_yml, os.path.join(dest_directory, os.path.basename(component_yml)))
+
+    def __create_base_folder_structure(self, component_name, component_test_config):
+        dest_directory = os.path.join(self.location, "tests", self.test_run_id, self.test_type, str(component_name),
+                                      str(component_test_config))
+        os.makedirs(dest_directory, exist_ok=True)
+        return os.path.realpath(dest_directory)
+
+    def __get_exit_status(self, exit_code):
+        if exit_code == 0:
+            return "SUCCESS"
+        else:
+            return "FAILED/ERROR"
+
+    def __generate_test_outcome_yml(self, component_name, component_test_config, exit_status, log_file_location):
+        dict_file = {
+            "test_type": self.test_type,
+            "test_run_id": self.test_run_id,
+            "component_name": component_name,
+            "test_config": component_test_config,
+            "status": exit_status,
+            "log_file_location": log_file_location
+        }
+        with open("%s.yml" % component_name, "w") as file:
+            yaml.dump(dict_file, file)
+        return os.path.realpath("%s.yml" % component_name)
+
+    def __generate_std_files(self, stdout, stderr, location):
+        stdout_file = open(os.path.join(location, "stdout.txt"), "w")
+        stderr_file = open(os.path.join(location, "stderr.txt"), "w")
+        try:
+            stdout_file.write(stdout)
+            stderr_file.write(stderr)
+        finally:
+            stdout_file.close()
+            stderr_file.close()
+
+    def cleanup(self):
+        if self.location:
+            logging.info(f"Removing the {os.path.realpath(self.location)} directory")
+            os.remove(os.path.realpath(self.location))

--- a/bundle-workflow/src/test_workflow/test_recorder.py
+++ b/bundle-workflow/src/test_workflow/test_recorder.py
@@ -116,7 +116,7 @@ class TestRecorder:
             return "FAILED/ERROR"
 
     def __generate_test_outcome_yml(self, component_name, component_test_config, exit_status, log_file_location):
-        dict_file = {
+        outcome = {
             "test_type": self.test_type,
             "test_run_id": self.test_run_id,
             "component_name": component_name,
@@ -125,20 +125,11 @@ class TestRecorder:
             "log_file_location": log_file_location
         }
         with open("%s.yml" % component_name, "w") as file:
-            yaml.dump(dict_file, file)
+            yaml.dump(outcome, file)
         return os.path.realpath("%s.yml" % component_name)
 
-    def __generate_std_files(self, stdout, stderr, location):
-        stdout_file = open(os.path.join(location, "stdout.txt"), "w")
-        stderr_file = open(os.path.join(location, "stderr.txt"), "w")
-        try:
+    def __generate_std_files(self, stdout, stderr, output_path):
+        with open(os.path.join(output_path, "stdout.txt"), "w") as stdout_file:
             stdout_file.write(stdout)
+        with open(os.path.join(output_path, "stderr.txt"), "w") as stderr_file:
             stderr_file.write(stderr)
-        finally:
-            stdout_file.close()
-            stderr_file.close()
-
-    def cleanup(self):
-        if self.location:
-            logging.info(f"Removing the {os.path.realpath(self.location)} directory")
-            os.remove(os.path.realpath(self.location))

--- a/bundle-workflow/src/test_workflow/test_recorder.py
+++ b/bundle-workflow/src/test_workflow/test_recorder.py
@@ -45,7 +45,6 @@ class TestRecorder:
             f"Recording local cluster logs for {component_name} with {component_test_config} config in {os.path.realpath(dest_directory)}")
         self.__generate_std_files(stdout, stderr, os.path.realpath(dest_directory))
         local_cluster_log_files = list(log_files)
-        print(f"Log files are: {local_cluster_log_files}")
         for log_file in local_cluster_log_files:
             dest_file = os.path.join(dest_directory, os.path.basename(log_file[0]))
             shutil.copyfile(log_file[0], dest_file)


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Adds test_recorder implementation and integration with integ_test_suite. 
Test_recorder will be instantiated by each test_suite. The test_recorder object will then be passed to test_publisher to store the results in a specific location (s3, long-lived-cluster, etc).

**To-Do:**
1. Integrate with other test_suite i.e. bwc-test, perf-test
2. Add UT
 
### Issues Resolved
#340 

### Tests:
```
/tmp/tmp93i0ybyw/tests/2/integ-test/index-management/with-security ~  ls local_cluster_logs test_outcome
local_cluster_logs:
gc.log                                 opensearch_deprecation.json            opensearch_index_indexing_slowlog.log  opensearch_server.json
gc.log.00                              opensearch_deprecation.log             opensearch_index_search_slowlog.json   stderr.txt
opensearch.log                         opensearch_index_indexing_slowlog.json opensearch_index_search_slowlog.log    stdout.txt

test_outcome:
index-management.yml stderr.txt           stdout.txt


~ cat test_outcome/index-management.yml
component_name: index-management
log_file_location: S3
status: FAILED/ERROR
test_config: with-security
test_run_id: '2'
test_type: integ-test
```
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
