### PR TITLE
Improving Test Coverage for sign_workflow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "./bundle-workflow/src"
+    ]
+}

--- a/bundle-workflow/src/assemble_workflow/bundles.py
+++ b/bundle-workflow/src/assemble_workflow/bundles.py
@@ -5,8 +5,7 @@
 # compatible open source license.
 
 from assemble_workflow.bundle_opensearch import BundleOpenSearch
-from assemble_workflow.bundle_opensearch_dashboards import \
-    BundleOpenSearchDashboards
+from assemble_workflow.bundle_opensearch_dashboards import BundleOpenSearchDashboards
 
 
 class Bundles:

--- a/bundle-workflow/src/ci_workflow/ci.py
+++ b/bundle-workflow/src/ci_workflow/ci.py
@@ -4,12 +4,15 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from ci_workflow.ci_check_gradle_dependencies_opensearch import \
-    CiCheckGradleDependenciesOpenSearchVersion
-from ci_workflow.ci_check_gradle_properties_version import \
-    CiCheckGradlePropertiesVersion
-from ci_workflow.ci_check_gradle_publish_to_maven_local import \
-    CiCheckGradlePublishToMavenLocal
+from ci_workflow.ci_check_gradle_dependencies_opensearch import (
+    CiCheckGradleDependenciesOpenSearchVersion,
+)
+from ci_workflow.ci_check_gradle_properties_version import (
+    CiCheckGradlePropertiesVersion,
+)
+from ci_workflow.ci_check_gradle_publish_to_maven_local import (
+    CiCheckGradlePublishToMavenLocal,
+)
 
 """
 This class is responsible for sanity checking the OpenSearch bundle.

--- a/bundle-workflow/src/manifests/bundle_manifest.py
+++ b/bundle-workflow/src/manifests/bundle_manifest.py
@@ -83,7 +83,9 @@ class BundleManifest(Manifest):
             build_id, opensearch_version, architecture
         )
         S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
-        bundle_manifest = BundleManifest.from_path(os.path.join(work_dir, 'manifest.yml'))
+        bundle_manifest = BundleManifest.from_path(
+            os.path.join(work_dir, "manifest.yml")
+        )
         os.remove(os.path.realpath(os.path.join(work_dir, "manifest.yml")))
         return bundle_manifest
 

--- a/bundle-workflow/src/manifests/test_manifest.py
+++ b/bundle-workflow/src/manifests/test_manifest.py
@@ -41,9 +41,7 @@ class TestManifest(Manifest):
                     "integ-test": {
                         "type": "dict",
                         "schema": {
-                            "build-dependencies": {
-                                "type": "list"
-                            },
+                            "build-dependencies": {"type": "list"},
                             "test-configs": {
                                 "type": "list",
                                 "allowed": [
@@ -59,9 +57,7 @@ class TestManifest(Manifest):
                     "bwc-test": {
                         "type": "dict",
                         "schema": {
-                            "build-dependencies": {
-                                "type": "list"
-                            },
+                            "build-dependencies": {"type": "list"},
                             "test-configs": {
                                 "type": "list",
                                 "allowed": [

--- a/bundle-workflow/src/manifests_workflow/input_manifests.py
+++ b/bundle-workflow/src/manifests_workflow/input_manifests.py
@@ -112,6 +112,8 @@ class InputManifests(Manifests):
                 manifest = InputManifest(data)
                 manifest_dir = os.path.join(self.manifests_path(), release_version)
                 os.makedirs(manifest_dir, exist_ok=True)
-                manifest_path = os.path.join(manifest_dir, f"opensearch-{release_version}.yml")
+                manifest_path = os.path.join(
+                    manifest_dir, f"opensearch-{release_version}.yml"
+                )
                 manifest.to_file(manifest_path)
                 logging.info(f"Wrote {manifest_path}")

--- a/bundle-workflow/src/run_bwc_test.py
+++ b/bundle-workflow/src/run_bwc_test.py
@@ -21,7 +21,12 @@ def main():
     with TemporaryDirectory(keep=args.keep) as work_dir:
         logging.info("Switching to temporary work_dir: " + work_dir)
         bundle_manifest = BundleManifest.from_s3(
-            args.s3_bucket, args.build_id, args.opensearch_version, args.architecture, work_dir)
+            args.s3_bucket,
+            args.build_id,
+            args.opensearch_version,
+            args.architecture,
+            work_dir,
+        )
         BwcTestSuite(bundle_manifest, work_dir, args.component, args.keep).execute()
 
 

--- a/bundle-workflow/src/run_integ_test.py
+++ b/bundle-workflow/src/run_integ_test.py
@@ -32,7 +32,9 @@ def pull_build_repo(work_dir):
 def main():
     args = TestArgs()
     console.configure(level=args.logging_level)
-    test_manifest_path = os.path.join(os.path.dirname(__file__), 'test_workflow/config/test_manifest.yml')
+    test_manifest_path = os.path.join(
+        os.path.dirname(__file__), "test_workflow/config/test_manifest.yml"
+    )
     test_manifest = TestManifest.from_path(test_manifest_path)
     integ_test_config = dict()
     for component in test_manifest.components:
@@ -42,9 +44,19 @@ def main():
         logging.info("Switching to temporary work_dir: " + work_dir)
         os.chdir(work_dir)
         bundle_manifest = BundleManifest.from_s3(
-            args.s3_bucket, args.build_id, args.opensearch_version, args.architecture, work_dir)
+            args.s3_bucket,
+            args.build_id,
+            args.opensearch_version,
+            args.architecture,
+            work_dir,
+        )
         build_manifest = BuildManifest.from_s3(
-            args.s3_bucket, args.build_id, args.opensearch_version, args.architecture, work_dir)
+            args.s3_bucket,
+            args.build_id,
+            args.opensearch_version,
+            args.architecture,
+            work_dir,
+        )
         pull_build_repo(work_dir)
         DependencyInstaller(build_manifest.build).install_all_maven_dependencies()
         failed_components = dict()
@@ -57,7 +69,7 @@ def main():
                     bundle_manifest,
                     build_manifest,
                     work_dir,
-                    args.s3_bucket
+                    args.s3_bucket,
                 )
                 status, security = test_suite.execute()
                 if status != 0:
@@ -72,11 +84,15 @@ def main():
 
         if passed_components:
             for component, result in passed_components.items():
-                logging.info(f'PASS: Integration Test for {component} {result[1]} with status code {result[0]}')
+                logging.info(
+                    f"PASS: Integration Test for {component} {result[1]} with status code {result[0]}"
+                )
 
         if failed_components:
             for component, result in failed_components.items():
-                logging.error(f'FAIL: Integration Test for {component} {result[1]} with status code {result[0]}')
+                logging.error(
+                    f"FAIL: Integration Test for {component} {result[1]} with status code {result[0]}"
+                )
             sys.exit(1)
 
 

--- a/bundle-workflow/src/run_perf_test.py
+++ b/bundle-workflow/src/run_perf_test.py
@@ -38,14 +38,16 @@ config = yaml.safe_load(args.config)
 
 def get_infra_repo_url():
     if "GITHUB_TOKEN" in os.environ:
-        return "https://${GITHUB_TOKEN}@github.com/opensearch-project/opensearch-infra.git"
+        return (
+            "https://${GITHUB_TOKEN}@github.com/opensearch-project/opensearch-infra.git"
+        )
     return "https://github.com/opensearch-project/opensearch-infra.git"
 
 
 def main():
     with TemporaryDirectory(keep=args.keep) as work_dir:
         os.chdir(work_dir)
-        current_workspace = os.path.join(work_dir, 'infra')
+        current_workspace = os.path.join(work_dir, "infra")
         GitRepository(get_infra_repo_url(), "main", current_workspace)
         security = False
         for component in manifest.components:
@@ -53,7 +55,9 @@ def main():
                 security = True
 
         with WorkingDirectory(current_workspace):
-            with PerfTestCluster.create(manifest, config, args.stack, security, current_workspace) as (
+            with PerfTestCluster.create(
+                manifest, config, args.stack, security, current_workspace
+            ) as (
                 test_cluster_endpoint,
                 test_cluster_port,
             ):

--- a/bundle-workflow/src/sign_workflow/signer.py
+++ b/bundle-workflow/src/sign_workflow/signer.py
@@ -23,7 +23,9 @@ class Signer:
     ACCEPTED_FILE_TYPES = [".zip", ".jar", ".war", ".pom", ".module", ".tar.gz"]
 
     def __init__(self):
-        self.git_repo = GitRepository(self.get_repo_url(), "HEAD", working_subdirectory="src")
+        self.git_repo = GitRepository(
+            self.get_repo_url(), "HEAD", working_subdirectory="src"
+        )
         self.git_repo.execute("./bootstrap")
         self.git_repo.execute("rm config.cfg")
 

--- a/bundle-workflow/src/sign_workflow/signer.py
+++ b/bundle-workflow/src/sign_workflow/signer.py
@@ -11,9 +11,6 @@ import os
 import pathlib
 
 from git.git_repository import GitRepository
-#
-#GitRepository = __import__(".opensearch-build.bundle-workflow.src.git.git_repository.GitRepository")
-# from "opensearch-build.bundle-workflow.src.git.git_repository" import GitRepository
 
 """
 This class is responsible for signing an artifact using the OpenSearch-signer-client and verifying its signature.

