### PR TITLE
Fixing BWC Test suite runner

### DIFF
--- a/bundle-workflow/src/manifests/bundle_manifest.py
+++ b/bundle-workflow/src/manifests/bundle_manifest.py
@@ -5,7 +5,7 @@
 # compatible open source license.
 
 import os
-
+import logging
 from aws.s3_bucket import S3Bucket
 from manifests.manifest import Manifest
 
@@ -79,6 +79,7 @@ class BundleManifest(Manifest):
     @staticmethod
     def from_s3(bucket_name, build_id, opensearch_version, architecture, work_dir=None):
         work_dir = work_dir if not None else str(os.getcwd())
+        logging.info("Working directory for from_s3 " + work_dir)
         manifest_s3_path = BundleManifest.get_bundle_manifest_relative_location(
             build_id, opensearch_version, architecture
         )

--- a/bundle-workflow/src/manifests/bundle_manifest.py
+++ b/bundle-workflow/src/manifests/bundle_manifest.py
@@ -84,6 +84,7 @@ class BundleManifest(Manifest):
             build_id, opensearch_version, architecture
         )
         S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
+        logging.info("Listing directory after fetching manifest: " + os.listdir(work_dir))
         with open("manifest.yml", "r") as file:
             bundle_manifest = BundleManifest.from_file(file)
         os.remove(os.path.realpath(os.path.join(work_dir, "manifest.yml")))

--- a/bundle-workflow/src/manifests/bundle_manifest.py
+++ b/bundle-workflow/src/manifests/bundle_manifest.py
@@ -83,8 +83,7 @@ class BundleManifest(Manifest):
             build_id, opensearch_version, architecture
         )
         S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
-        with open(work_dir + "/manifest.yml", "r") as file:
-            bundle_manifest = BundleManifest.from_file(file)
+        bundle_manifest = BundleManifest.from_path(os.path.join(work_dir, 'manifest.yml'))
         os.remove(os.path.realpath(os.path.join(work_dir, "manifest.yml")))
         return bundle_manifest
 

--- a/bundle-workflow/src/manifests/bundle_manifest.py
+++ b/bundle-workflow/src/manifests/bundle_manifest.py
@@ -84,7 +84,7 @@ class BundleManifest(Manifest):
             build_id, opensearch_version, architecture
         )
         S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
-        logging.info("Listing directory after fetching manifest: " + os.listdir(work_dir))
+        logging.info("Listing directory after fetching manifest: " + str(os.listdir(work_dir)))
         with open("manifest.yml", "r") as file:
             bundle_manifest = BundleManifest.from_file(file)
         os.remove(os.path.realpath(os.path.join(work_dir, "manifest.yml")))

--- a/bundle-workflow/src/manifests/bundle_manifest.py
+++ b/bundle-workflow/src/manifests/bundle_manifest.py
@@ -5,7 +5,7 @@
 # compatible open source license.
 
 import os
-import logging
+
 from aws.s3_bucket import S3Bucket
 from manifests.manifest import Manifest
 
@@ -79,12 +79,10 @@ class BundleManifest(Manifest):
     @staticmethod
     def from_s3(bucket_name, build_id, opensearch_version, architecture, work_dir=None):
         work_dir = work_dir if not None else str(os.getcwd())
-        logging.info("Working directory for from_s3 " + work_dir)
         manifest_s3_path = BundleManifest.get_bundle_manifest_relative_location(
             build_id, opensearch_version, architecture
         )
         S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
-        logging.info("Listing directory after fetching manifest: " + str(os.listdir(work_dir)))
         with open(work_dir + "/manifest.yml", "r") as file:
             bundle_manifest = BundleManifest.from_file(file)
         os.remove(os.path.realpath(os.path.join(work_dir, "manifest.yml")))

--- a/bundle-workflow/src/manifests/bundle_manifest.py
+++ b/bundle-workflow/src/manifests/bundle_manifest.py
@@ -85,7 +85,7 @@ class BundleManifest(Manifest):
         )
         S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
         logging.info("Listing directory after fetching manifest: " + str(os.listdir(work_dir)))
-        with open("manifest.yml", "r") as file:
+        with open(work_dir + "/manifest.yml", "r") as file:
             bundle_manifest = BundleManifest.from_file(file)
         os.remove(os.path.realpath(os.path.join(work_dir, "manifest.yml")))
         return bundle_manifest

