### PR TITLE
Added support to run tests for plugins with nested directory

### DIFF
--- a/bundle-workflow/scripts/default/integtest.sh
+++ b/bundle-workflow/scripts/default/integtest.sh
@@ -18,12 +18,11 @@ function usage() {
     echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
     echo -e "-v OPENSEARCH_VERSION\t, no defaults"
     echo -e "-n SNAPSHOT\t, defaults to false"
-    echo -e "-d DIRECTORY\t, defaults to running directory. Some repos have more than 1 directory/component, specify the working directory to separate tests."
     echo -e "-h\tPrint this message."
     echo "--------------------------------------------------------------------------"
 }
 
-while getopts ":hb:p:s:c:v:n:d:" arg; do
+while getopts ":hb:p:s:c:v:n:" arg; do
     case $arg in
         h)
             usage
@@ -46,9 +45,6 @@ while getopts ":hb:p:s:c:v:n:d:" arg; do
             ;;
         n)
             SNAPSHOT=$OPTARG
-            ;;
-        d)
-            DIRECTORY=$OPTARG
             ;;
         :)
             echo "-${OPTARG} requires an argument"
@@ -90,8 +86,4 @@ then
   PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
 
-if [ -n "$DIRECTORY" ]
-then
-  cd $DIRECTORY
-fi
 ./gradlew integTest -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.clustername="opensearch-integrationtest" -Dhttps=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD --console=plain

--- a/bundle-workflow/scripts/default/integtest.sh
+++ b/bundle-workflow/scripts/default/integtest.sh
@@ -18,11 +18,12 @@ function usage() {
     echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
     echo -e "-v OPENSEARCH_VERSION\t, no defaults"
     echo -e "-n SNAPSHOT\t, defaults to false"
+    echo -e "-d DIRECTORY\t, defaults to running directory. Some repos have more than 1 directory/component, specify the working directory to separate tests."
     echo -e "-h\tPrint this message."
     echo "--------------------------------------------------------------------------"
 }
 
-while getopts ":hb:p:s:c:v:n" arg; do
+while getopts ":hb:p:s:c:v:n:d:" arg; do
     case $arg in
         h)
             usage
@@ -45,6 +46,9 @@ while getopts ":hb:p:s:c:v:n" arg; do
             ;;
         n)
             SNAPSHOT=$OPTARG
+            ;;
+        d)
+            DIRECTORY=$OPTARG
             ;;
         :)
             echo "-${OPTARG} requires an argument"
@@ -86,4 +90,8 @@ then
   PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
 
+if [ -n "$DIRECTORY" ]
+then
+  cd $DIRECTORY
+fi
 ./gradlew integTest -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.clustername="opensearch-integrationtest" -Dhttps=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD --console=plain

--- a/bundle-workflow/src/manifests/test_manifest.py
+++ b/bundle-workflow/src/manifests/test_manifest.py
@@ -15,6 +15,7 @@ class TestManifest(Manifest):
         schema-version: '1.0'
         components:
           - name: index-management
+            working-directory: optional relative directory to run commands in
             integ-test:
               test-configs:
                 - with-security
