### PR TITLE
Support plugin specific config

### DIFF
--- a/bundle-workflow/src/manifests/test_manifest.py
+++ b/bundle-workflow/src/manifests/test_manifest.py
@@ -22,7 +22,7 @@ class TestManifest(Manifest):
                 - without-security
                 - with-less-security
               additional-cluster-configs:
-                - "path.repo : /tmp/tmp_dir"
+                - key : value
             bwc-test:
               test-configs:
                 - with-security
@@ -50,7 +50,7 @@ class TestManifest(Manifest):
                                 ],
                             },
                             "additional-cluster-configs": {
-                                "type": "list",
+                                "type": "dict",
                             },
                         },
                     },

--- a/bundle-workflow/src/manifests/test_manifest.py
+++ b/bundle-workflow/src/manifests/test_manifest.py
@@ -21,6 +21,8 @@ class TestManifest(Manifest):
                 - with-security
                 - without-security
                 - with-less-security
+              additional-cluster-configs:
+                - "path.repo : /tmp/tmp_dir"
             bwc-test:
               test-configs:
                 - with-security
@@ -46,6 +48,9 @@ class TestManifest(Manifest):
                                     "without-security",
                                     "with-less-security",
                                 ],
+                            },
+                            "additional-cluster-configs": {
+                                "type": "list",
                             },
                         },
                     },

--- a/bundle-workflow/src/test_workflow/config/test_manifest.yml
+++ b/bundle-workflow/src/test_workflow/config/test_manifest.yml
@@ -4,6 +4,8 @@ components:
       test-configs:
         - with-security
         - without-security
+      additional-cluster-configs:
+        - "path.repo: /tmp/tmp_dir"
     bwc-test:
       test-configs:
         - with-security
@@ -31,6 +33,8 @@ components:
       test-configs:
         - with-security
         - without-security
+      additional-cluster-configs:
+        - "plugins.destination.host.deny_list: [10.0.0.0/8, 127.0.0.1]"
     bwc-test:
       test-configs:
         - with-security
@@ -40,6 +44,8 @@ components:
       test-configs:
         - with-security
         - without-security
+      additional-cluster-configs:
+        - "script.context.field.max_compilations_rate: 1000/1m"
     bwc-test:
       test-configs:
         - with-security

--- a/bundle-workflow/src/test_workflow/config/test_manifest.yml
+++ b/bundle-workflow/src/test_workflow/config/test_manifest.yml
@@ -4,8 +4,6 @@ components:
       test-configs:
         - with-security
         - without-security
-      additional-cluster-configs:
-        - "path.repo: /tmp/tmp_dir"
     bwc-test:
       test-configs:
         - with-security
@@ -34,7 +32,7 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        - "plugins.destination.host.deny_list: [10.0.0.0/8, 127.0.0.1]"
+        plugins.destination.host.deny_list : [10.0.0.0/8, 127.0.0.1]
     bwc-test:
       test-configs:
         - with-security
@@ -45,7 +43,7 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        - "script.context.field.max_compilations_rate: 1000/1m"
+        script.context.field.max_compilations_rate: 1000/1m
     bwc-test:
       test-configs:
         - with-security

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -79,7 +79,7 @@ class IntegTestSuite:
     def _setup_cluster_and_execute_test_config(self, config):
         security = self._is_security_enabled(config)
         if "additional-cluster-configs" in self.test_config.integ_test.keys():
