### PR TITLE
Add alerting specific integtest.sh to use -Dsecurity parameter

### DIFF
--- a/bundle-workflow/scripts/components/alerting/integtest.sh
+++ b/bundle-workflow/scripts/components/alerting/integtest.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -e
+
+function usage() {
+    echo ""
+    echo "This script is used to run integration tests for plugin installed on a remote OpenSearch/Dashboards cluster."
+    echo "--------------------------------------------------------------------------"
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Required arguments:"
+    echo "None"
+    echo ""
+    echo "Optional arguments:"
+    echo -e "-b BIND_ADDRESS\t, defaults to localhost | 127.0.0.1, can be changed to any IP or domain name for the cluster location."
+    echo -e "-p BIND_PORT\t, defaults to 9200 or 5601 depends on OpenSearch or Dashboards, can be changed to any port for the cluster location."
+    echo -e "-s SECURITY_ENABLED\t(true | false), defaults to true. Specify the OpenSearch/Dashboards have security enabled or not."
+    echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
+    echo -e "-v OPENSEARCH_VERSION\t, no defaults"
+    echo -e "-n SNAPSHOT\t, defaults to false"
+    echo -e "-h\tPrint this message."
+    echo "--------------------------------------------------------------------------"
+}
+
+while getopts ":hb:p:s:c:v:n:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        b)
+            BIND_ADDRESS=$OPTARG
+            ;;
+        p)
+            BIND_PORT=$OPTARG
+            ;;
+        s)
+            SECURITY_ENABLED=$OPTARG
+            ;;
+        c)
+            CREDENTIAL=$OPTARG
+            ;;
+        v)
+            OPENSEARCH_VERSION=$OPTARG
+            ;;
+        n)
+            SNAPSHOT=$OPTARG
+            ;;
+        :)
+            echo "-${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${OPTARG}"
+            exit 1
+            ;;
+    esac
+done
+
+
+if [ -z "$BIND_ADDRESS" ]
+then
+  BIND_ADDRESS="localhost"
+fi
+
+if [ -z "$BIND_PORT" ]
+then
+  BIND_PORT="9200"
+fi
+
+if [ -z "$SECURITY_ENABLED" ]
+then
+  SECURITY_ENABLED="true"
+fi
+
+if [ -z "$SNAPSHOT" ]
+then
+  SNAPSHOT="false"
+fi
+
+if [ -z "$CREDENTIAL" ]
+then
+  CREDENTIAL="admin:admin"
+  USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
+  PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
+fi
+
+./gradlew integTest -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.clustername="opensearch-integrationtest" -Dhttps=$SECURITY_ENABLED -Dsecurity=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD --console=plain

--- a/bundle-workflow/scripts/components/alerting/integtest.sh
+++ b/bundle-workflow/scripts/components/alerting/integtest.sh
@@ -82,8 +82,9 @@ fi
 if [ -z "$CREDENTIAL" ]
 then
   CREDENTIAL="admin:admin"
-  USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
-  PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
+
+USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
+PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 
 ./gradlew integTest -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.clustername="opensearch-integrationtest" -Dhttps=$SECURITY_ENABLED -Dsecurity=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD --console=plain

--- a/bundle-workflow/scripts/default/integtest.sh
+++ b/bundle-workflow/scripts/default/integtest.sh
@@ -82,8 +82,9 @@ fi
 if [ -z "$CREDENTIAL" ]
 then
   CREDENTIAL="admin:admin"
-  USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
-  PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
+
+USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
+PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 
 ./gradlew integTest -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.clustername="opensearch-integrationtest" -Dhttps=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD --console=plain


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add alerting specific integtest.sh to use -Dsecurity parameter.
This is specifically needed for the alerting plugin integTest.
 
<details><summary>Test Alerting with this fixes logs</summary>
<p>

