### PR TITLE
Support -p platform in build scripts.

### DIFF
--- a/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/scripts/components/OpenSearch-Dashboards/build.sh
@@ -11,12 +11,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch Dashboards version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
-    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-p PLATFORM\t[Optional] Platform, default is 'uname -s'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, default is 'uname -m'."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -30,6 +31,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG
@@ -53,17 +57,19 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
+[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 # Assemble distribution artifact
 # see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
 case $ARCHITECTURE in
     x64)
-        TARGET="--linux"
-        QUALIFIER="linux-x64"
+        TARGET="--$PLATFORM"
+        QUALIFIER="$PLATFORM-x64"
         ;;
     arm64)
-        TARGET="--linux-arm"
-        QUALIFIER="linux-arm64"
+        TARGET="--$PLATFORM-arm"
+        QUALIFIER="$PLATFORM-arm64"
         ;;
     *)
         echo "Unsupported architecture: ${ARCHITECTURE}"

--- a/scripts/components/OpenSearch/build.sh
+++ b/scripts/components/OpenSearch/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
-    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-p PLATFORM\t[Optional] Platform, default is 'uname -s'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, default is 'uname -m'."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG
@@ -68,16 +72,19 @@ mkdir -p $OUTPUT/maven/org/opensearch
 # Copy maven publications to be promoted
 cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org
 
+[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
+
 # Assemble distribution artifact
 # see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
 case $ARCHITECTURE in
     x64)
-        TARGET="linux-tar"
-        QUALIFIER="linux-x64"
+        TARGET="$PLATFORM-tar"
+        QUALIFIER="$PLATFORM-x64"
         ;;
     arm64)
-        TARGET="linux-arm64-tar"
-        QUALIFIER="linux-arm64"
+        TARGET="$PLATFORM-arm64-tar"
+        QUALIFIER="$PLATFORM-arm64"
         ;;
     *)
         echo "Unsupported architecture: ${ARCHITECTURE}"

--- a/scripts/components/alerting/build.sh
+++ b/scripts/components/alerting/build.sh
@@ -54,24 +54,25 @@ while getopts ":h:v:s:o:p:a:" arg; do
 done
 
 if [ -z "$VERSION" ]; then
-    echo "Error: You must specify the OpenSearch Dashboards version"
+    echo "Error: You must specify the OpenSearch version"
     usage
     exit 1
 fi
 
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
 mkdir -p $OUTPUT/plugins
