### PR TITLE
Refactored default build.sh scripts.

### DIFF
--- a/bundle-workflow/README.md
+++ b/bundle-workflow/README.md
@@ -44,7 +44,7 @@ each component's build script that defines which version the component should bu
 
 #### OpenSearch Dashboards
 
-The build order allows us first pull down `OpenSearch Dashboards` and then utilize it to build other components. Be sure to pass `-d true` flag to build the plugin for `OpenSearch Dashboards`.
+The build order allows us first pull down `OpenSearch Dashboards` and then utilize it to build other components.
 *NOTE*: Building plugins requires having the core repository pulled down so it has access to bootstrap and build the modules utilized by plugins.
 
 ### Check Out Source

--- a/bundle-workflow/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/bundle-workflow/scripts/components/OpenSearch-Dashboards/build.sh
@@ -13,11 +13,10 @@ function usage() {
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
-    echo -e "-d DASHBOARDS\t[Optional] Build OpenSearch Dashboards, default is 'false'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:d:" arg; do
+while getopts ":h:v:s:o:a:" arg; do
     case $arg in
         h)
             usage
@@ -34,9 +33,6 @@ while getopts ":h:v:s:o:a:d:" arg; do
             ;;
         a)
             ARCHITECTURE=$OPTARG
-            ;;
-        d)
-            DASHBOARDS=$OPTARG
             ;;
         :)
             echo "Error: -${OPTARG} requires an argument"

--- a/bundle-workflow/scripts/default/opensearch-dashboards/build.sh
+++ b/bundle-workflow/scripts/default/opensearch-dashboards/build.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:a:d:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch Dashboards version"
+    usage
+    exit 1
+fi
+
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+mkdir -p $OUTPUT/plugins
+PLUGIN_NAME=$(basename "$PWD")
+# TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
+# This makes it so there is a dependency on having Dashboards pulled already.
+cp -r ../$PLUGIN_NAME/ ../OpenSearch-Dashboards/plugins
+echo "BUILD MODULES FOR $PLUGIN_NAME"
+(cd ../OpenSearch-Dashboards && yarn osd bootstrap)
+echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
+(cd ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME && yarn plugin-helpers build)
+echo "COPY $PLUGIN_NAME.zip"
+cp -r ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/

--- a/bundle-workflow/scripts/default/opensearch/build.sh
+++ b/bundle-workflow/scripts/default/opensearch/build.sh
@@ -20,7 +20,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:d:" arg; do
+while getopts ":h:v:s:o:a:" arg; do
     case $arg in
         h)
             usage
@@ -37,9 +37,6 @@ while getopts ":h:v:s:o:a:d:" arg; do
             ;;
         a)
             ARCHITECTURE=$OPTARG
-            ;;
-        d)
-            DASHBOARDS=$OPTARG
             ;;
         :)
             echo "Error: -${OPTARG} requires an argument"
@@ -59,32 +56,16 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
-[[ "$SNAPSHOT" == "true" && "$DASHBOARDS" == "false" ]] && VERSION=$VERSION-SNAPSHOT
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
 mkdir -p $OUTPUT
 
