### PR TITLE
Added Unit Tests for test_args and test_component

### DIFF
--- a/bundle-workflow/Pipfile
+++ b/bundle-workflow/Pipfile
@@ -21,6 +21,7 @@ jproperties = "~=2.1.1"
 sortedcontainers = "*"
 cerberus = "~=1.3.4"
 psutil = "~=5.8"
+semantic-version = "~=2.8.5"
 
 [dev-packages]
 

--- a/bundle-workflow/Pipfile.lock
+++ b/bundle-workflow/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8a5785c223f6b3a85851cdcd373f26b4961a137bc0e6b2e433037b6abb22e2de"
+            "sha256": "7842b6de8dc0aa9e0d4d9dbf381c3423172f7ee8d1f462915d64761ab78a51bb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,35 +26,35 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:9b6679e3c54f8c32c09872948450ece87473cbc830cfd6c84dad58eb014329ba",
-                "sha256:caa96b7c2be2168b6efc25ab1fb61c996174bcfbcab21b5f642608185daa6403"
+                "sha256:3a270f002818703d5f2eef5296c2fd8b44ef21a3f3290a716ec2202da8dd464e",
+                "sha256:8bc3211a7d7767c2c72ae9b226edb5eec5bb96989c83696832b8a5c35feb356a"
             ],
             "index": "pypi",
