### PR TITLE
Added platform to manifests.

### DIFF
--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -23,12 +23,18 @@ class BundleRecorder:
             build.id,
             build.name,
             build.version,
+            build.platform,
             build.architecture,
             self.__get_tar_location(),
         )
 
     def __get_tar_name(self, build):
-        parts = [build.name.lower().replace(" ", "-"), build.version, "linux", build.architecture]
+        parts = [
+            build.name.lower().replace(" ", "-"),
+            build.version,
+            build.platform,
+            build.architecture,
+        ]
         return "-".join(parts) + ".tar.gz"
 
     def __get_public_url_path(self, folder, rel_path):
@@ -70,15 +76,16 @@ class BundleRecorder:
         self.get_manifest().to_file(manifest_path)
 
     class BundleManifestBuilder:
-        def __init__(self, build_id, name, version, arch, location):
+        def __init__(self, build_id, name, version, platform, arch, location):
             self.data = {}
             self.data["build"] = {}
             self.data["build"]["id"] = build_id
             self.data["build"]["name"] = name
             self.data["build"]["version"] = str(version)
+            self.data["build"]["platform"] = platform
             self.data["build"]["architecture"] = arch
             self.data["build"]["location"] = location
-            self.data["schema-version"] = "1.0"
+            self.data["schema-version"] = "1.1"
             # We need to store components as a hash so that we can append artifacts by component name
             # When we convert to a BundleManifest this will get converted back into a list
             self.data["components"] = []

--- a/src/build_workflow/build_recorder.py
+++ b/src/build_workflow/build_recorder.py
@@ -61,8 +61,9 @@ class BuildRecorder:
             self.data["build"]["id"] = target.build_id
             self.data["build"]["name"] = target.name
             self.data["build"]["version"] = target.opensearch_version
+            self.data["build"]["platform"] = target.platform
             self.data["build"]["architecture"] = target.arch
-            self.data["schema-version"] = "1.1"
+            self.data["schema-version"] = "1.2"
             self.components_hash = {}
 
         def append_component(self, name, version, repository_url, ref, commit_id):

--- a/src/manifests/bundle_manifest.py
+++ b/src/manifests/bundle_manifest.py
@@ -16,11 +16,12 @@ class BundleManifest(Manifest):
     The manifest contains information about the bundle that was built (in the `assemble` section),
     and the components that made up the bundle in the `components` section.
 
-    The format for schema version 1.0 is:
-        schema-version: "1.0"
+    The format for schema version 1.1 is:
+        schema-version: "1.1"
         build:
           name: string
           version: string
+          platform: linux or darwin
           architecture: x64 or arm64
           location: /relative/path/to/tarball
         components:
@@ -36,6 +37,7 @@ class BundleManifest(Manifest):
             "required": True,
             "type": "dict",
             "schema": {
+                "platform": {"required": True, "type": "string"},
                 "architecture": {"required": True, "type": "string"},
                 "id": {"required": True, "type": "string"},
                 "location": {"required": True, "type": "string"},
@@ -43,7 +45,7 @@ class BundleManifest(Manifest):
                 "version": {"required": True, "type": "string"},
             },
         },
