### PR TITLE
Support working-directory in integration tests.

### DIFF
--- a/src/test_workflow/bwc_test/bwc_test_suite.py
+++ b/src/test_workflow/bwc_test/bwc_test_suite.py
@@ -24,12 +24,11 @@ class BwcTestSuite:
     def __init__(self, manifest, work_dir, component=None, keep=False):
         self.manifest = manifest
         self.work_dir = work_dir
-        self.script_finder = ScriptFinder()
         self.component = component
         self.keep = keep
 
     def run_tests(self, work_dir, component_name):
-        script = self.script_finder.find_bwc_test_script(
+        script = ScriptFinder.find_bwc_test_script(
             component_name, work_dir
         )
         cmd = f"{script}"

--- a/src/test_workflow/integ_test/integ_test_suite.py
+++ b/src/test_workflow/integ_test/integ_test_suite.py
@@ -42,13 +42,13 @@ class IntegTestSuite:
         self.work_dir = work_dir
         self.test_config = test_config
         self.s3_bucket_name = s3_bucket_name
-        self.script_finder = ScriptFinder()
         self.additional_cluster_config = None
         self.test_recorder = test_recorder
         self.repo = GitRepository(
             self.component.repository,
             self.component.commit_id,
             os.path.join(self.work_dir, self.component.name),
+            test_config.working_directory
         )
         self.save_logs = test_recorder.test_results_logs
 
@@ -115,8 +115,8 @@ class IntegTestSuite:
             )
 
     def __execute_integtest_sh(self, endpoint, port, security, test_config):
-        script = self.script_finder.find_integ_test_script(
-            self.component.name, self.repo.dir
+        script = ScriptFinder.find_integ_test_script(
+            self.component.name, self.repo.working_directory
         )
         if os.path.exists(script):
             cmd = f"{script} -b {endpoint} -p {port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/data/test_manifest.yml
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/data/test_manifest.yml
@@ -31,4 +31,12 @@ components:
       test-configs:
         - with-security
         - without-security
+  - name: dashboards-reports
+    working-directory: reports-scheduler
+    integ-test:
+      test-configs:
+        - with-security
+    bwc-test:
+      test-configs:
+        - with-security
 schema-version: '1.0'


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

1. The schema already specifies a working directory, but it's not used.
2. There's no need to create instances of ScriptFinder since all `find` methods are class methods.
 
### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/632.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
