### PR TITLE
Fix another sed issue on MacOS

### DIFF
--- a/bundle-workflow/scripts/components/k-NN/build.sh
+++ b/bundle-workflow/scripts/components/k-NN/build.sh
@@ -71,7 +71,7 @@ cd jni
 
 # For x64, generalize arch so library is compatible for processors without simd instruction extensions
 if [ "$ARCHITECTURE" = "x64" ]; then 
-    sed -i 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
+    sed -i -e 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
 fi
 
 cmake .


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
add `-e` option so that k-NN component could build on both Linux and MacOS
Same to this PR https://github.com/opensearch-project/opensearch-build/pull/544
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
