### PR TITLE
Fixed integ test to run on all plugins

### DIFF
--- a/bundle-workflow/src/run_integ_test.py
+++ b/bundle-workflow/src/run_integ_test.py
@@ -59,11 +59,12 @@ def main():
                     work_dir,
                     args.s3_bucket
                 )
-                status, security = test_suite.execute()
-                if status != 0:
-                    failed_components[component.name] = [status, security]
-                else:
-                    passed_components[component.name] = [status, security]
+                test_configs = test_suite.execute()
+                for security, status in test_configs.items():
+                    if status != 0:
+                        failed_components[(component.name, security)] = status
+                    else:
+                        passed_components[(component.name, security)] = status
             else:
                 logging.info(
                     "Skipping tests for %s, as it is currently not supported"
@@ -72,11 +73,11 @@ def main():
 
         if passed_components:
             for component, result in passed_components.items():
-                logging.info(f'PASS: Integration Test for {component} {result[1]} with status code {result[0]}')
+                logging.info(f'PASS: Integration Test for {component[0]} {component[1]} with status code {result}')
 
         if failed_components:
             for component, result in failed_components.items():
-                logging.error(f'FAIL: Integration Test for {component} {result[1]} with status code {result[0]}')
+                logging.error(f'FAIL: Integration Test for {component[0]} {component[1]} with status code {result}')
             sys.exit(1)
 
 

--- a/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
+++ b/bundle-workflow/src/test_workflow/integ_test/integ_test_suite.py
@@ -46,10 +46,12 @@ class IntegTestSuite:
 
     def execute(self):
         self.__install_build_dependencies()
+        test_configs = dict()
         for config in self.test_config.integ_test["test-configs"]:
             security = self.__is_security_enabled(config)
             status = self.__setup_cluster_and_execute_test_config(security)
-            return status, config
+            test_configs[config] = status
+        return test_configs
 
     def __install_build_dependencies(self):
         if "build-dependencies" in self.test_config.integ_test:

--- a/bundle-workflow/tests/test_integ_workflow/integ_test/test_integ_test_suite.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/test_integ_test_suite.py
@@ -50,7 +50,7 @@ class TestIntegSuite(unittest.TestCase):
         mock_system_execute.return_value = 200, "success", "failure"
         mock_local_test_cluster.create().__enter__.return_value = "localhost", "9200"
         mock_script_finder.return_value = "integtest.sh"
-        integ_test_suite.execute()
+        test_configs = integ_test_suite.execute()
         mock_system_execute.assert_has_calls(
             [
                 call(
@@ -67,6 +67,7 @@ class TestIntegSuite(unittest.TestCase):
                 )
             ]
         )
+        self.assertEqual(test_configs, {'with-security': 200, 'without-security': 200})
 
     @patch.object(
         IntegTestSuite, "_IntegTestSuite__setup_cluster_and_execute_test_config"

--- a/bundle-workflow/tests/test_integ_workflow/integ_test/test_integ_test_suite.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/test_integ_test_suite.py
@@ -58,6 +58,12 @@ class TestIntegSuite(unittest.TestCase):
                     "/tmpdir/job-scheduler",
                     True,
                     False,
+                ),
+                call(
+                    "integtest.sh -b localhost -p 9200 -s false -v 1.1.0",
+                    "/tmpdir/job-scheduler",
+                    True,
+                    False,
                 )
             ]
         )


### PR DESCRIPTION
### Description
Fixed integ test to run on all plugins.
Added UT for the change.
Test Summary:
```
2021-09-28 17:45:39 INFO     PASS: Integration Test for sql with-security with status code 0
2021-09-28 17:45:39 INFO     PASS: Integration Test for sql without-security with status code 0
2021-09-28 17:45:39 INFO     PASS: Integration Test for alerting without-security with status code 0
2021-09-28 17:45:39 INFO     PASS: Integration Test for k-NN without-security with status code 0
2021-09-28 17:45:39 INFO     PASS: Integration Test for anomaly-detection with-security with status code 0
2021-09-28 17:45:39 INFO     PASS: Integration Test for anomaly-detection without-security with status code 0
2021-09-28 17:45:39 INFO     PASS: Integration Test for asynchronous-search with-security with status code 0
2021-09-28 17:45:39 INFO     PASS: Integration Test for asynchronous-search without-security with status code 0
2021-09-28 17:45:39 INFO     PASS: Integration Test for dashboards-reports without-security with status code 0
2021-09-28 17:45:39 INFO     PASS: Integration Test for dashboards-notebooks without-security with status code 0
2021-09-28 17:45:39 ERROR    FAIL: Integration Test for alerting with-security with status code 1
2021-09-28 17:45:39 ERROR    FAIL: Integration Test for index-management with-security with status code 1
2021-09-28 17:45:39 ERROR    FAIL: Integration Test for index-management without-security with status code 1
2021-09-28 17:45:39 ERROR    FAIL: Integration Test for k-NN with-security with status code 1
```
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
