### PR TITLE
Added checkout workflow that checks out source code from a manifest.

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -88,11 +88,11 @@ build.sh: error: the following arguments are required: manifest
 
 ### Code Linting
 
-This project uses a [pre-commit hook](https://pre-commit.com/) for linting python code. Make sure to activate pipenv shell.
+This project uses a [pre-commit hook](https://pre-commit.com/) for linting python code.
 
 ```
-$ pre-commit install
-$ pre-commit run --all-files
+$ pipenv run pre-commit install
+$ pipenv run pre-commit run --all-files
 ```
 Pre-commit hook will run isort, flake8, mypy and pytest before making a commit.
 
@@ -152,7 +152,7 @@ cd bundle-workflow
 The pre-commit hook checks for imports, type, style and test.
 
 ```
-pre-commit run --all-files
+pipenv run pre-commit run --all-files
 ```
 
 Auto-fix format and sort imports by running.

--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -1,5 +1,6 @@
 - [OpenSearch Bundle Workflow](#opensearch-bundle-workflow)
   - [How it works](#how-it-works)
+  - [Check Out Source](#check-out-source)
   - [Build from Source](#build-from-source)
     - [Custom Build Scripts](#custom-build-scripts)
   - [Assemble the Bundle](#assemble-the-bundle)
@@ -36,6 +37,21 @@ Within each build script components have the option to place artifacts in a set 
 The build order allows us to first publish `OpenSearch` followed by `common-utils` and publish these artifacts to maven local so that
 they are available for each component.  In order to ensure that the same versions are used, a `-Dopensearch.version` flag is passed to
 each component's build script that defines which version the component should build against.
+
+### Check Out Source
+
+The [checkout workflow](src/checkout_workflow) checks out source code for a given manifest for further examination.
+
+```bash
+./bundle-workflow/checkout.sh manfiests/1.1.0/opensearch-1.1.0.yml
+```
+
+The following options are available.
+
+| name               | description                                                             |
+|--------------------|-------------------------------------------------------------------------|
+| -v, --verbose      | Show more verbose output.                                               |
+
 
 ### Build from Source
 
@@ -218,7 +234,7 @@ The following options are available.
 
 ### Auto-Generate Manifests
 
-The [manifests workflow](src/manifests) reacts to version increments in OpenSearch and its components by extracting Gradle properties from project branches. Currently OpenSearch `main`, and `x.y` branches are checked out one-by-one, published to local maven, and their versions extracted using `./gradlew properties`. When a new version is found, a new input manifest is added to [manifests](../manifests), and [a pull request is opened](../.github/workflows/manifests.yml) (e.g. [opensearch-build#491](https://github.com/opensearch-project/opensearch-build/pull/491)).
+The [manifests workflow](src/manifests_workflow) reacts to version increments in OpenSearch and its components by extracting Gradle properties from project branches. Currently OpenSearch `main`, and `x.y` branches are checked out one-by-one, published to local maven, and their versions extracted using `./gradlew properties`. When a new version is found, a new input manifest is added to [manifests](../manifests), and [a pull request is opened](../.github/workflows/manifests.yml) (e.g. [opensearch-build#491](https://github.com/opensearch-project/opensearch-build/pull/491)).
 
 Show information about existing manifests. 
 

--- a/bundle-workflow/checkout.sh
+++ b/bundle-workflow/checkout.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -e
+
+DIR="$(dirname "$0")"
+"$DIR/run.sh" "$DIR/src/run_checkout.py" $@

--- a/bundle-workflow/src/checkout_workflow/__init__.py
+++ b/bundle-workflow/src/checkout_workflow/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/bundle-workflow/src/checkout_workflow/checkout_args.py
+++ b/bundle-workflow/src/checkout_workflow/checkout_args.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import argparse
+import logging
+
+
+class CheckoutArgs:
+    manifest: str
+
+    def __init__(self):
+        parser = argparse.ArgumentParser(description="Checkout an OpenSearch Bundle")
+        parser.add_argument(
+            "manifest", type=argparse.FileType("r"), help="Manifest file."
+        )
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Show more verbose output.",
+            action="store_const",
+            default=logging.INFO,
+            const=logging.DEBUG,
+            dest="logging_level",
+        )
+
+        args = parser.parse_args()
+        self.logging_level = args.logging_level
+        self.manifest = args.manifest

--- a/bundle-workflow/src/run_checkout.py
+++ b/bundle-workflow/src/run_checkout.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import logging
+import os
+import sys
+
+from checkout_workflow.checkout_args import CheckoutArgs
+from git.git_repository import GitRepository
+from manifests.input_manifest import InputManifest
+from system import console
+from system.temporary_directory import TemporaryDirectory
+
+
+def main():
+    args = CheckoutArgs()
+    console.configure(level=args.logging_level)
+    manifest = InputManifest.from_file(args.manifest)
+
+    with TemporaryDirectory(keep=True) as work_dir:
+        logging.info(f"Checking out into {work_dir}")
+
+        os.chdir(work_dir)
+
+        for component in manifest.components:
+
+            logging.info(f"Checking out {component.name}")
+            GitRepository(
+                component.repository,
+                component.ref,
+                os.path.join(work_dir, component.name),
+                component.working_directory,
+            )
+
+    logging.info(f"Done, checked out into {work_dir}.")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bundle-workflow/tests/test_run_checkout.py
+++ b/bundle-workflow/tests/test_run_checkout.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from run_checkout import main
+
+
+class TestRunChecout(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def capfd(self, capfd):
+        self.capfd = capfd
+
+    @patch("argparse._sys.argv", ["run_checkout.py", "--help"])
+    def test_usage(self):
+        with self.assertRaises(SystemExit):
+            main()
+
+        out, _ = self.capfd.readouterr()
+        self.assertTrue(out.startswith("usage:"))
+
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"
+        )
+    )
+
+    @patch("argparse._sys.argv", ["run_checkout.py", OPENSEARCH_MANIFEST])
+    @patch(
+        "run_checkout.GitRepository", return_value=MagicMock(working_directory="dummy")
+    )
+    @patch("run_checkout.TemporaryDirectory")
+    def test_main(self, mock_temp, mock_repo):
+        mock_temp.return_value.__enter__.return_value = tempfile.gettempdir()
+
+        main()
+
+        # each repository is checked out locally
+        mock_repo.assert_has_calls(
+            [
+                call(
+                    "https://github.com/opensearch-project/OpenSearch.git",
+                    "1.1",
+                    os.path.join(tempfile.gettempdir(), "OpenSearch"),
+                    None,
+                ),
+                call(
+                    "https://github.com/opensearch-project/common-utils.git",
+                    "1.1",
+                    os.path.join(tempfile.gettempdir(), "common-utils"),
+                    None,
+                ),
+                call(
+                    "https://github.com/opensearch-project/dashboards-reports.git",
+                    "1.1",
+                    os.path.join(tempfile.gettempdir(), "dashboards-reports"),
+                    "reports-scheduler",
+                ),
+            ],
+            any_order=True,
+        )
+
+        self.assertEqual(mock_repo.call_count, 14)

--- a/bundle-workflow/tests/tests_checkout_workflow/__init__.py
+++ b/bundle-workflow/tests/tests_checkout_workflow/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))

--- a/bundle-workflow/tests/tests_checkout_workflow/test_checkout_args.py
+++ b/bundle-workflow/tests/tests_checkout_workflow/test_checkout_args.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import logging
+import os
+import unittest
+from unittest.mock import patch
+
+from checkout_workflow.checkout_args import CheckoutArgs
+
+
+class TestCheckoutArgs(unittest.TestCase):
+
+    CHECKOUT_PY = os.path.realpath(
+        os.path.join(os.path.dirname(__file__), "../../src/run_checkout.py")
+    )
+
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__), "../../../manifests/1.1.0/opensearch-1.1.0.yml"
+        )
+    )
+
+    @patch("argparse._sys.argv", [CHECKOUT_PY, OPENSEARCH_MANIFEST])
+    def test_manifest(self):
+        self.assertEqual(CheckoutArgs().manifest.name, TestCheckoutArgs.OPENSEARCH_MANIFEST)
+
+    @patch("argparse._sys.argv", [CHECKOUT_PY, OPENSEARCH_MANIFEST, "--verbose"])
+    def test_verbose_true(self):
+        self.assertTrue(CheckoutArgs().logging_level, logging.DEBUG)


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description
I needed to check which repos still had an integtest.sh, so I wrote a quick workflow to checkout all the source inside a manifest.

Example:

```
./bundle-workflow/checkout manifests/1.1.0/opensearch-1.1.0.yml

...
2021-09-23 18:39:24 INFO     Checking out dashboards-notebooks
2021-09-23 18:39:24 INFO     Executing "git init" in /tmp/tmpt8k92ega/dashboards-notebooks
2021-09-23 18:39:24 INFO     Executing "git remote add origin https://github.com/opensearch-project/dashboards-notebooks.git" in /tmp/tmpt8k92ega/dashboards-notebooks
2021-09-23 18:39:24 INFO     Executing "git fetch --depth 1 origin 1.1" in /tmp/tmpt8k92ega/dashboards-notebooks
2021-09-23 18:39:25 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmpt8k92ega/dashboards-notebooks
2021-09-23 18:39:25 INFO     Executing "git rev-parse HEAD" in /tmp/tmpt8k92ega/dashboards-notebooks
2021-09-23 18:39:25 INFO     Checked out https://github.com/opensearch-project/dashboards-notebooks.git@1.1 into /tmp/tmpt8k92ega/dashboards-notebooks at 29223519fba729144ea7ff3b8f80f6c3d71c64d9
2021-09-23 18:39:25 INFO     Keeping /tmp/tmpt8k92ega
2021-09-23 18:39:25 INFO     Done, checked out into /tmp/tmpt8k92ega.
```
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
