### PR TITLE
Revert "Use a released version of create-an-issue."

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -1,7 +1,7 @@
 ---
 name: Release
 title: "[RELEASE] Release version {{ env.VERSION }}"
-labels: untriaged, release
+labels: untriaged, release, v{{ env.VERSION }}
 ---
 
 ## Release OpenSearch and OpenSearch Dashboards {{ env.VERSION }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,11 +23,11 @@ jobs:
         version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v2
-      - uses: JasonEtco/create-an-issue@v2.6
+      - uses: dblock/create-an-issue@v2.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ matrix.version }}
         with:
-          search_existing: all
+          search_existing: open, closed
           update_existing: false
           filename: .github/ISSUE_TEMPLATE/release_template.md


### PR DESCRIPTION
Reverts opensearch-project/opensearch-build#634

I introduced a bug, fixed in https://github.com/JasonEtco/create-an-issue/pull/118/files. Reverting for now so this thing doesn't open issues every nightly run.