### PR TITLE
Updated CI image to include JDK-8/11/17 distributions, kept JDK-14 as the default one

### DIFF
--- a/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
@@ -68,12 +68,12 @@ RUN set -eux; \
         regex="temurin([0-9]+)[-]"; \
         if [[ $jdk =~ $regex ]]; then \
             MAJOR=${BASH_REMATCH[1]}; \
-            curl -LfsSo /tmp/openjdk.tar.gz ${BINARY_URL}; \
-            echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+            curl -LfsSo /tmp/openjdk-${MAJOR}.tar.gz ${BINARY_URL}; \
+            echo "${ESUM} */tmp/openjdk-${MAJOR}.tar.gz" | sha256sum -c -; \
             mkdir -p /opt/java/openjdk-${MAJOR}; \
             cd /opt/java/openjdk-${MAJOR}; \
-            tar -xf /tmp/openjdk.tar.gz --strip-components=1; \
-            rm -rf /tmp/openjdk.tar.gz; \
+            tar -xf /tmp/openjdk-${MAJOR}.tar.gz --strip-components=1; \
+            rm -rf /tmp/openjdk-${MAJOR}.tar.gz; \
             echo "export JAVA${MAJOR}_HOME=/opt/java/openjdk-${MAJOR}" >> /etc/profile.d/java_home.sh; \
         fi; \
     done;


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Updated CI image to include JDK-8/11/17 distributions, kept JDK-14 as the default one so the 1.x branches will continue to build properly.

```
declare -x JAVA11_HOME="/opt/java/openjdk-11"
declare -x JAVA14_HOME="/usr/lib/jvm/adoptopenjdk-14-hotspot"
declare -x JAVA17_HOME="/opt/java/openjdk-17"
declare -x JAVA8_HOME="/opt/java/openjdk-8"
declare -x JAVA_HOME="/usr/lib/jvm/adoptopenjdk-14-hotspot"
```
 
### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/732, part of https://github.com/opensearch-project/OpenSearch/issues/1351
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