-            "version": "==1.18.43"
+            "version": "==1.18.44"
         },
         "boto3-stubs": {
             "hashes": [
-                "sha256:0cb9decb35017407689ec959034e14338b55dae143d54105fb4d51178680bac6",
-                "sha256:5aed83f0650ce240c15389e1b8bcc9e488caa1308f3c264d78fe17b6e4f0e3a5"
+                "sha256:70cfe52235c9a3f12a66d7ef90da4490c591041b509a11385ce70c33d02ad107",
+                "sha256:a118686d2910347e7af926ff544681b76333d3d72252e86828357dd9a5f11831"
             ],
             "index": "pypi",
-            "version": "==1.18.43"
+            "version": "==1.18.44"
         },
         "botocore": {
             "hashes": [
-                "sha256:b74d0a5fe0f7b73fa4b5670eaa9ff456b0bce70966d478dcd631c91458916eb6",
-                "sha256:de7bf9c9098578d386b785b5b6eab954acccd3f79fe3e2eb971da608c967082b"
+                "sha256:2e134c9f799015e448086ed2b809fe50cc776f6600f093d1a44772288e61260f",
+                "sha256:c7640cb49c0e009bea4ad767715acbe0d305b7007235f52422bf31b5d23be8f1"
             ],
             "index": "pypi",
-            "version": "==1.21.43"
+            "version": "==1.21.44"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:a66cd6c940c44810102cc17961fe07532eb939786fc004ec9108e7a7224455d3",
-                "sha256:d853c51f06438e4095a779e41f4df66655cf2677641484086d344cb7860a6327"
+                "sha256:450432250be7f5d124604297a12656cec7fe8e6fc1d4f462b81b71a0e31bc9b3",
+                "sha256:725b90e307cc44a6c9044739cca5b094aeaac8878620ea23a572229cdacc7d91"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.43"
+            "version": "==1.21.44"
         },
         "cerberus": {
             "hashes": [
@@ -72,11 +72,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:7098e7e862f6370a2a8d1a6398cd359815c45d12626267652c3f13dec58e2367",
-                "sha256:fa471a601dfea0f492e4f4fca035cd82155e65dc45c9b83bf4322dfab63755dd"
+                "sha256:5d209c0a931f215cee683b6445e2d77677e7e75e159f78def0db09d68fafcaa6",
+                "sha256:5ec46d183433dcbd0ab716f2d7f29d8dee50505b3fdb40c6b985c7c4f5a3591f"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.5"
+            "version": "==2.0.6"
         },
         "coverage": {
             "hashes": [
@@ -371,6 +371,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==0.5.0"
         },
+        "semantic-version": {
+            "hashes": [
+                "sha256:45e4b32ee9d6d70ba5f440ec8cc5221074c7f4b0e8918bdab748cc37912440a9",
+                "sha256:d2cb2de0558762934679b9a104e82eca7af448c9f4974d1f3eeccff651df8a54"
+            ],
+            "index": "pypi",
+            "version": "==2.8.5"
+        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -441,11 +449,11 @@
         },
         "types-requests": {
             "hashes": [
-                "sha256:a5a305b43ea57bf64d6731f89816946a405b591eff6de28d4c0fd58422cee779",
-                "sha256:e21541c0f55c066c491a639309159556dd8c5833e49fcde929c4c47bdb0002ee"
+                "sha256:225ac2e86549b6ef3a8a44bf955f80b4955855704a15d2883d8445c8df637242",
+                "sha256:26e90866bcd773d76b316de7e6bd6e24641f9e1653cf27241c533886600f6824"
             ],
             "index": "pypi",
-            "version": "==2.25.6"
+            "version": "==2.25.8"
         },
         "typing-extensions": {
             "hashes": [

--- a/bundle-workflow/src/test_workflow/test_args.py
+++ b/bundle-workflow/src/test_workflow/test_args.py
@@ -9,7 +9,7 @@
 
 import argparse
 import logging
-
+import semantic_version
 
 class TestArgs:
     s3_bucket: str
@@ -57,6 +57,12 @@ class TestArgs:
             dest="logging_level",
         )
         args = parser.parse_args()
+
+        if not semantic_version.validate(args.opensearch_version):
+            raise ValueError("Invalid version number")
+        if args.architecture not in ['x64', 'arm64']:
+            raise ValueError("Architecture is not supported. Supported architectures are arm64 and x64")
+        
         self.s3_bucket = args.s3_bucket
         self.opensearch_version = args.opensearch_version
         self.build_id = args.build_id

--- a/bundle-workflow/src/test_workflow/test_args.py
+++ b/bundle-workflow/src/test_workflow/test_args.py
@@ -13,14 +13,13 @@ import logging
 import semantic_version  # type:ignore
 
 
-class CheckOpenSearchVersion(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        if not semantic_version.validate(values):
-            raise ValueError(f"Invalid version number: {values}")
-        setattr(namespace, self.dest, values)
-
-
 class TestArgs:
+    class CheckSemanticVersion(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            if not semantic_version.validate(values):
+                raise ValueError(f"Invalid version number: {values}")
+            setattr(namespace, self.dest, values)
+
     s3_bucket: str
     opensearch_version: str
     build_id: int
@@ -36,20 +35,32 @@ class TestArgs:
             "--s3-bucket", type=str, help="S3 bucket name", required=True
         )
         parser.add_argument(
-            "--opensearch-version", type=str, action=CheckOpenSearchVersion, help="OpenSearch version to test", required=True
+            "--opensearch-version",
+            type=str,
+            action=self.CheckSemanticVersion,
+            help="OpenSearch version to test",
+            required=True,
         )
         parser.add_argument(
-            "--build-id", type=int, help="The build id for the built artifact", required=True
+            "--build-id",
+            type=int,
+            help="The build id for the built artifact",
+            required=True,
         )
         parser.add_argument(
-            "--architecture", type=str, choices=["x64", "arm64"], help="The os architecture e.g. x64, arm64", required=True
+            "--architecture",
+            type=str,
+            choices=["x64", "arm64"],
+            help="The os architecture e.g. x64, arm64",
+            required=True,
         )
         parser.add_argument(
-            "--test-run-id", type=int, help="The unique execution id for the test", required=True
+            "--test-run-id",
+            type=int,
+            help="The unique execution id for the test",
+            required=True,
         )
-        parser.add_argument(
-            "--component", type=str, help="Test a specific component"
-        )
+        parser.add_argument("--component", type=str, help="Test a specific component")
         parser.add_argument(
             "--keep",
             dest="keep",

--- a/bundle-workflow/tests/tests_test_workflow/__init__.py
+++ b/bundle-workflow/tests/tests_test_workflow/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))

--- a/bundle-workflow/tests/tests_test_workflow/test_test_args.py
+++ b/bundle-workflow/tests/tests_test_workflow/test_test_args.py
@@ -46,6 +46,47 @@ class TestTestArgs(unittest.TestCase):
             "--build-id",
             "30",
             "--architecture",
+            "xyz",
+            "--test-run-id",
+            "6",
+        ],
+    )
+    def test_invalid_architecture(self):
+        with self.assertRaises(SystemExit):
+            self.assertEqual(TestArgs().architecture, "invalid")
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1111",
+            "--build-id",
+            "30",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+        ],
+    )
+    def test_invalid_version(self):
+        with self.assertRaises(ValueError) as context:
+            TestArgs().CheckSemanticVersion
+        self.assertEqual("Invalid version number: 1111", str(context.exception))
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--architecture",
             "x64",
             "--test-run-id",
             "6",
@@ -91,7 +132,7 @@ class TestTestArgs(unittest.TestCase):
         ],
     )
     def test_verbose_default(self):