-        "schema-version": {"required": True, "type": "string", "allowed": ["1.0"]},
+        "schema-version": {"required": True, "type": "string", "allowed": ["1.1"]},
         "components": {
             "required": True,
             "type": "list",
@@ -69,7 +71,7 @@ class BundleManifest(Manifest):
 
     def __to_dict__(self):
         return {
-            "schema-version": "1.0",
+            "schema-version": "1.1",
             "build": self.build.__to_dict__(),
             "components": list(
                 map(lambda component: component.__to_dict__(), self.components)
@@ -77,34 +79,43 @@ class BundleManifest(Manifest):
         }
 
     @staticmethod
-    def from_s3(bucket_name, build_id, opensearch_version, architecture, work_dir=None):
+    def from_s3(
+        bucket_name, build_id, opensearch_version, platform, architecture, work_dir=None
+    ):
         work_dir = work_dir if not None else str(os.getcwd())
         manifest_s3_path = BundleManifest.get_bundle_manifest_relative_location(
-            build_id, opensearch_version, architecture
+            build_id, opensearch_version, platform, architecture
         )
         S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
-        bundle_manifest = BundleManifest.from_path(os.path.join(work_dir, 'manifest.yml'))
+        bundle_manifest = BundleManifest.from_path(
+            os.path.join(work_dir, "manifest.yml")
+        )
         os.remove(os.path.realpath(os.path.join(work_dir, "manifest.yml")))
         return bundle_manifest
 
     @staticmethod
-    def get_tarball_relative_location(build_id, opensearch_version, architecture):
-        return f"bundles/{opensearch_version}/{build_id}/{architecture}/opensearch-{opensearch_version}-linux-{architecture}.tar.gz"
+    def get_tarball_relative_location(
+        build_id, opensearch_version, platform, architecture
+    ):
+        # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
+        return f"bundles/{opensearch_version}/{build_id}/{architecture}/opensearch-{opensearch_version}-{platform}-{architecture}.tar.gz"
 
     @staticmethod
-    def get_tarball_name(opensearch_version, architecture):
-        return f"opensearch-{opensearch_version}-linux-{architecture}.tar.gz"
+    def get_tarball_name(opensearch_version, platform, architecture):
+        return f"opensearch-{opensearch_version}-{platform}-{architecture}.tar.gz"
 
     @staticmethod
     def get_bundle_manifest_relative_location(
-        build_id, opensearch_version, architecture
+        build_id, opensearch_version, platform, architecture
     ):
+        # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
         return f"bundles/{opensearch_version}/{build_id}/{architecture}/manifest.yml"
 
     class Build:
         def __init__(self, data):
             self.name = data["name"]
             self.version = data["version"]
+            self.platform = data["platform"]
             self.architecture = data["architecture"]
             self.location = data["location"]
             self.id = data["id"]
@@ -113,6 +124,7 @@ class BundleManifest(Manifest):
             return {
                 "name": self.name,
                 "version": self.version,
+                "platform": self.platform,
                 "architecture": self.architecture,
                 "location": self.location,
                 "id": self.id,

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -55,7 +55,7 @@ def main():
 
     with tempfile.TemporaryDirectory() as work_dir:
         logging.info(
-            f"Bundling {build.name} ({build.architecture}) into {output_dir} ..."
+            f"Bundling {build.name} ({build.architecture}) on {build.platform} into {output_dir} ..."
         )
 
         os.chdir(work_dir)

--- a/src/run_integ_test.py
+++ b/src/run_integ_test.py
@@ -34,7 +34,9 @@ def pull_build_repo(work_dir):
 def main():
     args = TestArgs()
     console.configure(level=args.logging_level)
-    test_manifest_path = os.path.join(os.path.dirname(__file__), 'test_workflow/config/test_manifest.yml')
+    test_manifest_path = os.path.join(
+        os.path.dirname(__file__), "test_workflow/config/test_manifest.yml"
+    )
     test_manifest = TestManifest.from_path(test_manifest_path)
     integ_test_config = dict()
     for component in test_manifest.components:
@@ -45,9 +47,21 @@ def main():
         test_recorder = TestRecorder(args.test_run_id, "integ-test", work_dir)
         os.chdir(work_dir)
         bundle_manifest = BundleManifest.from_s3(
-            args.s3_bucket, args.build_id, args.opensearch_version, args.architecture, work_dir)
+            args.s3_bucket,
+            args.build_id,
+            args.opensearch_version,
+            args.platform,
+            args.architecture,
+            work_dir,
+        )
         build_manifest = BuildManifest.from_s3(
-            args.s3_bucket, args.build_id, args.opensearch_version, args.architecture, work_dir)
+            args.s3_bucket,
+            args.build_id,
+            args.opensearch_version,
+            args.platform,
+            args.architecture,
+            work_dir,
+        )
         pull_build_repo(work_dir)
         DependencyInstaller(build_manifest.build).install_all_maven_dependencies()
         all_results = TestSuiteResults()
@@ -60,7 +74,7 @@ def main():
                     build_manifest,
                     work_dir,
                     args.s3_bucket,
-                    test_recorder
+                    test_recorder,
                 )
                 test_results = test_suite.execute()
                 all_results.append(component.name, test_results)

--- a/src/test_workflow/dependency_installer.py
+++ b/src/test_workflow/dependency_installer.py
@@ -20,14 +20,11 @@ class DependencyInstaller:
     def __init__(self, build):
         self.build_id = build.id
         self.version = build.version
-        self.arch = build.architecture
+        self.platform = build.platform
+        self.architecture = build.architecture
         self.s3_bucket = S3Bucket(self.ARTIFACT_S3_BUCKET)
-        self.s3_maven_location = (
-            f"builds/{self.version}/{self.build_id}/{self.arch}/maven/org/opensearch"
-        )
-        self.s3_build_location = (
-            f"builds/{self.version}/{self.build_id}/{self.arch}/plugins"
-        )
+        self.s3_maven_location = f"builds/{self.version}/{self.build_id}/{self.platform}/{self.architecture}/maven/org/opensearch"
+        self.s3_build_location = f"builds/{self.version}/{self.build_id}/{self.platform}/{self.architecture}/plugins"
         self.maven_local_path = os.path.join(
             os.path.expanduser("~"), ".m2/repository/org/opensearch/"
         )

--- a/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/src/test_workflow/perf_test/perf_test_cluster.py
@@ -10,54 +10,60 @@ class PerfTestCluster(TestCluster):
     """
     Represents a performance test cluster. This class deploys the opensearch bundle with CDK and returns the private IP.
     """
-    def __init__(self, bundle_manifest, config, stack_name, security, current_workspace):
+
+    def __init__(
+        self, bundle_manifest, config, stack_name, security, current_workspace
+    ):
         self.manifest = bundle_manifest
-        self.work_dir = 'opensearch-cluster/cdk/single-node/'
+        self.work_dir = "opensearch-cluster/cdk/single-node/"
         self.current_workspace = current_workspace
         self.stack_name = stack_name
         self.cluster_endpoint = None
         self.cluster_port = None
-        self.output_file = 'output.json'
+        self.output_file = "output.json"
         self.ip_address = None
-        self.security = 'enable' if security else 'disable'
-        role = config['Constants']['Role']
+        self.security = "enable" if security else "disable"
+        role = config["Constants"]["Role"]
         params_dict = {
-            'url': self.manifest.build.location,
-            'security_group_id': config['Constants']['SecurityGroupId'],
-            'vpc_id': config['Constants']['VpcId'],
-            'account_id': config['Constants']['AccountId'],
-            'region': config['Constants']['Region'],
-            'stack_name': self.stack_name,
-            'security': self.security,
-            'architecture': self.manifest.build.architecture,
+            "url": self.manifest.build.location,
+            "security_group_id": config["Constants"]["SecurityGroupId"],
+            "vpc_id": config["Constants"]["VpcId"],
+            "account_id": config["Constants"]["AccountId"],
+            "region": config["Constants"]["Region"],
+            "stack_name": self.stack_name,
+            "security": self.security,
+            "platform": self.manifest.build.platform,
+            "architecture": self.manifest.build.architecture,
         }
         params_list = []
         for key, value in params_dict.items():
