### PR TITLE
Add snapshot location repo for IM test

### DIFF
--- a/bundle-workflow/src/test_workflow/config/test_manifest.yml
+++ b/bundle-workflow/src/test_workflow/config/test_manifest.yml
@@ -6,82 +6,84 @@ components:
       test-configs:
         - with-security
         - without-security
-    bwc-test:
-      test-configs:
-        - with-security
-        - without-security
-
-  - name: anomaly-detection
-    integ-test:
-      build-dependencies:
-        - job-scheduler
-      test-configs:
-        - with-security
-        - without-security
-    bwc-test:
-      test-configs:
-        - with-security
-        - without-security
-
-  - name: asynchronous-search
-    integ-test:
-      test-configs:
-        - with-security
-        - without-security
-    bwc-test:
-      test-configs:
-        - with-security
-        - without-security
-
-  - name: alerting
-    integ-test:
-      test-configs:
-        - with-security
-        - without-security
       additional-cluster-configs:
-        plugins.destination.host.deny_list : [10.0.0.0/8, 127.0.0.1]
+        path.repo: ["/tmp"]
     bwc-test:
       test-configs:
         - with-security
         - without-security
-
-  - name: sql
-    integ-test:
-      test-configs:
-        - with-security
-        - without-security
-      additional-cluster-configs:
-        script.context.field.max_compilations_rate: 1000/1m
-    bwc-test:
-      test-configs:
-        - with-security
-        - without-security
-
-  - name: k-NN
-    integ-test:
-      test-configs:
-        - with-security
-        - without-security
-    bwc-test:
-      test-configs:
-        - with-security
-        - without-security
-
-  - name: dashboards-reports
-    working-directory: reports-scheduler
-    integ-test:
-      test-configs:
-        - without-security
-    bwc-test:
-      test-configs:
-        - without-security
-
-  - name: dashboards-notebooks
-    working-directory: opensearch-notebooks
-    integ-test:
-      test-configs:
-        - without-security
-    bwc-test:
-      test-configs:
-        - without-security
+#
+#  - name: anomaly-detection
+#    integ-test:
+#      build-dependencies:
+#        - job-scheduler
+#      test-configs:
+#        - with-security
+#        - without-security
+#    bwc-test:
+#      test-configs:
+#        - with-security
+#        - without-security
+#
+#  - name: asynchronous-search
+#    integ-test:
+#      test-configs:
+#        - with-security
+#        - without-security
+#    bwc-test:
+#      test-configs:
+#        - with-security
+#        - without-security
+#
+#  - name: alerting
+#    integ-test:
+#      test-configs:
+#        - with-security
+#        - without-security
+#      additional-cluster-configs:
+#        plugins.destination.host.deny_list : [10.0.0.0/8, 127.0.0.1]
+#    bwc-test:
+#      test-configs:
+#        - with-security
+#        - without-security
+#
+#  - name: sql
+#    integ-test:
+#      test-configs:
+#        - with-security
+#        - without-security
+#      additional-cluster-configs:
+#        script.context.field.max_compilations_rate: 1000/1m
+#    bwc-test:
+#      test-configs:
+#        - with-security
+#        - without-security
+#
+#  - name: k-NN
+#    integ-test:
+#      test-configs:
+#        - with-security
+#        - without-security
+#    bwc-test:
+#      test-configs:
+#        - with-security
+#        - without-security
+#
+#  - name: dashboards-reports
+#    working-directory: reports-scheduler
+#    integ-test:
+#      test-configs:
+#        - without-security
+#    bwc-test:
+#      test-configs:
+#        - without-security
+#
+#  - name: dashboards-notebooks
+#    working-directory: opensearch-notebooks
+#    integ-test:
+#      test-configs:
+#        - without-security
+#    bwc-test:
+#      test-configs:
+#        - without-security
 schema-version: '1.0'

--- a/bundle-workflow/src/test_workflow/config/test_manifest.yml
+++ b/bundle-workflow/src/test_workflow/config/test_manifest.yml
@@ -12,78 +12,78 @@ components:
       test-configs:
         - with-security
         - without-security
