### PR TITLE
Handle child processes

### DIFF
--- a/bundle-workflow/Pipfile
+++ b/bundle-workflow/Pipfile
@@ -20,6 +20,7 @@ pytest-cov = "~=2.10.0"
 jproperties = "~=2.1.1"
 sortedcontainers = "*"
 cerberus = "~=1.3.4"
+psutil = "~=5.8"
 
 [dev-packages]
 

--- a/bundle-workflow/Pipfile.lock
+++ b/bundle-workflow/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "eb9b1591234af18d83c81883a2b02b5d9dbf5484f015e4548974d613ace24662"
+            "sha256": "8a5785c223f6b3a85851cdcd373f26b4961a137bc0e6b2e433037b6abb22e2de"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,35 +26,35 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:63b9846c26e0905f4e9e39d6b59f152330c53a926d693439161c43dcf9779365",
-                "sha256:a9232185d8e7e2fd2b166c0ebee5d7b1f787fdb3093f33bbf5aa932c08f0ccac"
+                "sha256:9b6679e3c54f8c32c09872948450ece87473cbc830cfd6c84dad58eb014329ba",
+                "sha256:caa96b7c2be2168b6efc25ab1fb61c996174bcfbcab21b5f642608185daa6403"
             ],
             "index": "pypi",