--- a/bundle-workflow/src/sign_workflow/signer.py
+++ b/bundle-workflow/src/sign_workflow/signer.py
@@ -11,6 +11,9 @@ import os
 import pathlib
 
 from git.git_repository import GitRepository
+#
+#GitRepository = __import__(".opensearch-build.bundle-workflow.src.git.git_repository.GitRepository")
+# from "opensearch-build.bundle-workflow.src.git.git_repository" import GitRepository
 
 """
 This class is responsible for signing an artifact using the OpenSearch-signer-client and verifying its signature.

--- a/bundle-workflow/src/test_workflow/bwc_test/bwc_test_suite.py
+++ b/bundle-workflow/src/test_workflow/bwc_test/bwc_test_suite.py
@@ -29,9 +29,7 @@ class BwcTestSuite:
         self.keep = keep
 
     def run_tests(self, work_dir, component_name):
-        script = self.script_finder.find_bwc_test_script(
-            component_name, work_dir
-        )
+        script = self.script_finder.find_bwc_test_script(component_name, work_dir)
         cmd = f"{script}"
         (status, stdout, stderr) = execute(cmd, work_dir, True, False)
         return (status, stdout, stderr)
@@ -40,7 +38,9 @@ class BwcTestSuite:
         test_component = TestComponent(component.repository, component.commit_id)
         test_component.checkout(os.path.join(self.work_dir, component.name))
         try:
-            console_output = self.run_tests(self.work_dir + "/" + component.name, component.name)
+            console_output = self.run_tests(
+                self.work_dir + "/" + component.name, component.name
+            )
             return console_output
         except:
             # TODO: Store and report test failures for {component}

--- a/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/integ_test/local_test_cluster.py
@@ -23,8 +23,15 @@ class LocalTestCluster(TestCluster):
     Represents an on-box test cluster. This class downloads a bundle (from a BundleManifest) and runs it as a background process.
     """
 
