### PR TITLE
Use Manifest.from_path everywhere.

### DIFF
--- a/bundle-workflow/src/manifests/build_manifest.py
+++ b/bundle-workflow/src/manifests/build_manifest.py
@@ -120,8 +120,7 @@ class BuildManifest(Manifest):
             build_id, opensearch_version, architecture
         )
         S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
-        with open("manifest.yml", "r") as file:
-            build_manifest = BuildManifest.from_file(file)
+        build_manifest = BuildManifest.from_path("manifest.yml")
         os.remove(os.path.realpath(os.path.join(work_dir, "manifest.yml")))
         return build_manifest
 

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -65,7 +65,9 @@ class IntegTestSuite:
         custom_local_path = os.path.join(
             self.repo.dir, "src/test/resources/job-scheduler"
         )
-        for file in glob.glob(custom_local_path + "/opensearch-job-scheduler-*.zip"):
+        for file in glob.glob(
+            os.path.join(custom_local_path, "opensearch-job-scheduler-*.zip")
+        ):
             os.unlink(file)
         job_scheduler = self.build_manifest.get_component("job-scheduler")
         DependencyInstaller(self.build_manifest.build).install_build_dependencies(

--- a/bundle-workflow/src/test_workflow/test_args.py
+++ b/bundle-workflow/src/test_workflow/test_args.py
@@ -85,3 +85,6 @@ class TestArgs:
         self.component = args.component
         self.keep = args.keep
         self.logging_level = args.logging_level
+
+
+TestArgs.__test__ = False  # type:ignore

--- a/bundle-workflow/src/test_workflow/test_component.py
+++ b/bundle-workflow/src/test_workflow/test_component.py
@@ -19,3 +19,6 @@ class TestComponent:
 
     def checkout(self, directory):
         return GitRepository(self.repository, self.commit_id, directory)
+
+
+TestComponent.__test__ = False  # type:ignore

--- a/bundle-workflow/tests/test_bwc_workflow/bwc_test/test_bwc_suite.py
+++ b/bundle-workflow/tests/test_bwc_workflow/bwc_test/test_bwc_suite.py
@@ -15,12 +15,10 @@ from test_workflow.bwc_test.bwc_test_suite import BwcTestSuite
 class TestBwcSuite(unittest.TestCase):
     def setUp(self):
         os.chdir(os.path.dirname(__file__))
-        manifest_file_handle = open("data/test_manifest.yaml", "r")
-        self.manifest = BundleManifest.from_file(manifest_file_handle)
+        self.manifest = BundleManifest.from_path("data/test_manifest.yaml")
         self.bwc_test_suite = BwcTestSuite(
             manifest=self.manifest, work_dir=".", component=None, keep=False
         )
-        manifest_file_handle.close()
 
     def test_execute(self):
         expected = []
@@ -41,7 +39,12 @@ class TestBwcSuite(unittest.TestCase):
     def test_component_bwctest(self, test_component_mock):
         component = self.manifest.components[1]
         self.bwc_test_suite.run_tests = MagicMock()
-        expected = [call("./" + self.manifest.components[1].name, self.manifest.components[1].name)]
+        expected = [
+            call(
+                "./" + self.manifest.components[1].name,
+                self.manifest.components[1].name,
+            )
+        ]
 
         self.bwc_test_suite.component_bwc_tests(component)
         test_component_mock.return_value.checkout.assert_called_with(

--- a/bundle-workflow/tests/test_integ_workflow/integ_test/test_integ_test_suite.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/test_integ_test_suite.py
@@ -131,8 +131,9 @@ class TestIntegSuite(unittest.TestCase):
     def test_execute_with_missing_job_scheduler(
         self, mock_install_build_dependencies, *mock
     ):
-        with open("data/build_manifest_missing_components.yml", "r") as file:
-            invalid_build_manifest = BuildManifest.from_file(file)
+        invalid_build_manifest = BuildManifest.from_path(
+            "data/build_manifest_missing_components.yml"
+        )
         test_config, component = self.__get_test_config_and_bundle_component(
             "index-management"
         )
@@ -144,8 +145,11 @@ class TestIntegSuite(unittest.TestCase):
             "/tmpdir",
             "s3_bucket_name",
         )
-        with self.assertRaises(BuildManifest.ComponentNotFoundError):
+        with self.assertRaises(BuildManifest.ComponentNotFoundError) as context:
             integ_test_suite.execute()
+        self.assertEqual(
+            str(context.exception), "job-scheduler not found in build manifest.yml"
+        )
         mock_install_build_dependencies.assert_not_called()
 
     def __get_test_config_and_bundle_component(self, component_name):

--- a/bundle-workflow/tests/tests_assemble_workflow/test_bundle.py
+++ b/bundle-workflow/tests/tests_assemble_workflow/test_bundle.py
@@ -15,114 +15,117 @@ from paths.script_finder import ScriptFinder
 
 class TestBundle(unittest.TestCase):
     def test_bundle(self):
-        with open(
-            os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        ) as f:
-            artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-            bundle = Bundle(BuildManifest.from_file(f), artifacts_path, MagicMock())
-            self.assertEqual(bundle.min_tarball.name, "OpenSearch")
-            self.assertEqual(len(bundle.plugins), 12)
-            self.assertEqual(bundle.artifacts_dir, artifacts_path)
-            self.assertIsNotNone(bundle.bundle_recorder)
-            self.assertEqual(bundle.installed_plugins, [])
-            self.assertTrue(
-                bundle.min_tarball_path.endswith(
-                    "/opensearch-min-1.1.0-linux-x64.tar.gz"
-                )
-            )
-            self.assertIsNotNone(bundle.archive_path)
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
+        )
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        bundle = Bundle(
+            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
+        )
+        self.assertEqual(bundle.min_tarball.name, "OpenSearch")
+        self.assertEqual(len(bundle.plugins), 12)
+        self.assertEqual(bundle.artifacts_dir, artifacts_path)
+        self.assertIsNotNone(bundle.bundle_recorder)
+        self.assertEqual(bundle.installed_plugins, [])
+        self.assertTrue(
+            bundle.min_tarball_path.endswith("/opensearch-min-1.1.0-linux-x64.tar.gz")
+        )
+        self.assertIsNotNone(bundle.archive_path)
 
     @patch.object(Bundle, "install_plugin")
     def test_bundle_install_plugins(self, mocks_bundle):
