### PR TITLE
Fix a sed issue on MacOS

### DIFF
--- a/bundle-workflow/scripts/components/security/build.sh
+++ b/bundle-workflow/scripts/components/security/build.sh
@@ -63,9 +63,9 @@ OPENSEARCH_RELEASE=$VERSION
 PLUGIN_VERSION=$(cat plugin-descriptor.properties | grep ^version= | cut -d= -f2 | sed "s/-SNAPSHOT//")
 [[ "$SNAPSHOT" == "true" ]] && PLUGIN_VERSION=$PLUGIN_VERSION-SNAPSHOT
 
-sed -i "s/\(^opensearch\.version=\).*\$/\1${OPENSEARCH_RELEASE}/" plugin-descriptor.properties
-sed -i "s/\(^version=\).*\$/\1${PLUGIN_VERSION}/" plugin-descriptor.properties
-sed -i "s/\(<opensearch.version>\).*\(<\/opensearch.version>\)/\1${VERSION}\2/g" pom.xml
+sed -i -e "s/\(^opensearch\.version=\).*\$/\1${OPENSEARCH_RELEASE}/" plugin-descriptor.properties
+sed -i -e "s/\(^version=\).*\$/\1${PLUGIN_VERSION}/" plugin-descriptor.properties
+sed -i -e "s/\(<opensearch.version>\).*\(<\/opensearch.version>\)/\1${VERSION}\2/g" pom.xml
 sed -i -e "1,/<version>/s/\(<version>\).*\(<\/version>\)/\1${PLUGIN_VERSION}\2/g" pom.xml
 
 mvn -B clean package -Padvanced -DskipTests


### PR DESCRIPTION
### Description
add `-e` option so `sed` could work on both GNU/Linux and macOS
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/543
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
