### PR TITLE
[Temp] remove OpenSearch Dashboards ARM64 from Jenkins messages

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -95,7 +95,7 @@ String getAllJenkinsMessages() {
     script {
         // Stages must be explicitly added to prevent overwriting
         // See https://ryan.himmelwright.net/post/jenkins-parallel-stashing/
-        def stages = ['build-x64', 'build-arm64']
+        def stages = ['build-x64']
         for (stage in stages) {
             unstash "notifications-${stage}"
         }


### PR DESCRIPTION
### Description
Missed in the temp removal of build-arm64 in this PR: https://github.com/opensearch-project/opensearch-build/pull/752

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
