### PR TITLE
[Bundle] include default files

### DIFF
--- a/src/assemble_workflow/bundle.py
+++ b/src/assemble_workflow/bundle.py
@@ -54,6 +54,10 @@ class Bundle(ABC):
             f'{post_install_script} -a "{self.artifacts_dir}" -o "{self.archive_path}"'
         )
 
+    @abstractmethod
+    def copy_default_files(self):
+        logging.info('Copied default files')
+
     def build_tar(self, dest):
         tar_name = self.bundle_recorder.tar_name
         with tarfile.open(tar_name, "w:gz") as tar:
@@ -109,3 +113,23 @@ class Bundle(ABC):
         if min_bundle is None:
             raise ValueError('Missing min "dist" in input artifacts.')
         return min_bundle
+
+    def copy_file(self, source, dest):
+        file = os.path.realpath(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                source,
+            )
+        )
+        if not os.path.isfile(file):
+            logging.error(
+                f"No file found at path: {file}"
+            )
+            exit(1)
+
+        shutil.copy2(
+            file,
+            os.path.join(
+                dest, os.path.basename(file)
+            ),
+        )

--- a/src/assemble_workflow/bundle_opensearch.py
+++ b/src/assemble_workflow/bundle_opensearch.py
@@ -4,6 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 
 from assemble_workflow.bundle import Bundle
@@ -15,3 +16,14 @@ class BundleOpenSearch(Bundle):
         cli_path = os.path.join(self.archive_path, "bin/opensearch-plugin")
         self._execute(f"{cli_path} install --batch file:{tmp_path}")
         super().install_plugin(plugin)
+
+    def copy_default_files(self):
+        self.__copy_tar_install_script()
+        return super().copy_default_files()
+
+    def __copy_tar_install_script(self):
+        logging.info(f'Copy opensearch-tar-install.sh to {self.archive_path}')
+        super().copy_file(
+            "../../scripts/legacy/tar/linux/opensearch-tar-install.sh",
+            self.archive_path
+        )

--- a/src/assemble_workflow/bundle_opensearch_dashboards.py
+++ b/src/assemble_workflow/bundle_opensearch_dashboards.py
@@ -4,6 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 
 from assemble_workflow.bundle import Bundle
@@ -15,3 +16,16 @@ class BundleOpenSearchDashboards(Bundle):
         cli_path = os.path.join(self.archive_path, "bin/opensearch-dashboards-plugin")
         self._execute(f"{cli_path} --allow-root install file:{tmp_path}")
         super().install_plugin(plugin)
+
+    def copy_default_files(self):
+        self.__copy_config()
+        return super().copy_default_files()
+
+    def __copy_config(self):
+        logging.info(f'Copy opensearch_dashboards.yml to {self.archive_path}')
+        super().copy_file(
+            "../../config/opensearch_dashboards.yml",
+            os.path.join(
+                self.archive_path, "config"
+            )
+        )

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -9,7 +9,6 @@
 import argparse
 import logging
 import os
-import shutil
 import sys
 import tempfile
 
@@ -35,18 +34,6 @@ def main():
 
     console.configure(level=args.logging_level)
 
-    tarball_installation_script = os.path.realpath(
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "../scripts/legacy/tar/linux/opensearch-tar-install.sh",
-        )
-    )
-    if not os.path.isfile(tarball_installation_script):
-        logging.error(
-            f"No installation script found at path: {tarball_installation_script}"
-        )
-        exit(1)
-
     build_manifest = BuildManifest.from_file(args.manifest)
     build = build_manifest.build
     artifacts_dir = os.path.dirname(os.path.realpath(args.manifest.name))
@@ -67,13 +54,7 @@ def main():
         bundle.install_plugins()
         logging.info(f"Installed plugins: {bundle.installed_plugins}")
 
