### PR TITLE
[Build] support building targets for inputted platform and arch 

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
         }
         stage('build') {
             parallel {
-                stage('build-x64') {
+                stage('build-linux-x64') {
                     agent {
                         docker {
                             label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
@@ -33,12 +33,62 @@ pipeline {
                     }
                     steps {
                         script {
-                            build()
+                            build("linux", "x64")
+                            assemble()
+                            publish()
                         }
                     }
                     post() {
                         always {
                             cleanWs disableDeferredWipeout: true, deleteDirs: true
+                        }
+                    }
+                }
+                stage('build-linux-arm64') {
+                    agent none
+                    stages {
+                        stage('build (linux-arm64)') {
+                            agent {
+                                docker {
+                                    label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
+                                    image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdk14-node10.24.1-cypress6.9.1-20211005'
+                                    alwaysPull true
+                                }
+                            }
+                            steps {
+                                script {
+                                    build("linux", "arm64")
+                                    zip zipFile: 'buildArtifacts.zip', archive: false, dir: 'artifacts'
+                                    archiveArtifacts artifacts: 'buildArtifacts.zip', fingerprint: true
+                                }
+                            }
+                            post() {
+                                always {
+                                    cleanWs disableDeferredWipeout: true, deleteDirs: true
+                                }
+                            }
+                        }
+                        stage('post-build (linux-arm64)') {
+                            agent {
+                                docker {
+                                    label 'Jenkins-Agent-al2-arm64-c6g4xlarge-Docker-Host'
+                                    image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdk14-node10.24.1-cypress6.9.1-20211005'
+                                    alwaysPull true
+                                }
+                            }
+                            steps {
+                                script {
+                                    copyArtifacts filter: 'buildArtifacts.zip', fingerprintArtifacts: true, projectName: env.JOB_NAME, selector: specific(env.BUILD_NUMBER)
+                                    unzip zipFile: 'buildArtifacts.zip', dir: './artifacts'
+                                    assemble()
+                                    publish()
+                                }
+                            }
+                            post() {
+                                always {
+                                    cleanWs disableDeferredWipeout: true, deleteDirs: true
+                                }
+                            }
                         }
                     }
                 }
@@ -59,14 +109,21 @@ pipeline {
     }
 }
 
-void build() {
+void build(platform, arch) {
     git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
 
-    sh "./build.sh manifests/$INPUT_MANIFEST"
-    sh './assemble.sh artifacts/manifest.yml'
+    sh "./build.sh manifests/$INPUT_MANIFEST -p $platform -a $arch"
+}
 
+void assemble() {
+    git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
+
+    sh './assemble.sh artifacts/manifest.yml'
+}
+
+void publish() {
     script { manifest = readYaml(file: 'artifacts/manifest.yml') }
-    def artifactPath = "${manifest.build.version}/${BUILD_NUMBER}/${manifest.build.architecture}";
+    def artifactPath = "${manifest.build.version}/${BUILD_NUMBER}/${manifest.build.platform}-${manifest.build.architecture}";
 
     withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
         s3Upload(file: 'artifacts', bucket: "${ARTIFACT_BUCKET_NAME}", path: "builds/opensearch-dashboards/${artifactPath}")
@@ -95,7 +152,7 @@ String getAllJenkinsMessages() {
     script {
         // Stages must be explicitly added to prevent overwriting
         // See https://ryan.himmelwright.net/post/jenkins-parallel-stashing/
-        def stages = ['build-x64']
+        def stages = ['build-linux-x64', 'build-linux-arm64']
         for (stage in stages) {
             unstash "notifications-${stage}"
         }

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -14,6 +14,8 @@ class BuildArgs:
     snapshot: bool
     component: str
     keep: bool
+    platform: str
+    arch: str
 
     def __init__(self):
         parser = argparse.ArgumentParser(description="Build an OpenSearch Bundle")
@@ -37,6 +39,12 @@ class BuildArgs:
             help="Do not delete the working temporary directory.",
         )
         parser.add_argument(
+            "-p", "--platform", type=str, help="Platform to build."
+        )
+        parser.add_argument(
+            "-a", "--arch", type=str, help="Architecture to build."
+        )
+        parser.add_argument(
             "-v",
             "--verbose",
             help="Show more verbose output.",
@@ -52,6 +60,8 @@ class BuildArgs:
         self.snapshot = args.snapshot
         self.component = args.component
         self.keep = args.keep
+        self.platform = args.platform
+        self.arch = args.arch
         self.script_path = sys.argv[0].replace("/src/run_build.py", "/build.sh")
 
     def component_command(self, name):

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -37,6 +37,8 @@ def main():
             version=manifest.build.version,
             snapshot=args.snapshot,
             output_dir=output_dir,
+            platform=args.platform,
+            arch=args.arch,
         )
 
         os.makedirs(target.output_dir, exist_ok=True)

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -7,7 +7,7 @@
 import os
 import tempfile
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 import pytest
 
@@ -34,11 +34,12 @@ class TestRunBuild(unittest.TestCase):
     )
 
     @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST])
+    @patch("run_build.BuildTarget", return_value=MagicMock(output_dir="artifacts"))
     @patch("run_build.Builder", return_value=MagicMock())
     @patch("run_build.BuildRecorder", return_value=MagicMock())
     @patch("run_build.GitRepository", return_value=MagicMock(working_directory="dummy"))
     @patch("run_build.TemporaryDirectory")
-    def test_main(self, mock_temp, mock_repo, mock_recorder, mock_builder, *mocks):
+    def test_main(self, mock_temp, mock_repo, mock_recorder, mock_builder, mock_target, *mocks):
         mock_temp.return_value.__enter__.return_value = tempfile.gettempdir()
 
         main()
@@ -68,6 +69,15 @@ class TestRunBuild(unittest.TestCase):
             any_order=True,
         )
 
+        mock_target.assert_called_once_with(
+            name="OpenSearch",
+            version="1.1.0",
+            snapshot=False,
+            platform=None,
+            arch=None,
+            output_dir=ANY
+        )
+
         self.assertEqual(mock_repo.call_count, 15)
 
         # each component is built and its artifacts exported
@@ -89,6 +99,56 @@ class TestRunBuild(unittest.TestCase):
         self.assertEqual(mock_builder.call_count, 15)
         self.assertEqual(mock_builder.return_value.build.call_count, 15)
         self.assertEqual(mock_builder.return_value.export_artifacts.call_count, 15)
+
+        # the output manifest is written
+        mock_recorder.return_value.write_manifest.assert_called()
+
+    OPENSEARCH_DASHBOARDS_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__), "../manifests/1.1.0/opensearch-dashboards-1.1.0.yml"
+        )
+    )
+
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_DASHBOARDS_MANIFEST, "-p", "testplatform", "-a", "testarch"])
+    @patch("run_build.BuildTarget", return_value=MagicMock(output_dir="artifacts"))
+    @patch("run_build.Builder", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.GitRepository", return_value=MagicMock(working_directory="dummy"))
+    @patch("run_build.TemporaryDirectory")
+    def test_main_with_arch(self, mock_temp, mock_repo, mock_recorder, mock_builder, mock_target, *mocks):
+        mock_temp.return_value.__enter__.return_value = tempfile.gettempdir()
+
+        main()
+
+        # each repository is checked out locally
+        mock_repo.assert_has_calls(
+            [
+                call(
+                    "https://github.com/opensearch-project/OpenSearch-Dashboards.git",
+                    "1.1",
+                    os.path.join(tempfile.gettempdir(), "OpenSearch-Dashboards"),
+                    None,
+                ),
+            ],
+            any_order=True,
+        )
+
+        mock_target.assert_called_once_with(
+            name="OpenSearch Dashboards",
+            version="1.1.0",
+            snapshot=False,
+            platform="testplatform",
+            arch="testarch",
+            output_dir=ANY
+        )
+
+        # each component is built and its artifacts exported
+        mock_builder.assert_has_calls(
+            [
+                call("OpenSearch-Dashboards", mock_repo.return_value, mock_recorder.return_value),
+            ],
+            any_order=True,
+        )
 
         # the output manifest is written
         mock_recorder.return_value.write_manifest.assert_called()

--- a/tests/tests_build_workflow/test_build_args.py
+++ b/tests/tests_build_workflow/test_build_args.py
@@ -64,6 +64,22 @@ class TestBuildArgs(unittest.TestCase):
     def test_component(self):
         self.assertEqual(BuildArgs().component, "xyz")
 
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_platform_default(self):
+        self.assertIsNone(BuildArgs().platform)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--platform", "xyz"])
+    def test_platform(self):
+        self.assertEqual(BuildArgs().platform, "xyz")
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_arch_default(self):
+        self.assertIsNone(BuildArgs().arch)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--arch", "xyz"])
+    def test_arch(self):
+        self.assertEqual(BuildArgs().arch, "xyz")
+
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
     def test_script_path(self):
         self.assertTrue(os.path.isfile(self.BUILD_PY))


### PR DESCRIPTION
### Description
Adding `platform` and `arch` as a build argument to be passed to
the build target. This enables cross-platform builds, for example,
we can build linux x64 on a linux ARM64 machine.

We would want to do this because some of the libraries that are
required for building (not for runtime) are not available for
certain operating systems.

Also updated the OpenSearch Dashboards Jenkinsfile to pass the
platform and arch.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/739
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
