### PR TITLE
Jenkins misc cleanup

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -1,8 +1,5 @@
 pipeline {
     agent none
-    environment {
-        OPENSEARCH_DASHBOARDS_BUILD_ID = "${BUILD_NUMBER}"
-    }
     triggers {
       parameterizedCron '''
         H */2 * * * %INPUT_MANIFEST=1.1.0/opensearch-dashboards-1.1.0.yml
@@ -88,7 +85,7 @@ void build() {
     sh './assemble.sh artifacts/manifest.yml'
 
     script { manifest = readYaml(file: 'artifacts/manifest.yml') }
-    def artifactPath = "${manifest.build.version}/${OPENSEARCH_DASHBOARDS_BUILD_ID}/${manifest.build.architecture}";
+    def artifactPath = "${manifest.build.version}/${BUILD_NUMBER}/${manifest.build.architecture}";
 
     withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
         s3Upload(file: 'artifacts', bucket: "${ARTIFACT_BUCKET_NAME}", path: "builds/opensearch-dashboards/${artifactPath}")

--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -2,7 +2,6 @@ pipeline {
     agent none
     triggers {
       parameterizedCron '''
-        H */2 * * * %INPUT_MANIFEST=1.1.0/opensearch-1.1.0.yml
         H */2 * * * %INPUT_MANIFEST=1.2.0/opensearch-1.2.0.yml
       '''
     }
@@ -53,7 +52,7 @@ pipeline {
                         }
                     }
                 }
-                stage('build-x86') {
+                stage('build-x64') {
                     agent {
                         docker {
                             label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
@@ -150,7 +149,7 @@ String getAllJenkinsMessages() {
     script {
         // Stages must be explicitly added to prevent overwriting
         // See https://ryan.himmelwright.net/post/jenkins-parallel-stashing/
-        def stages = ['build-x86', 'build-arm64']
+        def stages = ['build-x64', 'build-arm64']
         for (stage in stages) {
             unstash "notifications-${stage}"
         }

--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -1,8 +1,5 @@
 pipeline {
     agent none
-    environment {
-        OPENSEARCH_BUILD_ID = "${BUILD_NUMBER}"
-    }
     triggers {
       parameterizedCron '''
         H */2 * * * %INPUT_MANIFEST=1.1.0/opensearch-1.1.0.yml
@@ -124,7 +121,7 @@ void build() {
     sh './assemble.sh artifacts/manifest.yml'
 
     script { manifest = readYaml(file: 'artifacts/manifest.yml') }
-    def artifactPath = "${manifest.build.version}/${OPENSEARCH_BUILD_ID}/${manifest.build.architecture}";
+    def artifactPath = "${manifest.build.version}/${BUILD_NUMBER}/${manifest.build.architecture}";
 
     withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
         s3Upload(file: 'artifacts', bucket: "${ARTIFACT_BUCKET_NAME}", path: "builds/${artifactPath}")


### PR DESCRIPTION
### Description

- Stop building OpenSearch 1.1.0.
- Rename x86 to x64 in the OpenSearch Jenkins.
- Remove unnecessary ID varaibles.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
