### PR TITLE
Automatically open an issue for every new release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -1,7 +1,7 @@
 ---
 name: Release
 title: "[RELEASE] Release version {{ env.VERSION }}"
-labels: untriaged, release
+labels: untriaged, release, v{{ env.VERSION }}
 ---
 
 ## Release OpenSearch and OpenSearch Dashboards {{ env.VERSION }}
@@ -14,22 +14,27 @@ I noticed that a manifest was automatically created in [manifests/{{ env.VERSION
 - [ ] Document any new quality requirements or changes.
 - [ ] Declare a pencils down date for new features to be merged.
 - [ ] Finalize scope and feature set and update [the Public Roadmap](https://github.com/orgs/opensearch-project/projects/1).
-- [ ] Create GitHub issues for the release in each component repository that link to this issue and assign an owner.
+- [ ] [Create a version label](https://github.com/opensearch-project/opensearch-plugins/blob/main/META.md#create-or-update-labels-in-all-plugin-repos) in each component repo.
+- [ ] [Create a release issue in every component repo](https://github.com/opensearch-project/opensearch-plugins/blob/main/META.md#create-an-issue-in-all-plugin-repos) that links back to this issue.
+- [ ] Ensure that all release issues created above are assigned to an owner in the component team.
 
 ### CI/CD
 
-- [ ] Create Jenklins workflows that run daily snapshot builds for OpenSearch and OpenSearch Dashboards. 
-- [ ] Increment each components' version to {{ env.VERSION }} and ensure working CI in component repositories.
-- [ ] Add each component to [manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml) and [manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml) with the corresponding checks. 
+- [ ] Create Jenkins workflows that run daily snapshot builds for OpenSearch and OpenSearch Dashboards. 
+- [ ] Increment each component version to {{ env.VERSION }} and ensure working CI in component repositories.
+- [ ] Make pull requests to add each component to [manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml) and [manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml) with the corresponding checks.
 
 ### Release
 
-- [ ] Declare a release candidate build and publish all test results.
+- [ ] Declare a release candidate build, and publish all test results.
+- [ ] Verify all issued labeled `v{{ env.VERSION }}` in all projects have been resolved.
 - [ ] Complete [documentation](https://github.com/opensearch-project/documentation-website) for this release.
-- [ ] Prepare a [blog post](https://github.com/opensearch-project/project-website) for this release.
+- [ ] Author and publish a [blog post](https://github.com/opensearch-project/project-website) for this release.
 - [ ] Gather, review and publish release notes.
 - [ ] Publish this release on [opensearch.org](https://opensearch.org/downloads.html).
 
 ### Post Release
 
-- [ ] Conduct a postmortem and publish its results.
+- [ ] Create [release tags](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging) for each component.
+- [ ] Update [this template](./release_template.md) with any new or missed steps.
+- [ ] Conduct a postmortem, and publish its results.

--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -6,14 +6,30 @@ labels: untriaged, release
 
 ## Release OpenSearch and OpenSearch Dashboards {{ env.VERSION }}
 
-I've noticed that a manifest has been automatically created in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}). Please follow the following checklist.
+I've noticed that a manifest was automatically created in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}). Please follow the following checklist to make a release.
 
-### OpenSearch
+### Preparation
 
-- [ ] Add a Jenklins workflow that runs daily snapshot builds. 
-- [ ] Increment each components' version to {{ env.VERSION }} and ensure working CI.
-- [ ] Add each component to [manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml) with the corresponding checks. 
+- [ ] Assign this issue to a release owner.
+- [ ] Document any new quality requirements or changes.
+- [ ] Declare a pencils down date for new features to be merged.
+- [ ] Finalize scope and feature set and update [the Public Roadmap](https://github.com/orgs/opensearch-project/projects/1).
+- [ ] Create GitHub issues for the release in each component repository that link to this issue and assign an owner.
 
-### OpenSearch Dashboards
+### CI/CD
 
-- [ ] TODO
+- [ ] Create Jenklins workflows that run daily snapshot builds for OpenSearch and OpenSearch Dashboards. 
+- [ ] Increment each components' version to {{ env.VERSION }} and ensure working CI in component repositories.
+- [ ] Add each component to [manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml) and [manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml) with the corresponding checks. 
+
+### Release
+
+- [ ] Declare a release candidate build and publish all test results.
+- [ ] Complete [documentation](https://github.com/opensearch-project/documentation-website) for this release.
+- [ ] Prepare a [blog post](https://github.com/opensearch-project/project-website) for this release.
+- [ ] Gather, review and publish release notes.
+- [ ] Publish this release on [opensearch.org](https://opensearch.org/downloads.html).
+
+### Post Release
+
+- [ ] Conduct a postmortem and publish its results.

--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -1,0 +1,19 @@
+---
+name: Release
+title: "[RELEASE] Release version {{ env.VERSION }}"
+labels: untriaged, release
+---
+
+## Release OpenSearch and OpenSearch Dashboards {{ env.VERSION }}
+
+I've noticed that a manifest has been automatically created in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}). Please follow the following checklist.
+
+### OpenSearch
+
+- [ ] Add a Jenklins workflow that runs daily snapshot builds. 
+- [ ] Increment each components' version to {{ env.VERSION }} and ensure working CI.
+- [ ] Add each component to [manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml) with the corresponding checks. 
+
+### OpenSearch Dashboards
+
+- [ ] TODO

--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -6,7 +6,7 @@ labels: untriaged, release
 
 ## Release OpenSearch and OpenSearch Dashboards {{ env.VERSION }}
 
-I've noticed that a manifest was automatically created in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}). Please follow the following checklist to make a release.
+I noticed that a manifest was automatically created in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}). Please follow the following checklist to make a release.
 
 ### Preparation
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,7 +1,6 @@
 name: releases
 
 on:
-  push:
   schedule:
     - cron: "0 0 * * *"
 
@@ -14,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - id: set-matrix
         # produces a list of versions, e.g. ["1.0.0","1.0.0","1.0.1","1.1.0","1.2.0","2.0.0"]
-        run: echo "::set-output name=matrix::$(ls manifests/**/opensearch*.yml | cut -d'/' -f2 | jq -R -s -c 'split("\n")[:-1]')"
+        run: echo "::set-output name=matrix::$(ls manifests/**/opensearch*.yml | cut -d'/' -f2 | sort | uniq | jq -R -s -c 'split("\n")[:-1]')"
 
   check:
     needs: list-manifest-versions
@@ -24,7 +23,7 @@ jobs:
         version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v2
-      - uses: dblock/create-an-issue@opensearch_v1
+      - uses: dblock/create-an-issue@v2.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ matrix.version }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -24,10 +24,11 @@ jobs:
         version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v2
-      - uses: JasonEtco/create-an-issue@v2
+      - uses: dblock/create-an-issue@opensearch_v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ matrix.version }}
         with:
-          update_existing: true
+          search_existing: open, closed
+          update_existing: false
           filename: .github/ISSUE_TEMPLATE/release_template.md

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,33 @@
+name: releases
+
+on:
+  push:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  list-manifest-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-matrix
+        # produces a list of versions, e.g. ["1.0.0","1.0.0","1.0.1","1.1.0","1.2.0","2.0.0"]
+        run: echo "::set-output name=matrix::$(ls manifests/**/opensearch*.yml | cut -d'/' -f2 | jq -R -s -c 'split("\n")[:-1]')"
+
+  check:
+    needs: list-manifest-versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ matrix.version }}
+        with:
+          update_existing: true
+          filename: .github/ISSUE_TEMPLATE/release_template.md

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ### Creating a New Version
 
-OpenSearch and OpenSearch Dashboards are distributed as bundles that include both core engines and plugins. Each new OpenSearch release process starts when any one component increments a version, typically on the `main` branch. For example, [OpenSearch#1192](https://github.com/opensearch-project/OpenSearch/pull/1192) incremented the version to 2.0. The [automation process in this repo](.github/workflows/manifests.yml) will notice this change and create a new manifest in [manifests](./manifests). A job is then added to start building this new version.  
+OpenSearch and OpenSearch Dashboards are distributed as bundles that include both core engines and plugins. Each new OpenSearch release process starts when any one component increments a version, typically on the `main` branch. For example, [OpenSearch#1192](https://github.com/opensearch-project/OpenSearch/pull/1192) incremented the version to 2.0. The [automation process in this repo](.github/workflows/manifests.yml) will notice this change and create a new manifest in [manifests](./manifests). [Another workflow](.github/workflows/releases.yml) will open an issue for this new release. A job is then (manually) added to the OpenSearch Jenkins CI to start building this new version.
 
 ### Building and Testing an OpenSearch Distribution
 
@@ -28,7 +28,7 @@ OpenSearch and its components are built from source, assembled, signed and teste
 
 ### Making a Release
 
-TODO
+The release process for OpenSearch and OpenSearch Dashboards follows [this release template](.github/ISSUE_TEMPLATE/release_template.md).
 
 ### Deploying infrastructure
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Automatically creates issues for every (new) release. For an example see https://github.com/dblock/opensearch-build/issues/20. It will leave existing issues that match the title alone, so if you close an issue it won't reopen a new one or edit any body/title. 

The latter required some code changes in https://github.com/JasonEtco/create-an-issue (https://github.com/JasonEtco/create-an-issue/pull/112 and https://github.com/JasonEtco/create-an-issue/pull/111). I made [a release](https://github.com/dblock/create-an-issue/releases/tag/v2.5.1-opensearch) in my fork with these changes.

With every new release we can keep improving the checklist!
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