Installing dependencies in ./bundle-workflow ...
Installing dependencies from Pipfile.lock (22bd6c)...
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 0/0 — 00:00:00
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Running ./bundle-workflow/src/run_integ_test.py --test-run-id 16 --s3-bucket artifact-bucket-stack-buildbucket-9omh0hnpg12q --opensearch-version 1.1.0 --build-id 315 --architecture x64 ...
2021-10-01 18:52:15 INFO     Switching to temporary work_dir: /tmp/tmp1ioyny2z
2021-10-01 18:52:15 INFO     TestRecorder recording logs in /tmp/tmp1ioyny2z/test-recorder/tests/16/integ-test
2021-10-01 18:52:15 INFO     Found credentials in environment variables.
2021-10-01 18:52:18 INFO     Pulling opensearch-build
2021-10-01 18:52:18 INFO     Executing "git init" in /tmp/tmp1ioyny2z/opensearch-build
2021-10-01 18:52:18 INFO     Executing "git remote add origin https://github.com/opensearch-project/opensearch-build.git" in /tmp/tmp1ioyny2z/opensearch-build
2021-10-01 18:52:18 INFO     Executing "git fetch --depth 1 origin main" in /tmp/tmp1ioyny2z/opensearch-build
2021-10-01 18:52:18 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmp1ioyny2z/opensearch-build
2021-10-01 18:52:18 INFO     Executing "git rev-parse HEAD" in /tmp/tmp1ioyny2z/opensearch-build
2021-10-01 18:52:18 INFO     Checked out https://github.com/opensearch-project/opensearch-build.git@main into /tmp/tmp1ioyny2z/opensearch-build at 323ad28c74239abf3a854d8fce13d3d61e19a35d
2021-10-01 18:52:19 INFO     Downloading all pre-built maven dependencies from s3
2021-10-01 19:00:09 INFO     Successfully downloaded maven dependencies
2021-10-01 19:00:09 INFO     Skipping tests for OpenSearch, as it is currently not supported
2021-10-01 19:00:09 INFO     Skipping tests for job-scheduler, as it is currently not supported
2021-10-01 19:00:09 INFO     Skipping tests for sql, as it is currently not supported
2021-10-01 19:00:09 INFO     Executing "git init" in /tmp/tmp1ioyny2z/alerting
2021-10-01 19:00:09 INFO     Executing "git remote add origin https://github.com/opensearch-project/alerting.git" in /tmp/tmp1ioyny2z/alerting
2021-10-01 19:00:09 INFO     Executing "git fetch --depth 1 origin 05eb22ea3a56ea982599a27562999d3de6b6472e" in /tmp/tmp1ioyny2z/alerting
2021-10-01 19:00:10 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmp1ioyny2z/alerting
2021-10-01 19:00:10 INFO     Executing "git rev-parse HEAD" in /tmp/tmp1ioyny2z/alerting
2021-10-01 19:00:10 INFO     Checked out https://github.com/opensearch-project/alerting.git@05eb22ea3a56ea982599a27562999d3de6b6472e into /tmp/tmp1ioyny2z/alerting at 05eb22ea3a56ea982599a27562999d3de6b6472e
2021-10-01 19:00:10 INFO     Additional config found: {'plugins.destination.host.deny_list': ['10.0.0.0/8', '127.0.0.1']}
2021-10-01 19:00:10 INFO     Creating local test cluster in /tmp/tmp1ioyny2z/local-test-cluster
2021-10-01 19:00:10 INFO     Downloading bundle from s3
2021-10-01 19:00:14 INFO     Downloaded bundle to /tmp/tmp1ioyny2z/local-test-cluster/opensearch-1.1.0-linux-x64.tar.gz
2021-10-01 19:00:14 INFO     Unpacking
2021-10-01 19:00:19 INFO     Unpacked
2021-10-01 19:00:19 INFO     Started OpenSearch with parent PID 4056
2021-10-01 19:00:19 INFO     Waiting for service to become available
2021-10-01 19:00:19 INFO     Pinging https://localhost:9200/_cluster/health attempt 0
2021-10-01 19:00:19 INFO     Service not available yet
2021-10-01 19:00:29 INFO     Pinging https://localhost:9200/_cluster/health attempt 1
2021-10-01 19:00:29 INFO     Service not available yet
2021-10-01 19:00:39 INFO     Pinging https://localhost:9200/_cluster/health attempt 2
/home/zhujiaxi/.local/share/virtualenvs/bundle-workflow-LMYIE2bG/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
2021-10-01 19:00:39 INFO     200: {"cluster_name":"opensearch","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"active_primary_shards":1,"active_shards":1,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0}
2021-10-01 19:00:39 INFO     Service is available
2021-10-01 19:00:39 INFO     ===============================================
2021-10-01 19:00:39 INFO     Running integration tests for alerting
2021-10-01 19:00:39 INFO     ===============================================
2021-10-01 19:00:39 INFO     Executing "/local/home/zhujiaxi/peterzhuamazon/opensearch-build/bundle-workflow/scripts/components/alerting/integtest.sh -b localhost -p 9200 -s true -v 1.1.0" in /tmp/tmp1ioyny2z/alerting
2021-10-01 19:03:56 INFO     Recording component test results for alerting at /tmp/tmp1ioyny2z/test-recorder/tests/16/integ-test/alerting/with-security/test-results
2021-10-01 19:03:56 INFO     Walking tree from /tmp/tmp1ioyny2z/alerting/build/reports/tests/integTest
2021-10-01 19:03:56 INFO     Integration test run failed for component alerting
2021-10-01 19:03:56 INFO     WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jetbrains.kotlin.com.intellij.util.ReflectionUtil (file:/local/home/zhujiaxi/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.4.31/6451ea797cef544e81f507b0d9959cd97ae09c0/kotlin-compiler-embeddable-1.4.31.jar) to method java.util.ResourceBundle.setParent(java.util.ResourceBundle)
WARNING: Please consider reporting this to the maintainers of org.jetbrains.kotlin.com.intellij.util.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Note: /tmp/tmp1ioyny2z/alerting/notification/src/main/java/org/opensearch/alerting/destination/Notification.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

2021-10-01 19:03:56 INFO     Sending SIGTERM to PID 4056
2021-10-01 19:03:56 INFO     Waiting for process to terminate
2021-10-01 19:03:56 INFO     Process terminated with exit code 143
2021-10-01 19:03:56 INFO     Walking tree from /tmp/tmp1ioyny2z/local-test-cluster/opensearch-1.1.0/logs
2021-10-01 19:03:56 INFO     Recording local cluster logs for alerting with test configuration as with-security at /tmp/tmp1ioyny2z/test-recorder/tests/16/integ-test/alerting/with-security/local-cluster-logs
2021-10-01 19:03:56 INFO     Additional config found: {'plugins.destination.host.deny_list': ['10.0.0.0/8', '127.0.0.1']}
2021-10-01 19:03:56 INFO     Creating local test cluster in /tmp/tmp1ioyny2z/local-test-cluster
2021-10-01 19:03:56 INFO     Downloading bundle from s3
2021-10-01 19:04:05 INFO     Downloaded bundle to /tmp/tmp1ioyny2z/local-test-cluster/opensearch-1.1.0-linux-x64.tar.gz
2021-10-01 19:04:05 INFO     Unpacking
2021-10-01 19:04:10 INFO     Unpacked
2021-10-01 19:04:10 INFO     Started OpenSearch with parent PID 7946
2021-10-01 19:04:10 INFO     Waiting for service to become available
2021-10-01 19:04:10 INFO     Pinging http://localhost:9200/_cluster/health attempt 0
2021-10-01 19:04:10 INFO     Service not available yet
2021-10-01 19:04:20 INFO     Pinging http://localhost:9200/_cluster/health attempt 1
2021-10-01 19:04:20 INFO     200: {"cluster_name":"opensearch","status":"yellow","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"active_primary_shards":2,"active_shards":2,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":1,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":66.66666666666666}
2021-10-01 19:04:20 INFO     Service is available
2021-10-01 19:04:20 INFO     ===============================================
2021-10-01 19:04:20 INFO     Running integration tests for alerting
2021-10-01 19:04:20 INFO     ===============================================
2021-10-01 19:04:20 INFO     Executing "/local/home/zhujiaxi/peterzhuamazon/opensearch-build/bundle-workflow/scripts/components/alerting/integtest.sh -b localhost -p 9200 -s false -v 1.1.0" in /tmp/tmp1ioyny2z/alerting
2021-10-01 19:06:04 INFO     Recording component test results for alerting at /tmp/tmp1ioyny2z/test-recorder/tests/16/integ-test/alerting/without-security/test-results
2021-10-01 19:06:04 INFO     Walking tree from /tmp/tmp1ioyny2z/alerting/build/reports/tests/integTest
2021-10-01 19:06:04 INFO     Integration test run failed for component alerting
2021-10-01 19:06:04 INFO     WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jetbrains.kotlin.com.intellij.util.ReflectionUtil (file:/local/home/zhujiaxi/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.4.31/6451ea797cef544e81f507b0d9959cd97ae09c0/kotlin-compiler-embeddable-1.4.31.jar) to method java.util.ResourceBundle.setParent(java.util.ResourceBundle)
WARNING: Please consider reporting this to the maintainers of org.jetbrains.kotlin.com.intellij.util.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

2021-10-01 19:06:04 INFO     Sending SIGTERM to PID 7946
2021-10-01 19:06:04 INFO     Waiting for process to terminate
2021-10-01 19:06:04 INFO     Process terminated with exit code 143
2021-10-01 19:06:04 INFO     Walking tree from /tmp/tmp1ioyny2z/local-test-cluster/opensearch-1.1.0/logs
2021-10-01 19:06:04 INFO     Recording local cluster logs for alerting with test configuration as without-security at /tmp/tmp1ioyny2z/test-recorder/tests/16/integ-test/alerting/without-security/local-cluster-logs
2021-10-01 19:06:04 INFO     Skipping tests for security, as it is currently not supported
2021-10-01 19:06:04 INFO     Skipping tests for cross-cluster-replication, as it is currently not supported
2021-10-01 19:06:04 INFO     Skipping tests for performance-analyzer, as it is currently not supported
2021-10-01 19:06:04 INFO     Skipping tests for index-management, as it is currently not supported
2021-10-01 19:06:04 INFO     Skipping tests for k-NN, as it is currently not supported
2021-10-01 19:06:04 INFO     Skipping tests for anomaly-detection, as it is currently not supported
2021-10-01 19:06:04 INFO     Skipping tests for asynchronous-search, as it is currently not supported
2021-10-01 19:06:04 INFO     Skipping tests for dashboards-reports, as it is currently not supported
2021-10-01 19:06:04 INFO     Skipping tests for dashboards-notebooks, as it is currently not supported
2021-10-01 19:06:04 INFO     PASS: Integration Test for alerting with-security with status code 0
2021-10-01 19:06:04 INFO     PASS: Integration Test for alerting without-security with status code 0
</p>
</details>

### Issues Resolved
#667
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
