### PR TITLE
Handle PUBLIC_ARTIFACT_URL without trailing slash

### DIFF
--- a/bundle-workflow/src/assemble_workflow/bundle_recorder.py
+++ b/bundle-workflow/src/assemble_workflow/bundle_recorder.py
@@ -31,7 +31,7 @@ class BundleRecorder:
         return "-".join(parts) + ".tar.gz"
 
     def __get_public_url_path(self, folder, rel_path):
-        path = "{}/{}/{}/{}".format(folder, self.version, self.build_id, rel_path)
+        path = "/".join((folder, self.version, self.build_id, rel_path))
         return urljoin(self.public_url + "/", path)
 
     def __get_location(self, folder_name, rel_path, abs_path):

--- a/bundle-workflow/src/assemble_workflow/bundle_recorder.py
+++ b/bundle-workflow/src/assemble_workflow/bundle_recorder.py
@@ -32,7 +32,7 @@ class BundleRecorder:
 
     def __get_public_url_path(self, folder, rel_path):
         path = "{}/{}/{}/{}".format(folder, self.version, self.build_id, rel_path)
-        return urljoin(self.public_url, path)
+        return urljoin(self.public_url + "/", path)
 
     def __get_location(self, folder_name, rel_path, abs_path):
         if self.public_url:

--- a/bundle-workflow/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/bundle-workflow/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -89,7 +89,7 @@ class TestBundleRecorder(unittest.TestCase):
                 self.assertEqual(yaml.safe_load(f), data)
 
     def test_record_component_public(self):
-        self.bundle_recorder.public_url = 'https://ci.opensearch.org/ci/xyz'
+        self.bundle_recorder.public_url = 'https://ci.opensearch.org/ci/os-distro-prod'
         component = BuildManifest.Component(
             {
                 "name": "job_scheduler",
@@ -115,7 +115,7 @@ class TestBundleRecorder(unittest.TestCase):
                 "components": [
                     {
                         "commit_id": "3913d7097934cbfe1fdcf919347f22a597d00b76",
-                        "location": "https://ci.opensearch.org/ci/xyz/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/plugins",
+                        "location": "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/plugins",
                         "name": component.name,
                         "ref": "main",
                         "repository": "https://github.com/opensearch-project/job_scheduler",
@@ -135,12 +135,12 @@ class TestBundleRecorder(unittest.TestCase):
 
         # Public URL - No trailing slash
         self.assertEqual(
-            get_location("https://ci.opensearch.org/ci/xyz"),
-            "https://ci.opensearch.org/ci/xyz/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/dir1/dir2/file"
+            get_location('https://ci.opensearch.org/ci/os-distro-prod'),
+            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/dir1/dir2/file"
         )
 
         # Public URL - Trailing slash
         self.assertEqual(
-            get_location("https://ci.opensearch.org/ci/xyz/"),
-            "https://ci.opensearch.org/ci/xyz/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/dir1/dir2/file"
+            get_location('https://ci.opensearch.org/ci/os-distro-prod/'),
+            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/dir1/dir2/file"
         )


### PR DESCRIPTION
### Description
In the build workflow the path was added as `https://ci.opensearch.org/ci/dbc`, and when `urljoin` was used on that value it unexpectly removed the last element on the url [[StackOverflow](https://stackoverflow.com/questions/10893374/python-confusions-with-urljoin)].

Instead of 'altering' the value in jenkins and breaking the notification message, updated the build script to handle this case and added many unit tests.
 
### Issues Resolved
Resolves #661
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
