### PR TITLE
[Build] bundle OpenSearch Dashboards

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -4,6 +4,8 @@
     - [Pyenv](#pyenv)
     - [Python 3.7](#python-37)
     - [Pipenv](#pipenv)
+    - [NVM and Node](#nvm-and-node)
+    - [Yarn](#yarn)
   - [Install Dependencies](#install-dependencies)
   - [Run Tests](#run-tests)
   - [Run bundle-workflow](#run-bundle-workflow)
@@ -46,6 +48,21 @@ This project uses [pipenv](https://pipenv.pypa.io/en/latest/), which is typicall
 ```
 $ pipenv --version
 pipenv, version 19.0
+```
+
+#### NVM and Node
+Install [nvm](https://github.com/nvm-sh/nvm/blob/master/README.md) to use the Node 10.24.1 version as it is required
+
+```
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+nvm install v10.24.1
+```
+
+#### Yarn
+[Yarn](https://classic.yarnpkg.com/en/docs/install) is required for building and running the OpenSearch Dashboards and plugins
+
+```
+npm install -g yarn
 ```
 
 ### Install Dependencies

--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -1,5 +1,7 @@
 - [OpenSearch Bundle Workflow](#opensearch-bundle-workflow)
   - [How it works](#how-it-works)
+    - [OpenSearch](#opensearch)
+    - [OpenSearch Dashboards](#opensearch-dashboards)
   - [Check Out Source](#check-out-source)
   - [Build from Source](#build-from-source)
     - [Custom Build Scripts](#custom-build-scripts)
@@ -15,11 +17,11 @@
 
 ## OpenSearch Bundle Workflow
 
-The bundle workflow builds a complete OpenSearch distribution from source. You can currently build 1.0, 1.1 and 1.1-SNAPSHOT.
+The bundle workflow builds a complete OpenSearch and OpenSearch Dashboards distribution from source. You can currently build 1.0, 1.1 and 1.1-SNAPSHOT.
 
 ### How it works
 
-This system performs a top-down build of all components required for a specific OpenSearch bundle release. 
+This system performs a top-down build of all components required for a specific OpenSearch and OpenSearch Dashboards bundle release. 
 The input to the system is a manifest that defines the order in which components should be built. 
 All manifests for our current releases are [here](/manifests).
  
@@ -34,9 +36,16 @@ Within each build script components have the option to place artifacts in a set 
 | /bundle       | Where the min bundle should be placed when built from `https://github.com/opensearch-project/OpenSearch`|
 | /libs         | Where any additional libs should be placed that are required during bundle assembly                     |
 
+#### OpenSearch
+
 The build order allows us to first publish `OpenSearch` followed by `common-utils` and publish these artifacts to maven local so that
 they are available for each component.  In order to ensure that the same versions are used, a `-Dopensearch.version` flag is passed to
 each component's build script that defines which version the component should build against.
+
+#### OpenSearch Dashboards
+
+The build order allows us first pull down `OpenSearch Dashboards` and then utilize it to build other components. Be sure to pass `-d true` flag to build the plugin for `OpenSearch Dashboards`.
+*NOTE*: Building plugins requires having the core repository pulled down so it has access to bootstrap and build the modules utilized by plugins.
 
 ### Check Out Source
 
@@ -64,20 +73,31 @@ Each build requires a manifest to be passed as input. We currently have the foll
 | [opensearch-1.1.0.yml](/manifests/1.1.0/opensearch-1.1.0.yml)               | Manifest for 1.1.0, the next version.                         |
 | [opensearch-1.2.0.yml](/manifests/1.2.0/opensearch-1.2.0.yml)               | Manifest for 1.2.0, the following version.                    |
 | [opensearch-2.0.0.yml](/manifests/2.0.0/opensearch-2.0.0.yml)               | Manifest for 2.0.0, the next major version of OpenSearch.     |
+| [opensearch-dashboards-1.1.0.yml](/manifests/1.1.0/opensearch-dashboards-1.1.0.yml)               | Manifest for 1.1.0, the next version.    
 
-The following example builds a shapshot version of OpenSearch 1.1.0.
+The following example builds a snapshot version of OpenSearch 1.1.0.
 
 ```bash
 ./bundle-workflow/build.sh manifests/1.1.0/opensearch-1.1.0.yml --snapshot
 ```
 
-The [OpenSearch repo](https://github.com/opensearch-project/OpenSearch) is built first, followed by [common-utils](https://github.com/opensearch-project/common-utils), and all declared plugin repositories. These dependencies are published to maven local under `~/.m2`, and subsequent project builds pick those up. All final output is placed into an `artifacts` folder along with a build output `manifest.yml` that contains output details.
+While the following builds a snapshot version of OpenSearch-Dashboards 1.1.0.
+
+```bash
+./bundle-workflow/build.sh manifests/1.1.0/opensearch-dashboards-1.1.0.yml --snapshot
+```
+
+The [OpenSearch repo](https://github.com/opensearch-project/OpenSearch) is built first, followed by [common-utils](https://github.com/opensearch-project/common-utils), and all declared plugin repositories. These dependencies are published to maven local under `~/.m2`, and subsequent project builds pick those up. 
+
+The [OpenSearch Dashboards repo](https://github.com/opensearch-project/OpenSearch-Dashboards) is built first, followed by all declared plugin repositories. 
+
+All final output is placed into an `artifacts` folder along with a build output `manifest.yml` that contains output details.
 
 Artifacts will contain the following folders.
 
 ```
 /artifacts
-  bundle/ <- contains opensearch min tarball 
+  bundle/ <- contains opensearch or opensearch-dashboards min tarball 
   maven/ <- all built maven artifacts
   plugins/ <- all built plugin zips
   core-plugins/ <- all built core plugins zip

--- a/bundle-workflow/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch-Dashboards/build.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch Dashboards version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-d DASHBOARDS\t[Optional] Build OpenSearch Dashboards, default is 'false'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:a:d:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        d)
+            DASHBOARDS=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch Dashboards version"
+    usage
+    exit 1
+fi
+
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+# Assemble distribution artifact
+# see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
+case $ARCHITECTURE in
+    x64)
+        TARGET="linux-tar"
+        QUALIFIER="linux-x64"
+        ;;
+    arm64)
+        TARGET="linux-arm64-tar"
+        QUALIFIER="linux-arm64"
+        ;;
+    *)
+        echo "Unsupported architecture: ${ARCHITECTURE}"
+        exit 1
+        ;;
+esac
+
+echo "Building node modules for core"
+yarn osd bootstrap
+
+echo "Building artifact"
+if [ "$SNAPSHOT" = "true" ]
+then
+    IDENTIFIER="-SNAPSHOT"
+    yarn build --skip-os-packages
+else
+    yarn build --skip-os-packages --release
+fi
+
+mkdir -p "${OUTPUT}/bundle"
+# Copy artifact to bundle output with -min in the name
+ARTIFACT_BUILD_NAME=opensearch-dashboards-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
+ARTIFACT_TARGET_NAME=opensearch-dashboards-min-$VERSION$IDENTIFIER-$QUALIFIER.tar.gz
+cp target/$ARTIFACT_BUILD_NAME $OUTPUT/bundle/$ARTIFACT_TARGET_NAME

--- a/bundle-workflow/scripts/default/build.sh
+++ b/bundle-workflow/scripts/default/build.sh
@@ -16,10 +16,11 @@ function usage() {
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-d DASHBOARDS\t[Optional] Build OpenSearch Dashboards, default is 'false'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:a:d:" arg; do
     case $arg in
         h)
             usage
@@ -36,6 +37,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         a)
             ARCHITECTURE=$OPTARG
+            ;;
+        d)
+            DASHBOARDS=$OPTARG
             ;;
         :)
             echo "Error: -${OPTARG} requires an argument"
@@ -55,15 +59,32 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
-[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[[ "$SNAPSHOT" == "true" && "$DASHBOARDS" == "false" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
 mkdir -p $OUTPUT
-./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
-zipPath=$(find . -path \*build/distributions/*.zip)
-distributions="$(dirname "${zipPath}")"
+if [[ "$DASHBOARDS" == "true" ]]; then
+    mkdir -p $OUTPUT/plugins
+    PLUGIN_NAME=$(basename "$PWD")
+    # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
+    # This makes it so there is a dependency on having Dashboards pulled already.
+    cp -r ../$PLUGIN_NAME/ ../OpenSearch-Dashboards/plugins
+    echo "BUILD MODULES FOR $PLUGIN_NAME"
+    (cd ../OpenSearch-Dashboards && yarn osd bootstrap)
+    echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
+    (cd ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME && yarn plugin-helpers build)
+    echo "COPY $PLUGIN_NAME.zip"
+    cp -r ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/
+else
+    ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
-echo "COPY ${distributions}/*.zip"
-mkdir -p $OUTPUT/plugins
-cp ${distributions}/*.zip ./$OUTPUT/plugins
+    zipPath=$(find . -path \*build/distributions/*.zip)
+    distributions="$(dirname "${zipPath}")"
+
+    echo "COPY ${distributions}/*.zip"
+    mkdir -p $OUTPUT/plugins
+    cp ${distributions}/*.zip ./$OUTPUT/plugins
+fi
+
+

--- a/bundle-workflow/src/assemble_workflow/bundle.py
+++ b/bundle-workflow/src/assemble_workflow/bundle.py
@@ -22,6 +22,11 @@ plugins can be found.
 
 
 class Bundle:
+
+    # TODO: [CLEANUP] For constants to compare can be cleaners
+    OPENSEARCH = "OpenSearch"
+    OPENSEARCH_DASHBOARDS = "OpenSearch Dashboards"
+
     def __init__(self, build_manifest, artifacts_dir, bundle_recorder):
         """
         Construct a new Bundle instance.
@@ -29,6 +34,7 @@ class Bundle:
         :param artifacts_dir: Dir location where build artifacts can be found locally
         :param bundle_recorder: The bundle recorder that will capture and build a BundleManifest
         """
+        self.name = build_manifest.build.name
         self.min_tarball = self.__get_min_bundle(build_manifest.components)
         self.plugins = self.__get_plugins(build_manifest.components)
         self.artifacts_dir = artifacts_dir
@@ -48,8 +54,14 @@ class Bundle:
 
     def install_plugin(self, plugin):
         tmp_path = self.__copy_component(plugin, "plugins")
-        cli_path = os.path.join(self.archive_path, "bin/opensearch-plugin")
-        self.__execute(f"{cli_path} install --batch file:{tmp_path}")
+        if self.name == self.OPENSEARCH:
+            cli_path = os.path.join(self.archive_path, "bin/opensearch-plugin")
+            self.__execute(f"{cli_path} install --batch file:{tmp_path}")
+        elif self.name == self.OPENSEARCH_DASHBOARDS:
+            cli_path = os.path.join(self.archive_path, "bin/opensearch-dashboards-plugin")
+            self.__execute(f"{cli_path} --allow-root install file:{tmp_path}")
+        else:
+            raise ValueError(f"Unsupported build: {self.name}")
         post_install_script = ScriptFinder.find_install_script(plugin.name)
         self.__execute(
             f'{post_install_script} -a "{self.artifacts_dir}" -o "{self.archive_path}"'

--- a/bundle-workflow/src/build_workflow/build_recorder.py
+++ b/bundle-workflow/src/build_workflow/build_recorder.py
@@ -17,6 +17,7 @@ class BuildRecorder:
     def __init__(self, target):
         self.build_manifest = self.BuildManifestBuilder(target)
         self.target = target
+        self.name = target.name
 
     def record_component(self, component_name, git_repo):
         self.build_manifest.append_component(
@@ -55,7 +56,7 @@ class BuildRecorder:
         logging.info(f"Created build manifest {manifest_path}")
 
     def __check_artifact(self, artifact_type, artifact_file):
-        if artifact_type == "plugins":
+        if artifact_type == "plugins" and self.name != "OpenSearch Dashboards":
             BuildArtifactCheckPlugin(self.target).check(artifact_file)
         elif artifact_type == "maven":
             BuildArtifactCheckMaven(self.target).check(artifact_file)

--- a/bundle-workflow/src/build_workflow/builder.py
+++ b/bundle-workflow/src/build_workflow/builder.py
@@ -35,6 +35,9 @@ class Builder:
             self.component_name, self.git_repo.working_directory
         )
         build_command = f"{build_script} -v {target.version} -a {target.arch} -s {str(target.snapshot).lower()} -o {self.output_path}"
+        # TODO: [CLEANUP] If statement to pass flag to tell scripts to build dashboards
+        if self.build_recorder.name == "OpenSearch Dashboards":
+            build_command += " -d true"
         self.git_repo.execute(build_command)
         self.build_recorder.record_component(self.component_name, self.git_repo)
 

--- a/manifests/1.1.0/opensearch-dashboards-1.1.0.yml
+++ b/manifests/1.1.0/opensearch-dashboards-1.1.0.yml
@@ -1,0 +1,43 @@
+---
+schema-version: "1.0"
+build:
+  name: OpenSearch Dashboards
+  version: 1.1.0
+components:
+  - name: OpenSearch-Dashboards
+    repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+    ref: "1.1"
+  # hybrid repo (workbench)
+  # - name: queryWorkbench
+  #   repository: https://github.com/opensearch-project/sql.git
+  #   ref: main
+  - name: alertingDashboards
+    repository: https://github.com/opensearch-project/alerting-dashboards-plugin
+    ref: main
+  # hybrid repo (dashboards-notifications)
+  # - name: notificationsDashboards
+  #   repository: https://github.com/opensearch-project/notifications.git
+  #   ref: main
+  # - name: securityDashboards
+  #   repository: https://github.com/opensearch-project/security-dashboards-plugin
+  #   ref: main
+  # - name: indexManagementDashboards
+  #   repository: https://github.com/opensearch-project/index-management-dashboards-plugin
+  #   ref: main
+  # - name: anomalyDetectionDashboards
+  #   repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
+  #   ref: main
+  # # hybrid repo (dashboards-reports)
+  # - name: reportsDashboards
+  #   repository: https://github.com/opensearch-project/dashboards-reports.git
+  #   ref: main
+  # # hybrid repo (dashboards-notebooks)
+  # - name: notebooksDashboards
+  #   repository: https://github.com/opensearch-project/dashboards-notebooks.git
+  #   ref: main
+  # - name: traceAnalyticsDashboards
+  #   repository: https://github.com/opensearch-project/trace-analytics.git
+  #   ref: main
+  # - name: ganttChartDashboards
+  #   repository: ????????
+  #   ref: main


### PR DESCRIPTION
### Description
Produce an OpenSearch Dashboards bundle with plugins provided by a manifest.

This requires the manifest to be in order with plugins first and then Dashboards
being last. The plugins will need to pulled down and placed in the plugins
folder. Then we need to bootstrap to generate the modules so that we can actually
install the plugins to the release build.

What is missing or not verified
* Environment setup, this requires nvm and yarn to be already set up.
We will need to set that up.
* Dropping the custom config into the bundle
* Signing of the artifact
* Tests

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>


### Issues Resolved
Partial https://github.com/opensearch-project/opensearch-build/issues/158

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
