### PR TITLE
Add checks to OpenSearch in auto-generated manifests.

### DIFF
--- a/bundle-workflow/src/manifests_workflow/component.py
+++ b/bundle-workflow/src/manifests_workflow/component.py
@@ -4,15 +4,28 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+from manifests.manifest import Manifest
+
 
 class Component:
-    def __init__(self, name, repo, snapshot=False):
+    def __init__(self, name, repo, snapshot=False, checks=[]):
         self.name = name
         self.git_repo = repo
         self.snapshot = snapshot
+        self.checks = checks
 
     @classmethod
     def gradle_cmd(self, target, props={}):
         cmd = [f"./gradlew {target}"]
         cmd.extend([f"-D{k}={v}" for k, v in props.items()])
         return " ".join(cmd)
+
+    def to_dict(self):
+        return Manifest.compact(
+            {
+                "name": self.name,
+                "repository": self.git_repo.url,
+                "ref": self.git_repo.ref,
+                "checks": self.checks,
+            }
+        )

--- a/bundle-workflow/src/manifests_workflow/component_opensearch_min.py
+++ b/bundle-workflow/src/manifests_workflow/component_opensearch_min.py
@@ -14,7 +14,12 @@ from system.properties_file import PropertiesFile
 
 class ComponentOpenSearchMin(Component):
     def __init__(self, repo, snapshot=False):
-        super().__init__("OpenSearch", repo, snapshot)
+        super().__init__(
+            "OpenSearch",
+            repo,
+            snapshot,
+            ["gradle:publish", "gradle:properties:version"],
+        )
 
     @classmethod
     def get_branches(self):

--- a/bundle-workflow/src/manifests_workflow/input_manifests.py
+++ b/bundle-workflow/src/manifests_workflow/input_manifests.py
@@ -107,13 +107,7 @@ class InputManifests(Manifests):
                 # TODO: copy OpenSearch and common-utils from the previous manifest
                 for component in main_versions[release_version]:
                     logging.info(f" Adding {component.name}")
-                    data["components"].append(
-                        {
-                            "name": component.name,
-                            "repository": component.git_repo.url,
-                            "ref": component.git_repo.ref,
-                        }
-                    )
+                    data["components"].append(component.to_dict())
 
                 manifest = InputManifest(data)
                 manifest_path = os.path.join(

--- a/bundle-workflow/tests/tests_manifests_workflow/test_component_opensearch.py
+++ b/bundle-workflow/tests/tests_manifests_workflow/test_component_opensearch.py
@@ -30,3 +30,12 @@ class TestComponentOpenSearch(unittest.TestCase):
         repo.output.return_value = "version=2.1"
         component = ComponentOpenSearch("common-utils", repo, "1.1.0")
         self.assertEqual(component.properties.get_value("version"), "2.1")
+
+    def test_to_dict(self):
+        repo = MagicMock(ref="ref", url="repo")
+        repo.output.return_value = "version=2.1"
+        component = ComponentOpenSearch("common-utils", repo, "1.1.0")
+        self.assertEqual(
+            component.to_dict(),
+            {"name": "common-utils", "ref": "ref", "repository": "repo"},
+        )

--- a/bundle-workflow/tests/tests_manifests_workflow/test_component_opensearch_min.py
+++ b/bundle-workflow/tests/tests_manifests_workflow/test_component_opensearch_min.py
@@ -50,3 +50,17 @@ class TestComponentOpenSearchMin(unittest.TestCase):
         repo.output.return_value = "version=2.1"
         component = ComponentOpenSearchMin(repo)
         self.assertEqual(component.properties.get_value("version"), "2.1")
+
+    def test_to_dict(self):
+        repo = MagicMock(ref="ref", url="repo")
+        repo.output.return_value = "version=2.1"
+        component = ComponentOpenSearchMin(repo)
+        self.assertEqual(
+            component.to_dict(),
+            {
+                "checks": ["gradle:publish", "gradle:properties:version"],
+                "name": "OpenSearch",
+                "ref": "ref",
+                "repository": "repo",
+            },
+        )


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

In https://github.com/opensearch-project/opensearch-build/pull/514 the generated manifests lacked basic checks. This adds version and build checks that ensures that the OpenSearch core builds successfully. 

I didn't add any automatic checks to the plugins because those aren't always the same (e.g. security doesn't have a version check because it uses maven that only builds one of the flavors of snapshot vs. non-snapshot and therefore we cannot check version without hacks), and because those would fail without first building OpenSearch.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
