### PR TITLE
Fix: 1.1 manifest and test using that data.

### DIFF
--- a/bundle-workflow/tests/tests_manifests/test_input_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_input_manifest.py
@@ -49,7 +49,7 @@ class TestInputManifest(unittest.TestCase):
             opensearch_component.repository,
             "https://github.com/opensearch-project/OpenSearch.git",
         )
-        self.assertEqual(opensearch_component.ref, "1.x")
+        self.assertEqual(opensearch_component.ref, "1.1")
         for component in manifest.components:
             self.assertIsInstance(component.ref, str)
 

--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -6,7 +6,7 @@ build:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: 1.1
+    ref: "1.1"
     checks:
       - gradle:publish
       - gradle:properties:version


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

In #468 we introduced a broken test that relies on this data and committed a Float type into the .yml. Both fixed here.

Tests don't re-run when manifest data changes, which I think is OK as we rarely rely on data here and it's going to be stable now.

The floats is something that should fail in manifest validation. Added https://github.com/opensearch-project/opensearch-build/issues/470.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
