### PR TITLE
Added support to integ test failed job

### DIFF
--- a/bundle-workflow/src/run_integ_test.py
+++ b/bundle-workflow/src/run_integ_test.py
@@ -59,11 +59,11 @@ def main():
                     work_dir,
                     args.s3_bucket
                 )
-                result = test_suite.execute()
-                if result[0] != 0:
-                    failed_components[component.name] = result
+                status, security = test_suite.execute()
+                if status != 0:
+                    failed_components[component.name] = [status, security]
                 else:
-                    passed_components[component.name] = result
+                    passed_components[component.name] = [status, security]
             else:
                 logging.info(
                     "Skipping tests for %s, as it is currently not supported"
@@ -72,14 +72,12 @@ def main():
 
         if passed_components:
             for component, result in passed_components.items():
-                logging.info(f'PASS: Integration Test for {component} with status code {result[0]}')
-                logging.info(result[1])
+                logging.info(f'PASS: Integration Test for {component} {result[1]} with status code {result[0]}')
 
         if failed_components:
             for component, result in failed_components.items():
-                logging.error(f'FAIL: Integration Test for {component} with status code {result[0]}')
-                logging.info(result[2])
-                sys.exit(1)
+                logging.error(f'FAIL: Integration Test for {component} {result[1]} with status code {result[0]}')
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/bundle-workflow/src/run_integ_test.py
+++ b/bundle-workflow/src/run_integ_test.py
@@ -47,6 +47,8 @@ def main():
             args.s3_bucket, args.build_id, args.opensearch_version, args.architecture, work_dir)
         pull_build_repo(work_dir)
         DependencyInstaller(build_manifest.build).install_all_maven_dependencies()
+        failed_components = dict()
+        passed_components = dict()
         for component in bundle_manifest.components:
             if component.name in integ_test_config.keys():
                 test_suite = IntegTestSuite(
@@ -57,12 +59,23 @@ def main():
                     work_dir,
                     args.s3_bucket
                 )
-                test_suite.execute()
+                status = test_suite.execute()
+                if status != 0:
+                    failed_components[component.name] = status
+                else:
+                    passed_components[component.name] = status
             else:
                 logging.info(
                     "Skipping tests for %s, as it is currently not supported"
                     % component.name
                 )
+
+        if failed_components:
+            for component, status in failed_components.items():
+                logging.error(f'FAIL: Integration Test for {component} with status code {status}')
+        if passed_components:
+            for component, status in passed_components.items():
+                logging.info(f'PASS: Integration Test for {component} with status code {status}')
 
 
 if __name__ == "__main__":

--- a/bundle-workflow/src/run_integ_test.py
+++ b/bundle-workflow/src/run_integ_test.py
@@ -59,23 +59,27 @@ def main():
                     work_dir,
                     args.s3_bucket
                 )
-                status = test_suite.execute()
-                if status != 0:
-                    failed_components[component.name] = status
+                result = test_suite.execute()
+                if result[0] != 0:
+                    failed_components[component.name] = result
                 else:
-                    passed_components[component.name] = status
+                    passed_components[component.name] = result
             else:
                 logging.info(
                     "Skipping tests for %s, as it is currently not supported"
                     % component.name
                 )
 
-        if failed_components:
-            for component, status in failed_components.items():
-                logging.error(f'FAIL: Integration Test for {component} with status code {status}')
         if passed_components:
-            for component, status in passed_components.items():
-                logging.info(f'PASS: Integration Test for {component} with status code {status}')
+            for component, result in passed_components.items():
+                logging.info(f'PASS: Integration Test for {component} with status code {result[0]}')
+                logging.info(result[1])
+
+        if failed_components:
+            for component, result in failed_components.items():
+                logging.error(f'FAIL: Integration Test for {component} with status code {result[0]}')
+                logging.info(result[2])
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -48,7 +48,7 @@ class IntegTestSuite:
         self.__install_build_dependencies()
         for config in self.test_config.integ_test["test-configs"]:
             security = self.__is_security_enabled(config)
-            self.__setup_cluster_and_execute_test_config(security)
+            return self.__setup_cluster_and_execute_test_config(security)
 
     def __install_build_dependencies(self):
         if "build-dependencies" in self.test_config.integ_test:
@@ -96,7 +96,7 @@ class IntegTestSuite:
                 "Running integration tests for " + self.component.name
             )
             os.chdir(self.work_dir)
-            self.__execute_integtest_sh(
+            return self.__execute_integtest_sh(
                 test_cluster_endpoint, test_cluster_port, security
             )
 
@@ -117,6 +117,7 @@ class IntegTestSuite:
                     "Integration test run failed for component " + self.component.name
                 )
                 logging.info(stderr)
+            return status
         else:
             logging.info(
                 f"{script} does not exist. Skipping integ tests for {self.name}"

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -117,7 +117,7 @@ class IntegTestSuite:
                     "Integration test run failed for component " + self.component.name
                 )
                 logging.info(stderr)
-            return status
+            return (status, stdout, stderr)
         else:
             logging.info(
                 f"{script} does not exist. Skipping integ tests for {self.name}"

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -48,7 +48,8 @@ class IntegTestSuite:
         self.__install_build_dependencies()
         for config in self.test_config.integ_test["test-configs"]:
             security = self.__is_security_enabled(config)
-            return self.__setup_cluster_and_execute_test_config(security)
+            status = self.__setup_cluster_and_execute_test_config(security)
+            return status, config
 
     def __install_build_dependencies(self):
         if "build-dependencies" in self.test_config.integ_test:
@@ -117,7 +118,7 @@ class IntegTestSuite:
                     "Integration test run failed for component " + self.component.name
                 )
                 logging.info(stderr)
-            return (status, stdout, stderr)
+            return status
         else:
             logging.info(
                 f"{script} does not exist. Skipping integ tests for {self.name}"

--- a/bundle-workflow/tests/test_integ_workflow/integ_test/test_integ_test_suite.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/test_integ_test_suite.py
@@ -58,13 +58,7 @@ class TestIntegSuite(unittest.TestCase):
                     "/tmpdir/job-scheduler",
                     True,
                     False,
-                ),
-                call(
-                    "integtest.sh -b localhost -p 9200 -s false -v 1.1.0",
-                    "/tmpdir/job-scheduler",
-                    True,
-                    False,
-                ),
+                )
             ]
         )
 


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Log status code if any plugin fails to run integ test
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/553
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
