### PR TITLE
Followup from auto-generation of branches

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -1,7 +1,6 @@
 name: versions
 
 on:
-  push:
   schedule:
     - cron: "0 0 * * *"
 

--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -169,7 +169,7 @@ The following options are available.
 
 ### Auto-Generate Manifests
 
-The [manifests workflow](src/manifests) reacts to version increments in OpenSearch and its components by extracting Gradle properties from project branches. When a new version is identified, it creates a new input manifest in [manifests](../manifests) and [opens a pull request](../.github/workflows/manifests.yml).
+The [manifests workflow](src/manifests) reacts to version increments in OpenSearch and its components by extracting Gradle properties from project branches. Currently OpenSearch `main`, and `x.y` branches are checked out one-by-one, published to local maven, and their versions extracted using `./gradlew properties`. When a new version is found, a new input manifest is added to [manifests](../manifests), and [a pull request is opened](../.github/workflows/manifests.yml) (e.g. [opensearch-build#491](https://github.com/opensearch-project/opensearch-build/pull/491)).
 
 Show information about existing manifests. 
 

--- a/bundle-workflow/src/manifests_workflow/component_opensearch_min.py
+++ b/bundle-workflow/src/manifests_workflow/component_opensearch_min.py
@@ -17,7 +17,7 @@ class ComponentOpenSearchMin(Component):
         super().__init__("OpenSearch", repo, snapshot)
 
     @classmethod
-    def get_root_branches(self):
+    def get_branches(self):
         branches = ["main"]
         remote_branches = (
             subprocess.check_output(
@@ -27,6 +27,7 @@ class ComponentOpenSearchMin(Component):
             .decode()
             .split("\n")
         )
+        # return "main" and "x.y" branches only
         branches.extend(filter(lambda b: re.match(r"[\d]+.[\dx]*", b), remote_branches))
         return branches
 

--- a/bundle-workflow/src/manifests_workflow/input_manifests.py
+++ b/bundle-workflow/src/manifests_workflow/input_manifests.py
@@ -48,7 +48,7 @@ class InputManifests(Manifests):
             os.chdir(work_dir)
 
             # check out and build OpenSearch#main, 1.x, etc.
-            opensearch_branches = ComponentOpenSearchMin.get_root_branches()
+            opensearch_branches = ComponentOpenSearchMin.get_branches()
             logging.info(f"Checking OpenSearch {opensearch_branches} branches")
             for branch in opensearch_branches:
                 opensearch = ComponentOpenSearchMin.checkout(

--- a/bundle-workflow/tests/tests_manifests_workflow/test_component_opensearch_min.py
+++ b/bundle-workflow/tests/tests_manifests_workflow/test_component_opensearch_min.py
@@ -13,12 +13,12 @@ from manifests_workflow.component_opensearch_min import ComponentOpenSearchMin
 
 class TestComponentOpenSearchMin(unittest.TestCase):
     @patch("subprocess.check_output")
-    def test_get_root_branches(self, mock):
+    def test_get_branches(self, mock):
         mock.return_value = "\n".join(
             ["main", "1.x", "1.21", "20.1", "something", "else"]
         ).encode()
         self.assertEqual(
-            ComponentOpenSearchMin.get_root_branches(), ["main", "1.x", "1.21", "20.1"]
+            ComponentOpenSearchMin.get_branches(), ["main", "1.x", "1.21", "20.1"]
         )
         mock.assert_called_with(
             "git ls-remote https://github.com/opensearch-project/OpenSearch.git refs/heads/* | cut -f2 | cut -d/ -f3",

--- a/bundle-workflow/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/bundle-workflow/tests/tests_manifests_workflow/test_input_manifests.py
@@ -46,7 +46,7 @@ class TestInputManifests(unittest.TestCase):
     ):
         mock_tmpdir.__enter__.return_value = "dir"
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
-        mock_component_opensearch_min.get_root_branches.return_value = ["main", "0.9.0"]
+        mock_component_opensearch_min.get_branches.return_value = ["main", "0.9.0"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
         mock_component_opensearch.return_value = MagicMock(name="common-utils")
         mock_component_opensearch.checkout.return_value = MagicMock(version="0.10.0")


### PR DESCRIPTION
### Description

- Do not try to discover new versions of OpenSearch on every push.
- Document what branches are being looked at for new versions.
 
### Issues Resolved

Followup from @mch2 comments in https://github.com/opensearch-project/opensearch-build/pull/461.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
