### PR TITLE
Use compileOnly configuration when checking dependency versions, faster.

### DIFF
--- a/bundle-workflow/src/ci_workflow/ci_check_gradle_dependencies.py
+++ b/bundle-workflow/src/ci_workflow/ci_check_gradle_dependencies.py
@@ -23,6 +23,7 @@ class CiCheckGradleDependencies(CiCheck):
                 f"./gradlew {self.gradle_project or ''}:dependencies",
                 f"-Dopensearch.version={self.target.opensearch_version}",
                 f"-Dbuild.snapshot={str(self.target.snapshot).lower()}",
+                "--configuration compileOnly",
                 '| grep -e "---"',
             ]
         )

--- a/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_dependencies.py
+++ b/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_dependencies.py
@@ -31,19 +31,19 @@ class TestCiCheckGradleDependencies(unittest.TestCase):
     def test_executes_gradle_dependencies(self):
         check = self.__mock_dependencies()
         check.git_repo.output.assert_called_once_with(
-            './gradlew :dependencies -Dopensearch.version=1.1.0 -Dbuild.snapshot=false | grep -e "---"'
+            './gradlew :dependencies -Dopensearch.version=1.1.0 -Dbuild.snapshot=false --configuration compileOnly | grep -e "---"'
         )
 
     def test_executes_gradle_dependencies_snapshot(self):
         check = self.__mock_dependencies(snapshot=True)
         check.git_repo.output.assert_called_once_with(
-            './gradlew :dependencies -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true | grep -e "---"'
+            './gradlew :dependencies -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true --configuration compileOnly | grep -e "---"'
         )
 
     def test_executes_gradle_dependencies_project(self):
         check = self.__mock_dependencies(snapshot=True, gradle_project="project")
         check.git_repo.output.assert_called_once_with(
-            './gradlew project:dependencies -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true | grep -e "---"'
+            './gradlew project:dependencies -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true --configuration compileOnly | grep -e "---"'
         )
 
     def test_loads_tree(self):

--- a/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_dependencies_opensearch.py
+++ b/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_dependencies_opensearch.py
@@ -56,7 +56,7 @@ class TestCiCheckGradleDependenciesOpenSearchVersion(unittest.TestCase):
             target=CiTarget(version="1.1.0", snapshot=True),
         )
         check.git_repo.output.assert_called_once_with(
-            './gradlew :dependencies -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true | grep -e "---"'
+            './gradlew :dependencies -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true --configuration compileOnly | grep -e "---"'
         )
 
 
@@ -69,5 +69,5 @@ class TestCheckGradlePluginDependenciesOpenSearchVersion(unittest.TestCase):
         )
         self.assertEqual(check.gradle_project, "plugin")
         check.git_repo.output.assert_called_once_with(
-            './gradlew plugin:dependencies -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true | grep -e "---"'
+            './gradlew plugin:dependencies -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true --configuration compileOnly | grep -e "---"'
         )


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Followup from https://github.com/opensearch-project/opensearch-build/pull/414#discussion_r706357455. Looks like `compileOnly` is inherited by all projects. 
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