@@ -34,6 +35,7 @@ class TestManifest(Manifest):
                 "type": "dict",
                 "schema": {
                     "name": {"required": True, "type": "string"},
+                    "working-directory": {"type": "string"},
                     "integ-test": {
                         "type": "dict",
                         "schema": {
@@ -82,15 +84,19 @@ class TestManifest(Manifest):
     class Component:
         def __init__(self, data):
             self.name = data["name"]
+            self.working_directory = data.get("working-directory", None)
             self.integ_test = data["integ-test"]
             self.bwc_test = data["bwc-test"]
 
         def __to_dict__(self):
-            return {
-                "name": self.name,
-                "integ-test": self.integ_test,
-                "bwc-test": self.bwc_test,
-            }
+            return Manifest.compact(
+                {
+                    "name": self.name,
+                    "working-directory": self.working_directory,
+                    "integ-test": self.integ_test,
+                    "bwc-test": self.bwc_test,
+                }
+            )
 
 
 TestManifest.__test__ = False  # type:ignore

--- a/bundle-workflow/src/test_workflow/config/test_manifest.yml
+++ b/bundle-workflow/src/test_workflow/config/test_manifest.yml
@@ -44,4 +44,20 @@ components:
       test-configs:
         - with-security
         - without-security
+  - name: dashboards-reports
+    working-directory: reports-scheduler
+    integ-test:
+      test-configs:
+        - without-security
+    bwc-test:
+      test-configs:
+        - without-security
+  - name: dashboards-notebooks
+    working-directory: opensearch-notebooks
+    integ-test:
+      test-configs:
+        - without-security
+    bwc-test:
+      test-configs:
+        - without-security
 schema-version: '1.0'

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -88,12 +88,11 @@ class IntegTestSuite:
             self.component.name, self.repo.dir
         )
         if os.path.exists(script):
-            cmd = (
-                f"{script} -b {endpoint} -p {port} -s {str(security).lower()} -v {self.bundle_manifest.build.version} -d {self.test_config.working_directory}"
-                if self.test_config.working_directory is not None
-                else f"{script} -b {endpoint} -p {port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
-            )
-            (status, stdout, stderr) = execute(cmd, self.repo.dir, True, False)
+            cmd = f"{script} -b {endpoint} -p {port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
+            if self.test_config.working_directory is not None:
+                (status, stdout, stderr) = execute(cmd, os.path.join(self.repo.dir, self.test_config.working_directory), True, False)
+            else:
+                (status, stdout, stderr) = execute(cmd, self.repo.dir, True, False)
         else:
             logging.info(
                 f"{script} does not exist. Skipping integ tests for {self.name}"

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -89,10 +89,8 @@ class IntegTestSuite:
         )
         if os.path.exists(script):
             cmd = f"{script} -b {endpoint} -p {port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
-            if self.test_config.working_directory is not None:
-                (status, stdout, stderr) = execute(cmd, os.path.join(self.repo.dir, self.test_config.working_directory), True, False)
-            else:
-                (status, stdout, stderr) = execute(cmd, self.repo.dir, True, False)
+            work_dir = os.path.join(self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
+            (status, stdout, stderr) = execute(cmd, work_dir, True, False)
         else:
             logging.info(
                 f"{script} does not exist. Skipping integ tests for {self.name}"

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -88,7 +88,11 @@ class IntegTestSuite:
             self.component.name, self.repo.dir
         )
         if os.path.exists(script):
-            cmd = f"{script} -b {endpoint} -p {port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
+            cmd = (
+                f"{script} -b {endpoint} -p {port} -s {str(security).lower()} -v {self.bundle_manifest.build.version} -d {self.test_config.working_directory}"
+                if self.test_config.working_directory is not None
+                else f"{script} -b {endpoint} -p {port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
+            )
             (status, stdout, stderr) = execute(cmd, self.repo.dir, True, False)
         else:
             logging.info(

--- a/bundle-workflow/tests/tests_manifests/data/opensearch-test-1.1.0.yml
+++ b/bundle-workflow/tests/tests_manifests/data/opensearch-test-1.1.0.yml
@@ -9,4 +9,12 @@ components:
       test-configs:
         - with-security
         - without-security
+  - name: dashboards-reports
+    working-directory: reports-scheduler
+    integ-test:
+      test-configs:
+        - without-security
+    bwc-test:
+      test-configs:
+        - without-security
 schema-version: '1.0'

--- a/bundle-workflow/tests/tests_manifests/test_test_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_test_manifest.py
@@ -14,6 +14,7 @@ from manifests.test_manifest import TestManifest
 
 class TestTestManifest(unittest.TestCase):
     def setUp(self):
+        self.maxDiff = None
         self.data_path = os.path.realpath(
             os.path.join(os.path.dirname(__file__), "data")
         )
@@ -37,6 +38,17 @@ class TestTestManifest(unittest.TestCase):
         )
         self.assertEqual(
             component.bwc_test, {"test-configs": ["with-security", "without-security"]}
+        )
+
+    def test_component_with_working_directory(self):
+        component = self.manifest.components[1]
+        self.assertEqual(component.name, "dashboards-reports")
+        self.assertEqual(component.working_directory, "reports-scheduler")
+        self.assertEqual(
+            component.integ_test, {"test-configs": ["without-security"]}
+        )
+        self.assertEqual(
+            component.bwc_test, {"test-configs": ["without-security"]}
         )
 
     def test_to_dict(self):


### PR DESCRIPTION
Signed-off-by: Vacha <vachshah@amazon.com>

### Description
Adding support to run tests for plugins with nested directory like `dashboards-reports` and `dashboards-notebooks`.
 
### Issues Resolved
#476 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
