### PR TITLE
Change Jenkins Docker Runner to CentOS7 so k-NN lib will not crash on OS with lower glibc version

### DIFF
--- a/bundle-workflow/Jenkinsfile
+++ b/bundle-workflow/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                     agent {
                         docker {
                             label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
-                            image 'opensearchstaging/ci-runner:al2-x64-arm64-jdk14-node10.24.1-20210924'
+                            image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdk14-node10.24.1-20210924'
                             // Unlike freestyle docker, pipeline docker does not login to the container and run commands
                             // It use executes which does not source the docker container internal ENV VAR
                             args '-e JAVA_HOME=/usr/lib/jvm/adoptopenjdk-14-hotspot'
@@ -59,7 +59,7 @@ pipeline {
                     agent {
                         docker {
                             label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
-                            image 'opensearchstaging/ci-runner:al2-x64-arm64-jdk14-node10.24.1-20210924'
+                            image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdk14-node10.24.1-20210924'
                             // Unlike freestyle docker, pipeline docker does not login to the container and run commands
                             // It use executes which does not source the docker container internal ENV VAR
                             args '-e JAVA_HOME=/usr/lib/jvm/adoptopenjdk-14-hotspot'
@@ -81,7 +81,7 @@ pipeline {
                     agent {
                         docker {
                             label 'Jenkins-Agent-al2-arm64-c6g4xlarge-Docker-Host'
-                            image 'opensearchstaging/ci-runner:al2-x64-arm64-jdk14-node10.24.1-20210924'
+                            image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdk14-node10.24.1-20210924'
                             // Unlike freestyle docker, pipeline docker does not login to the container and run commands
                             // It use executes which does not source the docker container internal ENV VAR
                             args '-e JAVA_HOME=/usr/lib/jvm/adoptopenjdk-14-hotspot'


### PR DESCRIPTION
### Description
Change Jenkins Docker Runner to CentOS7 so k-NN lib will not crash on OS with lower glibc version
 
### Issues Resolved
#481
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