-        self.assertTrue(TestArgs().logging_level, logging.INFO)
+        self.assertEqual(TestArgs().logging_level, logging.INFO)
 
     @patch(
         "argparse._sys.argv",

--- a/bundle-workflow/tests/tests_test_workflow/test_test_args.py
+++ b/bundle-workflow/tests/tests_test_workflow/test_test_args.py
@@ -1,8 +1,188 @@
-import argparse
+import logging
 import os
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 from test_workflow.test_args import TestArgs
 
+
 class TestTestArgs(unittest.TestCase):
+
+    ARGS_PY = os.path.realpath(
+        os.path.join(os.path.dirname(__file__), "../../src/run_bwc_test.py")
+    )
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+        ],
+    )
+    def test_s3_bucket(self):
+        self.assertEqual(TestArgs().s3_bucket, "xyz")
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+        ],
+    )
+    def test_opensearch_version(self):
+        self.assertEqual(TestArgs().opensearch_version, "1.1.0")
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+        ],
+    )
+    def test_build_id(self):
+        self.assertEqual(TestArgs().build_id, 30)
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+        ],
+    )
+    def test_architecture(self):
+        self.assertEqual(TestArgs().architecture, "x64")
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+            "--component",
+            "xyz",
+        ],
+    )
+    def test_test_run_id(self):
+        self.assertEqual(TestArgs().test_run_id, 6)
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+        ],
+    )
+    def test_keep_default(self):
+        self.assertFalse(TestArgs().keep)
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+            "--keep",
+        ],
+    )
+    def test_keep_true(self):
+        self.assertTrue(TestArgs().keep)
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+        ],
+    )
+    def test_verbose_default(self):
+        self.assertTrue(TestArgs().logging_level, logging.INFO)
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+            "--verbose",
+        ],
+    )
+    def test_verbose_true(self):
+        self.assertTrue(TestArgs().logging_level, logging.DEBUG)

--- a/bundle-workflow/tests/tests_test_workflow/test_test_args.py
+++ b/bundle-workflow/tests/tests_test_workflow/test_test_args.py
@@ -1,0 +1,8 @@
+import argparse
+import os
+import unittest
+from unittest.mock import call, patch
+
+from test_workflow.test_args import TestArgs
+
+class TestTestArgs(unittest.TestCase):

--- a/bundle-workflow/tests/tests_test_workflow/test_test_args.py
+++ b/bundle-workflow/tests/tests_test_workflow/test_test_args.py
@@ -28,85 +28,11 @@ class TestTestArgs(unittest.TestCase):
             "6",
         ],
     )
-    def test_s3_bucket(self):
+    def test_required_arguments(self):
         self.assertEqual(TestArgs().s3_bucket, "xyz")
-
-    @patch(
-        "argparse._sys.argv",
-        [
-            ARGS_PY,
-            "--s3-bucket",
-            "xyz",
-            "--opensearch-version",
-            "1.1.0",
-            "--build-id",
-            "30",
-            "--architecture",
-            "x64",
-            "--test-run-id",
-            "6",
-        ],
-    )
-    def test_opensearch_version(self):
         self.assertEqual(TestArgs().opensearch_version, "1.1.0")
-
-    @patch(
-        "argparse._sys.argv",
-        [
-            ARGS_PY,
-            "--s3-bucket",
-            "xyz",
-            "--opensearch-version",
-            "1.1.0",
-            "--build-id",
-            "30",
-            "--architecture",
-            "x64",
-            "--test-run-id",
-            "6",
-        ],
-    )
-    def test_build_id(self):
         self.assertEqual(TestArgs().build_id, 30)
-
-    @patch(
-        "argparse._sys.argv",
-        [
-            ARGS_PY,
-            "--s3-bucket",
-            "xyz",
-            "--opensearch-version",
-            "1.1.0",
-            "--build-id",
-            "30",
-            "--architecture",
-            "x64",
-            "--test-run-id",
-            "6",
-        ],
-    )
-    def test_architecture(self):
         self.assertEqual(TestArgs().architecture, "x64")
-
-    @patch(
-        "argparse._sys.argv",
-        [
-            ARGS_PY,
-            "--s3-bucket",
-            "xyz",
-            "--opensearch-version",
-            "1.1.0",
-            "--build-id",
-            "30",
-            "--architecture",
-            "x64",
-            "--test-run-id",
-            "6",
-            "--component",
-            "xyz",
-        ],
-    )
-    def test_test_run_id(self):
         self.assertEqual(TestArgs().test_run_id, 6)
 
     @patch(

--- a/bundle-workflow/tests/tests_test_workflow/test_test_component.py
+++ b/bundle-workflow/tests/tests_test_workflow/test_test_component.py
@@ -1,0 +1,20 @@
+import os
+import tempfile
+import unittest
+
+from test_workflow.test_component import TestComponent
+
+
+class TestTestComponent(unittest.TestCase):
+    def setUp(self):
+        self.test_component = TestComponent(
+            "https://github.com/opensearch-project/.github",
+            "8ac515431bf24caf92fea9d9b0af3b8f10b88453",
+        )
+
+    def test_checkout(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir, ".github")
+            repo = self.test_component.checkout(subdir)
+            self.assertEqual(repo.url, "https://github.com/opensearch-project/.github")
+            self.assertEqual(repo.ref, "8ac515431bf24caf92fea9d9b0af3b8f10b88453")


### PR DESCRIPTION
### Description
Added Unit Tests for test_args and test_component. 
Added validation for architecture and version in test_args
 
### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/532 and  https://github.com/opensearch-project/opensearch-build/issues/522
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
