### PR TITLE
Fix: adjust script path.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: bundle-workflow
+name: tests
 
 on:
   push:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -8,7 +8,7 @@
     - [Yarn](#yarn)
   - [Install Dependencies](#install-dependencies)
   - [Run Tests](#run-tests)
-  - [Run bundle-workflow](#run-bundle-workflow)
+  - [Build OpenSearch](#build-opensearch)
   - [Code Linting](#code-linting)
   - [Type Checking](#type-checking)
   - [Code Coverage](#code-coverage)
@@ -24,11 +24,15 @@ Fork this repository on GitHub, and clone locally with `git clone`.
 
 #### Pyenv
 
-Use pyenv to manage multiple versions of Python. This can be easily installed with [pyenv-installer](https://github.com/pyenv/pyenv-installer).
+Use pyenv to manage multiple versions of Python. This can be installed with [pyenv-installer](https://github.com/pyenv/pyenv-installer).
+
+```
+curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+```
 
 #### Python 3.7
 
-Python projects in this repository, including the [bundle-workflow](./bundle-workflow) project, use Python 3.7. See the [Python Beginners Guide](https://wiki.python.org/moin/BeginnersGuide) if you have never worked with the language. 
+Python projects in this repository use Python 3.7. See the [Python Beginners Guide](https://wiki.python.org/moin/BeginnersGuide) if you have never worked with the language.
 
 ```
 $ python3 --version
@@ -38,7 +42,8 @@ Python 3.7.11
 If you are using pyenv.
 
 ```
-$ pyenv install 3.7.11
+pyenv install 3.7.12
+pyenv global 3.7.12
 ```
 
 #### Pipenv
@@ -46,6 +51,8 @@ $ pyenv install 3.7.11
 This project uses [pipenv](https://pipenv.pypa.io/en/latest/), which is typically installed with `pip install --user pipenv`. Pipenv automatically creates and manages a virtualenv for your projects, as well as adds/removes packages from your `Pipfile` as you install/uninstall packages. It also generates the ever-important `Pipfile.lock`, which is used to produce deterministic builds.
 
 ```
+$ pip install pipenv
+
 $ pipenv --version
 pipenv, version 19.0
 ```
@@ -86,7 +93,7 @@ $ pipenv run pytest
 2 passed in 02s
 ```
 
-### Run bundle-workflow
+### Build OpenSearch
 
 Try running `./build.sh`. It should complete and show usage.
 
@@ -134,7 +141,7 @@ All done! ✨ 🍰 ✨
 23 files left unchanged.
 ```
 
-If your code isn't properly formatted, don't worry, [a CI workflow](./github/workflows/bundle-workflow.yml) will make sure to remind you. 
+If your code isn't properly formatted, don't worry, [a CI workflow](./github/workflows/tests.yml) will make sure to remind you. 
 
 ### Type Checking
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_logo_default.svg" height="64px"/>
 
-[![tests](https://github.com/opensearch-project/opensearch-build/actions/workflows/bundle-workflow.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/bundle-workflow.yml)
+[![tests](https://github.com/opensearch-project/opensearch-build/actions/workflows/tests.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/tests.yml)
 [![manifests](https://github.com/opensearch-project/opensearch-build/actions/workflows/manifests.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/manifests.yml)
 [![codecov](https://codecov.io/gh/opensearch-project/opensearch-build/branch/main/graph/badge.svg?token=03S5XZ80UI)](https://codecov.io/gh/opensearch-project/opensearch-build)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,19 +1,11 @@
 - [Scripts](#scripts)
-  - [Bundle Workflow](#bundle-workflow)
-  - [Legacy Scripts](#legacy-scripts)
     - [Run Deployment Script](#run-deployment-script)
       - [Requirements](#requirements)
       - [Usage](#usage)
   
 ## Scripts
 
-### Bundle Workflow
-
-This folder contains default and custom scripts located by [src/paths/script_finder.py](ScriptFinder).
-
-### Legacy Scripts
-
-This folder contains the following scripts which are used in either tar/docker or legacy github actions.
+This folder contains default and custom scripts located by [src/paths/script_finder.py](ScriptFinder), and the following scripts which are used in either tar/docker or legacy github actions.
 
 #### Run Deployment Script
 

--- a/scripts/legacy/tar/linux/opensearch-tar-build.sh
+++ b/scripts/legacy/tar/linux/opensearch-tar-build.sh
@@ -153,7 +153,7 @@ mkdir -p $WORKING_DIR/data
 chmod 755 $WORKING_DIR/data/
 
 # Copy the tarball installation script 
-cp $REPO_ROOT/release/tar/linux/opensearch-tar-install.sh $WORKING_DIR/
+cp $REPO_ROOT/scripts/legacy/tar/linux/opensearch-tar-install.sh $WORKING_DIR/
 
 # Setup k-NN-library
 mkdir -p $WORKING_DIR/plugins/opensearch-knn/knnlib

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -38,7 +38,7 @@ def main():
     tarball_installation_script = os.path.realpath(
         os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
-            "../release/tar/linux/opensearch-tar-install.sh",
+            "../scripts/legacy/tar/linux/opensearch-tar-install.sh",
         )
     )
     if not os.path.isfile(tarball_installation_script):

--- a/tests/test_run_assemble.py
+++ b/tests/test_run_assemble.py
@@ -52,7 +52,7 @@ class TestRunAssemble(unittest.TestCase):
             os.path.realpath(
                 os.path.join(
                     os.path.dirname(os.path.abspath(__file__)),
-                    "../release/tar/linux/opensearch-tar-install.sh",
+                    "../scripts/legacy/tar/linux/opensearch-tar-install.sh",
                 )
             ),
             "path/opensearch-tar-install.sh",


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Fixes build, broken in https://github.com/opensearch-project/opensearch-build/pull/711.

Renames bundle workflow to just tests.
 
### Issues Resolved

Closes #723.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