-if [[ "$DASHBOARDS" == "true" ]]; then
-    mkdir -p $OUTPUT/plugins
-    PLUGIN_NAME=$(basename "$PWD")
-    # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
-    # This makes it so there is a dependency on having Dashboards pulled already.
-    cp -r ../$PLUGIN_NAME/ ../OpenSearch-Dashboards/plugins
-    echo "BUILD MODULES FOR $PLUGIN_NAME"
-    (cd ../OpenSearch-Dashboards && yarn osd bootstrap)
-    echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-    (cd ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME && yarn plugin-helpers build)
-    echo "COPY $PLUGIN_NAME.zip"
-    cp -r ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/
-else
-    ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
-    zipPath=$(find . -path \*build/distributions/*.zip)
-    distributions="$(dirname "${zipPath}")"
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
 
-    echo "COPY ${distributions}/*.zip"
-    mkdir -p $OUTPUT/plugins
-    cp ${distributions}/*.zip ./$OUTPUT/plugins
-fi
-
-
+echo "COPY ${distributions}/*.zip"
+mkdir -p $OUTPUT/plugins
+cp ${distributions}/*.zip ./$OUTPUT/plugins

--- a/bundle-workflow/src/build_workflow/builder.py
+++ b/bundle-workflow/src/build_workflow/builder.py
@@ -28,22 +28,23 @@ class Builder:
         self.git_repo = git_repo
         self.build_recorder = build_recorder
         self.output_path = "artifacts"
-        self.artifacts_path = os.path.join(self.git_repo.working_directory, self.output_path)
+        self.artifacts_path = os.path.join(
+            self.git_repo.working_directory, self.output_path
+        )
 
     def build(self, target):
         build_script = ScriptFinder.find_build_script(
-            self.component_name, self.git_repo.working_directory
+            target.name, self.component_name, self.git_repo.working_directory
         )
         build_command = f"{build_script} -v {target.version} -a {target.arch} -s {str(target.snapshot).lower()} -o {self.output_path}"
-        # TODO: [CLEANUP] If statement to pass flag to tell scripts to build dashboards
-        if self.build_recorder.name == "OpenSearch Dashboards":
-            build_command += " -d true"
         self.git_repo.execute(build_command)
         self.build_recorder.record_component(self.component_name, self.git_repo)
 
     def export_artifacts(self):
         for artifact_type in ["maven", "bundle", "plugins", "libs", "core-plugins"]:
-            for dir, dirs, files in os.walk(os.path.join(self.artifacts_path, artifact_type)):
+            for dir, dirs, files in os.walk(
+                os.path.join(self.artifacts_path, artifact_type)
+            ):
                 for file_name in files:
                     absolute_path = os.path.join(dir, file_name)
                     relative_path = os.path.relpath(absolute_path, self.artifacts_path)

--- a/bundle-workflow/src/paths/script_finder.py
+++ b/bundle-workflow/src/paths/script_finder.py
@@ -49,14 +49,20 @@ class ScriptFinder:
         return script
 
     @classmethod
-    def find_build_script(cls, component_name, git_dir):
+    def find_build_script(cls, project, component_name, git_dir):
         paths = [
             os.path.realpath(os.path.join(git_dir, "build.sh")),
             os.path.realpath(os.path.join(git_dir, "scripts/build.sh")),
             os.path.realpath(
                 os.path.join(cls.component_scripts_path, component_name, "build.sh")
             ),
-            os.path.realpath(os.path.join(cls.default_scripts_path, "build.sh")),
+            os.path.realpath(
+                os.path.join(
+                    cls.default_scripts_path,
+                    project.replace(" ", "-").lower(),
+                    "build.sh",
+                )
+            ),
         ]
 
         return cls.__find_script("build.sh", paths)

--- a/bundle-workflow/tests/tests_build_workflow/test_builder.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_builder.py
@@ -25,12 +25,12 @@ class TestBuilder(unittest.TestCase):
         self.assertEqual(self.builder.component_name, "component")
 
     def test_build(self):
-        self.builder.build(BuildTarget(version="1.0.0", arch="x64", snapshot=False))
+        self.builder.build(BuildTarget(name="OpenSearch", version="1.0.0", arch="x64", snapshot=False))
         self.builder.git_repo.execute.assert_called_with(
             " ".join(
                 [
                     os.path.realpath(
-                        os.path.join(ScriptFinder.default_scripts_path, "build.sh")
+                        os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")
                     ),
                     "-v 1.0.0",
                     "-a x64",
@@ -44,12 +44,12 @@ class TestBuilder(unittest.TestCase):
         )
 
     def test_build_snapshot(self):
-        self.builder.build(BuildTarget(version="1.0.0", arch="x64", snapshot=True))
+        self.builder.build(BuildTarget(name="OpenSearch", version="1.0.0", arch="x64", snapshot=True))
         self.builder.git_repo.execute.assert_called_with(
             " ".join(
                 [
                     os.path.realpath(
-                        os.path.join(ScriptFinder.default_scripts_path, "build.sh")
+                        os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")
                     ),
                     "-v 1.0.0",
                     "-a x64",

--- a/bundle-workflow/tests/tests_paths/test_script_finder.py
+++ b/bundle-workflow/tests/tests_paths/test_script_finder.py
@@ -30,10 +30,23 @@ class TestScriptFinder(unittest.TestCase):
 
     # find_build_script
 
-    def test_find_build_script_default(self):
+    def test_find_build_script_opensearch_default(self):
         self.assertEqual(
-            os.path.join(ScriptFinder.default_scripts_path, "build.sh"),
-            ScriptFinder.find_build_script("invalid", self.component_without_scripts),
+            os.path.join(ScriptFinder.default_scripts_path, "opensearch/build.sh"),
+            ScriptFinder.find_build_script(
+                "OpenSearch", "invalid", self.component_without_scripts
+            ),
+            msg="A component without an override resolves to a default.",
+        )
+
+    def test_find_build_script_opensearch_dashboards_default(self):
+        self.assertEqual(
+            os.path.join(
+                ScriptFinder.default_scripts_path, "opensearch-dashboards/build.sh"
+            ),
+            ScriptFinder.find_build_script(
+                "OpenSearch-Dashboards", "invalid", self.component_without_scripts
+            ),
             msg="A component without an override resolves to a default.",
         )
 
@@ -41,7 +54,7 @@ class TestScriptFinder(unittest.TestCase):
         self.assertEqual(
             os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/build.sh"),
             ScriptFinder.find_build_script(
-                "OpenSearch", self.component_without_scripts
+                "OpenSearch", "OpenSearch", self.component_without_scripts
             ),
             msg="A component without scripts resolves to a component override.",
         )
@@ -49,7 +62,9 @@ class TestScriptFinder(unittest.TestCase):
     def test_find_build_script_component_script(self):
         self.assertEqual(
             os.path.join(self.component_with_scripts, "build.sh"),
-            ScriptFinder.find_build_script("OpenSearch", self.component_with_scripts),
+            ScriptFinder.find_build_script(
+                "OpenSearch", "OpenSearch", self.component_with_scripts
+            ),
             msg="A component with a script resolves to the script at the root.",
         )
 
@@ -57,7 +72,7 @@ class TestScriptFinder(unittest.TestCase):
         self.assertEqual(
             os.path.join(self.component_with_scripts_folder, "scripts/build.sh"),
             ScriptFinder.find_build_script(
-                "OpenSearch", self.component_with_scripts_folder
+                "OpenSearch", "OpenSearch", self.component_with_scripts_folder
             ),
             msg="A component with a scripts folder resolves to a script in that folder.",
         )
@@ -68,7 +83,9 @@ class TestScriptFinder(unittest.TestCase):
             ScriptFinder.ScriptNotFoundError,
             "Could not find build.sh script. Looked in .*",
         ):
-            ScriptFinder.find_build_script("anything", self.component_without_scripts)
+            ScriptFinder.find_build_script(
+                "OpenSearch", "anything", self.component_without_scripts
+            )
 
     # find_integ_test_script
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description
Followup from https://github.com/opensearch-project/opensearch-build/pull/590, refactors build scripts to avoid IFs.

Incidentally fixes https://github.com/opensearch-project/opensearch-build/issues/598.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