-            params_list.append(f' -c {key}={value}')
-        role_params = f' --require-approval=never --plugin cdk-assume-role-credential-plugin'\
-                      f' -c assume-role-credentials:writeIamRoleName={role} -c assume-role-credentials:readIamRoleName={role} '
-        self.params = ''.join(params_list) + role_params
+            params_list.append(f" -c {key}={value}")
+        role_params = (
+            f" --require-approval=never --plugin cdk-assume-role-credential-plugin"
+            f" -c assume-role-credentials:writeIamRoleName={role} -c assume-role-credentials:readIamRoleName={role} "
+        )
+        self.params = "".join(params_list) + role_params
 
     def create_cluster(self):
         os.chdir(self.work_dir)
-        command = f'cdk deploy {self.params} --outputs-file {self.output_file}'
+        command = f"cdk deploy {self.params} --outputs-file {self.output_file}"
         logging.info(f'Executing "{command}" in {os.getcwd()}')
         subprocess.check_call(command, cwd=os.getcwd(), shell=True)
-        with open(self.output_file, 'r') as read_file:
+        with open(self.output_file, "r") as read_file:
             load_output = json.load(read_file)
-        self.ip_address = load_output[self.stack_name]['PrivateIp']
-        logging.info('Private IP:', self.ip_address)
+        self.ip_address = load_output[self.stack_name]["PrivateIp"]
+        logging.info("Private IP:", self.ip_address)
 
     def endpoint(self):
         self.cluster_endpoint = self.ip_address
         return self.cluster_endpoint
 
     def port(self):
-        self.cluster_port = 443 if self.security == 'enable' else 9200
+        self.cluster_port = 443 if self.security == "enable" else 9200
         return self.cluster_port
 
     def destroy(self):
         os.chdir(os.path.join(self.current_workspace, self.work_dir))
-        command = f'cdk destroy {self.params} --force'
+        command = f"cdk destroy {self.params} --force"
         logging.info(f'Executing "{command}" in {os.getcwd()}')
         subprocess.check_call(command, cwd=os.getcwd(), shell=True)

--- a/src/test_workflow/test_args.py
+++ b/src/test_workflow/test_args.py
@@ -23,6 +23,7 @@ class TestArgs:
     s3_bucket: str
     opensearch_version: str
     build_id: int
+    platform: str
     architecture: str
     test_run_id: int
     component: str
@@ -45,6 +46,13 @@ class TestArgs:
             "--build-id",
             type=int,
             help="The build id for the built artifact",
+            required=True,
+        )
+        parser.add_argument(
+            "--platform",
+            type=str,
+            choices=["linux", "darwin"],
+            help="The os name e.g. linux, darwin",
             required=True,
         )
         parser.add_argument(
@@ -80,6 +88,7 @@ class TestArgs:
         self.s3_bucket = args.s3_bucket
         self.opensearch_version = args.opensearch_version
         self.build_id = args.build_id
+        self.platform = args.platform
         self.architecture = args.architecture
         self.test_run_id = args.test_run_id
         self.component = args.component

--- a/tests/data/opensearch-build-1.1.0.yml
+++ b/tests/data/opensearch-build-1.1.0.yml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: c3ff7a232d25403fa8cc14c97799c323
   name: OpenSearch
@@ -2480,4 +2481,4 @@ components:
   ref: main
   repository: https://github.com/opensearch-project/dashboards-notebooks.git
   version: 1.1.0.0
-schema-version: '1.1'
+schema-version: '1.2'

--- a/tests/tests_assemble_workflow/data/opensearch-build-1.1.0.yml
+++ b/tests/tests_assemble_workflow/data/opensearch-build-1.1.0.yml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: c3ff7a232d25403fa8cc14c97799c323
   name: OpenSearch
@@ -2480,4 +2481,4 @@ components:
   ref: main
   repository: https://github.com/opensearch-project/dashboards-notebooks.git
   version: 1.1.0.0
-schema-version: '1.1'
+schema-version: '1.2'

--- a/tests/tests_assemble_workflow/data/opensearch-dashboards-build-1.1.0.yml
+++ b/tests/tests_assemble_workflow/data/opensearch-dashboards-build-1.1.0.yml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: c94ebec444a94ada86a230c9297b1d73
   name: OpenSearch Dashboards
@@ -20,4 +21,4 @@ components:
   ref: main
   repository: https://github.com/opensearch-project/alerting-dashboards-plugin
   version: 1.1.0.0
-schema-version: '1.1'
+schema-version: '1.2'

--- a/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -43,6 +43,7 @@ class TestBundleRecorder(unittest.TestCase):
             self.bundle_recorder.get_manifest().to_dict(),
             {
                 "build": {
+                    "platform": "linux",
                     "architecture": "x64",
                     "id": "c3ff7a232d25403fa8cc14c97799c323",
                     "location": "output_dir/opensearch-1.1.0-linux-x64.tar.gz",
@@ -58,7 +59,7 @@ class TestBundleRecorder(unittest.TestCase):
                         "repository": "https://github.com/opensearch-project/job_scheduler",
                     }
                 ],
-                "schema-version": "1.0",
+                "schema-version": "1.1",
             },
         )
 
