### PR TITLE
enable all non hybrid opensearch-dashboard plugins to the build process

### DIFF
--- a/manifests/1.1.0/opensearch-dashboards-1.1.0.yml
+++ b/manifests/1.1.0/opensearch-dashboards-1.1.0.yml
@@ -19,12 +19,12 @@ components:
   # - name: notificationsDashboards
   #   repository: https://github.com/opensearch-project/notifications.git
   #   ref: main
-  # - name: securityDashboards
-  #   repository: https://github.com/opensearch-project/security-dashboards-plugin
-  #   ref: main
-  # - name: indexManagementDashboards
-  #   repository: https://github.com/opensearch-project/index-management-dashboards-plugin
-  #   ref: main
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin
+    ref: "1.1"
+  - name: indexManagementDashboards
+    repository: https://github.com/opensearch-project/index-management-dashboards-plugin
+    ref: "1.1"
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     ref: "1.1"
@@ -36,9 +36,9 @@ components:
   # - name: notebooksDashboards
   #   repository: https://github.com/opensearch-project/dashboards-notebooks.git
   #   ref: main
-  # - name: traceAnalyticsDashboards
-  #   repository: https://github.com/opensearch-project/trace-analytics.git
-  #   ref: main
+  - name: traceAnalyticsDashboards
+    repository: https://github.com/opensearch-project/trace-analytics.git
+    ref: "1.1"
   # - name: ganttChartDashboards
   #   repository: ????????
   #   ref: main


### PR DESCRIPTION
### Description
enable all the non hybrid opensearchDashboard plugins to the build process. there are several remain hybrid plugins need to change the config filename, will be addressed separately.

Test:
verify that these plugin artifacts are generated properly by build process.
 
### Issues Resolved
#680 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
