### PR TITLE
ScriptFinder logic temporary update to use correct integtest.sh 

### DIFF
--- a/bundle-workflow/src/paths/script_finder.py
+++ b/bundle-workflow/src/paths/script_finder.py
@@ -64,8 +64,9 @@ class ScriptFinder:
     @classmethod
     def find_integ_test_script(cls, component_name, git_dir):
         paths = [
-            os.path.realpath(os.path.join(git_dir, "integtest.sh")),
-            os.path.realpath(os.path.join(git_dir, "scripts/integtest.sh")),
+            # TODO: Uncomment this after the integtest.sh tool is removed from plugin repos. See issue #497
+            # os.path.realpath(os.path.join(git_dir, "integtest.sh")),
+            # os.path.realpath(os.path.join(git_dir, "scripts/integtest.sh")),
             os.path.realpath(
                 os.path.join(cls.component_scripts_path, component_name, "integtest.sh")
             ),

--- a/bundle-workflow/tests/tests_paths/test_script_finder.py
+++ b/bundle-workflow/tests/tests_paths/test_script_finder.py
@@ -92,6 +92,7 @@ class TestScriptFinder(unittest.TestCase):
             msg="A component without scripts resolves to a component override.",
         )
 
+    @unittest.skip('See https://github.com/opensearch-project/opensearch-build/issues/497')
     def test_find_integ_test_script_component_script(self):
         self.assertEqual(
             os.path.join(self.component_with_scripts, "integtest.sh"),
@@ -101,6 +102,7 @@ class TestScriptFinder(unittest.TestCase):
             msg="A component with a script resolves to the script at the root.",
         )
 
+    @unittest.skip('See https://github.com/opensearch-project/opensearch-build/issues/497')
     def test_find_integ_test_script_component_script_in_folder(self):
         self.assertEqual(
             os.path.join(self.component_with_scripts_folder, "scripts/integtest.sh"),


### PR DESCRIPTION
ScriptFinder logic temporary update to use correct integtest.sh  until #497 is fixed in plugin repos

Signed-off-by: Himanshu Setia <setiah@amazon.com>
 
### Issues Resolved
#469 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