-    def __init__(self, work_dir, component_name, additional_cluster_config, bundle_manifest, security_enabled,
-                 s3_bucket_name=None):
+    def __init__(
+        self,
+        work_dir,
+        component_name,
+        additional_cluster_config,
+        bundle_manifest,
+        security_enabled,
+        s3_bucket_name=None,
+    ):
         self.manifest = bundle_manifest
         self.work_dir = os.path.join(work_dir, "local-test-cluster")
         os.makedirs(self.work_dir, exist_ok=True)
@@ -42,8 +49,10 @@ class LocalTestCluster(TestCluster):
         if not self.security_enabled:
             self.disable_security(self.install_dir)
         if self.additional_cluster_config is not None:
-            self.__add_plugin_specific_config(self.additional_cluster_config,
-                                              os.path.join(self.install_dir, "config", "opensearch.yml"))
+            self.__add_plugin_specific_config(
+                self.additional_cluster_config,
+                os.path.join(self.install_dir, "config", "opensearch.yml"),
+            )
         self.process = subprocess.Popen(
             "./opensearch-tar-install.sh",
             cwd=self.install_dir,
@@ -71,16 +80,21 @@ class LocalTestCluster(TestCluster):
 
     def __download_tarball_from_s3(self):
         s3_path = BundleManifest.get_tarball_relative_location(
-            self.manifest.build.id, self.manifest.build.version, self.manifest.build.architecture)
+            self.manifest.build.id,
+            self.manifest.build.version,
+            self.manifest.build.architecture,
+        )
         S3Bucket(self.bucket_name).download_file(s3_path, self.work_dir)
