### PR TITLE
Fix the lib location for deploy single cluster script

### DIFF
--- a/scripts/deploy_single_tar_cluster.sh
+++ b/scripts/deploy_single_tar_cluster.sh
@@ -11,8 +11,8 @@
 set -e
 
 # Source lib
-. ../../lib/shell/file_management.sh
-. ../../lib/shell/process_control.sh
+. ../lib/shell/file_management.sh
+. ../lib/shell/process_control.sh
 
 
 ROOT=`dirname $(realpath $0)`; echo $ROOT; cd $ROOT


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Fix the lib location for deploy single cluster script
 
### Issues Related:
#604
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