--- a/bundle-workflow/src/run_bwc_test.py
+++ b/bundle-workflow/src/run_bwc_test.py
@@ -11,7 +11,6 @@ import sys
 from manifests.bundle_manifest import BundleManifest
 from system import console
 from system.temporary_directory import TemporaryDirectory
-from system.working_directory import WorkingDirectory
 from test_workflow.bwc_test.bwc_test_suite import BwcTestSuite
 from test_workflow.test_args import TestArgs
 
@@ -21,10 +20,9 @@ def main():
     console.configure(level=args.logging_level)
     with TemporaryDirectory(keep=args.keep) as work_dir:
         logging.info("Switching to temporary work_dir: " + work_dir)
-        with WorkingDirectory(work_dir) as cur_dir:
-            bundle_manifest = BundleManifest.from_s3(
-                args.s3_bucket, args.build_id, args.opensearch_version, args.architecture, cur_dir)
-            BwcTestSuite(bundle_manifest, cur_dir, args.component, args.keep).execute()
+        bundle_manifest = BundleManifest.from_s3(
+            args.s3_bucket, args.build_id, args.opensearch_version, args.architecture, work_dir)
+        BwcTestSuite(bundle_manifest, work_dir, args.component, args.keep).execute()
 
 
 if __name__ == "__main__":

--- a/bundle-workflow/test.sh
+++ b/bundle-workflow/test.sh
@@ -20,6 +20,7 @@ case $1 in
   ;;
   *)
   echo "Invalid Test suite"
+  exit 1
   ;;
 esac
 


### PR DESCRIPTION
### Description
- BWC test suite does not run on Jenkins due to mis-configured directory.
- Also fixes the path to read downloaded manifest predictable.

Before:
```
Running ./bundle-workflow/src/run_bwc_test.py --s3-bucket <artifact_s3_bucket> --opensearch-version 1.1.0 --build-id 163 --architecture x64 --test-run-id 6 ...
2021-09-17 21:50:08 INFO     Switching to temporary work_dir: /tmp/tmp70l5b7_e
Traceback (most recent call last):
  File "/var/jenkins/workspace/bwc-test/bundle-workflow/src/run_bwc_test.py", line 31, in <module>
    sys.exit(main())
  File "/var/jenkins/workspace/bwc-test/bundle-workflow/src/run_bwc_test.py", line 26, in main
    args.s3_bucket, args.build_id, args.opensearch_version, args.architecture, cur_dir)
  File "/var/jenkins/workspace/bwc-test/bundle-workflow/src/manifests/bundle_manifest.py", line 85, in from_s3
    S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
  File "/var/jenkins/workspace/bwc-test/bundle-workflow/src/aws/s3_bucket.py", line 99, in download_file
    local_dir = Path(dest)
  File "/usr/lib64/python3.7/pathlib.py", line 1027, in __new__
    self = cls._from_parts(args, init=False)
  File "/usr/lib64/python3.7/pathlib.py", line 674, in _from_parts
    drv, root, parts = self._parse_args(args)
  File "/usr/lib64/python3.7/pathlib.py", line 658, in _parse_args
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

After:
```
Running ./bundle-workflow/src/run_bwc_test.py --s3-bucket <artifact_s3_bucket> --opensearch-version 1.1.0 --build-id 163 --architecture x64 --test-run-id 6 ...
2021-09-20 23:33:43 INFO     Switching to temporary work_dir: /tmp/tmpt8ckozxc
2021-09-20 23:33:44 INFO     Executing "git init" in /tmp/tmpt8ckozxc/OpenSearch
2021-09-20 23:33:44 INFO     Executing "git remote add origin https://github.com/opensearch-project/OpenSearch.git" in /tmp/tmpt8ckozxc/OpenSearch
2021-09-20 23:33:44 INFO     Executing "git fetch --depth 1 origin c10346550558ec24bba9b0ed36dbe880a24756a1" in /tmp/tmpt8ckozxc/OpenSearch
2021-09-20 23:33:46 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmpt8ckozxc/OpenSearch
2021-09-20 23:33:47 INFO     Executing "git rev-parse HEAD" in /tmp/tmpt8ckozxc/OpenSearch
2021-09-20 23:33:47 INFO     Checked out https://github.com/opensearch-project/OpenSearch.git@c10346550558ec24bba9b0ed36dbe880a24756a1 into /tmp/tmpt8ckozxc/OpenSearch at c10346550558ec24bba9b0ed36dbe880a24756a1
```
 
### Issues Resolved
Closes #536 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
