### PR TITLE
Only build the target architecture for OpenSearch Dashboards.

### DIFF
--- a/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/scripts/components/OpenSearch-Dashboards/build.sh
@@ -58,11 +58,11 @@ fi
 # see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
 case $ARCHITECTURE in
     x64)
-        TARGET="linux-tar"
+        TARGET="--linux"
         QUALIFIER="linux-x64"
         ;;
     arm64)
-        TARGET="linux-arm64-tar"
+        TARGET="--linux-arm"
         QUALIFIER="linux-arm64"
         ;;
     *)
@@ -75,13 +75,10 @@ echo "Building node modules for core"
 yarn osd bootstrap
 
 echo "Building artifact"
-if [ "$SNAPSHOT" = "true" ]
-then
-    IDENTIFIER="-SNAPSHOT"
-    yarn build --skip-os-packages
-else
-    yarn build --skip-os-packages --release
-fi
+[[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
+[[ "$SNAPSHOT" != "true" ]] && RELEASE="--release"
+
+yarn build-platform $TARGET --skip-os-packages $RELEASE
 
 mkdir -p "${OUTPUT}/bundle"
 # Copy artifact to bundle output with -min in the name


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Use https://github.com/opensearch-project/OpenSearch-Dashboards/pull/795 to only build the target arch for OpenSearch dashboards. 

<strike>
This doesn't work on 1.1 because that PR wasn't backported to 1.1. We have several options:

1. Backport https://github.com/opensearch-project/OpenSearch-Dashboards/pull/795 to 1.1.
2. Commit the old `build.sh` into OpenSearch-Dashboards#1.1, and the new `build.sh` that comes in this PR into OpenSearch-Dashboards#main. This is ultimately where those scripts need to end up going.
3. Stop trying to build OpenSearch Dashboards 1.1, move the manifest to 1.2 as part of this PR, and use main. This means we won't be able to build a patch version for 1.1 without backporting 795. 
4. Do an `if` in the default script based on the version being built (gross). 

@kavilla what would you prefer?
</strike>

The fix was backported, we chose 1.
 
### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/592.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