@@ -69,13 +70,14 @@ class TestBundleRecorder(unittest.TestCase):
             manifest.to_dict(),
             {
                 "build": {
+                    "platform": "linux",
                     "architecture": "x64",
                     "id": "c3ff7a232d25403fa8cc14c97799c323",
                     "location": "output_dir/opensearch-1.1.0-linux-x64.tar.gz",
                     "name": "OpenSearch",
                     "version": "1.1.0",
                 },
-                "schema-version": "1.0",
+                "schema-version": "1.1",
             },
         )
 
@@ -89,7 +91,7 @@ class TestBundleRecorder(unittest.TestCase):
                 self.assertEqual(yaml.safe_load(f), data)
 
     def test_record_component_public(self):
-        self.bundle_recorder.public_url = 'https://ci.opensearch.org/ci/os-distro-prod'
+        self.bundle_recorder.public_url = "https://ci.opensearch.org/ci/os-distro-prod"
         component = BuildManifest.Component(
             {
                 "name": "job_scheduler",
@@ -106,6 +108,7 @@ class TestBundleRecorder(unittest.TestCase):
             self.bundle_recorder.get_manifest().to_dict(),
             {
                 "build": {
+                    "platform": "linux",
                     "architecture": "x64",
                     "id": "c3ff7a232d25403fa8cc14c97799c323",
                     "location": "output_dir/opensearch-1.1.0-linux-x64.tar.gz",
@@ -121,32 +124,36 @@ class TestBundleRecorder(unittest.TestCase):
                         "repository": "https://github.com/opensearch-project/job_scheduler",
                     }
                 ],
-                "schema-version": "1.0",
+                "schema-version": "1.1",
             },
         )
 
     def test_get_location_scenarios(self):
         def get_location(public_url):
             self.bundle_recorder.public_url = public_url
-            return self.bundle_recorder._BundleRecorder__get_location("builds", "dir1/dir2/file", "/tmp/builds/foo/dir1/dir2/file")
+            return self.bundle_recorder._BundleRecorder__get_location(
+                "builds", "dir1/dir2/file", "/tmp/builds/foo/dir1/dir2/file"
+            )
 
         # No public URL - Fallback to ABS Path
         self.assertEqual(get_location(None), "/tmp/builds/foo/dir1/dir2/file")
 
         # Public URL - No trailing slash
         self.assertEqual(
-            get_location('https://ci.opensearch.org/ci/os-distro-prod'),
-            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/x64/dir1/dir2/file"
+            get_location("https://ci.opensearch.org/ci/os-distro-prod"),
+            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/x64/dir1/dir2/file",
         )
 
         # Public URL - Trailing slash
         self.assertEqual(
-            get_location('https://ci.opensearch.org/ci/os-distro-prod/'),
-            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/x64/dir1/dir2/file"
+            get_location("https://ci.opensearch.org/ci/os-distro-prod/"),
+            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c3ff7a232d25403fa8cc14c97799c323/x64/dir1/dir2/file",
         )
 
     def test_tar_name(self):
-        self.assertEqual(self.bundle_recorder.tar_name, "opensearch-1.1.0-linux-x64.tar.gz")
+        self.assertEqual(
+            self.bundle_recorder.tar_name, "opensearch-1.1.0-linux-x64.tar.gz"
+        )
 
 
 class TestBundleRecorderDashboards(unittest.TestCase):
@@ -176,6 +183,7 @@ class TestBundleRecorderDashboards(unittest.TestCase):
             self.bundle_recorder.get_manifest().to_dict(),
             {
                 "build": {
+                    "platform": "linux",
                     "architecture": "x64",
                     "id": "c94ebec444a94ada86a230c9297b1d73",
                     "location": "output_dir/opensearch-dashboards-1.1.0-linux-x64.tar.gz",
@@ -191,7 +199,7 @@ class TestBundleRecorderDashboards(unittest.TestCase):
                         "repository": "https://github.com/opensearch-project/alerting-dashboards-plugin",
                     }
                 ],
-                "schema-version": "1.0",
+                "schema-version": "1.1",
             },
         )
 
@@ -202,13 +210,14 @@ class TestBundleRecorderDashboards(unittest.TestCase):
             manifest.to_dict(),
             {
                 "build": {
+                    "platform": "linux",
                     "architecture": "x64",
                     "id": "c94ebec444a94ada86a230c9297b1d73",
                     "location": "output_dir/opensearch-dashboards-1.1.0-linux-x64.tar.gz",
                     "name": "OpenSearch Dashboards",
                     "version": "1.1.0",
                 },
-                "schema-version": "1.0",
+                "schema-version": "1.1",
             },
         )
 
@@ -222,7 +231,7 @@ class TestBundleRecorderDashboards(unittest.TestCase):
                 self.assertEqual(yaml.safe_load(f), data)
 
     def test_record_component_public(self):
-        self.bundle_recorder.public_url = 'https://ci.opensearch.org/ci/os-distro-prod'
+        self.bundle_recorder.public_url = "https://ci.opensearch.org/ci/os-distro-prod"
         component = BuildManifest.Component(
             {
                 "name": "alertingDashboards",
@@ -239,6 +248,7 @@ class TestBundleRecorderDashboards(unittest.TestCase):
             self.bundle_recorder.get_manifest().to_dict(),
             {
                 "build": {
+                    "platform": "linux",
                     "architecture": "x64",
                     "id": "c94ebec444a94ada86a230c9297b1d73",
                     "location": "output_dir/opensearch-dashboards-1.1.0-linux-x64.tar.gz",
@@ -254,29 +264,34 @@ class TestBundleRecorderDashboards(unittest.TestCase):
                         "repository": "https://github.com/opensearch-project/alerting-dashboards-plugin",
                     }
                 ],
-                "schema-version": "1.0",
+                "schema-version": "1.1",
             },
         )
 
     def test_get_location_scenarios(self):
         def get_location(public_url):
             self.bundle_recorder.public_url = public_url
