### PR TITLE
Fix knn lib build on arm centos 7

### DIFF
--- a/bundle-workflow/scripts/components/k-NN/build.sh
+++ b/bundle-workflow/scripts/components/k-NN/build.sh
@@ -74,6 +74,11 @@ if [ "$ARCHITECTURE" = "x64" ]; then
     sed -i -e 's/-march=native/-march=x86-64/g' external/nmslib/similarity_search/CMakeLists.txt
 fi
 
+# For arm, march=native is broken in centos 7. Manually override to lowest version of armv8.
+if [ "$ARCHITECTURE" = "arm64" ]; then
+    sed -i -e 's/-march=native/-march=armv8-a/g' external/nmslib/similarity_search/CMakeLists.txt
+fi
+
 cmake .
 make
 


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Sets architecture override for k-NN library on arm to armv8-a.

@peterzhuamazon confirmed it is working by compiling library on an arm centos 7 machine (see [this comment](https://github.com/opensearch-project/opensearch-build/issues/481#issuecomment-929512075)).

### Issues Resolved
#481 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
