### PR TITLE
[Temp] remove ARM64 build from OpenSearch Dashboards Jenkinsfile

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -42,25 +42,6 @@ pipeline {
                         }
                     }
                 }
-                stage('build-arm64') {
-                    agent {
-                        docker {
-                            label 'Jenkins-Agent-al2-arm64-c6g4xlarge-Docker-Host'
-                            image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdk14-node10.24.1-cypress6.9.1-20211005'
-                            alwaysPull true
-                        }
-                    }
-                    steps {
-                        script {
-                            build()
-                        }
-                    }
-                    post() {
-                        always {
-                            cleanWs disableDeferredWipeout: true, deleteDirs: true
-                        }
-                    }
-                }
             }
             post() {
                 success {


### PR DESCRIPTION
### Description
Temp removal of ARM64 until a subsequent commit can deal with the
issue of ARM64 builds failing here:
https://github.com/opensearch-project/opensearch-build/issues/739

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