-        with open(
-            os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        ) as f:
-            bundle = Bundle(
-                BuildManifest.from_file(f),
-                os.path.join(os.path.dirname(__file__), "data/artifacts"),
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
+        )
+        bundle = Bundle(
+            BuildManifest.from_path(manifest_path),
+            os.path.join(os.path.dirname(__file__), "data/artifacts"),
+            MagicMock(),
+        )
+
+        bundle.install_plugins()
+        self.assertEqual(mocks_bundle.call_count, 12)
+
+    @patch("os.path.isfile", return_value=True)
+    def test_bundle_install_plugin(self, *mocks):
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
+        )
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        bundle = Bundle(
+            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
+        )
+
+        plugin = bundle.plugins[0]  # job-scheduler
+
+        with patch("shutil.copyfile") as mock_copyfile:
+            with patch("subprocess.check_call") as mock_check_call:
+                bundle.install_plugin(plugin)
+
+                self.assertEqual(mock_copyfile.call_count, 1)
+                self.assertEqual(mock_check_call.call_count, 2)
+
+                install_plugin_bin = os.path.join(
+                    bundle.archive_path, "bin/opensearch-plugin"
+                )
+                mock_check_call.assert_has_calls(
+                    [
+                        call(
+                            f'{install_plugin_bin} install --batch file:{os.path.join(bundle.tmp_dir.name, "opensearch-job-scheduler-1.1.0.0.zip")}',
+                            cwd=bundle.archive_path,
+                            shell=True,
+                        ),
+                        call(
+                            f'{ScriptFinder.find_install_script("opensearch-job-scheduler")} -a "{artifacts_path}" -o "{bundle.archive_path}"',
+                            cwd=bundle.archive_path,
+                            shell=True,
+                        ),
+                    ]
+                )
+
+    def test_bundle_build_tar(self):
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
+        )
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        bundle = Bundle(
+            BuildManifest.from_path(manifest_path),
+            artifacts_path,
+            MagicMock(tar_name="opensearch.tar"),
+        )
+
+        with patch("tarfile.open") as mock_tarfile_open:
+            mock_tarfile_add = MagicMock()
+            mock_tarfile_open.return_value.__enter__.return_value.add = mock_tarfile_add
+            with patch("shutil.copyfile") as mock_copyfile:
+                bundle.build_tar(os.path.dirname(__file__))
+                mock_tarfile_open.assert_called_with("opensearch.tar", "w:gz")
+                mock_tarfile_add.assert_called_with(
+                    os.path.join(bundle.tmp_dir.name, "bundle"), arcname="bundle"
+                )
+                self.assertEqual(mock_copyfile.call_count, 1)
+
+    def test_bundle_does_not_exist_raises_error(self):
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
+        )
+        with self.assertRaisesRegex(
+            FileNotFoundError,
+            "does-not-exist/bundle/opensearch-min-1.1.0-linux-x64.tar.gz",
+        ):
+            Bundle(
+                BuildManifest.from_path(manifest_path),
+                os.path.join(os.path.dirname(__file__), "data/does-not-exist"),
                 MagicMock(),
             )
 
