### PR TITLE
Adding unit tests for local_test_cluster

### DIFF
--- a/bundle-workflow/tests/test_integ_workflow/integ_test/test_local_test_cluster.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/test_local_test_cluster.py
@@ -123,10 +123,14 @@ class LocalTestClusterTests(unittest.TestCase):
             False,
             "dummy-bucket",
         )
-        with self.assertRaises(ClusterCreationException):
+        with self.assertRaises(ClusterCreationException) as err:
             local_test_cluster.wait_for_service()
             requests.get.assert_called_once_with(
                 "http://localhost:9200/_cluster/health",
                 verify=False,
                 auth=("admin", "admin"),
             )
+        self.assertEqual(
+            str(err.exception),
+            "Cluster is not available after 10 attempts",
+        )

--- a/bundle-workflow/tests/test_integ_workflow/integ_test/test_local_test_cluster.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/test_local_test_cluster.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
+
+import requests
+
+from manifests.bundle_manifest import BundleManifest
+from test_workflow.integ_test.local_test_cluster import LocalTestCluster
+from test_workflow.test_cluster import ClusterCreationException
+
+
+class MockResponse:
+    def __init__(self, text, status_code):
+        self.text = text
+        self.status_code = status_code
+
+
+class LocalTestClusterTests(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+        self.data_path = os.path.realpath(
+            os.path.join(os.path.dirname(__file__), "../../tests_manifests/data")
+        )
+        self.manifest_filename = os.path.join(
+            self.data_path, "opensearch-bundle-1.1.0.yml"
+        )
+        self.manifest = BundleManifest.from_path(self.manifest_filename)
+        with tempfile.TemporaryDirectory() as work_dir:
+            self.local_test_cluster = LocalTestCluster(work_dir, "index-management", "", self.manifest, True, "dummy-bucket")
+
+    def mocked_response(*args, **kwargs):
+        if args[0] == "https://localhost:9200/_cluster/health":
+            return MockResponse({"status": "green"}, 200)
+        else:
+            return MockResponse({"status": "red"}, 404)
+
+    @patch("subprocess.Popen")
+    def test_create_cluster(self, *mocks):
+        self.local_test_cluster.download = MagicMock()
+        self.local_test_cluster.wait_for_service = MagicMock()
+        with patch("builtins.open", mock_open()):
+            with open("stdout.txt", "w") as stdout, open("stderr.txt", "w") as stderr:
+                self.local_test_cluster.create_cluster()
+                subprocess.Popen.assert_called_with(
+                    "./opensearch-tar-install.sh",
+                    cwd=f"opensearch-{self.manifest.build.version}",
+                    shell=True,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+
+    def test_endpoint(self):
+        self.assertEqual(self.local_test_cluster.endpoint(), "localhost")
+
+    def test_port(self):
+        self.assertEqual(self.local_test_cluster.port(), 9200)
+
+    def test_url(self):
+        self.assertEqual(self.local_test_cluster.url("/_cluster/health"), "https://localhost:9200/_cluster/health")
+
+    @patch("os.chdir")
+    @patch("subprocess.check_call")
+    @patch("test_workflow.integ_test.local_test_cluster.S3Bucket")
+    def test_download(self, mock_s3_bucket, *mocks):
+        s3_bucket = mock_s3_bucket.return_value
+        with tempfile.TemporaryDirectory() as work_dir:
+            local_test_cluster = LocalTestCluster(work_dir, "index-management", "", self.manifest, True, "bucket_name")
+            s3_path = BundleManifest.get_tarball_relative_location(
+                self.manifest.build.id, self.manifest.build.version, self.manifest.build.architecture)
+            work_dir_path = os.path.join(work_dir, "local-test-cluster")
+            bundle_name = BundleManifest.get_tarball_name(self.manifest.build.version, self.manifest.build.architecture)
+            local_test_cluster.download()
+            os.chdir.assert_called_once_with(work_dir_path)
+            s3_bucket.download_file.assert_called_once_with(s3_path, work_dir_path)
+            subprocess.check_call.assert_called_once_with(f"tar -xzf {bundle_name}", shell=True)
+
+    @patch("subprocess.check_call")
+    def test_disable_security(self, mock_subprocess):
+        self.local_test_cluster.disable_security("tmp")
+        mock_subprocess.assert_called_once_with(
+            f'echo "plugins.security.disabled: true" >> {os.path.join("tmp", "config", "opensearch.yml")}',
+            shell=True,
+        )
+
+    @patch("requests.get", side_effect=mocked_response)
+    def test_wait_for_service(self, mock_requests):
+        self.local_test_cluster.wait_for_service()
+        requests.get.assert_called_once_with(self.local_test_cluster.url("/_cluster/health"), verify=False, auth=("admin", "admin"))
+
+    @patch("requests.get", side_effect=mocked_response)
+    def test_wait_for_service_cluster_unavailable(self, mock_requests):
+        with tempfile.TemporaryDirectory() as work_dir:
+            local_test_cluster = LocalTestCluster(work_dir, "index-management", "", self.manifest, False, "dummy-bucket")
+            with self.assertRaises(ClusterCreationException):
+                local_test_cluster.wait_for_service()
+                requests.get.assert_called_once_with("http://localhost:9200/_cluster/health", verify=False, auth=("admin", "admin"))

--- a/bundle-workflow/tests/test_integ_workflow/integ_test/test_local_test_cluster.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/test_local_test_cluster.py
@@ -11,16 +11,11 @@ import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
 import requests
+import yaml
 
 from manifests.bundle_manifest import BundleManifest
 from test_workflow.integ_test.local_test_cluster import LocalTestCluster
 from test_workflow.test_cluster import ClusterCreationException
-
-
-class MockResponse:
-    def __init__(self, text, status_code):
-        self.text = text
-        self.status_code = status_code
 
 
 class LocalTestClusterTests(unittest.TestCase):
@@ -33,16 +28,32 @@ class LocalTestClusterTests(unittest.TestCase):
             self.data_path, "opensearch-bundle-1.1.0.yml"
         )
         self.manifest = BundleManifest.from_path(self.manifest_filename)
-        with tempfile.TemporaryDirectory() as work_dir:
-            self.local_test_cluster = LocalTestCluster(work_dir, "index-management", "", self.manifest, True, "dummy-bucket")
+        self.work_dir = tempfile.TemporaryDirectory()
+        self.local_test_cluster = LocalTestCluster(
+            self.work_dir.name,
+            "sql",
+            {"script.context.field.max_compilations_rate": "1000/1m"},
+            self.manifest,
+            True,
+            "dummy-bucket",
+        )
 
-    def mocked_response(*args, **kwargs):
+    def tearDown(self):
+        self.work_dir.cleanup()
+
+    class MockResponse:
+        def __init__(self, text, status_code):
+            self.text = text
+            self.status_code = status_code
+
+    def __mock_response(*args, **kwargs):
         if args[0] == "https://localhost:9200/_cluster/health":
-            return MockResponse({"status": "green"}, 200)
+            return LocalTestClusterTests.MockResponse({"status": "green"}, 200)
         else:
-            return MockResponse({"status": "red"}, 404)
+            return LocalTestClusterTests.MockResponse({"status": "red"}, 404)
 
     @patch("subprocess.Popen")
+    @patch("yaml.dump")
     def test_create_cluster(self, *mocks):
         self.local_test_cluster.download = MagicMock()
         self.local_test_cluster.wait_for_service = MagicMock()
@@ -56,6 +67,9 @@ class LocalTestClusterTests(unittest.TestCase):
                     stdout=stdout,
                     stderr=stderr,
                 )