-            return self.bundle_recorder._BundleRecorder__get_location("builds", "dir1/dir2/file", "/tmp/builds/foo/dir1/dir2/file")
+            return self.bundle_recorder._BundleRecorder__get_location(
+                "builds", "dir1/dir2/file", "/tmp/builds/foo/dir1/dir2/file"
+            )
 
         # No public URL - Fallback to ABS Path
         self.assertEqual(get_location(None), "/tmp/builds/foo/dir1/dir2/file")
 
         # Public URL - No trailing slash
         self.assertEqual(
-            get_location('https://ci.opensearch.org/ci/os-distro-prod'),
-            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c94ebec444a94ada86a230c9297b1d73/x64/dir1/dir2/file"
+            get_location("https://ci.opensearch.org/ci/os-distro-prod"),
+            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c94ebec444a94ada86a230c9297b1d73/x64/dir1/dir2/file",
         )
 
         # Public URL - Trailing slash
         self.assertEqual(
-            get_location('https://ci.opensearch.org/ci/os-distro-prod/'),
-            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c94ebec444a94ada86a230c9297b1d73/x64/dir1/dir2/file"
+            get_location("https://ci.opensearch.org/ci/os-distro-prod/"),
+            "https://ci.opensearch.org/ci/os-distro-prod/builds/1.1.0/c94ebec444a94ada86a230c9297b1d73/x64/dir1/dir2/file",
         )
 
     def test_tar_name(self):
-        self.assertEqual(self.bundle_recorder.tar_name, "opensearch-dashboards-1.1.0-linux-x64.tar.gz")
+        self.assertEqual(
+            self.bundle_recorder.tar_name,
+            "opensearch-dashboards-1.1.0-linux-x64.tar.gz",
+        )

--- a/tests/tests_assemble_workflow/test_bundles.py
+++ b/tests/tests_assemble_workflow/test_bundles.py
@@ -39,9 +39,10 @@ class TestBundles(unittest.TestCase):
     def test_bundle_opensearch_invalid(self):
         manifest = BuildManifest(
             {
-                "schema-version": "1.1",
+                "schema-version": "1.2",
                 "build": {
                     "name": "invalid",
+                    "platform": "linux",
                     "architecture": "x86",
                     "id": "id",
                     "version": "1.0.0",

--- a/tests/tests_build_workflow/test_build_recorder.py
+++ b/tests/tests_build_workflow/test_build_recorder.py
@@ -28,6 +28,7 @@ class TestBuildRecorder(unittest.TestCase):
                 output_dir="output_dir",
                 name="OpenSearch",
                 version="1.1.0",
+                platform="linux",
                 arch="x64",
                 snapshot=snapshot,
             )
@@ -55,6 +56,7 @@ class TestBuildRecorder(unittest.TestCase):
             recorder.get_manifest().to_dict(),
             {
                 "build": {
+                    "platform": "linux",
                     "architecture": "x64",
                     "id": "1",
                     "name": "OpenSearch",
@@ -70,7 +72,7 @@ class TestBuildRecorder(unittest.TestCase):
                         "version": "1.1.0.0",
                     }
                 ],
-                "schema-version": "1.1",
+                "schema-version": "1.2",
             },
         )
 
@@ -129,12 +131,13 @@ class TestBuildRecorder(unittest.TestCase):
             manifest.to_dict(),
             {
                 "build": {
+                    "platform": "linux",
                     "architecture": "x64",
                     "id": "1",
                     "name": "OpenSearch",
                     "version": "1.1.0",
                 },
-                "schema-version": "1.1",
+                "schema-version": "1.2",
             },
         )
 

--- a/tests/tests_manifests/data/opensearch-build-1.1.0.yml
+++ b/tests/tests_manifests/data/opensearch-build-1.1.0.yml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: c3ff7a232d25403fa8cc14c97799c323
   name: OpenSearch
@@ -2480,4 +2481,4 @@ components:
   ref: main
   repository: https://github.com/opensearch-project/dashboards-notebooks.git
   version: 1.1.0.0
-schema-version: '1.1'
+schema-version: '1.2'

--- a/tests/tests_manifests/data/opensearch-build-1.2.0.yml
+++ b/tests/tests_manifests/data/opensearch-build-1.2.0.yml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: c3ff7a232d25403fa8cc14c97799c323
   name: OpenSearch
@@ -2480,4 +2481,4 @@ components:
   ref: main
   repository: https://github.com/opensearch-project/dashboards-notebooks.git
   version: 1.2.0.0
-schema-version: '1.1'
+schema-version: '1.2'

--- a/tests/tests_manifests/data/opensearch-bundle-1.1.0.yml
+++ b/tests/tests_manifests/data/opensearch-bundle-1.1.0.yml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: c3ff7a232d25403fa8cc14c97799c323
   location: bundle/opensearch-1.1.0-linux-x64.tar.gz
@@ -70,4 +71,4 @@ components:
   name: dashboards-notebooks
   ref: main
   repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.0'
+schema-version: '1.1'

