### PR TITLE
[Version] Bump opensearch-1.1.0.yml to new 1.1 branch

### DIFF
--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -6,7 +6,7 @@ build:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: 1.x
+    ref: 1.1
     checks:
       - gradle:publish
       - gradle:properties:version


### PR DESCRIPTION
Bump ref parameter in opensearch-1.1.0.yml to reference new 1.1 branch.