### PR TITLE
Removed dependencies from test-manifest.yml for Integ and BWC tests

### DIFF
--- a/bundle-workflow/src/manifests/test_manifest.py
+++ b/bundle-workflow/src/manifests/test_manifest.py
@@ -16,9 +16,6 @@ class TestManifest(Manifest):
         components:
           - name: index-management
             integ-test:
-              dependencies:
-                - job-scheduler
-                - alerting
               test-configs:
                 - with-security
                 - without-security

--- a/bundle-workflow/src/manifests/test_manifest.py
+++ b/bundle-workflow/src/manifests/test_manifest.py
@@ -40,7 +40,6 @@ class TestManifest(Manifest):
                     "integ-test": {
                         "type": "dict",
                         "schema": {
-                            "dependencies": {"type": "list"},
                             "test-configs": {
                                 "type": "list",
                                 "allowed": [
@@ -54,7 +53,6 @@ class TestManifest(Manifest):
                     "bwc-test": {
                         "type": "dict",
                         "schema": {
-                            "dependencies": {"type": "list"},
                             "test-configs": {
                                 "type": "list",
                                 "allowed": [

--- a/bundle-workflow/src/test_workflow/config/test_manifest.yml
+++ b/bundle-workflow/src/test_workflow/config/test_manifest.yml
@@ -1,76 +1,46 @@
 components:
   - name: index-management
     integ-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security
     bwc-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security
   - name: anomaly-detection
     integ-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security
     bwc-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security
   - name: asynchronous-search
     integ-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security
     bwc-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security
   - name: sql
     integ-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security
     bwc-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security
   - name: k-NN
     integ-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security
     bwc-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security

--- a/bundle-workflow/tests/tests_manifests/data/opensearch-test-1.1.0.yml
+++ b/bundle-workflow/tests/tests_manifests/data/opensearch-test-1.1.0.yml
@@ -1,9 +1,6 @@
 components:
   - name: index-management
     integ-test:
-      dependencies:
-        - job-scheduler
-        - alerting
       test-configs:
         - with-security
         - without-security

--- a/bundle-workflow/tests/tests_manifests/test_test_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_test_manifest.py
@@ -28,7 +28,6 @@ class TestTestManifest(unittest.TestCase):
         self.assertEqual(
             component.integ_test,
             {
-                "dependencies": ["job-scheduler", "alerting"],
                 "test-configs": [
                     "with-security",
                     "without-security",


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Currently,  Integ test pulls the common dependencies at once before the run for any plugin and that specific plugin can pick up the dependencies required from there. Same goes for BWC as well.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/521
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