-            self.additional_cluster_config = self.test_config.integ_test["additional-cluster-configs"]
+            self.additional_cluster_config = self.test_config.integ_test.get("additional-cluster-configs")
             logging.info(f"Additional config found: {self.additional_cluster_config}")
         with LocalTestCluster.create(self.work_dir, self.component.name, self.additional_cluster_config,
                                      self.bundle_manifest, security, self.s3_bucket_name) as (test_cluster_endpoint,

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -27,6 +27,7 @@ class IntegTestSuite:
         self.test_config = test_config
         self.s3_bucket_name = s3_bucket_name
         self.script_finder = ScriptFinder()
+        self.additional_cluster_config = None
         self.repo = GitRepository(
             self.component.repository,
             self.component.commit_id,
@@ -77,8 +78,12 @@ class IntegTestSuite:
 
     def _setup_cluster_and_execute_test_config(self, config):
         security = self._is_security_enabled(config)
-        with LocalTestCluster.create(self.work_dir, self.component.name, self.bundle_manifest,
-                                     security, self.s3_bucket_name) as (test_cluster_endpoint, test_cluster_port):
+        if "additional-cluster-configs" in self.test_config.integ_test.keys():
+            self.additional_cluster_config = self.test_config.integ_test["additional-cluster-configs"]
+            logging.info(f"Additional config found: {self.additional_cluster_config}")
+        with LocalTestCluster.create(self.work_dir, self.component.name, self.additional_cluster_config,
+                                     self.bundle_manifest, security, self.s3_bucket_name) as (test_cluster_endpoint,
+                                                                                              test_cluster_port):
             logging.info("component name: " + self.component.name)
             os.chdir(self.work_dir)
             # TODO: (Create issue) Since plugins don't have integtest.sh in version branch, hardcoded it to main

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -77,7 +77,8 @@ class IntegTestSuite:
 
     def _setup_cluster_and_execute_test_config(self, config):
         security = self._is_security_enabled(config)
-        with LocalTestCluster.create(self.work_dir, self.bundle_manifest, security, self.s3_bucket_name) as (test_cluster_endpoint, test_cluster_port):
+        with LocalTestCluster.create(self.work_dir, self.component.name, self.bundle_manifest,
+                                     security, self.s3_bucket_name) as (test_cluster_endpoint, test_cluster_port):
             logging.info("component name: " + self.component.name)
             os.chdir(self.work_dir)
             # TODO: (Create issue) Since plugins don't have integtest.sh in version branch, hardcoded it to main

--- a/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
@@ -11,6 +11,7 @@ import time
 
 import psutil  # type: ignore
 import requests
+import yaml
 
 from aws.s3_bucket import S3Bucket
 from manifests.bundle_manifest import BundleManifest
@@ -27,8 +28,6 @@ class LocalTestCluster(TestCluster):
         self.manifest = bundle_manifest
         self.work_dir = os.path.join(work_dir, "local-test-cluster")
         os.makedirs(self.work_dir, exist_ok=True)
-        # Required by IM plugin as an additional config
-        os.makedirs("/tmp/tmp_dir", exist_ok=True)
         self.component_name = component_name
         self.security_enabled = security_enabled
         self.bucket_name = s3_bucket_name
@@ -92,10 +91,9 @@ class LocalTestCluster(TestCluster):
             shell=True,
         )
 
-    def __add_plugin_specific_config(self, additional_config, file):
-        with open(file, "a") as f:
-            for config in additional_config:
-                f.write(f"\n{config}")
+    def __add_plugin_specific_config(self, additional_config: dict, file):
+        with open(file, "a") as yamlfile:
+            yamlfile.write(yaml.dump(additional_config))
 
     def wait_for_service(self):
         logging.info("Waiting for service to become available")

--- a/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
@@ -22,21 +22,18 @@ class LocalTestCluster(TestCluster):
     Represents an on-box test cluster. This class downloads a bundle (from a BundleManifest) and runs it as a background process.
     """
 
-    def __init__(self, work_dir, component_name, bundle_manifest, security_enabled, s3_bucket_name):
+    def __init__(self, work_dir, component_name, additional_cluster_config, bundle_manifest, security_enabled,
+                 s3_bucket_name=None):
         self.manifest = bundle_manifest
         self.work_dir = os.path.join(work_dir, "local-test-cluster")
-        self.tmp_dir = os.path.join(self.work_dir, "tmp_dir")
         os.makedirs(self.work_dir, exist_ok=True)
-        os.makedirs(self.tmp_dir, exist_ok=True)
+        # Required by IM plugin as an additional config
+        os.makedirs("/tmp/tmp_dir", exist_ok=True)
         self.component_name = component_name
         self.security_enabled = security_enabled
         self.bucket_name = s3_bucket_name
+        self.additional_cluster_config = additional_cluster_config
         self.process = None
-        self.plugin_specific_config = {
-            "alerting": ["plugins.destination.host.deny_list: [10.0.0.0/8,  127.0.0.1]"],
-            "sql": ["script.context.field.max_compilations_rate: 1000/1m"],
-            "index-management": ["path.repo: %s" % os.path.realpath(self.tmp_dir)]
-        }
 
     def create_cluster(self):
         self.download()
@@ -45,7 +42,9 @@ class LocalTestCluster(TestCluster):
         self.install_dir = f"opensearch-{self.manifest.build.version}"
         if not self.security_enabled:
             self.disable_security(self.install_dir)
-        self.__add_plugin_specific_config(self.plugin_specific_config, os.path.join(self.install_dir, "config", "opensearch.yml"))
+        if self.additional_cluster_config is not None:
+            self.__add_plugin_specific_config(self.additional_cluster_config,
+                                              os.path.join(self.install_dir, "config", "opensearch.yml"))
         self.process = subprocess.Popen(
             "./opensearch-tar-install.sh",
             cwd=self.install_dir,
@@ -93,13 +92,10 @@ class LocalTestCluster(TestCluster):
             shell=True,
         )
 
-    def __add_plugin_specific_config(self, additional_config: dict, file):
-        if self.component_name in additional_config.keys():
-            with open(file, "a") as f:
-                plugin_config = additional_config.get(self.component_name)
-                if plugin_config is not None:
-                    for config in plugin_config:
-                        f.write(f"\n{config}")
+    def __add_plugin_specific_config(self, additional_config, file):
+        with open(file, "a") as f:
+            for config in additional_config:
+                f.write(f"\n{config}")
 
     def wait_for_service(self):
         logging.info("Waiting for service to become available")


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Adds plugin specific configuration in `opensearch.yml` before the cluster starts
 
### Issues Resolved
#493 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