--- a/tests/tests_manifests/test_build_manifest.py
+++ b/tests/tests_manifests/test_build_manifest.py
@@ -24,7 +24,7 @@ class TestBuildManifest(unittest.TestCase):
         self.manifest = BuildManifest.from_path(self.manifest_filename)
 
     def test_build(self):
-        self.assertEqual(self.manifest.version, "1.1")
+        self.assertEqual(self.manifest.version, "1.2")
         self.assertEqual(self.manifest.build.name, "OpenSearch")
         self.assertEqual(self.manifest.build.version, "1.1.0")
         self.assertEqual(len(self.manifest.components), 15)
@@ -52,8 +52,9 @@ class TestBuildManifest(unittest.TestCase):
 
     def test_get_manifest_relative_location(self):
         actual = BuildManifest.get_build_manifest_relative_location(
-            "25", "1.1.0", "x64"
+            "25", "1.1.0", "linux", "x64"
         )
+        # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
         expected = "builds/1.1.0/25/x64/manifest.yml"
         self.assertEqual(
             actual, expected, "the manifest relative location is not as expected"
@@ -76,12 +77,14 @@ class TestBuildManifest(unittest.TestCase):
         s3_download_path = BuildManifest.get_build_manifest_relative_location(
             self.manifest.build.id,
             self.manifest.build.version,
+            self.manifest.build.platform,
             self.manifest.build.architecture,
         )
         BuildManifest.from_s3(
             "bucket_name",
             self.manifest.build.id,
             self.manifest.build.version,
+            self.manifest.build.platform,
             self.manifest.build.architecture,
             "/xyz",
         )

--- a/tests/tests_manifests/test_bundle_manifest.py
+++ b/tests/tests_manifests/test_bundle_manifest.py
@@ -24,12 +24,13 @@ class TestBundleManifest(unittest.TestCase):
         self.manifest = BundleManifest.from_path(self.manifest_filename)
 
     def test_build(self):
-        self.assertEqual(self.manifest.version, "1.0")
+        self.assertEqual(self.manifest.version, "1.1")
         self.assertEqual(self.manifest.build.name, "OpenSearch")
         self.assertEqual(self.manifest.build.version, "1.1.0")
         self.assertEqual(
             self.manifest.build.location, "bundle/opensearch-1.1.0-linux-x64.tar.gz"
         )
+        self.assertEqual(self.manifest.build.platform, "linux")
         self.assertEqual(self.manifest.build.architecture, "x64")
         self.assertEqual(len(self.manifest.components), 13)
 
@@ -57,23 +58,25 @@ class TestBundleManifest(unittest.TestCase):
 
     def test_get_manifest_relative_location(self):
         actual = BundleManifest.get_bundle_manifest_relative_location(
-            "25", "1.1.0", "x64"
+            "25", "1.1.0", "linux", "x64"
         )
+        # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
         expected = "bundles/1.1.0/25/x64/manifest.yml"
         self.assertEqual(
             actual, expected, "the manifest relative location is not as expected"
         )
 
     def test_get_tarball_relative_location(self):
-        actual = BundleManifest.get_tarball_relative_location("25", "1.1.0", "x64")
-        expected = "bundles/1.1.0/25/x64/opensearch-1.1.0-linux-x64.tar.gz"
+        actual = BundleManifest.get_tarball_relative_location("25", "1.1.0", "darwin", "x64")
+        # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
+        expected = "bundles/1.1.0/25/x64/opensearch-1.1.0-darwin-x64.tar.gz"
         self.assertEqual(
             actual, expected, "the tarball relative location is not as expected"
         )
 
     def test_get_tarball_name(self):
-        actual = BundleManifest.get_tarball_name("1.1.0", "x64")
-        expected = "opensearch-1.1.0-linux-x64.tar.gz"
+        actual = BundleManifest.get_tarball_name("1.1.0", "darwin", "x64")
+        expected = "opensearch-1.1.0-darwin-x64.tar.gz"
         self.assertEqual(actual, expected, "the tarball name is not as expected")
 
     @patch("os.remove")
@@ -85,12 +88,14 @@ class TestBundleManifest(unittest.TestCase):
         s3_download_path = BundleManifest.get_bundle_manifest_relative_location(
             self.manifest.build.id,
             self.manifest.build.version,
+            self.manifest.build.platform,
             self.manifest.build.architecture,
         )
         BundleManifest.from_s3(
             "bucket_name",
             self.manifest.build.id,
             self.manifest.build.version,
+            self.manifest.build.platform,
             self.manifest.build.architecture,
             "/xyz",
         )

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/data/test_manifest.yaml
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/data/test_manifest.yaml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: 41d5ae25183d4e699e92debfbe3f83bd
   location: https://artifacts.opensearch.org/bundles/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/opensearch-1.0.0-linux-x64.tar.gz
@@ -60,4 +61,4 @@ components:
     name: dashboards-notebooks
     ref: "1.0.0.0"
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.0'
+schema-version: '1.1'

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_run_bwc_test.py
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_run_bwc_test.py
@@ -15,13 +15,14 @@ class TestRunBwcTest(unittest.TestCase):
     @contextmanager
     def __mock_args(self):
         with patch("run_bwc_test.TestArgs") as mock_test_args:
-            mock_test_args.s3_bucket = 's3bucket'
-            mock_test_args.architecture = 'x64'
-            mock_test_args.opensearch_version = '1.1.0'
+            mock_test_args.s3_bucket = "s3bucket"
+            mock_test_args.platform = "linux"
+            mock_test_args.architecture = "x64"
+            mock_test_args.opensearch_version = "1.1.0"
             mock_test_args.build_id = 100
             mock_test_args.test_run_id = 1
             mock_test_args.keep = False
-            mock_test_args.logging_level = 'INFO'
+            mock_test_args.logging_level = "INFO"
             yield mock_test_args
 
     @patch("run_bwc_test.console")

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/data/build_manifest.yml
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/data/build_manifest.yml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: c3ff7a232d25403fa8cc14c97799c323
   name: OpenSearch
@@ -2480,4 +2481,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.1'
+schema-version: '1.2'

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/data/build_manifest_missing_components.yml
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/data/build_manifest_missing_components.yml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: c3ff7a232d25403fa8cc14c97799c323
   name: OpenSearch
@@ -2460,4 +2461,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.1'
+schema-version: '1.2'

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/data/bundle_manifest.yml
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/data/bundle_manifest.yml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: c3ff7a232d25403fa8cc14c97799c323
   location: bundle/opensearch-1.1.0-linux-x64.tar.gz
@@ -70,4 +71,4 @@ components:
     name: dashboards-notebooks
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.0'
+schema-version: '1.1'

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster.py
@@ -41,7 +41,7 @@ class LocalTestClusterTests(unittest.TestCase):
             True,
             "with-security",
             mock_test_recorder,
-            "dummy-bucket"
+            "dummy-bucket",
         )
 
     def tearDown(self):
