### PR TITLE
[Bundle] post-install for min applications

### DIFF
--- a/scripts/components/OpenSearch-Dashboards/install.sh
+++ b/scripts/components/OpenSearch-Dashboards/install.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-a ARTIFACTS\t[Required] Location of build artifacts."
+    echo -e "-o OUTPUT\t[Required] Output path."
+    echo -e "-h help"
+}
+
+while getopts ":h:a:o:" arg; do
+    case $arg in
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARTIFACTS=$OPTARG
+            ;;
+        h)
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+## Setup default config
+(
+    DIR="$(dirname "$0")"
+    echo $DIR
+    cd $DIR
+    cp ../../../config/opensearch_dashboards.yml "$OUTPUT/config/"
+)

--- a/scripts/components/OpenSearch/install.sh
+++ b/scripts/components/OpenSearch/install.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-a ARTIFACTS\t[Required] Location of build artifacts."
+    echo -e "-o OUTPUT\t[Required] Output path."
+    echo -e "-h help"
+}
+
+while getopts ":h:a:o:" arg; do
+    case $arg in
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        a)
+            ARTIFACTS=$OPTARG
+            ;;
+        h)
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+## Copy the tar installation script into the bundle
+(
+    DIR="$(dirname "$0")"
+    echo $DIR
+    cd $DIR
+    cp ../../../scripts/legacy/tar/linux/opensearch-tar-install.sh "$OUTPUT/"
+)

--- a/src/assemble_workflow/bundle.py
+++ b/src/assemble_workflow/bundle.py
@@ -39,6 +39,12 @@ class Bundle(ABC):
         self.min_tarball_path = self._copy_component(self.min_tarball, "dist")
         self.__unpack_min_tarball(self.tmp_dir.name)
 
+    def install_min(self):
+        post_install_script = ScriptFinder.find_install_script(self.min_tarball.name)
+        self._execute(
+            f'{post_install_script} -a "{self.artifacts_dir}" -o "{self.archive_path}"'
+        )
+
     def install_plugins(self):
         for plugin in self.plugins:
             logging.info(f"Installing {plugin.name}")

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -9,7 +9,6 @@
 import argparse
 import logging
 import os
-import shutil
 import sys
 import tempfile
 
@@ -35,18 +34,6 @@ def main():
 
     console.configure(level=args.logging_level)
 
-    tarball_installation_script = os.path.realpath(
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            "../scripts/legacy/tar/linux/opensearch-tar-install.sh",
-        )
-    )
-    if not os.path.isfile(tarball_installation_script):
-        logging.error(
-            f"No installation script found at path: {tarball_installation_script}"
-        )
-        exit(1)
-
     build_manifest = BuildManifest.from_file(args.manifest)
     build = build_manifest.build
     artifacts_dir = os.path.dirname(os.path.realpath(args.manifest.name))
@@ -64,16 +51,9 @@ def main():
 
         bundle = Bundles.create(build_manifest, artifacts_dir, bundle_recorder)
 
+        bundle.install_min()
         bundle.install_plugins()
         logging.info(f"Installed plugins: {bundle.installed_plugins}")
-
-        # Copy the tar installation script into the bundle
-        shutil.copy2(
-            tarball_installation_script,
-            os.path.join(
-                bundle.archive_path, os.path.basename(tarball_installation_script)
-            ),
-        )
 
         #  Save a copy of the manifest inside of the tar
         bundle_recorder.write_manifest(bundle.archive_path)

--- a/tests/test_run_assemble.py
+++ b/tests/test_run_assemble.py
@@ -46,17 +46,8 @@ class TestRunAssemble(unittest.TestCase):
 
         main()
 
+        mock_bundle.install_min.assert_called()
         mock_bundle.install_plugins.assert_called()
-
-        mock_copy.assert_called_with(
-            os.path.realpath(
-                os.path.join(
-                    os.path.dirname(os.path.abspath(__file__)),
-                    "../scripts/legacy/tar/linux/opensearch-tar-install.sh",
-                )
-            ),
-            "path/opensearch-tar-install.sh",
-        )
 
         mock_bundle.build_tar.assert_called_with("curdir/bundle")
 

--- a/tests/tests_assemble_workflow/test_bundle_opensearch.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch.py
@@ -32,6 +32,30 @@ class TestBundleOpenSearch(unittest.TestCase):
         )
         self.assertIsNotNone(bundle.archive_path)
 
+    def test_bundle_install_min(self):
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
+        )
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        bundle = BundleOpenSearch(
+            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
+        )
+
+        with patch("subprocess.check_call") as mock_check_call:
+            bundle.install_min()
+
+            self.assertEqual(mock_check_call.call_count, 1)
+
+            mock_check_call.assert_has_calls(
+                [
+                    call(
+                        f'{ScriptFinder.find_install_script("OpenSearch")} -a "{artifacts_path}" -o "{bundle.archive_path}"',
+                        cwd=bundle.archive_path,
+                        shell=True,
+                    ),
+                ]
+            )
+
     @patch.object(BundleOpenSearch, "install_plugin")
     def test_bundle_install_plugins(self, mocks_bundle):
         manifest_path = os.path.join(

--- a/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
@@ -35,6 +35,30 @@ class TestBundleOpenSearchDashboards(unittest.TestCase):
         )
         self.assertIsNotNone(bundle.archive_path)
 
+    def test_bundle_install_min(self):
+        manifest_path = os.path.join(
+            os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml"
+        )
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        bundle = BundleOpenSearchDashboards(
+            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
+        )
+
+        with patch("subprocess.check_call") as mock_check_call:
+            bundle.install_min()
+
+            self.assertEqual(mock_check_call.call_count, 1)
+
+            mock_check_call.assert_has_calls(
+                [
+                    call(
+                        f'{ScriptFinder.find_install_script("OpenSearch-Dashboards")} -a "{artifacts_path}" -o "{bundle.archive_path}"',
+                        cwd=bundle.archive_path,
+                        shell=True,
+                    ),
+                ]
+            )
+
     @patch("os.path.isfile", return_value=True)
     def test_bundle_install_plugin(self, *mocks):
         manifest_path = os.path.join(


### PR DESCRIPTION
### Description
Adding install script for OpenSearch and OpenSearch Dashboards so
the bundles include default files.

These files include:
* opensearch-tar-install.sh
* config/opensearch_dashboards.yml

However, we did not want to include opensearch-tar-install.sh into
the OpenSearch Dashboards bundle because the script will fail to
execute as it is only expected to be an OpenSearch project.

Previous PR:
https://github.com/opensearch-project/opensearch-build/pull/758

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/610
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
