### PR TITLE
Change k-NN to pull submodule to fix build break

### DIFF
--- a/bundle-workflow/scripts/components/k-NN/build.sh
+++ b/bundle-workflow/scripts/components/k-NN/build.sh
@@ -63,6 +63,12 @@ mkdir -p $OUTPUT/libs
 
 # Build knnlib and copy it to libs
 cd jni
+
+# For x64, generalize arch so library is compatible for processors without simd instruction extensions
+if [ "$ARCHITECTURE" = "x64" ]; then 
+    sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
+fi
+
 cmake .
 make
 

--- a/bundle-workflow/scripts/components/k-NN/build.sh
+++ b/bundle-workflow/scripts/components/k-NN/build.sh
@@ -61,6 +61,11 @@ fi
 work_dir=$PWD
 mkdir -p $OUTPUT/libs
 
+# Pull library submodule explicitly. While "cmake ." actually pulls the submodule if its not there, we 
+# need to pull it before calling cmake. Also, we need to call it from the root git directory.
+# Otherwise, the submodule update call may fail on earlier versions of git.
+git submodule update --init -- jni/external/nmslib
+
 # Build knnlib and copy it to libs
 cd jni
 


### PR DESCRIPTION
### Description
This change pulls the nmslib submodule before editing its CMakeLists file. 

