### PR TITLE
Remove "Beta" tag from bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
-labels: 'bug, untriaged, Beta'
+labels: 'bug, untriaged'
 assignees: ''
 ---
 


### PR DESCRIPTION
Signed-off-by: Barani <bbarani@amazon.com>

### Description
Newly created issues (for bugs) are adding the 'Beta' tag to the issues. 
 
### Issues Resolved
"Beta" tag wont be added to the issues created for reporting bugs.
https://github.com/opensearch-project/opensearch-build/issues/475
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
