### PR TITLE
Add distribution type to url and change url location

### DIFF
--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -6,52 +6,50 @@
 
 import os
 from urllib.parse import urljoin
-
 from manifests.bundle_manifest import BundleManifest
-
+from assemble_workflow.public_urls import PublicURLpath
 
 class BundleRecorder:
     def __init__(self, build, output_dir, artifacts_dir):
         self.output_dir = output_dir
         self.build_id = build.id
-        self.public_url = os.getenv("PUBLIC_ARTIFACT_URL", None)
         self.version = build.version
         self.tar_name = self.__get_tar_name(build)
         self.artifacts_dir = artifacts_dir
         self.arch = build.architecture
+        self.urls = PublicURLpath(build).urls_path
         self.bundle_manifest = self.BundleManifestBuilder(
             build.id,
             build.name,
             build.version,
             build.architecture,
-            self.__get_tar_location(),
+            self.__get_tar_location(self.urls["bundles"]),
         )
 
     def __get_tar_name(self, build):
         parts = [build.name.lower().replace(" ", "-"), build.version, "linux", build.architecture]
         return "-".join(parts) + ".tar.gz"
 
-    def __get_public_url_path(self, folder, rel_path):
-        path = "/".join((folder, self.version, self.build_id, self.arch, rel_path))
-        return urljoin(self.public_url + "/", path)
+    def __get_public_url_path(self, url_path, rel_path):
+        return urljoin(url_path + "/", rel_path)
 
-    def __get_location(self, folder_name, rel_path, abs_path):
-        if self.public_url:
-            return self.__get_public_url_path(folder_name, rel_path)
+    def __get_location(self, url_path, rel_path, abs_path):
+        if url_path:
+            return self.__get_public_url_path(url_path, rel_path)
         return abs_path
 
     # Assembled bundles are expected to be served from a separate "bundles" folder
     # Example: https://artifacts.opensearch.org/bundles/1.0.0/<build-id
-    def __get_tar_location(self):
+    def __get_tar_location(self, url_path):
         return self.__get_location(
-            "bundles", self.tar_name, os.path.join(self.output_dir, self.tar_name)
+            url_path, self.tar_name, os.path.join(self.output_dir, self.tar_name)
         )
 
     # Build artifacts are expected to be served from a "builds" folder
     # Example: https://artifacts.opensearch.org/builds/1.0.0/<build-id>
-    def __get_component_location(self, component_rel_path):
+    def __get_component_location(self, component_rel_path, url_path):
         abs_path = os.path.join(self.artifacts_dir, component_rel_path)
-        return self.__get_location("builds", component_rel_path, abs_path)
+        return self.__get_location(url_path, component_rel_path, abs_path)
 
     def record_component(self, component, rel_path):
         self.bundle_manifest.append_component(
@@ -59,7 +57,7 @@ class BundleRecorder:
             component.repository,
             component.ref,
             component.commit_id,
-            self.__get_component_location(rel_path),
+            self.__get_component_location(rel_path, self.urls["builds"]),
         )
 
     def get_manifest(self):

--- a/src/assemble_workflow/public_urls.py
+++ b/src/assemble_workflow/public_urls.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+from urllib.parse import urljoin
+
+class PublicURLpath:
+    def __init__(self, build): 
+        self.public_url = os.getenv("PUBLIC_ARTIFACT_URL", None)
+        self.urls_path = {
+            "bundles": self.get_url(build, self.public_url, "bundles"), 
+            "builds": self.get_url(build, self.public_url, "builds")
+            }
+
+    def get_url (self, build, public_url, folder):
+        if public_url:
+            return "/".join((public_url, build.name.replace(' ', '-').lower(), folder, build.version, build.id, build.architecture))
+        return public_url
+            


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Add distribution build to avoid path collision for OpenSearch and OpenSearch Dashboard. 
Create a new file to process the public_url to use it as a absolute path in `bundle_recorder.py` 
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/669
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
