### PR TITLE
Updated CI image to include JDK-8/11/17 distributions, kept JDK-14 as the default one (al2 image)

### DIFF
--- a/docker/ci/dockerfiles/ci-runner.al2.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.al2.dockerfile
@@ -31,6 +31,46 @@ RUN yum install -y libnss3.so xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x1
 # Add Yarn dependencies
 RUN yum groupinstall -y "Development Tools" && yum clean all && rm -rf /var/cache/yum/*
 
+# Downloads JDK-8, JDK-11 and JDK-17 distributions using Eclipse Adoptium project.
+# The distributions are extracted to /opt/java/ folder with environment variables JAVA8_HOME,
+# JAVA11_HOME and JAVA17_HOME exported and pointing at respective ones.
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    JDKS=""; \
+    case "${ARCH}" in \
+       aarch64|arm64) \
+         # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
+         JDKS+="f287cdc2a688c2df247ea0d8bfe2863645b73848e4e5c35b02a8a3d2d6b69551@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz "; \
+         JDKS+="105bdc12fcd54c551e8e8ac96bc82412467244c32063689c41cee29ceb7452a2@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.12_7.tar.gz "; \
+         JDKS+="e08e6d8c84da28a2c49ccd511f8835c329fbdd8e4faff662c58fa24cca74021d@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_aarch64_linux_hotspot_17_35.tar.gz "; \
+         ;; \
+       amd64|x86_64) \
+         # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
+         JDKS+="cc13f274becf9dd5517b6be583632819dfd4dd81e524b5c1b4f406bdaf0e063a@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz "; \
+         JDKS+="8770f600fc3b89bf331213c7aa21f8eedd9ca5d96036d1cd48cb2748a3dbefd2@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz "; \
+         JDKS+="6f1335d9a7855159f982dac557420397be9aa85f3f7bc84e111d25871c02c0c7@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz "; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    for jdk in ${JDKS}; do \
+        ESUM=$(echo ${jdk} | cut -d '@' -f1); \
+        BINARY_URL=$(echo ${jdk} | cut -d '@' -f2); \
+        regex="temurin([0-9]+)[-]"; \
+        if [[ $jdk =~ $regex ]]; then \
+            MAJOR=${BASH_REMATCH[1]}; \
+            curl -LfsSo /tmp/openjdk-${MAJOR}.tar.gz ${BINARY_URL}; \
+            echo "${ESUM} */tmp/openjdk-${MAJOR}.tar.gz" | sha256sum -c -; \
+            mkdir -p /opt/java/openjdk-${MAJOR}; \
+            cd /opt/java/openjdk-${MAJOR}; \
+            tar -xf /tmp/openjdk-${MAJOR}.tar.gz --strip-components=1; \
+            rm -rf /tmp/openjdk-${MAJOR}.tar.gz; \
+            echo "export JAVA${MAJOR}_HOME=/opt/java/openjdk-${MAJOR}" >> /etc/profile.d/java_home.sh; \
+        fi; \
+    done;
+
 # Install higher version of maven 3.8.x
 RUN export MAVEN_URL=`curl -s https://maven.apache.org/download.cgi | grep -Eo '["\047].*.bin.tar.gz["\047]' | tr -d '"'`  && \
     mkdir -p $MAVEN_DIR && (curl -s $MAVEN_URL | tar xzf - --strip-components=1 -C $MAVEN_DIR) && \
@@ -48,10 +88,10 @@ RUN groupadd -g 1000 opensearch && \
     mkdir -p /usr/share/opensearch && \
     chown -R 1000:1000 /usr/share/opensearch
 
-# Set JAVA_HOME
+# Set JAVA_HOME and JAVA14_HOME
 # AdoptOpenJDK apparently does not add JAVA_HOME after installation
-RUN echo "export JAVA_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh
-
+RUN echo "export JAVA_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh && \
+    echo "export JAVA14_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh
 # Change User
 USER 1000
 WORKDIR /usr/share/opensearch


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Ports https://github.com/opensearch-project/opensearch-build/pull/754 to AmazonLinux2 image.

Updated CI image to include JDK-8/11/17 distributions, kept JDK-14 as the default one so the 1.x branches will continue to build properly.

```
declare -x JAVA11_HOME="/opt/java/openjdk-11"
declare -x JAVA14_HOME="/usr/lib/jvm/adoptopenjdk-14-hotspot"
declare -x JAVA17_HOME="/opt/java/openjdk-17"
declare -x JAVA8_HOME="/opt/java/openjdk-8"
declare -x JAVA_HOME="/usr/lib/jvm/adoptopenjdk-14-hotspot"
```
 
### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/732, part of opensearch-project/OpenSearch#1351
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
