### PR TITLE
Fix URLs to include architecture.

### DIFF
--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -18,6 +18,7 @@ class BundleRecorder:
         self.version = build.version
         self.tar_name = self.__get_tar_name(build)
         self.artifacts_dir = artifacts_dir
+        self.arch = build.architecture
         self.bundle_manifest = self.BundleManifestBuilder(
             build.id,
             build.name,
@@ -31,7 +32,7 @@ class BundleRecorder:
         return "-".join(parts) + ".tar.gz"
 
     def __get_public_url_path(self, folder, rel_path):
-        path = "/".join((folder, self.version, self.build_id, rel_path))
+        path = "/".join((folder, self.version, self.build_id, self.arch, rel_path))
         return urljoin(self.public_url + "/", path)
 
     def __get_location(self, folder_name, rel_path, abs_path):

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -42,7 +42,7 @@ def main():
         )
     )
     if not os.path.isfile(tarball_installation_script):
-        logging.info(
+        logging.error(
             f"No installation script found at path: {tarball_installation_script}"
         )
         exit(1)

--- a/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -115,7 +115,7 @@ class TestBundleRecorder(unittest.TestCase):
                 "components": [
                     {
                         "commit_id": "3913d7097934cbfe1fdcf919347f22a597d00b76",
-                        "location": "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/plugins",
+                        "location": "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/x64/plugins",
                         "name": component.name,
                         "ref": "main",
                         "repository": "https://github.com/opensearch-project/job_scheduler",
@@ -136,13 +136,13 @@ class TestBundleRecorder(unittest.TestCase):
         # Public URL - No trailing slash
         self.assertEqual(
             get_location('https://ci.opensearch.org/ci/os-distro-prod'),
-            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/dir1/dir2/file"
+            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/x64/dir1/dir2/file"
         )
 
         # Public URL - Trailing slash
         self.assertEqual(
             get_location('https://ci.opensearch.org/ci/os-distro-prod/'),
-            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/dir1/dir2/file"
+            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/x64/dir1/dir2/file"
         )
 
     def test_tar_name(self):
@@ -248,7 +248,7 @@ class TestBundleRecorderDashboards(unittest.TestCase):
                 "components": [
                     {
                         "commit_id": "ae789280740d7000d1f13245019414abeedfc286",
-                        "location": "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c94ebec444a94ada86a230c9297b1d73/plugins",
+                        "location": "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c94ebec444a94ada86a230c9297b1d73/x64/plugins",
                         "name": component.name,
                         "ref": "main",
                         "repository": "https://github.com/opensearch-project/alerting-dashboards-plugin",
@@ -269,13 +269,13 @@ class TestBundleRecorderDashboards(unittest.TestCase):
         # Public URL - No trailing slash
         self.assertEqual(
             get_location('https://ci.opensearch.org/ci/os-distro-prod'),
-            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c94ebec444a94ada86a230c9297b1d73/dir1/dir2/file"
+            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c94ebec444a94ada86a230c9297b1d73/x64/dir1/dir2/file"
         )
 
         # Public URL - Trailing slash
         self.assertEqual(
             get_location('https://ci.opensearch.org/ci/os-distro-prod/'),
-            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c94ebec444a94ada86a230c9297b1d73/dir1/dir2/file"
+            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c94ebec444a94ada86a230c9297b1d73/x64/dir1/dir2/file"
         )
 
     def test_tar_name(self):


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Fixes URLs in the manifests.
 
### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/714.

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