@@ -114,11 +114,14 @@ class LocalTestClusterTests(unittest.TestCase):
         s3_path = BundleManifest.get_tarball_relative_location(
             self.manifest.build.id,
             self.manifest.build.version,
+            self.manifest.build.platform,
             self.manifest.build.architecture,
         )
         work_dir_path = os.path.join(self.work_dir.name, "local-test-cluster")
         bundle_name = BundleManifest.get_tarball_name(
-            self.manifest.build.version, self.manifest.build.architecture
+            self.manifest.build.version,
+            self.manifest.build.platform,
+            self.manifest.build.architecture,
         )
         self.local_test_cluster.download()
         os.chdir.assert_called_once_with(work_dir_path)
@@ -148,7 +151,7 @@ class LocalTestClusterTests(unittest.TestCase):
             False,
             "without-security",
             mock_test_recorder,
-            "dummy-bucket"
+            "dummy-bucket",
         )
         with self.assertRaises(ClusterCreationException) as err:
             local_test_cluster.wait_for_service()
@@ -158,17 +161,27 @@ class LocalTestClusterTests(unittest.TestCase):
                 auth=("admin", "admin"),
             )
         self.assertEqual(
-            str(err.exception),
-            "Cluster is not available after 10 attempts",
+            str(err.exception), "Cluster is not available after 10 attempts"
         )
 
-    @patch("test_workflow.integ_test.local_test_cluster.psutil.Process", side_effect=__mock_process)
+    @patch(
+        "test_workflow.integ_test.local_test_cluster.psutil.Process",
+        side_effect=__mock_process,
+    )
     @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.wait")
     @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.terminate")
-    @patch("test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock())
-    def test_terminate_process(self, mock_logging, mock_terminate, mock_wait, mock_process):
-        self.local_test_cluster.stdout = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
-        self.local_test_cluster.stderr = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
+    @patch(
+        "test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock()
+    )
+    def test_terminate_process(
+        self, mock_logging, mock_terminate, mock_wait, mock_process
+    ):
+        self.local_test_cluster.stdout = tempfile.NamedTemporaryFile(
+            dir=self.local_test_cluster.work_dir
+        )
+        self.local_test_cluster.stderr = tempfile.NamedTemporaryFile(
+            dir=self.local_test_cluster.work_dir
+        )
         self.local_test_cluster.process = self.process
         self.local_test_cluster.terminate_process()
         mock_process.assert_called_once_with(self.process.pid)
@@ -183,13 +196,24 @@ class LocalTestClusterTests(unittest.TestCase):
         )
         mock_logging.debug.assert_has_calls([call("Checking for child processes")])
 
-    @patch("test_workflow.integ_test.local_test_cluster.psutil.Process", side_effect=__mock_process)
+    @patch(
+        "test_workflow.integ_test.local_test_cluster.psutil.Process",
+        side_effect=__mock_process,
+    )
     @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.wait")
     @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.terminate")
