### PR TITLE
Check alerting for OpenSearch dependency version.

### DIFF
--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -156,6 +156,8 @@ To use checks, nest them under `checks` in the manifest.
   checks:
     - gradle:publish
     - gradle:properties:version
+    - gradle:dependencies:opensearch.version
+    - gradle:dependencies:opensearch.version: alerting
 ```
 
 The following checks are available.
@@ -164,7 +166,6 @@ The following checks are available.
 |-----------------------------------------------|---------------------------------------------------------------|
 | gradle:properties:version                     | Check version of the component.                               |
 | gradle:dependencies:opensearch.version        | Check dependency on the correct version of OpenSearch.        |
-| gradle:plugin.dependencies:opensearch.version | Check plugin dependency on the correct version of OpenSearch. |                                              |
 | gradle:publish                                | Check that publishing to Maven local works, and publish.      |
 
 The following example sanity-checks components in the the OpenSearch 1.1.0 manifest.

--- a/bundle-workflow/src/ci_workflow/ci.py
+++ b/bundle-workflow/src/ci_workflow/ci.py
@@ -4,9 +4,8 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from ci_workflow.ci_check_gradle_dependencies_opensearch import (
-    CiCheckGradleDependenciesOpenSearchVersion,
-    CiCheckGradlePluginDependenciesOpenSearchVersion)
+from ci_workflow.ci_check_gradle_dependencies_opensearch import \
+    CiCheckGradleDependenciesOpenSearchVersion
 from ci_workflow.ci_check_gradle_properties_version import \
     CiCheckGradlePropertiesVersion
 from ci_workflow.ci_check_gradle_publish_to_maven_local import \
@@ -21,7 +20,6 @@ class Ci:
     CHECKS = {
         "gradle:properties:version": CiCheckGradlePropertiesVersion,
         "gradle:dependencies:opensearch.version": CiCheckGradleDependenciesOpenSearchVersion,
-        "gradle:plugin.dependencies:opensearch.version": CiCheckGradlePluginDependenciesOpenSearchVersion,
         "gradle:publish": CiCheckGradlePublishToMavenLocal,
     }
 
@@ -46,8 +44,8 @@ class Ci:
 
     def check(self):
         for check in self.component.checks:
-            klass = Ci.CHECKS[check]
+            klass = Ci.CHECKS[check.name]
             if klass is None:
                 raise Ci.InvalidCheckError(check)
-            instance = klass(self.component, self.git_repo, self.target)
+            instance = klass(self.component, self.git_repo, self.target, check.args)
             instance.check()

--- a/bundle-workflow/src/ci_workflow/ci_check.py
+++ b/bundle-workflow/src/ci_workflow/ci_check.py
@@ -8,10 +8,11 @@ from abc import ABC, abstractmethod
 
 
 class CiCheck(ABC):
-    def __init__(self, component, git_repo, target):
+    def __init__(self, component, git_repo, target, args=None):
         self.component = component
         self.git_repo = git_repo
         self.target = target
+        self.args = args
 
     @abstractmethod
     def check(self):

--- a/bundle-workflow/src/ci_workflow/ci_check_gradle_dependencies.py
+++ b/bundle-workflow/src/ci_workflow/ci_check_gradle_dependencies.py
@@ -12,9 +12,9 @@ from system.properties_file import PropertiesFile
 
 
 class CiCheckGradleDependencies(CiCheck):
-    def __init__(self, component, git_repo, target, gradle_project=None):
-        super().__init__(component, git_repo, target)
-        self.gradle_project = gradle_project
+    def __init__(self, component, git_repo, target, args):
+        super().__init__(component, git_repo, target, args)
+        self.gradle_project = args if args else None
         self.dependencies = self.__get_dependencies()
 
     def __get_dependencies(self):

--- a/bundle-workflow/src/ci_workflow/ci_check_gradle_dependencies_opensearch.py
+++ b/bundle-workflow/src/ci_workflow/ci_check_gradle_dependencies_opensearch.py
@@ -9,7 +9,7 @@ import logging
 from ci_workflow.ci_check_gradle_dependencies import CiCheckGradleDependencies
 
 
-class CiCheckGradleDependenciesProjectOpenSearchVersion(CiCheckGradleDependencies):
+class CiCheckGradleDependenciesOpenSearchVersion(CiCheckGradleDependencies):
     def check(self):
         self.dependencies.check_value(
             "org.opensearch:opensearch", self.target.opensearch_version
@@ -17,17 +17,3 @@ class CiCheckGradleDependenciesProjectOpenSearchVersion(CiCheckGradleDependencie
         logging.info(
             f"Checked {self.component.name} OpenSearch dependency ({self.target.opensearch_version})."
         )
-
-
-class CiCheckGradleDependenciesOpenSearchVersion(
-    CiCheckGradleDependenciesProjectOpenSearchVersion
-):
-    def __init__(self, component, git_repo, target):
-        super().__init__(component, git_repo, target, gradle_project=None)
-
-
-class CiCheckGradlePluginDependenciesOpenSearchVersion(
-    CiCheckGradleDependenciesProjectOpenSearchVersion
-):
-    def __init__(self, component, git_repo, target):
-        super().__init__(component, git_repo, target, gradle_project="plugin")

--- a/bundle-workflow/src/ci_workflow/ci_check_gradle_properties.py
+++ b/bundle-workflow/src/ci_workflow/ci_check_gradle_properties.py
@@ -9,8 +9,8 @@ from system.properties_file import PropertiesFile
 
 
 class CiCheckGradleProperties(CiCheck):
-    def __init__(self, component, git_repo, target):
-        super().__init__(component, git_repo, target)
+    def __init__(self, component, git_repo, target, args=None):
+        super().__init__(component, git_repo, target, args)
         self.properties = self.__get_properties()
 
     def __get_properties(self):

--- a/bundle-workflow/src/manifests/input_manifest.py
+++ b/bundle-workflow/src/manifests/input_manifest.py
@@ -60,7 +60,9 @@ class InputManifest(Manifest):
             self.repository = data["repository"]
             self.ref = data["ref"]
             self.working_directory = data.get("working_directory", None)
-            self.checks = data.get("checks", [])
+            self.checks = list(
+                map(lambda entry: InputManifest.Check(entry), data.get("checks", []))
+            )
 
         def __to_dict__(self):
             return Manifest.compact(
@@ -69,6 +71,22 @@ class InputManifest(Manifest):
                     "repository": self.repository,
                     "ref": self.ref,
                     "working_directory": self.working_directory,
-                    "checks": self.checks,
+                    "checks": list(map(lambda check: check.__to_dict__(), self.checks)),
                 }
             )
+
+    class Check:
+        def __init__(self, data):
+            if isinstance(data, dict):
+                if len(data) != 1:
+                    raise ValueError(f"Invalid check format: {data}")
+                self.name, self.args = next(iter(data.items()))
+            else:
+                self.name = data
+                self.args = None
+
+        def __to_dict__(self):
+            if self.args:
+                return {self.name: self.args}
+            else:
+                return self.name

--- a/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_dependencies.py
+++ b/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_dependencies.py
@@ -25,7 +25,7 @@ class TestCiCheckGradleDependencies(unittest.TestCase):
             component=MagicMock(),
             git_repo=git_repo,
             target=CiTarget(version="1.1.0", snapshot=snapshot),
-            gradle_project=gradle_project,
+            args=gradle_project,
         )
 
     def test_executes_gradle_dependencies(self):

--- a/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_dependencies_opensearch.py
+++ b/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_dependencies_opensearch.py
@@ -7,9 +7,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from ci_workflow.ci_check_gradle_dependencies_opensearch import (
-    CiCheckGradleDependenciesOpenSearchVersion,
-    CiCheckGradlePluginDependenciesOpenSearchVersion)
+from ci_workflow.ci_check_gradle_dependencies_opensearch import \
+    CiCheckGradleDependenciesOpenSearchVersion
 from ci_workflow.ci_target import CiTarget
 from system.properties_file import PropertiesFile
 
@@ -25,6 +24,7 @@ class TestCiCheckGradleDependenciesOpenSearchVersion(unittest.TestCase):
                 component=MagicMock(),
                 git_repo=MagicMock(),
                 target=CiTarget(version="1.1.0", snapshot=True),
+                args=None,
             )
 
     def test_gradle_project(self):
@@ -54,20 +54,19 @@ class TestCiCheckGradleDependenciesOpenSearchVersion(unittest.TestCase):
             component=MagicMock(),
             git_repo=MagicMock(),
             target=CiTarget(version="1.1.0", snapshot=True),
+            args=None,
         )
         check.git_repo.output.assert_called_once_with(
             './gradlew :dependencies -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true | grep -e "---"'
         )
 
-
-class TestCheckGradlePluginDependenciesOpenSearchVersion(unittest.TestCase):
-    def test_executes_gradle_plugin_command(self):
-        check = CiCheckGradlePluginDependenciesOpenSearchVersion(
+    def test_executes_gradle_command_with_arg(self):
+        check = CiCheckGradleDependenciesOpenSearchVersion(
             component=MagicMock(),
             git_repo=MagicMock(),
             target=CiTarget(version="1.1.0", snapshot=True),
+            args="plugin",
         )
-        self.assertEqual(check.gradle_project, "plugin")
         check.git_repo.output.assert_called_once_with(
             './gradlew plugin:dependencies -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true | grep -e "---"'
         )

--- a/bundle-workflow/tests/tests_manifests/test_input_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_input_manifest.py
@@ -43,6 +43,7 @@ class TestInputManifest(unittest.TestCase):
         self.assertEqual(manifest.build.name, "OpenSearch")
         self.assertEqual(manifest.build.version, "1.1.0")
         self.assertEqual(len(manifest.components), 14)
+        # opensearch component
         opensearch_component = manifest.components[0]
         self.assertEqual(opensearch_component.name, "OpenSearch")
         self.assertEqual(
@@ -50,8 +51,19 @@ class TestInputManifest(unittest.TestCase):
             "https://github.com/opensearch-project/OpenSearch.git",
         )
         self.assertEqual(opensearch_component.ref, "1.1")
+        # components
         for component in manifest.components:
             self.assertIsInstance(component.ref, str)
+        # alerting component checks
+        alerting_component = next(
+            c for c in manifest.components if c.name == "alerting"
+        )
+        self.assertIsNotNone(alerting_component)
+        self.assertEqual(len(alerting_component.checks), 2)
+        for check in alerting_component.checks:
+            self.assertIsInstance(check, InputManifest.Check)
+        self.assertIsNone(alerting_component.checks[0].args)
+        self.assertEqual(alerting_component.checks[1].args, "alerting")
 
     def test_to_dict(self):
         path = os.path.join(self.manifests_path, "opensearch-1.1.0.yml")

--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -42,7 +42,6 @@ components:
     ref: "1.1"
     checks:
       - gradle:properties:version
-#      - gradle:dependencies:opensearch.version: plugin
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: "1.1"

--- a/manifests/opensearch-1.1.0.yml
+++ b/manifests/opensearch-1.1.0.yml
@@ -27,13 +27,13 @@ components:
     ref: "1.1"
     checks:
       - gradle:properties:version
-      - gradle:plugin.dependencies:opensearch.version
+      - gradle:dependencies:opensearch.version: plugin
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
     ref: "1.1"
     checks:
       - gradle:properties:version
-#      - gradle:plugin.dependencies:opensearch.version
+      - gradle:dependencies:opensearch.version: alerting
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: main
@@ -42,7 +42,7 @@ components:
     ref: "1.1"
     checks:
       - gradle:properties:version
-#      - gradle:plugin.dependencies:opensearch.version
+#      - gradle:dependencies:opensearch.version: plugin
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: "1.1"


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

To get dependencies in our various projects we run any flavor of `./gradlew :dependencies`, `./gradlew plugin:dependencies` and for alerting `./gradlew alerting:dependencies`.

- Gets rid of `CiCheckGradlePluginDependenciesOpenSearchVersion` by making `CiCheckGradleDependenciesOpenSearchVersion` take an optional gradle project name.   
- Enables dependency check for alerting which needs to run `./gradlew alerting:dependencies`.

I considered aligning alerting to support either plugin:dependencies or just :dependencies, but that looked like a non-trivial exercise and it's too late for 1.1.

### Issues Resolved

Part of #437.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
