### PR TITLE
Move Workdir after COPY so home dir in dashboards docker image is owned by dashboards user

### DIFF
--- a/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
@@ -62,9 +62,6 @@ ARG UID=1000
 ARG GID=1000
 ARG OPENSEARCH_DASHBOARDS_HOME=/usr/share/opensearch-dashboards
 
-# Setup OpenSearch-dashboards
-WORKDIR $OPENSEARCH_DASHBOARDS_HOME
-
 # Update packages
 # Install the tools we need: tar and gzip to unpack the OpenSearch tarball, and shadow-utils to give us `groupadd` and `useradd`.
 # Install which to allow running of securityadmin.sh
@@ -78,6 +75,9 @@ RUN groupadd -g $GID opensearch-dashboards && \
     adduser -u $UID -g $GID -d $OPENSEARCH_DASHBOARDS_HOME opensearch-dashboards
 
 COPY --from=linux_stage_0 --chown=$UID:$GID $OPENSEARCH_DASHBOARDS_HOME $OPENSEARCH_DASHBOARDS_HOME
+
+# Setup OpenSearch-dashboards
+WORKDIR $OPENSEARCH_DASHBOARDS_HOME
 
 # Change user
 USER $UID


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Move Workdir after COPY so home dir in dashboards docker image is owned by dashboards user
 
### Issues Resolved
#728 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