-#
-#  - name: anomaly-detection
-#    integ-test:
-#      build-dependencies:
-#        - job-scheduler
-#      test-configs:
-#        - with-security
-#        - without-security
-#    bwc-test:
-#      test-configs:
-#        - with-security
-#        - without-security
-#
-#  - name: asynchronous-search
-#    integ-test:
-#      test-configs:
-#        - with-security
-#        - without-security
-#    bwc-test:
-#      test-configs:
-#        - with-security
-#        - without-security
-#
-#  - name: alerting
-#    integ-test:
-#      test-configs:
-#        - with-security
-#        - without-security
-#      additional-cluster-configs:
-#        plugins.destination.host.deny_list : [10.0.0.0/8, 127.0.0.1]
-#    bwc-test:
-#      test-configs:
-#        - with-security
-#        - without-security
-#
-#  - name: sql
-#    integ-test:
-#      test-configs:
-#        - with-security
-#        - without-security
-#      additional-cluster-configs:
-#        script.context.field.max_compilations_rate: 1000/1m
-#    bwc-test:
-#      test-configs:
-#        - with-security
-#        - without-security
-#
-#  - name: k-NN
-#    integ-test:
-#      test-configs:
-#        - with-security
-#        - without-security
-#    bwc-test:
-#      test-configs:
-#        - with-security
-#        - without-security
-#
-#  - name: dashboards-reports
-#    working-directory: reports-scheduler
-#    integ-test:
-#      test-configs:
-#        - without-security
-#    bwc-test:
-#      test-configs:
-#        - without-security
-#
-#  - name: dashboards-notebooks
-#    working-directory: opensearch-notebooks
-#    integ-test:
-#      test-configs:
-#        - without-security
-#    bwc-test:
-#      test-configs:
-#        - without-security
+
+  - name: anomaly-detection
+    integ-test:
+      build-dependencies:
+        - job-scheduler
+      test-configs:
+        - with-security
+        - without-security
+    bwc-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: asynchronous-search
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+    bwc-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: alerting
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        plugins.destination.host.deny_list : [10.0.0.0/8, 127.0.0.1]
+    bwc-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: sql
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        script.context.field.max_compilations_rate: 1000/1m
+    bwc-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: k-NN
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+    bwc-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: dashboards-reports
+    working-directory: reports-scheduler
+    integ-test:
+      test-configs:
+        - without-security
+    bwc-test:
+      test-configs:
+        - without-security
+
+  - name: dashboards-notebooks
+    working-directory: opensearch-notebooks
+    integ-test:
+      test-configs:
+        - without-security
+    bwc-test:
+      test-configs:
+        - without-security
 schema-version: '1.0'


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add snapshot location repo for IM test.
It is initially presented in here:
https://github.com/opensearch-project/opensearch-build/blob/main/scripts/deploy_single_tar_cluster.sh#L111

Currently missed in the new test-workflows setup:

<details><summary>IM Test with repo location setup log</summary>
<p>