-    @patch("test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock())
-    def test_terminate_process_timeout(self, mock_logging, mock_terminate, mock_wait, mock_process):
-        self.local_test_cluster.stdout = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
-        self.local_test_cluster.stderr = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
+    @patch(
+        "test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock()
+    )
+    def test_terminate_process_timeout(
+        self, mock_logging, mock_terminate, mock_wait, mock_process
+    ):
+        self.local_test_cluster.stdout = tempfile.NamedTemporaryFile(
+            dir=self.local_test_cluster.work_dir
+        )
+        self.local_test_cluster.stderr = tempfile.NamedTemporaryFile(
+            dir=self.local_test_cluster.work_dir
+        )
         mock_wait.side_effect = subprocess.TimeoutExpired(cmd="pass", timeout=1)
         with self.assertRaises(subprocess.TimeoutExpired):
             self.local_test_cluster.process = self.process

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_run_integ_test.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_run_integ_test.py
@@ -21,13 +21,14 @@ class TestRunIntegTest(unittest.TestCase):
     @contextmanager
     def __mock_args(self):
         with patch("run_integ_test.TestArgs") as mock_test_args:
-            mock_test_args.s3_bucket = 's3bucket'
-            mock_test_args.architecture = 'x64'
-            mock_test_args.opensearch_version = '1.1.0'
+            mock_test_args.s3_bucket = "s3bucket"
+            mock_test_args.platform = "linux"
+            mock_test_args.architecture = "x64"
+            mock_test_args.opensearch_version = "1.1.0"
             mock_test_args.build_id = 100
             mock_test_args.test_run_id = 1
             mock_test_args.keep = False
-            mock_test_args.logging_level = 'INFO'
+            mock_test_args.logging_level = "INFO"
             yield mock_test_args
 
     @patch("run_integ_test.console")
@@ -38,7 +39,14 @@ class TestRunIntegTest(unittest.TestCase):
     @patch.object(BundleManifest, "from_s3")
     @patch.object(BuildManifest, "from_s3")
     @patch("run_integ_test.IntegTestSuite")
-    def test_run_integ_test(self, mock_integ_test_suite, mock_build_from_s3, mock_bundle_from_s3, mock_results, *mock):
+    def test_run_integ_test(
+        self,
+        mock_integ_test_suite,
+        mock_build_from_s3,
+        mock_bundle_from_s3,
+        mock_results,
+        *mock
+    ):
         """
         test_manifest.yml has 8 plugin components listed for integration tests. This test ensures all get executed
         as part of integration test job.
@@ -61,7 +69,14 @@ class TestRunIntegTest(unittest.TestCase):
     @patch.object(BundleManifest, "from_s3")
     @patch.object(BuildManifest, "from_s3")
     @patch("run_integ_test.IntegTestSuite")
-    def test_run_integ_test_failure(self, mock_integ_test_suite, mock_build_from_s3, mock_bundle_from_s3, mock_results, *mock):
+    def test_run_integ_test_failure(
+        self,
+        mock_integ_test_suite,
+        mock_build_from_s3,
+        mock_bundle_from_s3,
+        mock_results,
+        *mock
+    ):
         """
         test_manifest.yml has 8 plugin components listed for integration tests. This test ensures all get executed
         as part of integration test job.

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/data/bundle_manifest.yaml
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/data/bundle_manifest.yaml
@@ -1,4 +1,5 @@
 build:
+  platform: linux
   architecture: x64
   id: 41d5ae25183d4e699e92debfbe3f83bd
   location: https://artifacts.opensearch.org/bundles/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/opensearch-1.0.0-linux-x64.tar.gz
@@ -60,4 +61,4 @@ components:
     name: dashboards-notebooks
     ref: 1.0.0.0
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.0'
+schema-version: '1.1'

--- a/tests/tests_test_workflow/test_test_args.py
+++ b/tests/tests_test_workflow/test_test_args.py
@@ -22,6 +22,8 @@ class TestTestArgs(unittest.TestCase):
             "1.1.0",
             "--build-id",
             "30",
+            "--platform",
+            "linux",
             "--architecture",
             "x64",
             "--test-run-id",
@@ -32,6 +34,7 @@ class TestTestArgs(unittest.TestCase):
         self.assertEqual(TestArgs().s3_bucket, "xyz")
         self.assertEqual(TestArgs().opensearch_version, "1.1.0")
         self.assertEqual(TestArgs().build_id, 30)
+        self.assertEqual(TestArgs().platform, "linux")
         self.assertEqual(TestArgs().architecture, "x64")
         self.assertEqual(TestArgs().test_run_id, 6)
 
@@ -45,6 +48,8 @@ class TestTestArgs(unittest.TestCase):
             "1.1.0",
             "--build-id",
             "30",
+            "--platform",
+            "linux",
             "--architecture",
             "xyz",
             "--test-run-id",
@@ -62,9 +67,33 @@ class TestTestArgs(unittest.TestCase):
             "--s3-bucket",
             "xyz",
             "--opensearch-version",
+            "1.1.0",
+            "--build-id",
+            "30",
+            "--platform",
+            "xyz",
+            "--architecture",
+            "x64",
+            "--test-run-id",
+            "6",
+        ],
+    )
+    def test_invalid_platform(self):
+        with self.assertRaises(SystemExit):
+            self.assertEqual(TestArgs().platform, "invalid")
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            "--s3-bucket",
+            "xyz",
+            "--opensearch-version",
             "1111",
             "--build-id",
             "30",
+            "--platform",
+            "linux",
             "--architecture",
             "x64",
             "--test-run-id",
@@ -86,6 +115,8 @@ class TestTestArgs(unittest.TestCase):
             "1.1.0",
             "--build-id",
             "30",
+            "--platform",
+            "linux",
             "--architecture",
             "x64",
             "--test-run-id",
@@ -105,6 +136,8 @@ class TestTestArgs(unittest.TestCase):
             "1.1.0",
             "--build-id",
             "30",
+            "--platform",
+            "linux",
             "--architecture",
             "x64",
             "--test-run-id",
@@ -125,6 +158,8 @@ class TestTestArgs(unittest.TestCase):
             "1.1.0",
             "--build-id",
             "30",
+            "--platform",
+            "linux",
             "--architecture",
             "x64",
             "--test-run-id",
@@ -144,6 +179,8 @@ class TestTestArgs(unittest.TestCase):
             "1.1.0",
             "--build-id",
             "30",
+            "--platform",
+            "linux",
             "--architecture",
             "x64",
             "--test-run-id",


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Continuing the effort to build on other platforms than Linux, https://github.com/opensearch-project/opensearch-build/issues/741.

- Added platform to build and bundle manifests.
- Expose platform in scripts that currently take architecture.
- Don't alter any build paths, but get ready for fix collisions in #669. 
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
