### PR TITLE
Refactored artifact checks for OpenSearch vs. OpenSearch Dashboards bundles.

### DIFF
--- a/bundle-workflow/src/build_workflow/build_artifact_checks.py
+++ b/bundle-workflow/src/build_workflow/build_artifact_checks.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+from build_workflow.opensearch.build_artifact_check_maven import \
+    BuildArtifactOpenSearchCheckMaven
+from build_workflow.opensearch.build_artifact_check_plugin import \
+    BuildArtifactOpenSearchCheckPlugin
+from build_workflow.opensearch_dashboards.build_artifact_check_plugin import \
+    BuildArtifactOpenSearchDashboardsCheckPlugin
+
+
+class BuildArtifactChecks:
+    TYPES = {
+        "OpenSearch": {
+            "plugins": BuildArtifactOpenSearchCheckPlugin,
+            "maven": BuildArtifactOpenSearchCheckMaven,
+        },
+        "OpenSearch Dashboards": {
+            "plugins": BuildArtifactOpenSearchDashboardsCheckPlugin
+        },
+    }
+
+    @classmethod
+    def from_name_and_type(cls, name, type):
+        checks = cls.TYPES.get(name, None)
+        if not checks:
+            raise ValueError(f"Unsupported bundle: {name}")
+        return checks.get(type, None)
+
+    @classmethod
+    def create(cls, target, artifact_type):
+        klass = cls.from_name_and_type(target.name, artifact_type)
+        if not klass:
+            return None
+        return klass(target)
+
+    @classmethod
+    def check(cls, target, artifact_type, path):
+        instance = cls.create(target, artifact_type)
+        if instance:
+            instance.check(path)

--- a/bundle-workflow/src/build_workflow/build_recorder.py
+++ b/bundle-workflow/src/build_workflow/build_recorder.py
@@ -8,8 +8,7 @@ import logging
 import os
 import shutil
 
-from build_workflow.build_artifact_check_maven import BuildArtifactCheckMaven
-from build_workflow.build_artifact_check_plugin import BuildArtifactCheckPlugin
+from build_workflow.build_artifact_checks import BuildArtifactChecks
 from manifests.build_manifest import BuildManifest
 
 
@@ -39,7 +38,7 @@ class BuildRecorder:
         dest_dir = os.path.dirname(dest_file)
         os.makedirs(dest_dir, exist_ok=True)
         # Check artifact
-        self.__check_artifact(artifact_type, artifact_file)
+        BuildArtifactChecks.check(self.target, artifact_type, artifact_file)
         # Copy the file
         shutil.copyfile(artifact_file, dest_file)
         # Notify the recorder
@@ -54,12 +53,6 @@ class BuildRecorder:
         manifest_path = os.path.join(self.target.output_dir, "manifest.yml")
         self.get_manifest().to_file(manifest_path)
         logging.info(f"Created build manifest {manifest_path}")
-
-    def __check_artifact(self, artifact_type, artifact_file):
-        if artifact_type == "plugins" and self.name != "OpenSearch Dashboards":
-            BuildArtifactCheckPlugin(self.target).check(artifact_file)
-        elif artifact_type == "maven":
-            BuildArtifactCheckMaven(self.target).check(artifact_file)
 
     class BuildManifestBuilder:
         def __init__(self, target):

--- a/bundle-workflow/src/build_workflow/opensearch/__init__.py
+++ b/bundle-workflow/src/build_workflow/opensearch/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/bundle-workflow/src/build_workflow/opensearch/build_artifact_check_maven.py
+++ b/bundle-workflow/src/build_workflow/opensearch/build_artifact_check_maven.py
@@ -12,7 +12,7 @@ from build_workflow.build_artifact_check import BuildArtifactCheck
 from system.properties_file import PropertiesFile
 
 
