### PR TITLE
[Docker] Create data dir and setup owner before volume mounts in docker-compose

### DIFF
--- a/release/docker/dockerfiles/opensearch.al2.dockerfile
+++ b/release/docker/dockerfiles/opensearch.al2.dockerfile
@@ -51,7 +51,9 @@ RUN groupadd -g $GID opensearch && \
 
 # Prepare working directory
 COPY opensearch-*.tgz /tmp/opensearch/
-RUN tar -xzpf /tmp/opensearch/opensearch-`uname -p`.tgz -C $OPENSEARCH_HOME --strip-components=1 && rm -rf /tmp/opensearch && chmod 750 $OPENSEARCH_HOME/plugins/opensearch-security/tools/*
+RUN tar -xzpf /tmp/opensearch/opensearch-`uname -p`.tgz -C $OPENSEARCH_HOME --strip-components=1 && rm -rf /tmp/opensearch && \
+    chmod 750 $OPENSEARCH_HOME/plugins/opensearch-security/tools/* && \
+    mkdir -p $OPENSEARCH_HOME/data && chown -R $UID:$GID $OPENSEARCH_HOME/data
 COPY opensearch-docker-entrypoint.sh opensearch-onetime-setup.sh $OPENSEARCH_HOME/
 COPY log4j2.properties opensearch.yml $OPENSEARCH_HOME/config/
 COPY performance-analyzer.properties $OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/pa_config/


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
[Docker] Create data dir and setup owner before volume mounts in docker-compose.


The data directory does not exist in tarball of OpenSearch, only get created when the cluster starts.
Tarball without `data`:
```
total 248
drwxr-xr-x  2 opensearch opensearch    263 Sep 30 17:17 bin
drwxr-xr-x  5 opensearch opensearch    157 Sep 30 17:18 config
drwxr-xr-x  9 opensearch opensearch    107 Sep 30 17:03 jdk
drwxr-xr-x  3 opensearch opensearch   4096 Sep 30 17:03 lib
-rw-r--r--  1 opensearch opensearch  11358 Sep 30 16:56 LICENSE.txt
drwxr-xr-x  2 opensearch opensearch      6 Sep 30 16:59 logs
-rw-r--r--  1 opensearch opensearch   3634 Sep 30 17:18 manifest.yml
drwxr-xr-x 19 opensearch opensearch   4096 Sep 30 17:04 modules
-rw-r--r--  1 opensearch opensearch 215355 Sep 30 17:03 NOTICE.txt
-rwxrwxr-x  1 opensearch opensearch   3092 Sep 30 16:55 opensearch-tar-install.sh
drwxr-xr-x  6 opensearch opensearch     59 Sep 30 17:17 performance-analyzer-rca
drwxr-xr-x 14 opensearch opensearch   4096 Sep 30 17:18 plugins
-rw-r--r--  1 opensearch opensearch  1761 Sep 30 16:56 README.md
```

If we use the docker image without docker-compose the `data` directory will be created by OpenSearch with right ownership:
```
docker run -it -d -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" <image repo link>
```
```
drwxr-xr-x  1 opensearch opensearch    146 Oct  4 20:59 data
```

We also provide a docker compose file in our website: https://opensearch.org/samples/docker-compose.yml
If we use the docker image with docker-compose, due to this line, docker-compose will create `data` directory before OpenSearch even started, and resulted in `root:root` ownership for the directory:
```
    volumes:
      - opensearch-data1:/usr/share/opensearch/data
```
```
drwxr-xr-x  2 root       root            6 Oct  4 18:54 data
```

This seems like a long time issue since 2016, not sure why it only happens in multi-arch image, not single-arch for us here.
https://github.com/docker/compose/issues/3270

The solution is shown in this PR, create the dir beforehand and assign `opensearch:opensearch` ownership.

Results:
```
total 260
-rw-r--r--  1 opensearch opensearch  11358 Sep 30 16:56 LICENSE.txt
-rw-r--r--  1 opensearch opensearch 215355 Sep 30 17:03 NOTICE.txt
-rw-r--r--  1 opensearch opensearch   1761 Sep 30 16:56 README.md
drwxr-xr-x  2 opensearch opensearch    263 Sep 30 17:17 bin
drwxr-xr-x  1 opensearch opensearch    150 Oct  4 19:51 config
drwxr-xr-x  3 opensearch opensearch    146 Oct  4 19:42 data
drwxr-xr-x  9 opensearch opensearch    107 Sep 30 17:03 jdk
drwxr-xr-x  3 opensearch opensearch   4096 Sep 30 17:03 lib
drwxr-xr-x  1 opensearch opensearch    103 Oct  4 19:51 logs
-rw-r--r--  1 opensearch opensearch   3634 Sep 30 17:18 manifest.yml
drwxr-xr-x 19 opensearch opensearch   4096 Sep 30 17:04 modules
-rwxr-xr-x  1 opensearch opensearch   5204 Oct  4 19:20 opensearch-docker-entrypoint.sh
-rwxr-xr-x  1 opensearch opensearch   2107 Oct  4 19:20 opensearch-onetime-setup.sh
-rwxrwxr-x  1 opensearch opensearch   3092 Sep 30 16:55 opensearch-tar-install.sh
drwxr-xr-x  6 opensearch opensearch     59 Sep 30 17:17 performance-analyzer-rca
drwxr-xr-x  1 opensearch opensearch     33 Sep 30 17:18 plugins
-rwxrwxr-x  1 opensearch opensearch    315 Oct  4 19:42 securityadmin_demo.sh
```
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/676#issuecomment-933803157
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
