### PR TITLE
Added remaining unit tests for local_test_cluster

### DIFF
--- a/bundle-workflow/tests/test_integ_workflow/integ_test/test_local_test_cluster.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/test_local_test_cluster.py
@@ -6,9 +6,10 @@
 
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch
 
 import requests
 import yaml
@@ -29,6 +30,7 @@ class LocalTestClusterTests(unittest.TestCase):
         )
         self.manifest = BundleManifest.from_path(self.manifest_filename)
         self.work_dir = tempfile.TemporaryDirectory()
+        self.process = self.__get_process()
         self.local_test_cluster = LocalTestCluster(
             self.work_dir.name,
             "sql",
@@ -46,11 +48,29 @@ class LocalTestClusterTests(unittest.TestCase):
             self.text = text
             self.status_code = status_code
 
+    class MockProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def children(self, recursive):
+            return []
+
     def __mock_response(*args, **kwargs):
         if args[0] == "https://localhost:9200/_cluster/health":
             return LocalTestClusterTests.MockResponse({"status": "green"}, 200)
         else:
             return LocalTestClusterTests.MockResponse({"status": "red"}, 404)
+
+    def __mock_process(*args, **kwargs):
+        return LocalTestClusterTests.MockProcess(12)
+
+    def __get_process(self):
+        return subprocess.Popen(
+            (sys.executable, "-c", "pass"),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
     @patch("subprocess.Popen")
     @patch("yaml.dump")
@@ -135,3 +155,71 @@ class LocalTestClusterTests(unittest.TestCase):
             str(err.exception),
             "Cluster is not available after 10 attempts",
         )
+
+    @patch(
+        "test_workflow.integ_test.local_test_cluster.psutil.Process",
+        side_effect=__mock_process,
+    )
+    @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.wait")
+    @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.terminate")
+    @patch(
+        "test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock()
+    )
+    def test_terminate_process(
+        self, mock_logging, mock_terminate, mock_wait, mock_process
+    ):
+        with open("stdout-tmp.txt", "w") as self.local_test_cluster.stdout, open(
+            "stderr-tmp.txt", "w"
+        ) as self.local_test_cluster.stderr:
+            self.local_test_cluster.process = self.process
+            self.local_test_cluster.terminate_process()
+            mock_process.assert_called_once_with(self.process.pid)
+            mock_terminate.assert_called_once()
+            mock_wait.assert_called_once_with(10)
+            mock_logging.info.assert_has_calls(
+                [
+                    call(f"Sending SIGTERM to PID {self.process.pid}"),
+                    call("Waiting for process to terminate"),
+                    call(
+                        f"Process terminated with exit code {self.process.returncode}"
+                    ),
+                ]
+            )
+            mock_logging.debug.assert_has_calls([call("Checking for child processes")])
+
+    @patch(
+        "test_workflow.integ_test.local_test_cluster.psutil.Process",
+        side_effect=__mock_process,
+    )
+    @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.wait")
+    @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.terminate")
+    @patch(
+        "test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock()
+    )
+    def test_terminate_process_timeout(
+        self, mock_logging, mock_terminate, mock_wait, mock_process
+    ):
+        with open("stdout-tmp.txt", "w") as self.local_test_cluster.stdout, open(
+            "stderr-tmp.txt", "w"
+        ) as self.local_test_cluster.stderr:
+            mock_wait.side_effect = subprocess.TimeoutExpired(cmd="pass", timeout=1)
+            with self.assertRaises(subprocess.TimeoutExpired):
+                self.local_test_cluster.process = self.process
+                self.local_test_cluster.terminate_process()
+                mock_process.assert_called_once_with(self.process.pid)
+                mock_terminate.assert_called_once()
+                mock_wait.assert_called_with(10)
+                mock_logging.info.assert_has_calls(
+                    [
+                        call(f"Sending SIGTERM to PID {self.process.pid}"),
+                        call("Waiting for process to terminate"),
+                        call(
+                            "Process did not terminate after 10 seconds. Sending SIGKILL"
+                        ),
+                        call("Waiting for process to terminate"),
+                        call("Process failed to terminate even after SIGKILL"),
+                        call(
+                            f"Process terminated with exit code {self.process.returncode}"
+                        ),
+                    ]
+                )


### PR DESCRIPTION
Signed-off-by: Vacha <vachshah@amazon.com>

### Description
Added remaining unit tests for local_test_cluster.

### Issues Resolved
#532 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