-class BuildArtifactCheckMaven(BuildArtifactCheck):
+class BuildArtifactOpenSearchCheckMaven(BuildArtifactCheck):
     def check(self, path):
         ext = os.path.splitext(path)[1]
         if ext not in [

--- a/bundle-workflow/src/build_workflow/opensearch/build_artifact_check_plugin.py
+++ b/bundle-workflow/src/build_workflow/opensearch/build_artifact_check_plugin.py
@@ -12,7 +12,7 @@ from build_workflow.build_artifact_check import BuildArtifactCheck
 from system.properties_file import PropertiesFile
 
 
-class BuildArtifactCheckPlugin(BuildArtifactCheck):
+class BuildArtifactOpenSearchCheckPlugin(BuildArtifactCheck):
     def check(self, path):
         if os.path.splitext(path)[1] != ".zip":
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")

--- a/bundle-workflow/src/build_workflow/opensearch_dashboards/__init__.py
+++ b/bundle-workflow/src/build_workflow/opensearch_dashboards/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/bundle-workflow/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
+++ b/bundle-workflow/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import re
+
+from build_workflow.build_artifact_check import BuildArtifactCheck
+
+
+class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
+    def check(self, path):
+        if os.path.splitext(path)[1] != ".zip":
+            raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")
+        version = re.sub(r'-SNAPSHOT$', '', self.target.opensearch_version)
+        if not path.endswith(f"-{version}.zip"):
+            raise BuildArtifactCheck.BuildArtifactInvalidError(
+                path, f"Expected filename to include {version}."
+            )

--- a/bundle-workflow/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_maven.py
+++ b/bundle-workflow/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_maven.py
@@ -9,18 +9,21 @@ from contextlib import contextmanager
 from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
-from build_workflow.build_artifact_check_maven import BuildArtifactCheckMaven
 from build_workflow.build_target import BuildTarget
+from build_workflow.opensearch.build_artifact_check_maven import \
+    BuildArtifactOpenSearchCheckMaven
 
 
-class TestBuildArtifactCheckMaven(unittest.TestCase):
+class TestBuildArtifactOpenSearchCheckMaven(unittest.TestCase):
     @contextmanager
     def __mock(self, props="", snapshot=True):
-        with patch("build_workflow.build_artifact_check_maven.ZipFile") as mock_zipfile:
+        with patch(
+            "build_workflow.opensearch.build_artifact_check_maven.ZipFile"
+        ) as mock_zipfile:
             mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = (
                 props
             )
-            yield BuildArtifactCheckMaven(
+            yield BuildArtifactOpenSearchCheckMaven(
                 BuildTarget(
                     build_id="1",
                     output_dir="output_dir",

--- a/bundle-workflow/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_plugin.py
+++ b/bundle-workflow/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_plugin.py
@@ -9,20 +9,21 @@ from contextlib import contextmanager
 from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
-from build_workflow.build_artifact_check_plugin import BuildArtifactCheckPlugin
 from build_workflow.build_target import BuildTarget
+from build_workflow.opensearch.build_artifact_check_plugin import \
+    BuildArtifactOpenSearchCheckPlugin
 
 
-class TestBuildArtifactCheckPlugin(unittest.TestCase):
+class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
     @contextmanager
     def __mock(self, props="", snapshot=True):
         with patch(
-            "build_workflow.build_artifact_check_plugin.ZipFile"
+            "build_workflow.opensearch.build_artifact_check_plugin.ZipFile"
         ) as mock_zipfile:
             mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = (
                 props
             )
-            yield BuildArtifactCheckPlugin(
+            yield BuildArtifactOpenSearchCheckPlugin(
                 BuildTarget(
                     build_id="1",
                     output_dir="output_dir",

--- a/bundle-workflow/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
+++ b/bundle-workflow/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from contextlib import contextmanager
+
+from build_workflow.build_artifact_check import BuildArtifactCheck
+from build_workflow.build_target import BuildTarget
+from build_workflow.opensearch_dashboards.build_artifact_check_plugin import \
+    BuildArtifactOpenSearchDashboardsCheckPlugin
+
+
+class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
+    @contextmanager
+    def __mock(self, snapshot=True):
+        yield BuildArtifactOpenSearchDashboardsCheckPlugin(
+            BuildTarget(
+                build_id="1",
+                output_dir="output_dir",
+                name="OpenSearch",
+                version="1.1.0",
+                arch="x64",
+                snapshot=snapshot,
+            )
+        )
+
+    def test_check_plugin_invalid_zip_version(self):
+        with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
+            with self.__mock() as mock:
+                mock.check("invalid.zip")
+        self.assertEqual(
+            "Artifact invalid.zip is invalid. Expected filename to include 1.1.0.",
+            str(context.exception),
+        )
+
+    def test_check_plugin_zip(self, *mocks):
+        with self.__mock(snapshot=False) as mock:
+            mock.check("valid-1.1.0.zip")
+
+    def test_check_plugin_snapshot_zip(self, *mocks):
+        with self.__mock(snapshot=True) as mock:
+            mock.check("valid-1.1.0.zip")

--- a/bundle-workflow/tests/tests_build_workflow/test_build_artifact_checks.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_build_artifact_checks.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from unittest.mock import patch
+
+from build_workflow.build_artifact_checks import BuildArtifactChecks
+from build_workflow.build_target import BuildTarget
+from build_workflow.opensearch.build_artifact_check_maven import \
+    BuildArtifactOpenSearchCheckMaven
+from build_workflow.opensearch.build_artifact_check_plugin import \
+    BuildArtifactOpenSearchCheckPlugin
+from build_workflow.opensearch_dashboards.build_artifact_check_plugin import \
+    BuildArtifactOpenSearchDashboardsCheckPlugin
+
+
+class TestBuildArtifactChecks(unittest.TestCase):
+    def __mock_target(self, name="OpenSearch"):
+        return BuildTarget(
+            build_id="1",
+            output_dir="output_dir",
+            name=name,
+            version="1.1.0",
+            arch="x64",
+            snapshot=True,
+        )
+
+    def test_opensearch_build_artifact_check_plugin(self):
+        target = self.__mock_target(name="OpenSearch")
+        check = BuildArtifactChecks.create(target, "plugins")
+        self.assertIs(type(check), BuildArtifactOpenSearchCheckPlugin)
+
+    def test_opensearch_build_artifact_check_maven(self):
+        target = self.__mock_target(name="OpenSearch")
+        check = BuildArtifactChecks.create(target, "maven")
+        self.assertIs(type(check), BuildArtifactOpenSearchCheckMaven)
+
+    def test_opensearch_build_artifact_check_other(self):
+        target = self.__mock_target(name="OpenSearch")
+        self.assertIsNone(BuildArtifactChecks.create(target, "other"))
+
+    def test_opensearch_dashboards_build_artifact_check_plugin(self):
+        target = self.__mock_target(name="OpenSearch Dashboards")
+        check = BuildArtifactChecks.create(target, "plugins")
+        self.assertIs(type(check), BuildArtifactOpenSearchDashboardsCheckPlugin)
+
+    def test_build_artifact_check_invalid(self):
+        target = self.__mock_target(name="invalid")
+        with self.assertRaises(ValueError) as ctx:
+            BuildArtifactChecks.create(target, "plugins")
+        self.assertEqual(str(ctx.exception), "Unsupported bundle: invalid")
+
+    @patch.object(BuildArtifactOpenSearchCheckPlugin, "check")
+    def test_check(self, mock_check):
+        target = self.__mock_target(name="OpenSearch")
+        BuildArtifactChecks.check(target, "plugins", "artifact.zip")
+        mock_check.assert_called_with("artifact.zip")

--- a/bundle-workflow/tests/tests_build_workflow/test_build_recorder.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_build_recorder.py
@@ -11,10 +11,12 @@ from unittest.mock import MagicMock, patch
 
 import yaml
 
-from build_workflow.build_artifact_check_maven import BuildArtifactCheckMaven
-from build_workflow.build_artifact_check_plugin import BuildArtifactCheckPlugin
 from build_workflow.build_recorder import BuildRecorder
 from build_workflow.build_target import BuildTarget
+from build_workflow.opensearch.build_artifact_check_maven import \
+    BuildArtifactOpenSearchCheckMaven
+from build_workflow.opensearch.build_artifact_check_plugin import \
+    BuildArtifactOpenSearchCheckPlugin
 from manifests.build_manifest import BuildManifest
 
 
@@ -101,7 +103,7 @@ class TestBuildRecorder(unittest.TestCase):
 
         recorder.record_component("security", MagicMock())
 
-        with patch.object(BuildArtifactCheckPlugin, "check") as mock_check:
+        with patch.object(BuildArtifactOpenSearchCheckPlugin, "check") as mock_check:
             recorder.record_artifact(
                 "security", "plugins", "../file1.zip", "invalid.file"
             )
@@ -115,7 +117,7 @@ class TestBuildRecorder(unittest.TestCase):
 
         recorder.record_component("security", MagicMock())
 
-        with patch.object(BuildArtifactCheckMaven, "check") as mock_check:
+        with patch.object(BuildArtifactOpenSearchCheckMaven, "check") as mock_check:
             recorder.record_artifact("security", "maven", "../file1.zip", "valid.jar")
 
         mock_check.assert_called_with("valid.jar")
@@ -149,7 +151,7 @@ class TestBuildRecorder(unittest.TestCase):
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
-    @patch.object(BuildArtifactCheckPlugin, "check")
+    @patch.object(BuildArtifactOpenSearchCheckPlugin, "check")
     def test_record_artifact_check_plugin_version_properties(self, *mocks):
         mock = self.__mock(snapshot=False)
         mock.record_component(
@@ -167,7 +169,7 @@ class TestBuildRecorder(unittest.TestCase):
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
-    @patch.object(BuildArtifactCheckPlugin, "check")
+    @patch.object(BuildArtifactOpenSearchCheckPlugin, "check")
     def test_record_artifact_check_plugin_version_properties_snapshot(self, *mocks):
         mock = self.__mock(snapshot=True)
         mock.record_component(


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Refactored artifact checks for OpenSearch vs. OpenSearch Dashboards bundles following #590. 

The dashboards zip check is super rudimentary. It needs to be extended to unpack the zip file's `opensearch-dashboards/alertingDashboards/package.json` and check the `version` field in that. Opened https://github.com/opensearch-project/opensearch-build/issues/618.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
