### PR TITLE
Failing test.sh when invalid test-suite is passed

### DIFF
--- a/bundle-workflow/test.sh
+++ b/bundle-workflow/test.sh
@@ -20,6 +20,7 @@ case $1 in
   ;;
   *)
   echo "Invalid Test suite"
+  exit 1
   ;;
 esac
 


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
Fails `test.sh` with a non-zero exit code.
See issue #525 for more details.

Change after this PR
```
+ ./bundle-workflow/test.sh --s3-bucket <artifact_bucket> --opensearch-version 1.1.0 --build-id 163 --architecture x64 --test-run-id 6
Invalid Test suite
Post stage
[Pipeline] cleanWs
[WS-CLEANUP] Deleting project workspace...
[WS-CLEANUP] Deferred wipeout is disabled by the job configuration...
[WS-CLEANUP] done
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] }
[Pipeline] // node
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // withEnv
[Pipeline] End of Pipeline
ERROR: script returned exit code 1
Finished: FAILURE
```
 
### Issues Resolved
Closes #525 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
