### PR TITLE
Generalize build arch for k-NN on x64

### DIFF
--- a/bundle-workflow/scripts/components/k-NN/build.sh
+++ b/bundle-workflow/scripts/components/k-NN/build.sh
@@ -65,7 +65,7 @@ mkdir -p $OUTPUT/libs
 cd jni
 
 # For x64, generalize arch so library is compatible for processors without simd instruction extensions
-if ["$ARCHITECTURE" = "x64"]; then 
+if [ "$ARCHITECTURE" = "x64" ]; then 
     sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
 fi
 

--- a/bundle-workflow/scripts/components/k-NN/build.sh
+++ b/bundle-workflow/scripts/components/k-NN/build.sh
@@ -63,6 +63,12 @@ mkdir -p $OUTPUT/libs
 
 # Build knnlib and copy it to libs
 cd jni
+
+# For x64, generalize arch so library is compatible for processors without simd instruction extensions
+if ["$ARCHITECTURE" = "x64"]; then 
+    sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
+fi
+
 cmake .
 make
 


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Adds generic x64 architecture option to k-NN library build.

The same thing was done in [ODFE](https://github.com/opendistro-for-elasticsearch/k-NN/blob/main/.github/workflows/CD.yml#L125).
 
### Issues Resolved
#481 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