-# For hybrid plugin it actually resides in 'ganttChartDashboards/gantt-chart'
-PLUGIN_FOLDER=$(basename "$PWD")
-PLUGIN_NAME=$(basename $(dirname "$PWD"))
-# TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
-# This makes it so there is a dependency on having Dashboards pulled already.
-cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
-echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
-echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build)
-echo "COPY $PLUGIN_NAME.zip"
-cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/
-rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x ktlint
+
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+
+echo "COPY ${distributions}/*.zip"
+cp ${distributions}/*.zip ./$OUTPUT/plugins
+
+./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x ktlint
+
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./notification/build/libs $OUTPUT/maven/org/opensearch/notification

--- a/scripts/components/job-scheduler/build.sh
+++ b/scripts/components/job-scheduler/build.sh
@@ -54,24 +54,19 @@ while getopts ":h:v:s:o:p:a:" arg; do
 done
 
 if [ -z "$VERSION" ]; then
-    echo "Error: You must specify the OpenSearch Dashboards version"
+    echo "Error: You must specify the OpenSearch version"
     usage
     exit 1
 fi
 
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
+./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./spi/build/distributions/* $OUTPUT/maven/org/opensearch
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
 mkdir -p $OUTPUT/plugins
-# For hybrid plugin it actually resides in 'ganttChartDashboards/gantt-chart'
-PLUGIN_FOLDER=$(basename "$PWD")
-PLUGIN_NAME=$(basename $(dirname "$PWD"))
-# TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
-# This makes it so there is a dependency on having Dashboards pulled already.
-cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
-echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
-echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build)
-echo "COPY $PLUGIN_NAME.zip"
-cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/
-rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER
+cp ./build/distributions/*.zip $OUTPUT/plugins

--- a/scripts/components/k-NN/build.sh
+++ b/scripts/components/k-NN/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/scripts/components/k-NN/build.sh
+++ b/scripts/components/k-NN/build.sh
@@ -83,6 +83,11 @@ if [ "$ARCHITECTURE" = "arm64" ]; then
     sed -i -e 's/-march=native/-march=armv8-a/g' external/nmslib/similarity_search/CMakeLists.txt
 fi
 
+if [ "$JAVA_HOME" = "" ]; then
+    export JAVA_HOME=`/usr/libexec/java_home`
+    echo "SET JAVA_HOME=$JAVA_HOME"
+fi
+
 cmake .
 make
 

--- a/scripts/components/notebooksDashboards/build.sh
+++ b/scripts/components/notebooksDashboards/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:d:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:d:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/scripts/components/notifications/build.sh
+++ b/scripts/components/notifications/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/scripts/components/notificationsDashboards/build.sh
+++ b/scripts/components/notificationsDashboards/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:d:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:d:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/scripts/components/performance-analyzer-rca/build.sh
+++ b/scripts/components/performance-analyzer-rca/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/scripts/components/performance-analyzer/build.sh
+++ b/scripts/components/performance-analyzer/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/scripts/components/queryWorkbenchDashboards/build.sh
+++ b/scripts/components/queryWorkbenchDashboards/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:d:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:d:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/scripts/components/reportsDashboards/build.sh
+++ b/scripts/components/reportsDashboards/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:d:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:d:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/scripts/components/security/build.sh
+++ b/scripts/components/security/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -14,12 +14,13 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:d:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -33,6 +34,9 @@ while getopts ":h:v:s:o:a:d:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/scripts/default/opensearch/build.sh
+++ b/scripts/default/opensearch/build.sh
@@ -14,13 +14,14 @@ function usage() {
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
     echo -e "-d DASHBOARDS\t[Optional] Build OpenSearch Dashboards, default is 'false'."
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:a:" arg; do
+while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -34,6 +35,9 @@ while getopts ":h:v:s:o:a:" arg; do
             ;;
         o)
             OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
             ;;
         a)
             ARCHITECTURE=$OPTARG

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -7,13 +7,14 @@
 import os
 import uuid
 
-from system.arch import current_arch
+from system.os import current_arch, current_platform
 
 
 class BuildTarget:
     build_id: str
     name: str
     version: str
+    platform: str
     arch: str
     snapshot: bool
     output_dir: str
@@ -21,17 +22,19 @@ class BuildTarget:
     def __init__(
         self,
         version,
+        platform=None,
         arch=None,
         name=None,
         snapshot=True,
         build_id=None,
         output_dir="artifacts",
     ):
-        self.build_id = os.getenv("OPENSEARCH_BUILD_ID") or os.getenv("OPENSEARCH_DASHBOARDS_BUILD_ID") or build_id or uuid.uuid4().hex
+        self.build_id = os.getenv("BUILD_NUMBER") or build_id or uuid.uuid4().hex
         self.name = name
         self.version = version
         self.snapshot = snapshot
         self.arch = arch or current_arch()
+        self.platform = platform or current_platform()
         self.output_dir = output_dir
 
     @property

--- a/src/build_workflow/builder.py
+++ b/src/build_workflow/builder.py
@@ -36,7 +36,21 @@ class Builder:
         build_script = ScriptFinder.find_build_script(
             target.name, self.component_name, self.git_repo.working_directory
         )
-        build_command = f"{build_script} -v {target.version} -a {target.arch} -s {str(target.snapshot).lower()} -o {self.output_path}"
+        build_command = " ".join(
+            [
+                build_script,
+                "-v",
+                target.version,
+                "-p",
+                target.platform,
+                "-a",
+                target.arch,
+                "-s",
+                str(target.snapshot).lower(),
+                "-o",
+                self.output_path,
+            ]
+        )
         self.git_repo.execute(build_command)
         self.build_recorder.record_component(self.component_name, self.git_repo)
 

--- a/src/paths/script_finder.py
+++ b/src/paths/script_finder.py
@@ -31,9 +31,9 @@ class ScriptFinder:
 
     For build.sh and integtest.sh scripts, given a component name and a checked-out Git repository,
     it will look in the following locations, in order:
-      * Root of the Git repository
-      * /scripts/<script-name> in the Git repository
       * <component_scripts_path>/<component_name>/<script-name>
+      * root of the component's Git repository
+      * /scripts/<script-name> in the component's Git repository
       * <default_scripts_path>/<script-name>
 
     For install.sh scripts, given a component name, it will look in the following locations, in order:
@@ -51,11 +51,11 @@ class ScriptFinder:
     @classmethod
     def find_build_script(cls, project, component_name, git_dir):
         paths = [
-            os.path.realpath(os.path.join(git_dir, "build.sh")),
-            os.path.realpath(os.path.join(git_dir, "scripts/build.sh")),
             os.path.realpath(
                 os.path.join(cls.component_scripts_path, component_name, "build.sh")
             ),
+            os.path.realpath(os.path.join(git_dir, "build.sh")),
+            os.path.realpath(os.path.join(git_dir, "scripts/build.sh")),
             os.path.realpath(
                 os.path.join(
                     cls.default_scripts_path,
@@ -70,11 +70,11 @@ class ScriptFinder:
     @classmethod
     def find_integ_test_script(cls, component_name, git_dir):
         paths = [
-            os.path.realpath(os.path.join(git_dir, "integtest.sh")),
-            os.path.realpath(os.path.join(git_dir, "scripts/integtest.sh")),
             os.path.realpath(
                 os.path.join(cls.component_scripts_path, component_name, "integtest.sh")
             ),
+            os.path.realpath(os.path.join(git_dir, "integtest.sh")),
+            os.path.realpath(os.path.join(git_dir, "scripts/integtest.sh")),
             os.path.realpath(os.path.join(cls.default_scripts_path, "integtest.sh")),
         ]
 

--- a/src/system/os.py
+++ b/src/system/os.py
@@ -15,3 +15,7 @@ def current_arch():
         return "arm64"
     else:
         raise ValueError(f"Unsupported architecture: {arch}")
+
+
+def current_platform():
+    return subprocess.check_output(["uname", "-s"]).decode().strip().lower()

--- a/tests/tests_build_workflow/test_build_target.py
+++ b/tests/tests_build_workflow/test_build_target.py
@@ -20,12 +20,8 @@ class TestBuildTarget(unittest.TestCase):
     def test_build_id_hex(self):
         self.assertEqual(len(BuildTarget(version="1.1.0", arch="x86").build_id), 32)
 
-    @patch.dict(os.environ, {"OPENSEARCH_BUILD_ID": "id"})
+    @patch.dict(os.environ, {"BUILD_NUMBER": "id"})
     def test_build_id_from_env(self):
-        self.assertEqual(BuildTarget(version="1.1.0", arch="x86").build_id, "id")
-
-    @patch.dict(os.environ, {"OPENSEARCH_DASHBOARDS_BUILD_ID": "id"})
-    def test_build_id_from_dashboards_env(self):
         self.assertEqual(BuildTarget(version="1.1.0", arch="x86").build_id, "id")
 
     def test_build_id_from_arg(self):

--- a/tests/tests_build_workflow/test_builder.py
+++ b/tests/tests_build_workflow/test_builder.py
@@ -25,14 +25,25 @@ class TestBuilder(unittest.TestCase):
         self.assertEqual(self.builder.component_name, "component")
 
     def test_build(self):
-        self.builder.build(BuildTarget(name="OpenSearch", version="1.0.0", arch="x64", snapshot=False))
+        self.builder.build(
+            BuildTarget(
+                name="OpenSearch",
+                version="1.0.0",
+                platform="linux",
+                arch="x64",
+                snapshot=False,
+            )
+        )
         self.builder.git_repo.execute.assert_called_with(
             " ".join(
                 [
                     os.path.realpath(
-                        os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")
+                        os.path.join(
+                            ScriptFinder.default_scripts_path, "opensearch", "build.sh"
+                        )
                     ),
                     "-v 1.0.0",
+                    "-p linux",
                     "-a x64",
                     "-s false",
                     "-o artifacts",
@@ -44,14 +55,25 @@ class TestBuilder(unittest.TestCase):
         )
 
     def test_build_snapshot(self):
-        self.builder.build(BuildTarget(name="OpenSearch", version="1.0.0", arch="x64", snapshot=True))
+        self.builder.build(
+            BuildTarget(
+                name="OpenSearch",
+                version="1.0.0",
+                platform="darwin",
+                arch="x64",
+                snapshot=True,
+            )
+        )
         self.builder.git_repo.execute.assert_called_with(
             " ".join(
                 [
                     os.path.realpath(
-                        os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")
+                        os.path.join(
+                            ScriptFinder.default_scripts_path, "opensearch", "build.sh"
+                        )
                     ),
                     "-v 1.0.0",
+                    "-p darwin",
                     "-a x64",
                     "-s true",
                     "-o artifacts",
@@ -75,17 +97,23 @@ class TestBuilder(unittest.TestCase):
         mock_walk.side_effect = self.mock_os_walk
         self.builder.export_artifacts()
         self.assertEqual(self.builder.build_recorder.record_artifact.call_count, 2)
-        self.builder.build_recorder.record_artifact.assert_has_calls([
-            call(
-                "component",
-                "maven",
-                os.path.relpath("/maven/artifact1.jar", self.builder.artifacts_path),
-                "/maven/artifact1.jar",
-            ),
-            call(
-                "component",
-                "core-plugins",
-                os.path.relpath("/core-plugins/plugin1.zip", self.builder.artifacts_path),
-                "/core-plugins/plugin1.zip",
-            ),
-        ])
+        self.builder.build_recorder.record_artifact.assert_has_calls(
+            [
+                call(
+                    "component",
+                    "maven",
+                    os.path.relpath(
+                        "/maven/artifact1.jar", self.builder.artifacts_path
+                    ),
+                    "/maven/artifact1.jar",
+                ),
+                call(
+                    "component",
+                    "core-plugins",
+                    os.path.relpath(
+                        "/core-plugins/plugin1.zip", self.builder.artifacts_path
+                    ),
+                    "/core-plugins/plugin1.zip",
+                ),
+            ]
+        )

--- a/tests/tests_paths/test_script_finder.py
+++ b/tests/tests_paths/test_script_finder.py
@@ -63,7 +63,7 @@ class TestScriptFinder(unittest.TestCase):
         self.assertEqual(
             os.path.join(self.component_with_scripts, "build.sh"),
             ScriptFinder.find_build_script(
-                "OpenSearch", "OpenSearch", self.component_with_scripts
+                "OpenSearch", "foobar", self.component_with_scripts
             ),
             msg="A component with a script resolves to the script at the root.",
         )
@@ -72,9 +72,18 @@ class TestScriptFinder(unittest.TestCase):
         self.assertEqual(
             os.path.join(self.component_with_scripts_folder, "scripts/build.sh"),
             ScriptFinder.find_build_script(
-                "OpenSearch", "OpenSearch", self.component_with_scripts_folder
+                "OpenSearch", "foobar", self.component_with_scripts_folder
             ),
             msg="A component with a scripts folder resolves to a script in that folder.",
+        )
+
+    def test_find_build_script_component_script_in_folder_with_default(self):
+        self.assertEqual(
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/build.sh"),
+            ScriptFinder.find_build_script(
+                "OpenSearch", "OpenSearch", self.component_with_scripts_folder
+            ),
+            msg="A component with a scripts folder resolves to the override.",
         )
 
     @patch("os.path.exists", return_value=False)
@@ -111,7 +120,9 @@ class TestScriptFinder(unittest.TestCase):
 
     def test_find_integ_test_script_component_script(self):
         self.assertEqual(
-            os.path.join(self.component_with_scripts, "integtest.sh"),
+            os.path.join(
+                ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"
+            ),
             ScriptFinder.find_integ_test_script(
                 "OpenSearch", self.component_with_scripts
             ),
@@ -121,6 +132,17 @@ class TestScriptFinder(unittest.TestCase):
     def test_find_integ_test_script_component_script_in_folder(self):
         self.assertEqual(
             os.path.join(self.component_with_scripts_folder, "scripts/integtest.sh"),
+            ScriptFinder.find_integ_test_script(
+                "foobar", self.component_with_scripts_folder
+            ),
+            msg="A component with a scripts folder resolves to an override.",
+        )
+
+    def test_find_integ_test_script_component_script_in_folder_with_default(self):
+        self.assertEqual(
+            os.path.join(
+                ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"
+            ),
             ScriptFinder.find_integ_test_script(
                 "OpenSearch", self.component_with_scripts_folder
             ),

--- a/tests/tests_system/test_os.py
+++ b/tests/tests_system/test_os.py
@@ -8,10 +8,11 @@ import subprocess
 import unittest
 from unittest.mock import patch
 
-from system.arch import current_arch
+from system.os import current_arch, current_platform
 
 
-class TestArch(unittest.TestCase):
+class TestOs(unittest.TestCase):
+    # current_arch
     def test_current_arch(self):
         self.assertTrue(current_arch() in ["x64", "arm64"])
 
@@ -37,3 +38,11 @@ class TestArch(unittest.TestCase):
     def test_subprocess_call(self, mock_subprocess):
         current_arch()
         subprocess.check_output.assert_called_with(["uname", "-m"])
+
+    # current_platform
+    def test_current_platform(self):
+        self.assertTrue(current_platform() in ["linux", "darwin"])
+
+    @patch("subprocess.check_output", return_value="Xyz".encode())
+    def test_current_platform_lowercase(self, mock_subprocess):
+        self.assertTrue(current_platform() == "xyz")


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Support for #740, adds `-p platform` to build scripts so we can pass `linux` or `darwin` around and default it to `uname -s`. This required re-overwriting common-utils, job-scheduler and alerting scripts. 

ScriptFinder is incorrectly picking the override from the repo with source code. The build repo should be the one always picked first because that's where we'd make a last minute fix, updated. 

Auto-resolving JAVA_HOME on MacOS.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