-        return BundleManifest.get_tarball_name(self.manifest.build.version, self.manifest.build.architecture)
+        return BundleManifest.get_tarball_name(
+            self.manifest.build.version, self.manifest.build.architecture
+        )
 
     def download(self):
         logging.info(f"Creating local test cluster in {self.work_dir}")
         os.chdir(self.work_dir)
         logging.info("Downloading bundle from s3")
         bundle_name = self.__download_tarball_from_s3()
-        logging.info(f'Downloaded bundle to {os.path.realpath(bundle_name)}')
+        logging.info(f"Downloaded bundle to {os.path.realpath(bundle_name)}")
         logging.info("Unpacking")
         subprocess.check_call(f"tar -xzf {bundle_name}", shell=True)
         logging.info("Unpacked")
@@ -104,7 +118,9 @@ class LocalTestCluster(TestCluster):
                 logging.info(f"Pinging {url} attempt {attempt}")
                 response = requests.get(url, verify=False, auth=("admin", "admin"))
                 logging.info(f"{response.status_code}: {response.text}")
-                if response.status_code == 200 and ('"status":"green"' or '"status":"yellow"' in response.text):
+                if response.status_code == 200 and (
+                    '"status":"green"' or '"status":"yellow"' in response.text
+                ):
                     logging.info("Service is available")
                     return
             except requests.exceptions.ConnectionError:

--- a/bundle-workflow/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/bundle-workflow/src/test_workflow/perf_test/perf_test_cluster.py
@@ -10,54 +10,59 @@ class PerfTestCluster(TestCluster):
     """
     Represents a performance test cluster. This class deploys the opensearch bundle with CDK and returns the private IP.
     """
-    def __init__(self, bundle_manifest, config, stack_name, security, current_workspace):
+
+    def __init__(
+        self, bundle_manifest, config, stack_name, security, current_workspace
+    ):
         self.manifest = bundle_manifest
-        self.work_dir = 'opensearch-cluster/cdk/single-node/'
+        self.work_dir = "opensearch-cluster/cdk/single-node/"
         self.current_workspace = current_workspace
         self.stack_name = stack_name
         self.cluster_endpoint = None
         self.cluster_port = None
-        self.output_file = 'output.json'
+        self.output_file = "output.json"
         self.ip_address = None
-        self.security = 'enable' if security else 'disable'
-        role = config['Constants']['Role']
+        self.security = "enable" if security else "disable"
+        role = config["Constants"]["Role"]
         params_dict = {
-            'url': self.manifest.build.location,
-            'security_group_id': config['Constants']['SecurityGroupId'],
-            'vpc_id': config['Constants']['VpcId'],
-            'account_id': config['Constants']['AccountId'],
-            'region': config['Constants']['Region'],
-            'stack_name': self.stack_name,
-            'security': self.security,
-            'architecture': self.manifest.build.architecture,
+            "url": self.manifest.build.location,
+            "security_group_id": config["Constants"]["SecurityGroupId"],
+            "vpc_id": config["Constants"]["VpcId"],
+            "account_id": config["Constants"]["AccountId"],
+            "region": config["Constants"]["Region"],
+            "stack_name": self.stack_name,
+            "security": self.security,
+            "architecture": self.manifest.build.architecture,
         }
         params_list = []
         for key, value in params_dict.items():
-            params_list.append(f' -c {key}={value}')
-        role_params = f' --require-approval=never --plugin cdk-assume-role-credential-plugin'\
-                      f' -c assume-role-credentials:writeIamRoleName={role} -c assume-role-credentials:readIamRoleName={role} '
-        self.params = ''.join(params_list) + role_params
+            params_list.append(f" -c {key}={value}")
+        role_params = (
+            f" --require-approval=never --plugin cdk-assume-role-credential-plugin"
+            f" -c assume-role-credentials:writeIamRoleName={role} -c assume-role-credentials:readIamRoleName={role} "
+        )
+        self.params = "".join(params_list) + role_params
 
     def create_cluster(self):
         os.chdir(self.work_dir)
-        command = f'cdk deploy {self.params} --outputs-file {self.output_file}'
+        command = f"cdk deploy {self.params} --outputs-file {self.output_file}"
         logging.info(f'Executing "{command}" in {os.getcwd()}')
         subprocess.check_call(command, cwd=os.getcwd(), shell=True)
-        with open(self.output_file, 'r') as read_file:
+        with open(self.output_file, "r") as read_file:
             load_output = json.load(read_file)