To test, I ran the following in an AL2 container on my macbook: 
```
bash-4.2# ./bundle-workflow/build.sh manifests/opensearch-1.1.0.yml --component k-NN --snapshot
Installing dependencies in ./bundle-workflow ...
Installing dependencies from Pipfile.lock (e67524)...
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 0/0 — 00:00:00
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Running ./bundle-workflow/src/build.py manifests/opensearch-1.1.0.yml --component k-NN --snapshot ...
2021-09-15 17:44:23 INFO     Building in /tmp/tmplz8kdalv
2021-09-15 17:44:23 INFO     Building OpenSearch (x64) into /opensearch-build/artifacts
2021-09-15 17:44:23 INFO     Skipping OpenSearch
2021-09-15 17:44:23 INFO     Skipping common-utils
2021-09-15 17:44:23 INFO     Skipping job-scheduler
2021-09-15 17:44:23 INFO     Skipping sql
2021-09-15 17:44:23 INFO     Skipping alerting
2021-09-15 17:44:23 INFO     Skipping security
2021-09-15 17:44:23 INFO     Skipping performance-analyzer-rca
2021-09-15 17:44:23 INFO     Skipping performance-analyzer
2021-09-15 17:44:23 INFO     Skipping index-management
2021-09-15 17:44:23 INFO     Building k-NN
2021-09-15 17:44:23 INFO     Executing "git init" in /tmp/tmplz8kdalv/k-NN
2021-09-15 17:44:23 INFO     Executing "git remote add origin https://github.com/opensearch-project/k-NN.git" in /tmp/tmplz8kdalv/k-NN
2021-09-15 17:44:23 INFO     Executing "git fetch --depth 1 origin 1.1" in /tmp/tmplz8kdalv/k-NN
2021-09-15 17:44:25 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmplz8kdalv/k-NN
2021-09-15 17:44:25 INFO     Executing "git rev-parse HEAD" in /tmp/tmplz8kdalv/k-NN
2021-09-15 17:44:25 INFO     Checked out https://github.com/opensearch-project/k-NN.git@1.1 into /tmp/tmplz8kdalv/k-NN at c21b480feec2b03f0f37b702b3b5e39dc7e6f5e8
2021-09-15 17:44:25 INFO     Executing "/opensearch-build/bundle-workflow/scripts/components/k-NN/build.sh -v 1.1.0 -a x64 -s true -o artifacts" in /tmp/tmplz8kdalv/k-NN
+ getopts :h:v:s:o:a: arg
+ case $arg in
+ VERSION=1.1.0
+ getopts :h:v:s:o:a: arg
+ case $arg in
+ ARCHITECTURE=x64
+ getopts :h:v:s:o:a: arg
+ case $arg in
+ SNAPSHOT=true
+ getopts :h:v:s:o:a: arg
+ case $arg in
+ OUTPUT=artifacts
+ getopts :h:v:s:o:a: arg
+ '[' -z 1.1.0 ']'
+ [[ true == \t\r\u\e ]]
+ VERSION=1.1.0-SNAPSHOT
+ '[' -z artifacts ']'
+ work_dir=/tmp/tmplz8kdalv/k-NN
+ mkdir -p artifacts/libs
+ git submodule update --init -- jni/external/nmslib
Submodule 'jni/external/nmslib' (https://github.com/nmslib/nmslib.git) registered for path 'jni/external/nmslib'
Cloning into '/tmp/tmplz8kdalv/k-NN/jni/external/nmslib'...
Submodule path 'jni/external/nmslib': checked out 'a2d6624e1315402662025debfdd614b505d9c3ef'
+ cd jni
+ '[' x64 = x64 ']'
+ sed -i s/-march=native/-march=x86-64/g external/nmslib/similarity_search/CMakeLists.txt
+ cmake .
-- The C compiler identification is GNU 7.3.1
...
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/tmplz8kdalv/k-NN/jni
+ make
Scanning dependencies of target NonMetricSpaceLib
[  2%] Building CXX object external/nmslib/similarity_search/src/CMakeFiles/NonMetricSpaceLib.dir/distcomp_js.cc.o
...
[ 98%] Built target NonMetricSpaceLib
Scanning dependencies of target KNNIndexV2_0_11
[100%] Building CXX object CMakeFiles/KNNIndexV2_0_11.dir/src/org_opensearch_knn_index_v2011_KNNIndex.cpp.o
/tmp/tmplz8kdalv/k-NN/jni/src/org_opensearch_knn_index_v2011_KNNIndex.cpp: In function ‘jlong Java_org_opensearch_knn_index_v2011_KNNIndex_init(JNIEnv*, jclass, jstring, jobjectArray, jstring)’:
/tmp/tmplz8kdalv/k-NN/jni/src/org_opensearch_knn_index_v2011_KNNIndex.cpp:242:12: warning: converting to non-pointer type ‘long int’ from NULL [-Wconversion-null]
     return NULL;
            ^~~~
Linking CXX shared library release/libKNNIndexV2_0_11.so
[100%] Built target KNNIndexV2_0_11
+ cd /tmp/tmplz8kdalv/k-NN
+ cp ./jni/release/libKNNIndexV2_0_11.so ./artifacts/libs
+ ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true
To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/6.6.1/userguide/gradle_daemon.html.
Daemon will be stopped at the end of the build stopping after processing
=======================================
OpenSearch Build Hamster says Hello!
  Gradle Version        : 6.6.1
  OS Info               : Linux 5.10.25-linuxkit (amd64)
  JDK Version           : 14 (OpenJDK)
  JAVA_HOME             : /opensearch-build/jdk-14
  Random Testing Seed   : 4305598C5C976C7B
  In FIPS 140 mode      : false
=======================================

> Task :compileJava
Note: /tmp/tmplz8kdalv/k-NN/src/main/java/org/opensearch/knn/index/KNNWeight.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.6.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 1m 34s
10 actionable tasks: 10 executed
++ find . -path '*build/distributions/*.zip'
+ zipPath=./build/distributions/opensearch-knn-1.1.0.0-SNAPSHOT.zip
++ dirname ./build/distributions/opensearch-knn-1.1.0.0-SNAPSHOT.zip
+ distributions=./build/distributions
+ echo 'COPY ./build/distributions/*.zip'
COPY ./build/distributions/*.zip
+ mkdir -p artifacts/plugins
+ cp ./build/distributions/opensearch-knn-1.1.0.0-SNAPSHOT.zip ./artifacts/plugins
2021-09-15 17:48:08 INFO     Recording plugins artifact for k-NN: plugins/opensearch-knn-1.1.0.0-SNAPSHOT.zip (from /tmp/tmplz8kdalv/k-NN/artifacts/plugins/opensearch-knn-1.1.0.0-SNAPSHOT.zip)
2021-09-15 17:48:08 INFO     Checked /tmp/tmplz8kdalv/k-NN/artifacts/plugins/opensearch-knn-1.1.0.0-SNAPSHOT.zip (1.1.0.0-SNAPSHOT)
2021-09-15 17:48:08 INFO     Recording libs artifact for k-NN: libs/libKNNIndexV2_0_11.so (from /tmp/tmplz8kdalv/k-NN/artifacts/libs/libKNNIndexV2_0_11.so)
2021-09-15 17:48:08 INFO     Skipping anomaly-detection
2021-09-15 17:48:08 INFO     Skipping asynchronous-search
2021-09-15 17:48:08 INFO     Skipping dashboards-reports
2021-09-15 17:48:08 INFO     Skipping dashboards-notebooks
2021-09-15 17:48:08 INFO     Created build manifest /opensearch-build/artifacts/manifest.yml
2021-09-15 17:48:08 INFO     Done.
```

In the future, we can explore changing nmslib build logic to pick up target architecture programmatically via cmake variables. I will create an issue for this.
 
### Issues Resolved
#483 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
