### PR TITLE
Parallel bundle build notifications

### DIFF
--- a/bundle-workflow/Jenkinsfile
+++ b/bundle-workflow/Jenkinsfile
@@ -102,10 +102,14 @@ pipeline {
             }
             post() {
                 success {
-                    publishNotification(":white_check_mark:", "Successful Build", "\n${getAllJenkinsMessages()}")
+                    node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                        publishNotification(":white_check_mark:", "Successful Build", "\n${getAllJenkinsMessages()}")
+                    }
                 }
                 failure {
-                    publishNotification(":warning:", "Failed Build", "")
+                    node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                        publishNotification(":warning:", "Failed Build", "")
+                    }
                 }
             }
         }
@@ -133,24 +137,36 @@ void build() {
 /** Publishes a notification to a slack instance*/
 void publishNotification(icon, msg, extra) {
     withCredentials([string(credentialsId: 'BUILD_NOTICE_WEBHOOK', variable: 'TOKEN')]) {
-        sh """curl -XPOST --header "Content-Type: application/json" --data '{"result_text": "$icon ${env.JOB_NAME} [${env.BUILD_NUMBER}] $msg ${env.BUILD_URL}\nManifest: ${INPUT_MANIFEST} $extra"}' $TOKEN"""
+        sh("""curl -XPOST --header "Content-Type: application/json" --data '{"result_text": "$icon ${env.JOB_NAME} [${env.BUILD_NUMBER}] $msg ${env.BUILD_URL}\nManifest: ${INPUT_MANIFEST} $extra"}' """ + "$TOKEN")
     }
 }
 
 /** Add a message to the jenkins queue */
 void addJenkinsMessage(message) {
-    writeFile(file: "notifications/${System.currentTimeMillis()}.msg", text: message)
-    stash(includes: "notifications/*" , name: "notifications")
+    writeFile(file: "notifications/${STAGE_NAME}.msg", text: message)
+    stash(includes: "notifications/*" , name: "notifications-${STAGE_NAME}")
 }
 
 /** Load all message in the jenkins queue and append them with a leading newline into a mutli-line string */
 String getAllJenkinsMessages() {
     script {
-        unstash 'notifications'
+        // Stages must be explicitly added to prevent overwriting
+        // See https://ryan.himmelwright.net/post/jenkins-parallel-stashing/
+        def stages = ['build-x86', 'build-arm64']
+        for (stage in stages) {
+            unstash "notifications-${stage}"
+        }
+
         def files = findFiles(excludes: '', glob: 'notifications/*')
         def data = ""
         for (file in files) {
             data = data + "\n" + readFile (file: file.path)
         }
+
+        // Delete all the notifications from the workspace
+        dir('notifications') {
+            deleteDir()
+        }
+        return data
     }
 }


### PR DESCRIPTION
With the move to parallel builds, without specificing an agent Jenkins was unable to send notifications.
Reusing the node from the x86 for both success/failure flows resolved this, tested on a fake job extensively.

Adjusted the way that jobs identified themselves, reusing the same stash caused the data to be overwritten, by
using job name to seperate the source this avoided any complex concurrency limitations.  In the future this
can be further improved by generating the architecture builds from script so the names do not need to be
duplicated.

Signed-off-by: Peter Nied <petern@amazon.com>

### Issues Resolved
Resolves #607 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Validate notification changes with internal `bundle-build-peternied` job

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