-        self.ip_address = load_output[self.stack_name]['PrivateIp']
-        logging.info('Private IP:', self.ip_address)
+        self.ip_address = load_output[self.stack_name]["PrivateIp"]
+        logging.info("Private IP:", self.ip_address)
 
     def endpoint(self):
         self.cluster_endpoint = self.ip_address
         return self.cluster_endpoint
 
     def port(self):
-        self.cluster_port = 443 if self.security == 'enable' else 9200
+        self.cluster_port = 443 if self.security == "enable" else 9200
         return self.cluster_port
 
     def destroy(self):
         os.chdir(os.path.join(self.current_workspace, self.work_dir))
-        command = f'cdk destroy {self.params} --force'
+        command = f"cdk destroy {self.params} --force"
         logging.info(f'Executing "{command}" in {os.getcwd()}')
         subprocess.check_call(command, cwd=os.getcwd(), shell=True)

--- a/bundle-workflow/src/test_workflow/perf_test/perf_test_suite.py
+++ b/bundle-workflow/src/test_workflow/perf_test/perf_test_suite.py
@@ -11,23 +11,25 @@ class PerfTestSuite:
 
     def __init__(self, bundle_manifest, endpoint, security, current_workspace):
         self.manifest = bundle_manifest
-        self.work_dir = 'mensor/'
+        self.work_dir = "mensor/"
         self.endpoint = endpoint
         self.security = security
         self.current_workspace = current_workspace
-        self.command = f'pipenv run python test_config.py -i {self.endpoint} -b {self.manifest.build.id}'\
-                       f' -a {self.manifest.build.architecture} -p {self.current_workspace}'
+        self.command = (
+            f"pipenv run python test_config.py -i {self.endpoint} -b {self.manifest.build.id}"
+            f" -a {self.manifest.build.architecture} -p {self.current_workspace}"
+        )
 
     def execute(self):
         try:
             with WorkingDirectory(self.work_dir):
                 dir = os.getcwd()
-                subprocess.check_call('python3 -m pipenv install', cwd=dir, shell=True)
-                subprocess.check_call('pipenv install', cwd=dir, shell=True)
+                subprocess.check_call("python3 -m pipenv install", cwd=dir, shell=True)
+                subprocess.check_call("pipenv install", cwd=dir, shell=True)
 
                 if self.security:
-                    subprocess.check_call(f'{self.command} -s', cwd=dir, shell=True)
+                    subprocess.check_call(f"{self.command} -s", cwd=dir, shell=True)
                 else:
-                    subprocess.check_call(f'{self.command}', cwd=dir, shell=True)
+                    subprocess.check_call(f"{self.command}", cwd=dir, shell=True)
         finally:
             os.chdir(self.current_workspace)

--- a/bundle-workflow/src/test_workflow/test_cluster.py
+++ b/bundle-workflow/src/test_workflow/test_cluster.py
@@ -12,6 +12,7 @@ class TestCluster(abc.ABC):
     """
     Abstract base class for all types of test clusters.
     """
+
     @classmethod
     @contextmanager
     def create(cls, *args):

--- a/bundle-workflow/tests/test_integ_workflow/integ_test/test_integ_test_suite.py
+++ b/bundle-workflow/tests/test_integ_workflow/integ_test/test_integ_test_suite.py
@@ -12,10 +12,12 @@ from git.git_repository import GitRepository
 from manifests.build_manifest import BuildManifest
 from manifests.bundle_manifest import BundleManifest
 from manifests.test_manifest import TestManifest
-from test_workflow.integ_test.integ_test_suite import (DependencyInstaller,
-                                                       IntegTestSuite,
-                                                       InvalidTestConfigError,
-                                                       ScriptFinder)
+from test_workflow.integ_test.integ_test_suite import (
+    DependencyInstaller,
+    IntegTestSuite,
+    InvalidTestConfigError,
+    ScriptFinder,
+)
 
 
 @patch("os.makedirs")

--- a/bundle-workflow/tests/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/bundle-workflow/tests/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -60,5 +60,7 @@ class TestPerfTestCluster(unittest.TestCase):
         with patch("test_workflow.perf_test.perf_test_cluster.os.chdir") as mock_chdir:
             with patch("subprocess.check_call") as mock_check_call:
                 self.perf_test_cluster.destroy()
-                mock_chdir.assert_called_once_with("current_workspace/opensearch-cluster/cdk/single-node/")
+                mock_chdir.assert_called_once_with(
+                    "current_workspace/opensearch-cluster/cdk/single-node/"
+                )
                 self.assertEqual(mock_check_call.call_count, 1)