$ ./bundle-workflow/test.sh integ-test --s3-bucket s3 bucket --opensearch-version 1.1.0 --build-id build id --architecture x64 --test-run-id test id
--s3-bucket s3 bucket>--opensearch-version 1.1.0 --build-id build id --architecture x64 --test-run-id test id
Installing dependencies in ./bundle-workflow ...
Installing dependencies from Pipfile.lock (22bd6c)...
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 0/0 — 00:00:00
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Running ./bundle-workflow/src/run_integ_test.py --s3-bucket artifact-bucket-stack-buildbucket-9omh0hnpg12q --opensearch-version 1.1.0 --build-id 315 --architecture x64 --test-run-id 16 ...
2021-10-01 01:00:55 INFO     Switching to temporary work_dir: /tmp/tmp8v35wd9a
2021-10-01 01:00:55 INFO     TestRecorder recording logs in /tmp/tmp8v35wd9a/test-recorder/tests/16/integ-test
2021-10-01 01:00:55 INFO     Found credentials in environment variables.
2021-10-01 01:00:57 INFO     Pulling opensearch-build
2021-10-01 01:00:57 INFO     Executing "git init" in /tmp/tmp8v35wd9a/opensearch-build
2021-10-01 01:00:57 INFO     Executing "git remote add origin https://github.com/opensearch-project/opensearch-build.git" in /tmp/tmp8v35wd9a/opensearch-build
2021-10-01 01:00:57 INFO     Executing "git fetch --depth 1 origin main" in /tmp/tmp8v35wd9a/opensearch-build
2021-10-01 01:00:58 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmp8v35wd9a/opensearch-build
2021-10-01 01:00:58 INFO     Executing "git rev-parse HEAD" in /tmp/tmp8v35wd9a/opensearch-build
2021-10-01 01:00:58 INFO     Checked out https://github.com/opensearch-project/opensearch-build.git@main into /tmp/tmp8v35wd9a/opensearch-build at 0149bf59d525e8719a408696812b9e63f7a91a37
2021-10-01 01:00:58 INFO     Downloading all pre-built maven dependencies from s3
2021-10-01 01:08:31 INFO     Successfully downloaded maven dependencies
2021-10-01 01:08:31 INFO     Skipping tests for OpenSearch, as it is currently not supported
2021-10-01 01:08:31 INFO     Skipping tests for job-scheduler, as it is currently not supported
2021-10-01 01:08:31 INFO     Skipping tests for sql, as it is currently not supported
2021-10-01 01:08:31 INFO     Skipping tests for alerting, as it is currently not supported
2021-10-01 01:08:31 INFO     Skipping tests for security, as it is currently not supported
2021-10-01 01:08:31 INFO     Skipping tests for cross-cluster-replication, as it is currently not supported
2021-10-01 01:08:31 INFO     Skipping tests for performance-analyzer, as it is currently not supported
2021-10-01 01:08:31 INFO     Executing "git init" in /tmp/tmp8v35wd9a/index-management
2021-10-01 01:08:31 INFO     Executing "git remote add origin https://github.com/opensearch-project/index-management.git" in /tmp/tmp8v35wd9a/index-management
2021-10-01 01:08:31 INFO     Executing "git fetch --depth 1 origin 4386d96fcb45fc53e6890b6044d5824e33a766cf" in /tmp/tmp8v35wd9a/index-management
2021-10-01 01:08:32 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmp8v35wd9a/index-management
2021-10-01 01:08:32 INFO     Executing "git rev-parse HEAD" in /tmp/tmp8v35wd9a/index-management
2021-10-01 01:08:32 INFO     Checked out https://github.com/opensearch-project/index-management.git@4386d96fcb45fc53e6890b6044d5824e33a766cf into /tmp/tmp8v35wd9a/index-management at 4386d96fcb45fc53e6890b6044d5824e33a766cf
2021-10-01 01:08:33 INFO     Additional config found: {'path.repo': ['/tmp']}
2021-10-01 01:08:33 INFO     Creating local test cluster in /tmp/tmp8v35wd9a/local-test-cluster
2021-10-01 01:08:33 INFO     Downloading bundle from s3
2021-10-01 01:08:38 INFO     Downloaded bundle to /tmp/tmp8v35wd9a/local-test-cluster/opensearch-1.1.0-linux-x64.tar.gz
2021-10-01 01:08:38 INFO     Unpacking
2021-10-01 01:08:43 INFO     Unpacked
2021-10-01 01:08:43 INFO     Started OpenSearch with parent PID 493
2021-10-01 01:08:43 INFO     Waiting for service to become available
2021-10-01 01:08:43 INFO     Pinging https://localhost:9200/_cluster/health attempt 0
2021-10-01 01:08:43 INFO     Service not available yet
2021-10-01 01:08:53 INFO     Pinging https://localhost:9200/_cluster/health attempt 1
2021-10-01 01:08:53 INFO     Service not available yet
2021-10-01 01:09:03 INFO     Pinging https://localhost:9200/_cluster/health attempt 2
/home/zhujiaxi/.local/share/virtualenvs/bundle-workflow-LMYIE2bG/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
2021-10-01 01:09:04 INFO     200: {"cluster_name":"opensearch","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"active_primary_shards":1,"active_shards":1,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0}
2021-10-01 01:09:04 INFO     Service is available
2021-10-01 01:09:04 INFO     ===============================================
2021-10-01 01:09:04 INFO     Running integration tests for index-management
2021-10-01 01:09:04 INFO     ===============================================
2021-10-01 01:09:04 INFO     Executing "/local/home/zhujiaxi/peterzhuamazon/opensearch-build/bundle-workflow/scripts/default/integtest.sh -b localhost -p 9200 -s true -v 1.1.0" in /tmp/tmp8v35wd9a/index-management
2021-10-01 01:27:19 INFO     Recording component test results for index-management at /tmp/tmp8v35wd9a/test-recorder/tests/16/integ-test/index-management/with-security/test-results
2021-10-01 01:27:19 INFO     Walking tree from /tmp/tmp8v35wd9a/index-management/build/reports/tests/integTest
2021-10-01 01:27:19 INFO     Integration test run failed for component index-management
2021-10-01 01:27:19 INFO     WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jetbrains.kotlin.com.intellij.util.ReflectionUtil (file:/local/home/zhujiaxi/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.4.31/6451ea797cef544e81f507b0d9959cd97ae09c0/kotlin-compiler-embeddable-1.4.31.jar) to method java.util.ResourceBundle.setParent(java.util.ResourceBundle)
WARNING: Please consider reporting this to the maintainers of org.jetbrains.kotlin.com.intellij.util.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

2021-10-01 01:27:19 INFO     Sending SIGTERM to PID 493
2021-10-01 01:27:19 INFO     Waiting for process to terminate
2021-10-01 01:27:19 INFO     Process terminated with exit code 143
2021-10-01 01:27:19 INFO     Walking tree from /tmp/tmp8v35wd9a/local-test-cluster/opensearch-1.1.0/logs
2021-10-01 01:27:19 INFO     Recording local cluster logs for index-management with test configuration as with-security at /tmp/tmp8v35wd9a/test-recorder/tests/16/integ-test/index-management/with-security/local-cluster-logs
2021-10-01 01:27:19 INFO     Additional config found: {'path.repo': ['/tmp']}
2021-10-01 01:27:19 INFO     Creating local test cluster in /tmp/tmp8v35wd9a/local-test-cluster
2021-10-01 01:27:19 INFO     Downloading bundle from s3
2021-10-01 01:27:24 INFO     Downloaded bundle to /tmp/tmp8v35wd9a/local-test-cluster/opensearch-1.1.0-linux-x64.tar.gz
2021-10-01 01:27:24 INFO     Unpacking
2021-10-01 01:27:29 INFO     Unpacked
2021-10-01 01:27:29 INFO     Started OpenSearch with parent PID 8140
2021-10-01 01:27:29 INFO     Waiting for service to become available
2021-10-01 01:27:29 INFO     Pinging http://localhost:9200/_cluster/health attempt 0
2021-10-01 01:27:29 INFO     Service not available yet
2021-10-01 01:27:39 INFO     Pinging http://localhost:9200/_cluster/health attempt 1
2021-10-01 01:27:39 INFO     200: {"cluster_name":"opensearch","status":"yellow","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"active_primary_shards":1,"active_shards":1,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":1,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":50.0}
2021-10-01 01:27:39 INFO     Service is available
2021-10-01 01:27:39 INFO     ===============================================
2021-10-01 01:27:39 INFO     Running integration tests for index-management
2021-10-01 01:27:39 INFO     ===============================================
2021-10-01 01:27:39 INFO     Executing "/local/home/zhujiaxi/peterzhuamazon/opensearch-build/bundle-workflow/scripts/default/integtest.sh -b localhost -p 9200 -s false -v 1.1.0" in /tmp/tmp8v35wd9a/index-management
2021-10-01 01:43:18 INFO     Recording component test results for index-management at /tmp/tmp8v35wd9a/test-recorder/tests/16/integ-test/index-management/without-security/test-results
2021-10-01 01:43:18 INFO     Walking tree from /tmp/tmp8v35wd9a/index-management/build/reports/tests/integTest
2021-10-01 01:43:18 INFO     Integration test run failed for component index-management
2021-10-01 01:43:18 INFO     WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jetbrains.kotlin.com.intellij.util.ReflectionUtil (file:/local/home/zhujiaxi/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.4.31/6451ea797cef544e81f507b0d9959cd97ae09c0/kotlin-compiler-embeddable-1.4.31.jar) to method java.util.ResourceBundle.setParent(java.util.ResourceBundle)
WARNING: Please consider reporting this to the maintainers of org.jetbrains.kotlin.com.intellij.util.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

2021-10-01 01:43:18 INFO     Sending SIGTERM to PID 8140
2021-10-01 01:43:18 INFO     Waiting for process to terminate
2021-10-01 01:43:18 INFO     Process terminated with exit code 143
2021-10-01 01:43:18 INFO     Walking tree from /tmp/tmp8v35wd9a/local-test-cluster/opensearch-1.1.0/logs
2021-10-01 01:43:18 INFO     Recording local cluster logs for index-management with test configuration as without-security at /tmp/tmp8v35wd9a/test-recorder/tests/16/integ-test/index-management/without-security/local-cluster-logs
2021-10-01 01:43:18 INFO     Skipping tests for k-NN, as it is currently not supported
2021-10-01 01:43:18 INFO     Skipping tests for anomaly-detection, as it is currently not supported
2021-10-01 01:43:18 INFO     Skipping tests for asynchronous-search, as it is currently not supported
2021-10-01 01:43:18 INFO     Skipping tests for dashboards-reports, as it is currently not supported
2021-10-01 01:43:18 INFO     Skipping tests for dashboards-notebooks, as it is currently not supported
2021-10-01 01:43:18 INFO     PASS: Integration Test for index-management with-security with status code 0
2021-10-01 01:43:18 INFO     PASS: Integration Test for index-management without-security with status code 0
</p>
</details>
 
### Issues Resolved
#667
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
