### PR TITLE
Delete the artifact renaming with -min as it has been added in opensearch repo

### DIFF
--- a/bundle-workflow/scripts/components/OpenSearch/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch/build.sh
@@ -87,12 +87,11 @@ esac
 
 ./gradlew :distribution:archives:$TARGET:assemble -Dbuild.snapshot=$SNAPSHOT
 
-# Copy artifact to bundle output with -min in the name
+# Copy artifact to bundle output
 [[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
-ARTIFACT_BUILD_NAME=`ls distribution/archives/$TARGET/build/distributions/ | grep "opensearch.*$QUALIFIER.tar.gz"`
-ARTIFACT_TARGET_NAME=`echo $ARTIFACT_BUILD_NAME | sed 's/opensearch/opensearch-min/g'`
+ARTIFACT_BUILD_NAME=`ls distribution/archives/$TARGET/build/distributions/ | grep "opensearch-min.*$QUALIFIER.tar.gz"`
 mkdir -p "${OUTPUT}/bundle"
-cp distribution/archives/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/bundle/$ARTIFACT_TARGET_NAME
+cp distribution/archives/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/bundle/$ARTIFACT_BUILD_NAME
 
 echo "Building core plugins..."
 mkdir -p "${OUTPUT}/core-plugins"


### PR DESCRIPTION

Signed-off-by: Xue Zhou <xuezhou@amazon.com>

### Description
From issue #[1094](https://github.com/opensearch-project/OpenSearch/issues/1094).
As the artifact name has been changed in PR [1251](https://github.com/opensearch-project/OpenSearch/pull/1251), we won't need the renaming here.

### Issues Resolved
#[1094](https://github.com/opensearch-project/OpenSearch/issues/1094)
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
