### PR TITLE
Change build task to assemble task

### DIFF
--- a/bundle-workflow/scripts/components/job-scheduler/build.sh
+++ b/bundle-workflow/scripts/components/job-scheduler/build.sh
@@ -56,7 +56,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
-./gradlew build --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 ./gradlew publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 mkdir -p $OUTPUT/maven/org/opensearch


### PR DESCRIPTION
### Description
This PR aims at resolving the build issues faced by the infra team. Currently, we have issues (https://github.com/opensearch-project/job-scheduler/issues/56) on job scheduler where the tests are flakey and are failing intermittently. But the open search build uses the task "assemble" to build the artifacts and not run additional checks for all other components which are packaged in the build. This PR makes the job scheduler component also run the assemble task and not the build task.

### Issues Resolved

 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
