### PR TITLE
Check values in opensearch-dashboards/plugin/opensearch_dashboards.json.

### DIFF
--- a/bundle-workflow/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
+++ b/bundle-workflow/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
@@ -4,18 +4,44 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 import re
+from zipfile import ZipFile
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
+from system.config_file import ConfigFile
 
 
 class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
     def check(self, path):
         if os.path.splitext(path)[1] != ".zip":
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")
-        version = re.sub(r'-SNAPSHOT$', '', self.target.opensearch_version)
-        if not path.endswith(f"-{version}.zip"):
+        opensearch_dashboards_version = re.sub(
+            r"-SNAPSHOT$", "", self.target.opensearch_version
+        )
+        match = re.search(
+            rf"^(\w+)-{opensearch_dashboards_version}.zip$", os.path.basename(path)
+        )
+        if not match:
             raise BuildArtifactCheck.BuildArtifactInvalidError(
-                path, f"Expected filename to include {version}."
+                path,
+                f"Expected filename to be in the format of pluginName-{opensearch_dashboards_version}.zip.",
             )
+        plugin_name = match.group(1)
+        with ZipFile(path, "r") as zip:
+            data = zip.read(
+                f"opensearch-dashboards/{plugin_name}/opensearch_dashboards.json"
+            ).decode("UTF-8")
+            config = ConfigFile(data)
+            try:
+                component_version = re.sub(
+                    r"-SNAPSHOT$", "", self.target.component_version
+                )
+                config.check_value("version", component_version)
+                config.check_value(
+                    "opensearchDashboardsVersion", opensearch_dashboards_version
+                )
+            except ConfigFile.CheckError as e:
+                raise BuildArtifactCheck.BuildArtifactInvalidError(path, e.__str__())
+            logging.info(f'Checked {path} ({config.get_value("version", "N/A")})')

--- a/bundle-workflow/src/system/config_file.py
+++ b/bundle-workflow/src/system/config_file.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import json
+
+
+class ConfigFile:
+    class CheckError(Exception):
+        pass
+
+    class UnexpectedKeyValueError(CheckError):
+        def __init__(self, key, expected, current=None):
+            super().__init__(
+                f"Expected to have {key}='{expected}', but was '{current}'."
+                if current
+                else f"Expected to have {key}='{expected}', but none was found."
+            )
+
+    class UnexpectedKeyValuesError(CheckError):
+        def __init__(self, key, expected, current=None):
+            super().__init__(
+                f"Expected to have {key}=any of {expected}, but was '{current}'."
+                if current
+                else f"Expected to have {key}=any of {expected}, but none was found."
+            )
+
+    @property
+    def data(self):
+        return self.__data
+
+    def __init__(self, data=None):
+        if type(data) is str:
+            self.__data = json.loads(data)
+        elif type(data) is dict:
+            self.__data = data
+        elif data is not None:
+            raise TypeError()
+        else:
+            self.__data = {}
+
+    def get_value(self, key, default_value=None):
+        try:
+            return self.__data[key]
+        except KeyError:
+            return default_value
+
+    def check_value(self, key, expected):
+        try:
+            value = self.__data[key]
+            if value != expected:
+                raise ConfigFile.UnexpectedKeyValueError(key, expected, value)
+        except KeyError:
+            raise ConfigFile.UnexpectedKeyValueError(key, expected)
+
+    def check_value_in(self, key, expected):
+        try:
+            value = self.__data[key]
+            if value not in expected:
+                raise ConfigFile.UnexpectedKeyValuesError(key, expected, value)
+        except KeyError:
+            if None not in expected:
+                raise ConfigFile.UnexpectedKeyValuesError(key, expected)

--- a/bundle-workflow/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
+++ b/bundle-workflow/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
@@ -6,6 +6,7 @@
 
 import unittest
 from contextlib import contextmanager
+from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
 from build_workflow.build_target import BuildTarget
@@ -15,31 +16,62 @@ from build_workflow.opensearch_dashboards.build_artifact_check_plugin import \
 
 class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
     @contextmanager
