### PR TITLE
Adding tests for assemble, sign and usage.

### DIFF
--- a/bundle-workflow/src/run_sign.py
+++ b/bundle-workflow/src/run_sign.py
@@ -9,46 +9,53 @@
 import argparse
 import logging
 import os
+import sys
 
 from manifests.build_manifest import BuildManifest
 from sign_workflow.signer import Signer
 from system import console
 
-parser = argparse.ArgumentParser(description="Sign artifacts")
-parser.add_argument(
-    "manifest", type=argparse.FileType("r"), help="Path to local manifest file."
-)
-parser.add_argument("--component", nargs="?", help="Component name")
-parser.add_argument("--type", nargs="?", help="Artifact type")
-parser.add_argument(
-    "-v",
-    "--verbose",
-    help="Show more verbose output.",
-    action="store_const",
-    default=logging.INFO,
-    const=logging.DEBUG,
-    dest="logging_level",
-)
-args = parser.parse_args()
 
-console.configure(level=args.logging_level)
+def main():
+    parser = argparse.ArgumentParser(description="Sign artifacts")
+    parser.add_argument(
+        "manifest", type=argparse.FileType("r"), help="Path to local manifest file."
+    )
+    parser.add_argument("--component", nargs="?", help="Component name")
+    parser.add_argument("--type", nargs="?", help="Artifact type")
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="Show more verbose output.",
+        action="store_const",
+        default=logging.INFO,
+        const=logging.DEBUG,
+        dest="logging_level",
+    )
+    args = parser.parse_args()
 
-manifest = BuildManifest.from_file(args.manifest)
-basepath = os.path.dirname(os.path.abspath(args.manifest.name))
-signer = Signer()
+    console.configure(level=args.logging_level)
 
-for component in manifest.components:
+    manifest = BuildManifest.from_file(args.manifest)
+    basepath = os.path.dirname(os.path.abspath(args.manifest.name))
+    signer = Signer()
 
-    if args.component and args.component != component.name:
-        logging.info(f"Skipping {component.name}")
-        continue
+    for component in manifest.components:
 
-    logging.info(f"Signing {component.name}")
-    for artifact_type in component.artifacts:
-
-        if args.type and args.type != artifact_type:
+        if args.component and args.component != component.name:
+            logging.info(f"Skipping {component.name}")
             continue
 
-        signer.sign_artifacts(component.artifacts[artifact_type], basepath)
+        logging.info(f"Signing {component.name}")
+        for artifact_type in component.artifacts:
 
-logging.info("Done.")
+            if args.type and args.type != artifact_type:
+                continue
+
+            signer.sign_artifacts(component.artifacts[artifact_type], basepath)
+
+    logging.info("Done.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bundle-workflow/tests/test_run_assemble.py
+++ b/bundle-workflow/tests/test_run_assemble.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+from run_assemble import main
+
+
+class TestRunAssemble(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def capfd(self, capfd):
+        self.capfd = capfd
+
+    @patch("argparse._sys.argv", ["run_assemble.py", "--help"])
+    def test_main(self, *mocks):
+        with self.assertRaises(SystemExit):
+            main()
+
+        out, _ = self.capfd.readouterr()
+        self.assertTrue(out.startswith("usage:"))

--- a/bundle-workflow/tests/test_run_build.py
+++ b/bundle-workflow/tests/test_run_build.py
@@ -9,10 +9,24 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, call, patch
 
+import pytest
+
 from run_build import main
 
 
-class TestBuild(unittest.TestCase):
+class TestRunBuild(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def capfd(self, capfd):
+        self.capfd = capfd
+
+    @patch("argparse._sys.argv", ["run_build.py", "--help"])
+    def test_usage(self):
+        with self.assertRaises(SystemExit):
+            main()
+
+        out, _ = self.capfd.readouterr()
+        self.assertTrue(out.startswith("usage:"))
+
     OPENSEARCH_MANIFEST = os.path.realpath(
         os.path.join(
             os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"

--- a/bundle-workflow/tests/test_run_ci.py
+++ b/bundle-workflow/tests/test_run_ci.py
@@ -9,17 +9,31 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, call, patch
 
+import pytest
+
 from run_ci import main
 
 
-class TestCi(unittest.TestCase):
+class TestRunCi(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def capfd(self, capfd):
+        self.capfd = capfd
+
+    @patch("argparse._sys.argv", ["run_ci.py", "--help"])
+    def test_usage(self):
+        with self.assertRaises(SystemExit):
+            main()
+
+        out, _ = self.capfd.readouterr()
+        self.assertTrue(out.startswith("usage:"))
+
     OPENSEARCH_MANIFEST = os.path.realpath(
         os.path.join(
             os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"
         )
     )
 
-    @patch("argparse._sys.argv", ["ci.py", OPENSEARCH_MANIFEST])
+    @patch("argparse._sys.argv", ["run_ci.py", OPENSEARCH_MANIFEST])
     @patch("run_ci.Ci", return_value=MagicMock())
     @patch("run_ci.GitRepository", return_value=MagicMock(working_directory="dummy"))
     @patch("run_ci.TemporaryDirectory")

--- a/bundle-workflow/tests/test_run_manifests.py
+++ b/bundle-workflow/tests/test_run_manifests.py
@@ -7,11 +7,25 @@
 import unittest
 from unittest.mock import MagicMock, call, patch
 
+import pytest
+
 from run_manifests import main
 
 
-class TestManifests(unittest.TestCase):
-    @patch("argparse._sys.argv", ["manifests.py", "list"])
+class TestRunManifests(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def capfd(self, capfd):
+        self.capfd = capfd
+
+    @patch("argparse._sys.argv", ["run_manifests.py", "--help"])
+    def test_usage(self):
+        with self.assertRaises(SystemExit):
+            main()
+
+        out, _ = self.capfd.readouterr()
+        self.assertTrue(out.startswith("usage:"))
+
+    @patch("argparse._sys.argv", ["run_manifests.py", "list"])
     @patch("run_manifests.logging", return_value=MagicMock())
     def test_main_list(self, mock_logging, *mocks):
         main()
@@ -27,3 +41,9 @@ class TestManifests(unittest.TestCase):
         )
 
         mock_logging.info.assert_has_calls([call("Done.")])
+
+    @patch("argparse._sys.argv", ["run_manifests.py", "update"])
+    @patch("run_manifests.InputManifests", return_value=MagicMock())
+    def test_main_update(self, mock_manifests, *mocks):
+        main()
+        mock_manifests.return_value.update.assert_called()

--- a/bundle-workflow/tests/test_run_sign.py
+++ b/bundle-workflow/tests/test_run_sign.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from unittest.mock import patch
+
+import pytest
+
+from run_sign import main
+
+
+class TestRunSign(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def capfd(self, capfd):
+        self.capfd = capfd
+
+    @patch("argparse._sys.argv", ["run_sign.py", "--help"])
+    def test_usage(self, *mocks):
+        with self.assertRaises(SystemExit):
+            main()
+
+        out, _ = self.capfd.readouterr()
+        self.assertTrue(out.startswith("usage:"))


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Adds tests for assemble and sign workflows. Checks that `--help` outputs usage.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