-        # Copy the tar installation script into the bundle
-        shutil.copy2(
-            tarball_installation_script,
-            os.path.join(
-                bundle.archive_path, os.path.basename(tarball_installation_script)
-            ),
-        )
+        bundle.copy_default_files()
 
         #  Save a copy of the manifest inside of the tar
         bundle_recorder.write_manifest(bundle.archive_path)

--- a/tests/test_run_assemble.py
+++ b/tests/test_run_assemble.py
@@ -38,8 +38,7 @@ class TestRunAssemble(unittest.TestCase):
     @patch("run_assemble.Bundles", return_value=MagicMock())
     @patch("run_assemble.BundleRecorder", return_value=MagicMock())
     @patch("tempfile.TemporaryDirectory")
-    @patch("shutil.copy2")
-    def test_main(self, mock_copy, mock_temp, mock_recorder, mock_bundles, *mocks):
+    def test_main(self, mock_temp, mock_recorder, mock_bundles, *mocks):
         mock_temp.return_value.__enter__.return_value = tempfile.gettempdir()
         mock_bundle = MagicMock(archive_path="path")
         mock_bundles.create.return_value = mock_bundle
@@ -48,15 +47,7 @@ class TestRunAssemble(unittest.TestCase):
 
         mock_bundle.install_plugins.assert_called()
 
-        mock_copy.assert_called_with(
-            os.path.realpath(
-                os.path.join(
-                    os.path.dirname(os.path.abspath(__file__)),
-                    "../scripts/legacy/tar/linux/opensearch-tar-install.sh",
-                )
-            ),
-            "path/opensearch-tar-install.sh",
-        )
+        mock_bundle.copy_default_files.assert_called()
 
         mock_bundle.build_tar.assert_called_with("curdir/bundle")
 

--- a/tests/tests_assemble_workflow/test_bundle.py
+++ b/tests/tests_assemble_workflow/test_bundle.py
@@ -17,6 +17,9 @@ class TestBundle(unittest.TestCase):
         def install_plugin(self, plugin):
             pass
 
+        def copy_default_files(self):
+            pass
+
     def test_bundle(self):
         manifest_path = os.path.join(
             os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"

--- a/tests/tests_assemble_workflow/test_bundle_opensearch.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch.py
@@ -104,3 +104,24 @@ class TestBundleOpenSearch(unittest.TestCase):
                     os.path.join(bundle.tmp_dir.name, "bundle"), arcname="bundle"
                 )
                 self.assertEqual(mock_copyfile.call_count, 1)
+
+    @patch("shutil.copy2")
+    def test_bundle_copy_default_files(self, mock_copy, *mocks):
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
+        )
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        bundle = BundleOpenSearch(
+            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
+        )
+        bundle.copy_default_files()
+
+        mock_copy.assert_called_with(
+            os.path.realpath(
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "../../scripts/legacy/tar/linux/opensearch-tar-install.sh",
+                )
+            ),
+            f'{bundle.archive_path}/opensearch-tar-install.sh',
+        )

--- a/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
@@ -71,3 +71,24 @@ class TestBundleOpenSearchDashboards(unittest.TestCase):
                         ),
                     ]
                 )
+
+    @patch("shutil.copy2")
+    def test_bundle_copy_default_files(self, mock_copy, *mocks):
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml"
+        )
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        bundle = BundleOpenSearchDashboards(
+            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
+        )
+        bundle.copy_default_files()
+
+        mock_copy.assert_called_with(
+            os.path.realpath(
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "../../config/opensearch_dashboards.yml",
+                )
+            ),
+            f'{bundle.archive_path}/config/opensearch_dashboards.yml',
+        )


### PR DESCRIPTION
### Description
Create the bundles with default files for OpenSearch and OpenSearch
Dashboards.

These files include:
* opensearch-tar-install.sh
* config/opensearch_dashboards.yml

However, we do not want to include opensearch-tar-install.sh into
the OpenSearch Dashboards bundle because the script will just fail
to run.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/610
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
