### PR TITLE
save OpenSearch Dashboards for plugin to reuse

### DIFF
--- a/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/scripts/components/OpenSearch-Dashboards/build.sh
@@ -78,9 +78,9 @@ case $ARCHITECTURE in
 esac
 
 echo "Copying dashboard to .cache for reuse"
-rm -rf ~/.cache/opensearch/OpenSearch-Dashboards/
-mkdir -p ~/.cache/opensearch/OpenSearch-Dashboards/
-cp -r . ~/.cache/opensearch/OpenSearch-Dashboards/
+rm -rf ~/.cache/opensearch-project/OpenSearch-Dashboards/
+mkdir -p ~/.cache/opensearch-project/OpenSearch-Dashboards/
+cp -r . ~/.cache/opensearch-project/OpenSearch-Dashboards/
 
 echo "Building node modules for core"
 yarn osd bootstrap

--- a/scripts/components/ganttChartDashboards/build.sh
+++ b/scripts/components/ganttChartDashboards/build.sh
@@ -20,6 +20,15 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_dashboard_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        if [ -d ~/.cache/opensearch-project/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from .cache"
+            cp -r ~/.cache/opensearch-project/OpenSearch-Dashboards/ ../../
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -67,6 +76,7 @@ PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_dashboard_from_cache
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)

--- a/scripts/components/notebooksDashboards/build.sh
+++ b/scripts/components/notebooksDashboards/build.sh
@@ -20,6 +20,15 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_dashboard_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        if [ -d ~/.cache/opensearch-project/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from .cache"
+            cp -r ~/.cache/opensearch-project/OpenSearch-Dashboards/ ../../
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -67,6 +76,7 @@ PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_dashboard_from_cache
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)

--- a/scripts/components/notificationsDashboards/build.sh
+++ b/scripts/components/notificationsDashboards/build.sh
@@ -20,6 +20,15 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_dashboard_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        if [ -d ~/.cache/opensearch-project/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from .cache"
+            cp -r ~/.cache/opensearch-project/OpenSearch-Dashboards/ ../../
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -67,6 +76,7 @@ PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_dashboard_from_cache
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)

--- a/scripts/components/queryWorkbenchDashboards/build.sh
+++ b/scripts/components/queryWorkbenchDashboards/build.sh
@@ -20,6 +20,15 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_dashboard_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        if [ -d ~/.cache/opensearch-project/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from .cache"
+            cp -r ~/.cache/opensearch-project/OpenSearch-Dashboards/ ../../
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -67,6 +76,7 @@ PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_dashboard_from_cache
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)

--- a/scripts/components/reportsDashboards/build.sh
+++ b/scripts/components/reportsDashboards/build.sh
@@ -20,6 +20,15 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_dashboard_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        if [ -d ~/.cache/opensearch-project/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from .cache"
+            cp -r ~/.cache/opensearch-project/OpenSearch-Dashboards/ ../../
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -67,6 +76,7 @@ PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_dashboard_from_cache
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -22,43 +22,43 @@ function usage() {
 
 function load_dashboard_from_cache() {
     if [ ! -d ../OpenSearch-Dashboards ]; then
-        if [ -d ~/.cache/opensearch/OpenSearch-Dashboards/ ]; then
+        if [ -d ~/.cache/opensearch-project/OpenSearch-Dashboards/ ]; then
             echo "Copy OpenSearch-Dashboards from .cache"
-            cp -r ~/.cache/opensearch/OpenSearch-Dashboards/ ../
+            cp -r ~/.cache/opensearch-project/OpenSearch-Dashboards/ ../
         fi
     fi
 }
 
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
-    h)
-        usage
-        exit 1
-        ;;
-    v)
-        VERSION=$OPTARG
-        ;;
-    s)
-        SNAPSHOT=$OPTARG
-        ;;
-    o)
-        OUTPUT=$OPTARG
-        ;;
-    p)
-        PLATFORM=$OPTARG
-        ;;
-    a)
-        ARCHITECTURE=$OPTARG
-        ;;
-    :)
-        echo "Error: -${OPTARG} requires an argument"
-        usage
-        exit 1
-        ;;
-    ?)
-        echo "Invalid option: -${arg}"
-        exit 1
-        ;;
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
     esac
 done
 


### PR DESCRIPTION
Signed-off-by: Tengda He <tengh@amazon.com>

### Description
Copy the OpenSearch-Dashboards git package to ~/.cache folder when building the OpenSearch-Dashboards component. Also create the  load_dashboard_from_cache function for plugin build to reuse OpenSearch-Dashboards source code. This approach allows following individual plugin to build, which means it will support cmd run of
./build-workflow/build.sh manifests/1.1.0/openseach-dashboards-1.1.0.yml --component=alertingDashboards

Test:
verified the plugin can be built independently 
ex: ./build-workflow/build.sh manifests/1.1.0/openseach-dashboards-1.1.0.yml --component=alertingDashboards

### Issues Resolved
#606 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