-    def __mock(self, snapshot=True):
-        yield BuildArtifactOpenSearchDashboardsCheckPlugin(
-            BuildTarget(
-                build_id="1",
-                output_dir="output_dir",
-                name="OpenSearch",
-                version="1.1.0",
-                arch="x64",
-                snapshot=snapshot,
+    def __mock(self, props={}, snapshot=True):
+        with patch(
+            "build_workflow.opensearch_dashboards.build_artifact_check_plugin.ZipFile"
+        ) as mock_zipfile:
+            mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = (
+                props
             )
-        )
+            yield BuildArtifactOpenSearchDashboardsCheckPlugin(
+                BuildTarget(
+                    build_id="1",
+                    output_dir="output_dir",
+                    name="OpenSearch",
+                    version="1.1.0",
+                    arch="x64",
+                    snapshot=snapshot,
+                )
+            )
 
     def test_check_plugin_invalid_zip_version(self):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock() as mock:
                 mock.check("invalid.zip")
         self.assertEqual(
-            "Artifact invalid.zip is invalid. Expected filename to include 1.1.0.",
+            "Artifact invalid.zip is invalid. Expected filename to be in the format of pluginName-1.1.0.zip.",
             str(context.exception),
         )
 
-    def test_check_plugin_zip(self, *mocks):
-        with self.__mock(snapshot=False) as mock:
-            mock.check("valid-1.1.0.zip")
+    def test_check_plugin_missing_name(self):
+        with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
+            with self.__mock() as mock:
+                mock.check("-1.1.0.zip")
+        self.assertEqual(
+            "Artifact -1.1.0.zip is invalid. Expected filename to be in the format of pluginName-1.1.0.zip.",
+            str(context.exception),
+        )
 
-    def test_check_plugin_snapshot_zip(self, *mocks):
-        with self.__mock(snapshot=True) as mock:
+    def test_check_plugin_version_properties_missing(self, *mocks):
+        with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
+            with self.__mock() as mock:
+                mock.check("valid-1.1.0.zip")
+        self.assertEqual(
+            "Artifact valid-1.1.0.zip is invalid. Expected to have version='1.1.0.0', but none was found.",
+            str(context.exception),
+        )
+
+    def test_check_plugin_version_properties_mismatch(self, *mocks):
+        with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
+            with self.__mock({"version": "1.2.3.4"}) as mock:
+                mock.check("valid-1.1.0.zip")
+            self.assertEqual(
+                "Artifact valid-1.1.0.zip is invalid. Expected to have version='1.1.0.0', but was '1.2.3.4'.",
+                str(context.exception),
+            )
+
+    def test_check_plugin_version_properties(self, *mocks):
+        with self.__mock(
+            {"opensearchDashboardsVersion": "1.1.0", "version": "1.1.0.0"}
+        ) as mock:
             mock.check("valid-1.1.0.zip")

--- a/bundle-workflow/tests/tests_system/test_config_file.py
+++ b/bundle-workflow/tests/tests_system/test_config_file.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+
+from system.config_file import ConfigFile
+
+
+class TestConfigFile(unittest.TestCase):
+    def test_blank(self):
+        f = ConfigFile()
+        self.assertEqual(f.data, {})
+
+    def test_get_value(self):
+        f = ConfigFile({"key": "value"})
+        self.assertEqual(f.get_value("key"), "value")
+        self.assertEqual(f.get_value("invalid"), None)
+        self.assertEqual(f.get_value("invalid", "default"), "default")
+
+    def test_check_value(self):
+        f = ConfigFile({"key": "value"})
+        f.check_value("key", "value")
+
+    def test_check_value_from_json(self):
+        f = ConfigFile('{"key":"value"}')
+        f.check_value("key", "value")
+
+    def test_check_value_invalid(self):
+        f = ConfigFile({"key": "value"})
+        with self.assertRaises(ConfigFile.UnexpectedKeyValueError) as err:
+            f.check_value("key", "invalid")
+        self.assertEqual(
+            str(err.exception), "Expected to have key='invalid', but was 'value'."
+        )
+
+    def test_check_value_none_found(self):
+        f = ConfigFile()
+        with self.assertRaises(ConfigFile.UnexpectedKeyValueError) as err:
+            f.check_value("invalid", "value")
+        self.assertEqual(
+            str(err.exception), "Expected to have invalid='value', but none was found."
+        )
+
+    def test_check_value_in(self):
+        f = ConfigFile({"key": "value"})
+        f.check_value_in("key", ["value"])
+
+    def test_check_value_in_invalid(self):
+        f = ConfigFile({"key": "value"})
+        with self.assertRaises(ConfigFile.UnexpectedKeyValuesError) as err:
+            f.check_value_in("key", ["one", "two"])
+        self.assertEqual(
+            str(err.exception),
+            "Expected to have key=any of ['one', 'two'], but was 'value'.",
+        )
+
+    def test_check_value_in_none_found(self):
+        f = ConfigFile()
+        with self.assertRaises(ConfigFile.UnexpectedKeyValuesError) as err:
+            f.check_value_in("invalid", ["one", "two"])
+        self.assertEqual(
+            str(err.exception),
+            "Expected to have invalid=any of ['one', 'two'], but none was found.",
+        )


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Opens  `opensearch_dashboards.json` from bundled OpenSearch Dashboards components and checks the versions in them. This ensures consistency of the package being produced.

Tested with the current manifest that includes alerting:

```
2021-09-30 23:00:38 INFO     Recording plugins artifact for alertingDashboards: plugins/alertingDashboards-1.1.0.zip (from /tmp/tmpkb8_1a0c/alertingDashboards/artifacts/plugins/alertingDashboards-1.1.0.zip)
2021-09-30 23:00:38 INFO     Checked /tmp/tmpkb8_1a0c/alertingDashboards/artifacts/plugins/alertingDashboards-1.1.0.zip (1.1.0.0)
2021-09-30 23:00:38 INFO     Created build manifest /home/ubuntu/source/opensearch-project/opensearch-build/dblock-opensearch-build/artifacts/manifest.yml
2021-09-30 23:00:45 INFO     Done.
```

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/618
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