-            bundle.install_plugins()
-            self.assertEqual(mocks_bundle.call_count, 12)
-
-    def test_bundle_install_plugin(self):
-        with open(
-            os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        ) as f:
-            artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-            bundle = Bundle(BuildManifest.from_file(f), artifacts_path, MagicMock())
-
-            plugin = bundle.plugins[0]  # job-scheduler
-            with patch("os.path.isfile", return_value=True):
-                with patch("shutil.copyfile") as mock_copyfile:
-                    with patch("subprocess.check_call") as mock_check_call:
-                        bundle.install_plugin(plugin)
-                        self.assertEqual(mock_copyfile.call_count, 1)
-                        self.assertEqual(mock_check_call.call_count, 2)
-                        install_plugin_bin = os.path.join(
-                            bundle.archive_path, "bin/opensearch-plugin"
-                        )
-                        mock_check_call.assert_has_calls(
-                            [
-                                call(
-                                    f'{install_plugin_bin} install --batch file:{os.path.join(bundle.tmp_dir.name, "opensearch-job-scheduler-1.1.0.0.zip")}',
-                                    cwd=bundle.archive_path,
-                                    shell=True,
-                                ),
-                                call(
-                                    f'{ScriptFinder.find_install_script("opensearch-job-scheduler")} -a "{artifacts_path}" -o "{bundle.archive_path}"',
-                                    cwd=bundle.archive_path,
-                                    shell=True,
-                                ),
-                            ]
-                        )
-
-    def test_bundle_build_tar(self):
-        with open(
-            os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        ) as f:
-            artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-            bundle = Bundle(
-                BuildManifest.from_file(f),
-                artifacts_path,
-                MagicMock(tar_name="opensearch.tar"),
-            )
-
-            with patch("tarfile.open") as mock_tarfile_open:
-                mock_tarfile_add = MagicMock()
-                mock_tarfile_open.return_value.__enter__.return_value.add = (
-                    mock_tarfile_add
-                )
-                with patch("shutil.copyfile") as mock_copyfile:
-                    bundle.build_tar(os.path.dirname(__file__))
-                    mock_tarfile_open.assert_called_with("opensearch.tar", "w:gz")
-                    mock_tarfile_add.assert_called_with(
-                        os.path.join(bundle.tmp_dir.name, "bundle"), arcname="bundle"
-                    )
-                    self.assertEqual(mock_copyfile.call_count, 1)
-
-    def test_bundle_does_not_exist_raises_error(self):
-        with open(
-            os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        ) as f:
-            with self.assertRaisesRegex(
-                FileNotFoundError,
-                "does-not-exist/bundle/opensearch-min-1.1.0-linux-x64.tar.gz",
-            ):
-                Bundle(
-                    BuildManifest.from_file(f),
-                    os.path.join(os.path.dirname(__file__), "data/does-not-exist"),
-                    MagicMock(),
-                )
-
     def test_bundle_invalid_archive_raises_error(self):
-        with open(
-            os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        ) as f:
-            with self.assertRaisesRegex(FileNotFoundError, "(/*)$"):
-                Bundle(
-                    BuildManifest.from_file(f),
-                    os.path.join(os.path.dirname(__file__), "data/invalid"),
-                    MagicMock(),
-                )
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
+        )
+        with self.assertRaisesRegex(FileNotFoundError, "(/*)$"):
+            Bundle(
+                BuildManifest.from_path(manifest_path),
+                os.path.join(os.path.dirname(__file__), "data/invalid"),
+                MagicMock(),
+            )

--- a/bundle-workflow/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/bundle-workflow/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -18,13 +18,13 @@ from manifests.bundle_manifest import BundleManifest
 class TestBundleRecorder(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
-        with open(
-            os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        ) as f:
-            manifest = BuildManifest.from_file(f)
-            self.bundle_recorder = BundleRecorder(
-                manifest.build, "output_dir", "artifacts_dir"
-            )
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
+        )
+        manifest = BuildManifest.from_path(manifest_path)
+        self.bundle_recorder = BundleRecorder(
+            manifest.build, "output_dir", "artifacts_dir"
+        )
 
     def test_record_component(self):
         component = BuildManifest.Component(


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Use `Manifest.from_path` everywhere in tests, making code simpler.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
