### PR TITLE
Fix: test_wait_for_service_cluster_unavailable is slow.

### DIFF
--- a/bundle-workflow/tests/test_integ_workflow/integ_test/__init__.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/__init__.py
@@ -7,4 +7,4 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../src"))

--- a/bundle-workflow/tests/test_integ_workflow/integ_test/test_local_test_cluster.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/test_local_test_cluster.py
@@ -113,8 +113,9 @@ class LocalTestClusterTests(unittest.TestCase):
             auth=("admin", "admin"),
         )
 
+    @patch("time.sleep")
     @patch("requests.get", side_effect=__mock_response)
-    def test_wait_for_service_cluster_unavailable(self, mock_requests):
+    def test_wait_for_service_cluster_unavailable(self, *mocks):
         local_test_cluster = LocalTestCluster(
             self.work_dir.name,
             "index-management",

--- a/bundle-workflow/tests/test_perf_workflow/perf_test/__init__.py
+++ b/bundle-workflow/tests/test_perf_workflow/perf_test/__init__.py
@@ -7,4 +7,4 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../src"))


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

- Mocks `time.sleep` to avoid actually waiting.
- Adds `__init__.py` so that tests can run outside of the suite.
 
### Issues Resolved

Closes #593. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
