### PR TITLE
Adding orchestrator pipeline and refactoring testsuite job

### DIFF
--- a/bundle-workflow/jenkins_workflow/test/README.md
+++ b/bundle-workflow/jenkins_workflow/test/README.md
@@ -1,5 +1,7 @@
-- [Tests Jenkins Job](#tests-jenkins-job)
-  - [Job Parameters](#job-parameters)
+- [Orchestrator](#orchestrator)
+  - [Input Parameters](#input-parameters)
+- [Testsuite](#testsuite)
+  - [Input Parameters](#input-parameters)
 
 ### Orchestrator
 

--- a/bundle-workflow/jenkins_workflow/test/README.md
+++ b/bundle-workflow/jenkins_workflow/test/README.md
@@ -1,8 +1,22 @@
 - [Tests Jenkins Job](#tests-jenkins-job)
   - [Job Parameters](#job-parameters)
-### Tests Jenkins Job
 
-This job runs integration/bwc tests for a bundle via `test.sh` in Jenkins.
+### Orchestrator
+
+This is a jenkins pipeline that kicks off all long running test jobs on a given build artifact. It accepts `build_id`, `opensearch_version` and `architecture` as input parameters to uniquely identify a build artifact. It kicks off `integ-test`, `bwc-test`, `perf-test` jobs in parallel and notifies the designated channels when the workflow finishes. 
+ 
+#### Input parameters
+
+| name        | description                                                |
+|-------------|------------------------------------------------------------|
+| opensearch_version |  OpenSearch version                                 |
+| build_id |  Unique identifier for a bundle build                         |
+| architecture | CPU Architecture of bundle                                |
+
+
+### Testsuite 
+
+This job runs integration/bwc/perf tests for a bundle via `test.sh` in Jenkins.
 
 #### Job Parameters
 | name        | description                                                |
@@ -12,4 +26,3 @@ This job runs integration/bwc tests for a bundle via `test.sh` in Jenkins.
 | build_id |  Unique identifier for a bundle build                         |
 | architecture | CPU Architecture of bundle                                |
 | test_run_id | Unique identifier for a test run                           |
-| test_suite | Run a specific test suite. [integ-test, bwc-test]           |

--- a/bundle-workflow/jenkins_workflow/test/orchestrator/Jenkinsfile
+++ b/bundle-workflow/jenkins_workflow/test/orchestrator/Jenkinsfile
@@ -1,0 +1,52 @@
+pipeline {
+    agent none
+    environment {
+        TEST_RUN_ID = "${BUILD_NUMBER}"
+    }
+    parameters {
+        string(name: 'opensearch_version')
+        string(name: 'build_id')
+        string(name: 'architecture')
+    }
+    stages {
+        stage('Execute Tests') {
+            steps {
+                parallel (
+                    IntegTests: {
+                        build job: 'integ-test',
+                        parameters: [
+                            string(name: 'opensearch_version', value: "${params.opensearch_version}"),
+                            string(name: 'build_id', value: "${params.build_id}"),
+                            string(name: 'architecture', value: "${params.architecture}"),
+                            string(name: 'test_run_id', value: "${TEST_RUN_ID}")
+                        ]
+                    },
+                    PerfTests: {
+                        build job: 'perf-test',
+                        parameters: [
+                            string(name: 'opensearch_version', value: "${params.opensearch_version}"),
+                            string(name: 'build_id', value: "${params.build_id}"),
+                            string(name: 'architecture', value: "${params.architecture}"),
+                            string(name: 'test_run_id', value: "${TEST_RUN_ID}")
+                        ]
+                    },
+                    BwcTests: {
+                        build job: 'bwc-test',
+                        parameters: [
+                            string(name: 'opensearch_version', value: "${params.opensearch_version}"),
+                            string(name: 'build_id', value: "${params.build_id}"),
+                            string(name: 'architecture', value: "${params.architecture}"),
+                            string(name: 'test_run_id', value: "${TEST_RUN_ID}")
+                        ]
+                    },
+                    failFast: false)
+            }
+        }
+        stage('Notify') {
+            steps {
+                echo "This step is stubbed. Its purpose is to notify different channels for successful build"
+            }
+            failFast false
+        }
+    }
+}

--- a/bundle-workflow/jenkins_workflow/test/testsuite/Jenkinsfile
+++ b/bundle-workflow/jenkins_workflow/test/testsuite/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                 }
             }
             steps {
-                sh "./bundle-workflow/test.sh ${env.JOB_NAME} --s3-bucket ${ARTIFACT_BUCKET_NAME} --opensearch-version ${opensearch_version} --build-id ${build_id} --architecture ${architecture} --test-run-id ${test_run_id}"
+                sh "./bundle-workflow/test.sh ${JOB_NAME} --s3-bucket ${ARTIFACT_BUCKET_NAME} --opensearch-version ${opensearch_version} --build-id ${build_id} --architecture ${architecture} --test-run-id ${test_run_id}"
             }
             post() {
                 always {

--- a/bundle-workflow/jenkins_workflow/test/testsuite/Jenkinsfile
+++ b/bundle-workflow/jenkins_workflow/test/testsuite/Jenkinsfile
@@ -34,11 +34,6 @@ pipeline {
                                             name: 'test_run_id',
                                             trim: true
                                     ),
-                                    string(
-                                            defaultValue: '',
-                                            name: 'test_suite',
-                                            trim: true
-                                    ),
                             ])
                     ])
                 }
@@ -64,7 +59,7 @@ pipeline {
                 }
             }
             steps {
-                sh "./bundle-workflow/test.sh ${test_suite} --s3-bucket ${ARTIFACT_BUCKET_NAME} --opensearch-version ${opensearch_version} --build-id ${build_id} --architecture ${architecture} --test-run-id ${test_run_id}"
+                sh "./bundle-workflow/test.sh ${env.JOB_NAME} --s3-bucket ${ARTIFACT_BUCKET_NAME} --opensearch-version ${opensearch_version} --build-id ${build_id} --architecture ${architecture} --test-run-id ${test_run_id}"
             }
             post() {
                 always {


### PR DESCRIPTION
This PR adds the DSL for orchestration pipeline and refactors the testsuite job to identify test-suite type based on the jenkins job name

Signed-off-by: Himanshu Setia <setiah@amazon.com>
 
### Issues Resolved
#262 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