--- a/bundle-workflow/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
+++ b/bundle-workflow/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
@@ -8,8 +8,7 @@ import os
 import unittest
 from unittest.mock import MagicMock, call, patch
 
-from assemble_workflow.bundle_opensearch_dashboards import \
-    BundleOpenSearchDashboards
+from assemble_workflow.bundle_opensearch_dashboards import BundleOpenSearchDashboards
 from manifests.build_manifest import BuildManifest
 from paths.script_finder import ScriptFinder
 

--- a/bundle-workflow/tests/tests_assemble_workflow/test_bundles.py
+++ b/bundle-workflow/tests/tests_assemble_workflow/test_bundles.py
@@ -9,8 +9,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from assemble_workflow.bundle_opensearch import BundleOpenSearch
-from assemble_workflow.bundle_opensearch_dashboards import \
-    BundleOpenSearchDashboards
+from assemble_workflow.bundle_opensearch_dashboards import BundleOpenSearchDashboards
 from assemble_workflow.bundles import Bundles
 from manifests.build_manifest import BuildManifest
 

--- a/bundle-workflow/tests/tests_build_workflow/test_build_artifact_check_maven.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_build_artifact_check_maven.py
@@ -40,7 +40,7 @@ class TestBuildArtifactCheckMaven(unittest.TestCase):
             mock.check("valid.jar")
 
     def test_record_maven_artifact_after_checking_maven_version_properties_snapshot(
-        self
+        self,
     ):
         with self.__mock("Implementation-Version: 1.1.0.0-SNAPSHOT") as mock:
             mock.check("valid.jar")

--- a/bundle-workflow/tests/tests_build_workflow/test_builder.py
+++ b/bundle-workflow/tests/tests_build_workflow/test_builder.py
@@ -25,12 +25,16 @@ class TestBuilder(unittest.TestCase):
         self.assertEqual(self.builder.component_name, "component")
 
     def test_build(self):