-            "version": "==1.18.42"
+            "version": "==1.18.43"
         },
         "boto3-stubs": {
             "hashes": [
-                "sha256:714f69dddb1503272fd1f6bce173a3d46ae728f5e726cf7b1984f07206729bf1",
-                "sha256:d62addf43d9b98f66e91f4f29d1de62b039731dfd92d1a6392e5e30091f7f98c"
+                "sha256:0cb9decb35017407689ec959034e14338b55dae143d54105fb4d51178680bac6",
+                "sha256:5aed83f0650ce240c15389e1b8bcc9e488caa1308f3c264d78fe17b6e4f0e3a5"
             ],
             "index": "pypi",
-            "version": "==1.18.42"
+            "version": "==1.18.43"
         },
         "botocore": {
             "hashes": [
-                "sha256:0952d1200968365b440045efe8e45bbae38cf603fee12bcfc3d7b5f963cbfa18",
-                "sha256:6de4fec4ee10987e4dea96f289553c2f45109fcaafcb74a5baee1221926e1306"
+                "sha256:b74d0a5fe0f7b73fa4b5670eaa9ff456b0bce70966d478dcd631c91458916eb6",
+                "sha256:de7bf9c9098578d386b785b5b6eab954acccd3f79fe3e2eb971da608c967082b"
             ],
             "index": "pypi",
-            "version": "==1.21.42"
+            "version": "==1.21.43"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:34314f8831e528628cb0d3d82f6a62e8c46dbf15f84123bc80ea66124c4ba274",
-                "sha256:f1d577cb13f2373e34f501662dc9108cfb85bed805d9ad00f2012744f41c26dd"
+                "sha256:a66cd6c940c44810102cc17961fe07532eb939786fc004ec9108e7a7224455d3",
+                "sha256:d853c51f06438e4095a779e41f4df66655cf2677641484086d344cb7860a6327"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.42"
+            "version": "==1.21.43"
         },
         "cerberus": {
             "hashes": [
@@ -229,6 +229,40 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==1.0.0"
+        },
+        "psutil": {
+            "hashes": [
+                "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64",
+                "sha256:02b8292609b1f7fcb34173b25e48d0da8667bc85f81d7476584d889c6e0f2131",
+                "sha256:0ae6f386d8d297177fd288be6e8d1afc05966878704dad9847719650e44fc49c",
+                "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6",
+                "sha256:0dd4465a039d343925cdc29023bb6960ccf4e74a65ad53e768403746a9207023",
+                "sha256:12d844996d6c2b1d3881cfa6fa201fd635971869a9da945cf6756105af73d2df",
+                "sha256:1bff0d07e76114ec24ee32e7f7f8d0c4b0514b3fae93e3d2aaafd65d22502394",
+                "sha256:245b5509968ac0bd179287d91210cd3f37add77dad385ef238b275bad35fa1c4",
+                "sha256:28ff7c95293ae74bf1ca1a79e8805fcde005c18a122ca983abf676ea3466362b",
+                "sha256:36b3b6c9e2a34b7d7fbae330a85bf72c30b1c827a4366a07443fc4b6270449e2",
+                "sha256:52de075468cd394ac98c66f9ca33b2f54ae1d9bff1ef6b67a212ee8f639ec06d",
+                "sha256:5da29e394bdedd9144c7331192e20c1f79283fb03b06e6abd3a8ae45ffecee65",
+                "sha256:61f05864b42fedc0771d6d8e49c35f07efd209ade09a5afe6a5059e7bb7bf83d",
+                "sha256:6223d07a1ae93f86451d0198a0c361032c4c93ebd4bf6d25e2fb3edfad9571ef",
+                "sha256:6323d5d845c2785efb20aded4726636546b26d3b577aded22492908f7c1bdda7",
+                "sha256:6ffe81843131ee0ffa02c317186ed1e759a145267d54fdef1bc4ea5f5931ab60",
+                "sha256:74f2d0be88db96ada78756cb3a3e1b107ce8ab79f65aa885f76d7664e56928f6",
+                "sha256:74fb2557d1430fff18ff0d72613c5ca30c45cdbfcddd6a5773e9fc1fe9364be8",
+                "sha256:90d4091c2d30ddd0a03e0b97e6a33a48628469b99585e2ad6bf21f17423b112b",
+                "sha256:90f31c34d25b1b3ed6c40cdd34ff122b1887a825297c017e4cbd6796dd8b672d",
+                "sha256:99de3e8739258b3c3e8669cb9757c9a861b2a25ad0955f8e53ac662d66de61ac",
+                "sha256:c6a5fd10ce6b6344e616cf01cc5b849fa8103fbb5ba507b6b2dee4c11e84c935",
+                "sha256:ce8b867423291cb65cfc6d9c4955ee9bfc1e21fe03bb50e177f2b957f1c2469d",
+                "sha256:d225cd8319aa1d3c85bf195c4e07d17d3cd68636b8fc97e6cf198f782f99af28",
+                "sha256:ea313bb02e5e25224e518e4352af4bf5e062755160f77e4b1767dd5ccb65f876",
+                "sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0",
+                "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3",
+                "sha256:fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563"
+            ],
+            "index": "pypi",
+            "version": "==5.8.0"
         },
         "py": {
             "hashes": [
@@ -427,7 +461,7 @@
                 "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
                 "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.6"
         },
         "zipp": {

--- a/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
@@ -93,7 +93,7 @@ class LocalTestCluster(TestCluster):
                 logging.info(f"Pinging {url} attempt {attempt}")
                 response = requests.get(url, verify=False, auth=("admin", "admin"))
                 logging.info(f"{response.status_code}: {response.text}")
-                if response.status_code == 200:
+                if response.status_code == 200 and '"status":"green"' in response.text:
                     logging.info("Cluster is green")
                     return
             except requests.exceptions.ConnectionError:

--- a/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
@@ -9,7 +9,7 @@ import os
 import subprocess
 import time
 
-import psutil
+import psutil  # type: ignore
 import requests
 
 from aws.s3_bucket import S3Bucket

--- a/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
@@ -103,12 +103,12 @@ class LocalTestCluster(TestCluster):
 
     def terminate_process(self):
         parent = psutil.Process(self.process.pid)
-        logging.info("Checking for child processes")
+        logging.debug("Checking for child processes")
         child_processes = parent.children(recursive=True)
         for child in child_processes:
-            logging.info(f"Found child process with pid {child.pid}")
+            logging.debug(f"Found child process with pid {child.pid}")
             if child.pid != self.process.pid:
-                logging.info(f"Sending SIGKILL to {child.pid} ")
+                logging.debug(f"Sending SIGKILL to {child.pid} ")
                 child.kill()
         logging.info(f"Sending SIGTERM to PID {self.process.pid}")
         self.process.terminate()


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The PID of the actual opensearch process was different from parent PID in ubuntu. 
This change checks for the child processes and kills them before terminating the actual PID.
In case of AL2 and MACOS, both actual process and PID are same. 
 
### Issues Resolved
#429 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