+                yaml.dump.assert_called_once_with(
+                    {"script.context.field.max_compilations_rate": "1000/1m"}
+                )
 
     def test_endpoint(self):
         self.assertEqual(self.local_test_cluster.endpoint(), "localhost")
@@ -64,41 +78,55 @@ class LocalTestClusterTests(unittest.TestCase):
         self.assertEqual(self.local_test_cluster.port(), 9200)
 
     def test_url(self):
-        self.assertEqual(self.local_test_cluster.url("/_cluster/health"), "https://localhost:9200/_cluster/health")
+        self.assertEqual(
+            self.local_test_cluster.url("/_cluster/health"),
+            "https://localhost:9200/_cluster/health",
+        )
 
     @patch("os.chdir")
     @patch("subprocess.check_call")
     @patch("test_workflow.integ_test.local_test_cluster.S3Bucket")
     def test_download(self, mock_s3_bucket, *mocks):
         s3_bucket = mock_s3_bucket.return_value
-        with tempfile.TemporaryDirectory() as work_dir:
-            local_test_cluster = LocalTestCluster(work_dir, "index-management", "", self.manifest, True, "bucket_name")
-            s3_path = BundleManifest.get_tarball_relative_location(
-                self.manifest.build.id, self.manifest.build.version, self.manifest.build.architecture)
-            work_dir_path = os.path.join(work_dir, "local-test-cluster")
-            bundle_name = BundleManifest.get_tarball_name(self.manifest.build.version, self.manifest.build.architecture)
-            local_test_cluster.download()
-            os.chdir.assert_called_once_with(work_dir_path)
-            s3_bucket.download_file.assert_called_once_with(s3_path, work_dir_path)
-            subprocess.check_call.assert_called_once_with(f"tar -xzf {bundle_name}", shell=True)
-
-    @patch("subprocess.check_call")
-    def test_disable_security(self, mock_subprocess):
-        self.local_test_cluster.disable_security("tmp")
-        mock_subprocess.assert_called_once_with(
-            f'echo "plugins.security.disabled: true" >> {os.path.join("tmp", "config", "opensearch.yml")}',
-            shell=True,
+        s3_path = BundleManifest.get_tarball_relative_location(
+            self.manifest.build.id,
+            self.manifest.build.version,
+            self.manifest.build.architecture,
+        )
+        work_dir_path = os.path.join(self.work_dir.name, "local-test-cluster")
+        bundle_name = BundleManifest.get_tarball_name(
+            self.manifest.build.version, self.manifest.build.architecture
+        )
+        self.local_test_cluster.download()
+        os.chdir.assert_called_once_with(work_dir_path)
+        s3_bucket.download_file.assert_called_once_with(s3_path, work_dir_path)
+        subprocess.check_call.assert_called_once_with(
+            f"tar -xzf {bundle_name}", shell=True
         )
 
-    @patch("requests.get", side_effect=mocked_response)
+    @patch("requests.get", side_effect=__mock_response)
     def test_wait_for_service(self, mock_requests):
         self.local_test_cluster.wait_for_service()
-        requests.get.assert_called_once_with(self.local_test_cluster.url("/_cluster/health"), verify=False, auth=("admin", "admin"))
+        requests.get.assert_called_once_with(
+            self.local_test_cluster.url("/_cluster/health"),
+            verify=False,
+            auth=("admin", "admin"),
+        )
 
-    @patch("requests.get", side_effect=mocked_response)
+    @patch("requests.get", side_effect=__mock_response)
     def test_wait_for_service_cluster_unavailable(self, mock_requests):
-        with tempfile.TemporaryDirectory() as work_dir:
-            local_test_cluster = LocalTestCluster(work_dir, "index-management", "", self.manifest, False, "dummy-bucket")
-            with self.assertRaises(ClusterCreationException):
-                local_test_cluster.wait_for_service()
-                requests.get.assert_called_once_with("http://localhost:9200/_cluster/health", verify=False, auth=("admin", "admin"))
+        local_test_cluster = LocalTestCluster(
+            self.work_dir.name,
+            "index-management",
+            "",
+            self.manifest,
+            False,
+            "dummy-bucket",
+        )
+        with self.assertRaises(ClusterCreationException):
+            local_test_cluster.wait_for_service()
+            requests.get.assert_called_once_with(
+                "http://localhost:9200/_cluster/health",
+                verify=False,
+                auth=("admin", "admin"),
+            )


### PR DESCRIPTION
Signed-off-by: Vacha <vachshah@amazon.com>

### Description
Added unit tests for `local_test_cluster.py`. 
 
### Issues Resolved
#532 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