-        self.builder.build(BuildTarget(name="OpenSearch", version="1.0.0", arch="x64", snapshot=False))
+        self.builder.build(
+            BuildTarget(name="OpenSearch", version="1.0.0", arch="x64", snapshot=False)
+        )
         self.builder.git_repo.execute.assert_called_with(
             " ".join(
                 [
                     os.path.realpath(
-                        os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")
+                        os.path.join(
+                            ScriptFinder.default_scripts_path, "opensearch", "build.sh"
+                        )
                     ),
                     "-v 1.0.0",
                     "-a x64",
@@ -44,12 +48,16 @@ class TestBuilder(unittest.TestCase):
         )
 
     def test_build_snapshot(self):
-        self.builder.build(BuildTarget(name="OpenSearch", version="1.0.0", arch="x64", snapshot=True))
+        self.builder.build(
+            BuildTarget(name="OpenSearch", version="1.0.0", arch="x64", snapshot=True)
+        )
         self.builder.git_repo.execute.assert_called_with(
             " ".join(
                 [
                     os.path.realpath(
-                        os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")
+                        os.path.join(
+                            ScriptFinder.default_scripts_path, "opensearch", "build.sh"
+                        )
                     ),
                     "-v 1.0.0",
                     "-a x64",
@@ -75,17 +83,23 @@ class TestBuilder(unittest.TestCase):
         mock_walk.side_effect = self.mock_os_walk
         self.builder.export_artifacts()
         self.assertEqual(self.builder.build_recorder.record_artifact.call_count, 2)
-        self.builder.build_recorder.record_artifact.assert_has_calls([
-            call(
-                "component",
-                "maven",
-                os.path.relpath("/maven/artifact1.jar", self.builder.artifacts_path),
-                "/maven/artifact1.jar",
-            ),
-            call(
-                "component",
-                "core-plugins",
-                os.path.relpath("/core-plugins/plugin1.zip", self.builder.artifacts_path),
-                "/core-plugins/plugin1.zip",
-            ),
-        ])
+        self.builder.build_recorder.record_artifact.assert_has_calls(
+            [
+                call(
+                    "component",
+                    "maven",
+                    os.path.relpath(
+                        "/maven/artifact1.jar", self.builder.artifacts_path
+                    ),
+                    "/maven/artifact1.jar",
+                ),
+                call(
+                    "component",
+                    "core-plugins",
+                    os.path.relpath(
+                        "/core-plugins/plugin1.zip", self.builder.artifacts_path
+                    ),
+                    "/core-plugins/plugin1.zip",
+                ),
+            ]
+        )

--- a/bundle-workflow/tests/tests_checkout_workflow/test_checkout_args.py
+++ b/bundle-workflow/tests/tests_checkout_workflow/test_checkout_args.py
@@ -26,7 +26,9 @@ class TestCheckoutArgs(unittest.TestCase):
 
     @patch("argparse._sys.argv", [CHECKOUT_PY, OPENSEARCH_MANIFEST])
     def test_manifest(self):
-        self.assertEqual(CheckoutArgs().manifest.name, TestCheckoutArgs.OPENSEARCH_MANIFEST)
+        self.assertEqual(
+            CheckoutArgs().manifest.name, TestCheckoutArgs.OPENSEARCH_MANIFEST
+        )
 
     @patch("argparse._sys.argv", [CHECKOUT_PY, OPENSEARCH_MANIFEST, "--verbose"])
     def test_verbose_true(self):

--- a/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_dependencies_opensearch.py
+++ b/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_dependencies_opensearch.py
@@ -7,8 +7,9 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from ci_workflow.ci_check_gradle_dependencies_opensearch import \
-    CiCheckGradleDependenciesOpenSearchVersion
+from ci_workflow.ci_check_gradle_dependencies_opensearch import (
+    CiCheckGradleDependenciesOpenSearchVersion,
+)
 from ci_workflow.ci_target import CiTarget
 from system.properties_file import PropertiesFile
 

--- a/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_properties_version.py
+++ b/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_properties_version.py
@@ -7,8 +7,9 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from ci_workflow.ci_check_gradle_properties_version import \
-    CiCheckGradlePropertiesVersion
+from ci_workflow.ci_check_gradle_properties_version import (
+    CiCheckGradlePropertiesVersion,
+)
 from ci_workflow.ci_target import CiTarget
 from manifests.input_manifest import InputManifest
 from system.properties_file import PropertiesFile

--- a/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_publish_to_maven_local.py
+++ b/bundle-workflow/tests/tests_ci_workflow/test_ci_check_gradle_publish_to_maven_local.py
@@ -7,8 +7,9 @@
 import unittest
 from unittest.mock import MagicMock
 
-from ci_workflow.ci_check_gradle_publish_to_maven_local import \
-    CiCheckGradlePublishToMavenLocal
+from ci_workflow.ci_check_gradle_publish_to_maven_local import (
+    CiCheckGradlePublishToMavenLocal,
+)
 from ci_workflow.ci_target import CiTarget
 
 

--- a/bundle-workflow/tests/tests_git/test_git_repository.py
+++ b/bundle-workflow/tests/tests_git/test_git_repository.py
@@ -92,7 +92,9 @@ class TestGitRepositoryWithWorkingDir(unittest.TestCase):
             working_subdirectory="ISSUE_TEMPLATE",
         )
 
-        self.assertEqual(repo.working_directory, os.path.join(repo.dir, "ISSUE_TEMPLATE"))
+        self.assertEqual(
+            repo.working_directory, os.path.join(repo.dir, "ISSUE_TEMPLATE")
+        )
 
         pwd = repo.output("pwd")
         self.assertEqual(pwd, os.path.join(repo.dir, "ISSUE_TEMPLATE"))

--- a/bundle-workflow/tests/tests_manifests/test_test_manifest.py
+++ b/bundle-workflow/tests/tests_manifests/test_test_manifest.py
@@ -43,12 +43,8 @@ class TestTestManifest(unittest.TestCase):
         component = self.manifest.components[1]
         self.assertEqual(component.name, "dashboards-reports")
         self.assertEqual(component.working_directory, "reports-scheduler")
-        self.assertEqual(
-            component.integ_test, {"test-configs": ["without-security"]}
-        )
-        self.assertEqual(
-            component.bwc_test, {"test-configs": ["without-security"]}
-        )
+        self.assertEqual(component.integ_test, {"test-configs": ["without-security"]})
+        self.assertEqual(component.bwc_test, {"test-configs": ["without-security"]})
 
     def test_to_dict(self):
         data = self.manifest.to_dict()

--- a/bundle-workflow/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/bundle-workflow/tests/tests_manifests_workflow/test_input_manifests.py
@@ -18,7 +18,8 @@ class TestInputManifests(unittest.TestCase):
         self.assertTrue(len(files) >= 2)
         manifest = os.path.realpath(
             os.path.join(
-                os.path.dirname(__file__), "../../../manifests/1.1.0/opensearch-1.1.0.yml"
+                os.path.dirname(__file__),
+                "../../../manifests/1.1.0/opensearch-1.1.0.yml",
             )
         )
         self.assertTrue(manifest in files)
@@ -63,8 +64,14 @@ class TestInputManifests(unittest.TestCase):
         self.assertEqual(mock_input_manifest().to_file.call_count, 2)
         calls = [
             call(
-                os.path.join(InputManifests.manifests_path(), "0.10.0/opensearch-0.10.0.yml")
+                os.path.join(
+                    InputManifests.manifests_path(), "0.10.0/opensearch-0.10.0.yml"
+                )
             ),
-            call(os.path.join(InputManifests.manifests_path(), "0.9.0/opensearch-0.9.0.yml")),
+            call(
+                os.path.join(
+                    InputManifests.manifests_path(), "0.9.0/opensearch-0.9.0.yml"
+                )
+            ),
         ]
         mock_input_manifest().to_file.assert_has_calls(calls)

--- a/bundle-workflow/tests/tests_sign_workflow/test_signer.py
+++ b/bundle-workflow/tests/tests_sign_workflow/test_signer.py
@@ -41,3 +41,17 @@ class TestSigner(unittest.TestCase):
         Signer()
         self.assertEqual(mock_execute.call_count, 2)
         mock_execute.assert_has_calls([call("./bootstrap"), call("rm config.cfg")])
+
+    @patch("sign_workflow.signer.GitRepository")
+    @patch("sign_workflow.signer.GitRepository.execute")
+    def test_signer_verify(self,mock_object,mock_execute):
+        signer = Signer()
+        signer.verify("/path/the-jar.jar.asc")
+        mock_execute.assert_has_calls([call().execute("gpg --verify-files /path/the-jar.jar.asc")])
+
+    @patch("sign_workflow.signer.GitRepository")
+    @patch("sign_workflow.signer.GitRepository.execute")
+    def test_signer_sign(self, mock_object, mock_execute):
+        signer = Signer()
+        signer.sign("/path/the-jar.jar")
+        mock_execute.assert_has_calls([call().execute("./opensearch-signer-client -i /path/the-jar.jar -o /path/the-jar.jar.asc -p pgp")])

--- a/bundle-workflow/tests/tests_sign_workflow/test_signer.py
+++ b/bundle-workflow/tests/tests_sign_workflow/test_signer.py
@@ -43,15 +43,21 @@ class TestSigner(unittest.TestCase):
         mock_execute.assert_has_calls([call("./bootstrap"), call("rm config.cfg")])
 
     @patch("sign_workflow.signer.GitRepository")
-    @patch("sign_workflow.signer.GitRepository.execute")
-    def test_signer_verify(self,mock_object,mock_execute):
+    def test_signer_verify(self, mock_repo):
         signer = Signer()
         signer.verify("/path/the-jar.jar.asc")
-        mock_execute.assert_has_calls([call().execute("gpg --verify-files /path/the-jar.jar.asc")])
+        mock_repo.assert_has_calls(
+            [call().execute("gpg --verify-files /path/the-jar.jar.asc")]
+        )
 
     @patch("sign_workflow.signer.GitRepository")
-    @patch("sign_workflow.signer.GitRepository.execute")
-    def test_signer_sign(self, mock_object, mock_execute):
+    def test_signer_sign(self, mock_repo):
         signer = Signer()
         signer.sign("/path/the-jar.jar")
-        mock_execute.assert_has_calls([call().execute("./opensearch-signer-client -i /path/the-jar.jar -o /path/the-jar.jar.asc -p pgp")])
+        mock_repo.assert_has_calls(
+            [
+                call().execute(
+                    "./opensearch-signer-client -i /path/the-jar.jar -o /path/the-jar.jar.asc -p pgp"
+                )
+            ]
+        )


### PR DESCRIPTION
Signed-off-by: Rishikesh Reddy Pasham rishireddy1159@gmail.com
### Description
Currently the test Coverage for bundle-workflow/src/sign_workflow is 87.10%. 
I am trying to improve the test coverage score.
Added: two functions [test_signer_verify, test_signer_sign] to bundle-workflow/tests/tests_sign_workflow/test_signer.py
 
### Issues Resolved
#650 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
