### PR TITLE
Added two unit test functions in test_signer.py to improve test coverage of sign_workflow

### DIFF
--- a/bundle-workflow/tests/tests_sign_workflow/test_signer.py
+++ b/bundle-workflow/tests/tests_sign_workflow/test_signer.py
@@ -41,3 +41,23 @@ class TestSigner(unittest.TestCase):
         Signer()
         self.assertEqual(mock_execute.call_count, 2)
         mock_execute.assert_has_calls([call("./bootstrap"), call("rm config.cfg")])
+
+    @patch("sign_workflow.signer.GitRepository")
+    def test_signer_verify(self, mock_repo):
+        signer = Signer()
+        signer.verify("/path/the-jar.jar.asc")
+        mock_repo.assert_has_calls(
+            [call().execute("gpg --verify-files /path/the-jar.jar.asc")]
+        )
+
+    @patch("sign_workflow.signer.GitRepository")
+    def test_signer_sign(self, mock_repo):
+        signer = Signer()
+        signer.sign("/path/the-jar.jar")
+        mock_repo.assert_has_calls(
+            [
+                call().execute(
+                    "./opensearch-signer-client -i /path/the-jar.jar -o /path/the-jar.jar.asc -p pgp"
+                )
+            ]
+        )


### PR DESCRIPTION

Signed-off-by : Rishikesh Reddy Pasham rishireddy1159@gmail.com

### Description
-> Improving test coverage score of sign_workflow from 87.10%.
-> I have added two unit test functions (test_signer_verify, test_signer_sign) in [opensearch-build/bundle-workflow/tests/tests_sign_workflow/test_signer.py ] file.
 
### Issues Resolved
#650 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
