### PR TITLE
Build OpenSearch on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
+          - windows-latest
     runs-on: ${{ matrix.os }}
     env:
       PYTHON_VERSION: 3.7

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ out.txt
 
 /artifacts/
 /bundle/
+
+/.vscode/

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -24,7 +24,7 @@ Fork this repository on GitHub, and clone locally with `git clone`.
 
 #### Pyenv
 
-Use pyenv to manage multiple versions of Python. This can be installed with [pyenv-installer](https://github.com/pyenv/pyenv-installer).
+Use pyenv to manage multiple versions of Python. This can be installed with [pyenv-installer](https://github.com/pyenv/pyenv-installer) on Linux and MacOS, and [pyenv-win](https://github.com/pyenv-win/pyenv-win#installation) on Windows.
 
 ```
 curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
@@ -42,7 +42,7 @@ Python 3.7.11
 If you are using pyenv.
 
 ```
-pyenv install 3.7.12
+pyenv install 3.7.12 # use 3.7.9 on Windows, the latest at the time of writing this
 pyenv global 3.7.12
 ```
 
@@ -57,7 +57,10 @@ $ pipenv --version
 pipenv, version 19.0
 ```
 
+On Windows, run `pyenv rehash` if `pipenv` cannot be found. This rehashes pyenv shims, creating a `pipenv` file in `/.pyenv/pyenv-win/shims/`.
+
 #### NVM and Node
+
 Install [nvm](https://github.com/nvm-sh/nvm/blob/master/README.md) to use the Node 10.24.1 version as it is required
 
 ```
@@ -66,6 +69,7 @@ nvm install v10.24.1
 ```
 
 #### Yarn
+
 [Yarn](https://classic.yarnpkg.com/en/docs/install) is required for building and running the OpenSearch Dashboards and plugins
 
 ```

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -16,6 +16,14 @@
         ]
     },
     "default": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197",
+                "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==1.4.0"
+        },
         "attrs": {
             "hashes": [
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
@@ -34,35 +42,35 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:68ee81a7ef40380a5ab973e242bbf8739d56a49f8691508c48760fb5066933e3",
-                "sha256:c2fd29e53464e4ab79c224363c20a02af19f7ecc8baf37f7886a893fc672272a"
+                "sha256:d468b1f63f22ccd6b4bfbdebe6fd0c0b4620f38276af965ed139fe3eb85d16bb",
+                "sha256:f93fed6153f7def66f1b17e6794c6ec3bec46229b213d3fa63f1eca126f5e992"
             ],
             "index": "pypi",
-            "version": "==1.18.45"
+            "version": "==1.19.0"
         },
         "boto3-stubs": {
             "hashes": [
-                "sha256:840cc77a88e4133a3471b3599ef05b4d054ac234284dc75ea7c620229dad653a",
-                "sha256:96778caf7dab653f79762168cc54822152e13fcf2793a903bb71e72cf153cc3c"
+                "sha256:af6ac293bf60c66ecfe7b33bbaeb4c53a765b42cc0744ee3d49e97454c63bd69",
+                "sha256:fcd7aef0cbdbcad7bf579c8c9fa5ae45c1947c1ecc74bd644bf8b4280df8fcd7"
             ],
             "index": "pypi",
-            "version": "==1.18.45"
+            "version": "==1.18.65"
         },
         "botocore": {
             "hashes": [
-                "sha256:1d31e461dfc9ddb9a86fdd47ebc61751adc8739b4f7160c687c04092e5fbe0aa",
-                "sha256:b3a77dcc7d54a3725aa0a9b44e4a79142a013584cd0568750a9ee9ab6970538f"
+                "sha256:b78184ff1b1512c8ac00ad2ec1cea513ead930ace95749ed39f9d059aafe0645",
+                "sha256:c9894037047a5e118be3e3ae6586ba32de7bb01257c46661874427720d52cde0"
             ],
             "index": "pypi",
-            "version": "==1.21.45"
+            "version": "==1.22.0"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:3a4d609d3dc6d4ca617b1c475e0ca528c363dc8190d26a8ccf97cc56531e4826",
-                "sha256:ab069e3ba59c58101cffb965e246eb31ac2fff2aba9abac7e7885bb0fe0f6b55"
+                "sha256:339db004986a53050b0cdc0cb17e88fdef97e18b4c0be0cebe8cd8df9007b71e",
+                "sha256:68071912afd45a2a0619459dea9db0f90d72f7e6b41e36309b94e4c0fede3e62"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.45"
+            "version": "==1.21.65"
         },
         "cerberus": {
             "hashes": [
@@ -73,10 +81,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
-                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
+                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
             ],
-            "version": "==2021.5.30"
+            "version": "==2021.10.8"
         },
         "cfgv": {
             "hashes": [
@@ -88,11 +96,19 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:5d209c0a931f215cee683b6445e2d77677e7e75e159f78def0db09d68fafcaa6",
-                "sha256:5ec46d183433dcbd0ab716f2d7f29d8dee50505b3fdb40c6b985c7c4f5a3591f"
+                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
+                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.6"
+            "version": "==2.0.7"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.4.4"
         },
         "coverage": {
             "hashes": [
@@ -141,10 +157,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
-                "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
+                "sha256:2b5eb3589e7fdda14599e7eb1a50e09b4cc14f34ed98b8ba56d33bfaafcbef2f",
+                "sha256:34a9f35f95c441e7b38209775d6e0337f9a3759f3565f6c5798f19618527c76f"
             ],
-            "version": "==3.0.12"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.3.1"
         },
         "flake8": {
             "hashes": [
@@ -156,26 +173,26 @@
         },
         "identify": {
             "hashes": [
-                "sha256:528a88021749035d5a39fe2ba67c0642b8341aaf71889da0e1ed669a429b87f0",
-                "sha256:de83a84d774921669774a2000bf87ebba46b4d1c04775f4a5d37deff0cf39f73"
+                "sha256:d1e82c83d063571bb88087676f81261a4eae913c492dafde184067c584bc7c05",
+                "sha256:fd08c97f23ceee72784081f1ce5125c8f53a02d3f2716dde79a6ab8f1039fea5"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==2.2.15"
+            "version": "==2.3.0"
         },
         "idna": {
             "hashes": [
-                "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
-                "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
             ],
             "markers": "python_version >= '3'",
-            "version": "==3.2"
+            "version": "==3.3"
         },
         "importlib-metadata": {
             "hashes": [
                 "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15",
                 "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version < '3.8' and python_version < '3.8'",
             "version": "==4.8.1"
         },
         "iniconfig": {
@@ -198,7 +215,7 @@
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.0"
         },
         "jproperties": {
@@ -269,11 +286,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:15b056538719b1c94bdaccb29e5f81879c7f7f0f4a153f46086d155dffcd4f0f",
-                "sha256:8003ac87717ae2c7ee1ea5a84a1a61e87f3fbd16eb5aadba194ea30a9019f648"
+                "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2",
+                "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.3.0"
+            "version": "==2.4.0"
         },
         "pluggy": {
             "hashes": [
@@ -354,7 +371,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -378,7 +395,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.2"
         },
         "pyyaml": {
@@ -445,7 +462,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "sortedcontainers": {
@@ -461,7 +478,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "typed-ast": {
@@ -502,19 +519,19 @@
         },
         "types-pyyaml": {
             "hashes": [
-                "sha256:1d9e431e9f1f78a65ea957c558535a3b15ad67ea4912bce48a6c1b613dcf81ad",
-                "sha256:f1d1357168988e45fa20c65aecb3911462246a84809015dd889ebf8b1db74124"
+                "sha256:3f4daa754357491625ae8c3a39c9e1b0d7cd5632bc4e1c35e7a7f75a64aa124b",
+                "sha256:e06083f85375a5678e4c19452ed6467ce2167b71db222313e1792cb8fc76859a"
             ],
             "index": "pypi",
-            "version": "==5.4.10"
+            "version": "==5.4.12"
         },
         "types-requests": {
             "hashes": [
-                "sha256:225ac2e86549b6ef3a8a44bf955f80b4955855704a15d2883d8445c8df637242",
-                "sha256:26e90866bcd773d76b316de7e6bd6e24641f9e1653cf27241c533886600f6824"
+                "sha256:b279284e51f668e38ee12d9665e4d789089f532dc2a0be4a1508ca0efd98ba9e",
+                "sha256:ba1d108d512e294b6080c37f6ae7cb2a2abf527560e2b671d1786c1fc46b541a"
             ],
             "index": "pypi",
-            "version": "==2.25.8"
+            "version": "==2.25.11"
         },
         "typing-extensions": {
             "hashes": [
@@ -522,7 +539,7 @@
                 "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7",
                 "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"
             ],
-            "markers": "python_version < '3.8'",
+            "markers": "python_version < '3.8' and python_version < '3.8'",
             "version": "==3.10.0.2"
         },
         "urllib3": {
@@ -530,24 +547,24 @@
                 "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
                 "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.7"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:4da4ac43888e97de9cf4fdd870f48ed864bbfd133d2c46cbdec941fed4a25aef",
-                "sha256:a4b987ec31c3c9996cf1bc865332f967fe4a0512c41b39652d6224f696e69da5"
+                "sha256:10062e34c204b5e4ec5f62e6ef2473f8ba76513a9a617e873f1f8fb4a519d300",
+                "sha256:bcc17f0b3a29670dd777d6f0755a4c04f28815395bca279cdcb213b97199a6b8"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.8.0"
+            "version": "==20.8.1"
         },
         "zipp": {
             "hashes": [
-                "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3",
-                "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"
+                "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
+                "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.5.0"
+            "version": "==3.6.0"
         }
     },
     "develop": {}

--- a/run.sh
+++ b/run.sh
@@ -20,4 +20,4 @@ export PIPENV_PIPFILE="$DIR/Pipfile"
 python3 -m pipenv install
 
 echo "Running "$1" ${@:2} ..."
-python3 -m pipenv run "$1" ${@:2}
+python3 -m pipenv run python "$1" ${@:2}

--- a/scripts/components/OpenSearch/build.sh
+++ b/scripts/components/OpenSearch/build.sh
@@ -72,18 +72,42 @@ mkdir -p $OUTPUT/maven/org/opensearch
 # Copy maven publications to be promoted
 cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org
 
+# Assemble distribution artifact
+# see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
+
 [ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
-# Assemble distribution artifact
-# see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
+case "$(uname -s)" in
+    Linux*) 
+        PACKAGE="tar"
+        EXT="tar.gz"
+        ;;
+    Darwin*)
+        PACKAGE="tar"
+        EXT="tar.gz"
+        ;;
+    CYGWIN*)
+        PACKAGE="zip"
+        EXT="zip"
+        ;;
+    MINGW*)
+        PACKAGE="zip"
+        EXT="zip"
+        ;;
+    *)
+        echo "Unsupported system: $(uname -s)"
+        exit 1
+        ;;
+esac
+
 case $ARCHITECTURE in
     x64)
-        TARGET="$PLATFORM-tar"
+        TARGET="$PLATFORM-$PACKAGE"
         QUALIFIER="$PLATFORM-x64"
         ;;
     arm64)
-        TARGET="$PLATFORM-arm64-tar"
+        TARGET="$PLATFORM-arm64-$PACKAGE"
         QUALIFIER="$PLATFORM-arm64"
         ;;
     *)
@@ -96,7 +120,7 @@ esac
 
 # Copy artifact to dist folder in bundle build output
 [[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
-ARTIFACT_BUILD_NAME=`ls distribution/archives/$TARGET/build/distributions/ | grep "opensearch-min.*$QUALIFIER.tar.gz"`
+ARTIFACT_BUILD_NAME=`ls distribution/archives/$TARGET/build/distributions/ | grep "opensearch-min.*$QUALIFIER.$EXT"`
 mkdir -p "${OUTPUT}/dist"
 cp distribution/archives/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/dist/$ARTIFACT_BUILD_NAME
 

--- a/src/assemble_workflow/bundle_opensearch.py
+++ b/src/assemble_workflow/bundle_opensearch.py
@@ -12,6 +12,6 @@ from assemble_workflow.bundle import Bundle
 class BundleOpenSearch(Bundle):
     def install_plugin(self, plugin):
         tmp_path = self._copy_component(plugin, "plugins")
-        cli_path = os.path.join(self.archive_path, "bin/opensearch-plugin")
+        cli_path = os.path.join(self.archive_path, "bin", "opensearch-plugin")
         self._execute(f"{cli_path} install --batch file:{tmp_path}")
         super().install_plugin(plugin)

--- a/src/assemble_workflow/bundle_opensearch_dashboards.py
+++ b/src/assemble_workflow/bundle_opensearch_dashboards.py
@@ -12,6 +12,6 @@ from assemble_workflow.bundle import Bundle
 class BundleOpenSearchDashboards(Bundle):
     def install_plugin(self, plugin):
         tmp_path = self._copy_component(plugin, "plugins")
-        cli_path = os.path.join(self.archive_path, "bin/opensearch-dashboards-plugin")
+        cli_path = os.path.join(self.archive_path, "bin", "opensearch-dashboards-plugin")
         self._execute(f"{cli_path} --allow-root install file:{tmp_path}")
         super().install_plugin(plugin)

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -6,6 +6,7 @@
 
 import argparse
 import logging
+import os
 import sys
 
 
@@ -75,7 +76,7 @@ class BuildArgs:
         self.keep = args.keep
         self.platform = args.platform
         self.architecture = args.architecture
-        self.script_path = sys.argv[0].replace("/src/run_build.py", "/build.sh")
+        self.script_path = sys.argv[0].replace(os.path.sep + os.path.join("src", "run_build.py"), f"{os.path.sep}build.sh")
 
     def component_command(self, name):
         return " ".join(

--- a/src/build_workflow/builder.py
+++ b/src/build_workflow/builder.py
@@ -34,6 +34,7 @@ class Builder:
         build_script = ScriptFinder.find_build_script(target.name, self.component_name, self.git_repo.working_directory)
         build_command = " ".join(
             [
+                "bash",
                 build_script,
                 "-v",
                 target.version,

--- a/src/ci_workflow/ci_args.py
+++ b/src/ci_workflow/ci_args.py
@@ -6,6 +6,7 @@
 
 import argparse
 import logging
+import os
 import sys
 
 
@@ -45,7 +46,7 @@ class CiArgs:
         self.component = args.component
         self.keep = args.keep
         self.logging_level = args.logging_level
-        self.script_path = sys.argv[0].replace("/src/run_ci.py", "/ci.sh")
+        self.script_path = sys.argv[0].replace(os.path.sep + os.path.join("src", "run_ci.py"), f"{os.path.sep}ci.sh")
 
     def component_command(self, name):
         return " ".join(

--- a/src/git/git_repository.py
+++ b/src/git/git_repository.py
@@ -29,9 +29,15 @@ class GitRepository:
             self.temp_dir = None
             self.dir = directory
             os.makedirs(self.dir, exist_ok=False)
-
         self.working_subdirectory = working_subdirectory
         self.__checkout__()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if self.temp_dir:
+            self.temp_dir.__exit__(exc_type, exc_value, exc_traceback)
 
     def __checkout__(self):
         # Check out the repository
@@ -41,13 +47,6 @@ class GitRepository:
         self.execute_silent("git checkout FETCH_HEAD", self.dir)
         self.sha = self.output("git rev-parse HEAD", self.dir)
         logging.info(f"Checked out {self.url}@{self.ref} into {self.dir} at {self.sha}")
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        if self.temp_dir:
-            self.temp_dir.__exit__(exc_type, exc_value, exc_traceback)
 
     @property
     def working_directory(self):

--- a/src/manifests/build_manifest.py
+++ b/src/manifests/build_manifest.py
@@ -19,7 +19,7 @@ schema-version: "1.2"
 build:
   name: string
   version: string
-  platform: linux or darwin
+  platform: linux, darwin or windows
   architecture: x64 or arm64
 components:
   - name: string

--- a/src/manifests/bundle_manifest.py
+++ b/src/manifests/bundle_manifest.py
@@ -21,7 +21,7 @@ class BundleManifest(Manifest):
         build:
           name: string
           version: string
-          platform: linux or darwin
+          platform: linux, darwin or windows
           architecture: x64 or arm64
           location: /relative/path/to/tarball
         components:

--- a/src/manifests/input_manifests.py
+++ b/src/manifests/input_manifests.py
@@ -16,5 +16,5 @@ class InputManifests(Manifests):
     def __init__(self):
         files = glob.glob(os.path.join(self.manifests_path, "**/opensearch-*.yml"))
         # there's an opensearch-1.0.0-maven.yml that we want to skip
-        files = [f for f in files if re.search(r"/opensearch-([0-9.]*)\.yml$", f)]
+        files = [f for f in files if re.search(r"[\\/]opensearch-([0-9.]*)\.yml$", f)]
         super().__init__(InputManifest, files)

--- a/src/manifests/manifests.py
+++ b/src/manifests/manifests.py
@@ -29,7 +29,7 @@ class Manifests(SortedDict):
 
     @property
     def manifests_path(self):
-        return os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests"))
+        return os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "manifests"))
 
     @property
     def versions(self):

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -23,7 +23,7 @@ class InputManifests(Manifests):
 
     @classmethod
     def manifests_path(self):
-        return os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests"))
+        return os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "manifests"))
 
     @classmethod
     def files(self, name):
@@ -49,7 +49,7 @@ class InputManifests(Manifests):
             logging.info(f"Checking {self.name} {branches} branches")
             for branch in branches:
                 c = min_klass.checkout(
-                    path=os.path.join(work_dir.name, f"{self.name.replace(' ', '')}/{branch}"),
+                    path=os.path.join(work_dir.name, self.name.replace(" ", ""), branch),
                     branch=branch,
                 )
                 version = c.version

--- a/src/paths/script_finder.py
+++ b/src/paths/script_finder.py
@@ -38,6 +38,7 @@ class ScriptFinder:
         script = next(filter(lambda path: os.path.exists(path), paths), None)
         if script is None:
             raise ScriptFinder.ScriptNotFoundError(name, paths)
+
         return script
 
     @classmethod

--- a/src/paths/script_finder.py
+++ b/src/paths/script_finder.py
@@ -14,9 +14,9 @@ class ScriptFinder:
             self.paths = paths
             super().__init__(f"Could not find {kind} script. Looked in {paths}.")
 
-    component_scripts_path = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../scripts/components"))
+    component_scripts_path = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.join("..", "..", "scripts", "components")))
 
-    default_scripts_path = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../scripts/default"))
+    default_scripts_path = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.join("..", "..", "scripts", "default")))
 
     """
     ScriptFinder is a helper that abstracts away the details of where to look for build, test and install scripts.
@@ -45,7 +45,7 @@ class ScriptFinder:
         paths = [
             os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "build.sh")),
             os.path.realpath(os.path.join(git_dir, "build.sh")),
-            os.path.realpath(os.path.join(git_dir, "scripts/build.sh")),
+            os.path.realpath(os.path.join(git_dir, "scripts", "build.sh")),
             os.path.realpath(
                 os.path.join(
                     cls.default_scripts_path,
@@ -62,7 +62,7 @@ class ScriptFinder:
         paths = [
             os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "integtest.sh")),
             os.path.realpath(os.path.join(git_dir, "integtest.sh")),
-            os.path.realpath(os.path.join(git_dir, "scripts/integtest.sh")),
+            os.path.realpath(os.path.join(git_dir, "scripts", "integtest.sh")),
             os.path.realpath(os.path.join(cls.default_scripts_path, "integtest.sh")),
         ]
 
@@ -81,7 +81,7 @@ class ScriptFinder:
     def find_bwc_test_script(cls, component_name, git_dir):
         paths = [
             os.path.realpath(os.path.join(git_dir, "bwctest.sh")),
-            os.path.realpath(os.path.join(git_dir, "scripts/bwctest.sh")),
+            os.path.realpath(os.path.join(git_dir, "scripts", "bwctest.sh")),
             os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "bwctest.sh")),
             os.path.realpath(os.path.join(cls.default_scripts_path, "bwctest.sh")),
         ]

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -25,7 +25,7 @@ def main():
     console.configure(level=args.logging_level)
     manifest = InputManifest.from_file(args.manifest)
 
-    with TemporaryDirectory(keep=args.keep) as work_dir:
+    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
         output_dir = os.path.join(os.getcwd(), "artifacts")
 
         logging.info(f"Building in {work_dir.name}")

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -25,7 +25,7 @@ def main():
     console.configure(level=args.logging_level)
     manifest = InputManifest.from_file(args.manifest)
 
-    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
+    with TemporaryDirectory(keep=args.keep) as work_dir:
         output_dir = os.path.join(os.getcwd(), "artifacts")
 
         logging.info(f"Building in {work_dir.name}")

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -56,6 +56,7 @@ def main():
                 continue
 
             logging.info(f"Building {component.name}")
+
             with GitRepository(
                 component.repository,
                 component.ref,

--- a/src/run_checkout.py
+++ b/src/run_checkout.py
@@ -30,12 +30,13 @@ def main():
         for component in manifest.components:
 
             logging.info(f"Checking out {component.name}")
-            GitRepository(
+            with GitRepository(
                 component.repository,
                 component.ref,
                 os.path.join(work_dir.name, component.name),
                 component.working_directory,
-            )
+            ) as repo:
+                logging.debug(f"Checked out {component.name} into {repo.dir}")
 
     logging.info(f"Done, checked out into {work_dir.name}.")
 

--- a/src/run_integ_test.py
+++ b/src/run_integ_test.py
@@ -24,17 +24,18 @@ from test_workflow.test_result.test_suite_results import TestSuiteResults
 
 def pull_build_repo(work_dir):
     logging.info("Pulling opensearch-build")
-    GitRepository(
+    with GitRepository(
         "https://github.com/opensearch-project/opensearch-build.git",
         "main",
         os.path.join(work_dir, "opensearch-build"),
-    )
+    ) as repo:
+        logging.info(f"Checked out opensearch-build into {repo.dir}")
 
 
 def main():
     args = TestArgs()
     console.configure(level=args.logging_level)
-    test_manifest_path = os.path.join(os.path.dirname(__file__), "test_workflow/config/test_manifest.yml")
+    test_manifest_path = os.path.join(os.path.dirname(__file__), "test_workflow", "config", "test_manifest.yml")
     test_manifest = TestManifest.from_path(test_manifest_path)
     integ_test_config = dict()
     for component in test_manifest.components:

--- a/src/run_perf_test.py
+++ b/src/run_perf_test.py
@@ -44,20 +44,20 @@ def main():
     with TemporaryDirectory(keep=args.keep) as work_dir:
         os.chdir(work_dir.name)
         current_workspace = os.path.join(work_dir.name, "infra")
-        GitRepository(get_infra_repo_url(), "main", current_workspace)
-        security = False
-        for component in manifest.components:
-            if component.name == "security":
-                security = True
+        with GitRepository(get_infra_repo_url(), "main", current_workspace):
+            security = False
+            for component in manifest.components:
+                if component.name == "security":
+                    security = True
 
-        with WorkingDirectory(current_workspace):
-            with PerfTestCluster.create(manifest, config, args.stack, security, current_workspace) as (
-                test_cluster_endpoint,
-                test_cluster_port,
-            ):
-                os.chdir(current_workspace)
-                perf_test_suite = PerfTestSuite(manifest, test_cluster_endpoint, security, current_workspace)
-                perf_test_suite.execute()
+            with WorkingDirectory(current_workspace):
+                with PerfTestCluster.create(manifest, config, args.stack, security, current_workspace) as (
+                    test_cluster_endpoint,
+                    test_cluster_port,
+                ):
+                    os.chdir(current_workspace)
+                    perf_test_suite = PerfTestSuite(manifest, test_cluster_endpoint, security, current_workspace)
+                    perf_test_suite.execute()
 
 
 if __name__ == "__main__":

--- a/src/system/os.py
+++ b/src/system/os.py
@@ -4,6 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import os
 import subprocess
 
 
@@ -18,4 +19,7 @@ def current_architecture():
 
 
 def current_platform():
-    return subprocess.check_output(["uname", "-s"]).decode().strip().lower()
+    if os.name == "nt":
+        return "windows"
+    else:
+        return subprocess.check_output(["uname", "-s"]).decode().strip().lower()

--- a/src/test_workflow/bwc_test/bwc_test_suite.py
+++ b/src/test_workflow/bwc_test/bwc_test_suite.py
@@ -29,15 +29,14 @@ class BwcTestSuite:
 
     def run_tests(self, work_dir, component_name):
         script = ScriptFinder.find_bwc_test_script(component_name, work_dir)
-        cmd = f"{script}"
-        (status, stdout, stderr) = execute(cmd, work_dir, True, False)
+        (status, stdout, stderr) = execute(script, work_dir, True, False)
         return (status, stdout, stderr)
 
     def component_bwc_tests(self, component):
         test_component = TestComponent(component.repository, component.commit_id)
         test_component.checkout(os.path.join(self.work_dir, component.name))
         try:
-            console_output = self.run_tests(self.work_dir + "/" + component.name, component.name)
+            console_output = self.run_tests(os.path.join(self.work_dir, component.name), component.name)
             return console_output
         except:
             # TODO: Store and report test failures for {component}

--- a/src/test_workflow/integ_test/integ_test_suite.py
+++ b/src/test_workflow/integ_test/integ_test_suite.py
@@ -68,7 +68,7 @@ class IntegTestSuite:
                 raise InvalidTestConfigError("Integration test job only supports job-scheduler build dependency at present.")
 
     def __copy_job_scheduler_artifact(self):
-        custom_local_path = os.path.join(self.repo.dir, "src/test/resources/job-scheduler")
+        custom_local_path = os.path.join(self.repo.dir, "src", "test", "resources", "job-scheduler")
         for file in glob.glob(os.path.join(custom_local_path, "opensearch-job-scheduler-*.zip")):
             os.unlink(file)
         job_scheduler = self.build_manifest.get_component("job-scheduler")

--- a/src/test_workflow/integ_test/local_test_cluster.py
+++ b/src/test_workflow/integ_test/local_test_cluster.py
@@ -171,11 +171,15 @@ class LocalTestCluster(TestCluster):
                 raise
         finally:
             logging.info(f"Process terminated with exit code {self.process.returncode}")
-            with open(os.path.join(os.path.realpath(self.work_dir), self.stdout.name), "r") as stdout:
-                self.local_cluster_stdout = stdout.read()
-            with open(os.path.join(os.path.realpath(self.work_dir), self.stderr.name), "r") as stderr:
-                self.local_cluster_stderr = stderr.read()
+            if self.stdout:
+                with open(os.path.join(self.work_dir, self.stdout.name), "r") as stdout:
+                    self.local_cluster_stdout = stdout.read()
+                    self.stdout.close()
+                    self.stdout = None
+            if self.stderr:
+                with open(os.path.join(self.work_dir, self.stderr.name), "r") as stderr:
+                    self.local_cluster_stderr = stderr.read()
+                self.stderr.close()
+                self.stderr = None
             self.return_code = self.process.returncode
-            self.stdout.close()
-            self.stderr.close()
             self.process = None

--- a/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/src/test_workflow/perf_test/perf_test_cluster.py
@@ -13,7 +13,7 @@ class PerfTestCluster(TestCluster):
 
     def __init__(self, bundle_manifest, config, stack_name, security, current_workspace):
         self.manifest = bundle_manifest
-        self.work_dir = "opensearch-cluster/cdk/single-node/"
+        self.work_dir = os.path.join("opensearch-cluster", "cdk", "single-node")
         self.current_workspace = current_workspace
         self.stack_name = stack_name
         self.cluster_endpoint = None

--- a/src/test_workflow/test_args.py
+++ b/src/test_workflow/test_args.py
@@ -49,8 +49,8 @@ class TestArgs:
         parser.add_argument(
             "--platform",
             type=str,
-            choices=["linux", "darwin"],
-            help="The os name e.g. linux, darwin",
+            choices=["linux", "darwin", "windows"],
+            help="The os name e.g. linux, darwin, windows",
             required=True,
         )
         parser.add_argument(

--- a/tests/test_aws/test_s3_bucket.py
+++ b/tests/test_aws/test_s3_bucket.py
@@ -4,6 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import os
 import unittest
 from unittest.mock import MagicMock, call, patch
 
@@ -115,10 +116,10 @@ class TestS3Bucket(unittest.TestCase):
         s3bucket = S3Bucket(bucket_name)
         s3bucket.upload_file(
             "tests/1.1.0/x64/opensearch-1.1.0-linux-x64.tar.gz",
-            "/tmp/opensearch-1.1.0-linux-x64.tar.gz",
+            os.path.join("tmp", "opensearch-1.1.0-linux-x64.tar.gz"),
         )
         mock_boto_client("s3").upload_file.assert_called_once_with(
-            "/tmp/opensearch-1.1.0-linux-x64.tar.gz",
+            os.path.join("tmp", "opensearch-1.1.0-linux-x64.tar.gz"),
             bucket_name,
             "tests/1.1.0/x64/opensearch-1.1.0-linux-x64.tar.gz",
         )
@@ -130,15 +131,15 @@ class TestS3Bucket(unittest.TestCase):
         mock_boto_client("sts").assume_role.return_value = expected_sts_response
         folder_path = "/"
         s3bucket = S3Bucket(bucket_name)
-        s3bucket.download_folder(folder_path, "/tmp")
+        s3bucket.download_folder(folder_path, "tmp")
         calls = [
             call(
                 "tests/1.1.0/x64/opensearch-1.1.0-linux-x64.tar.gz",
-                "/tmp/tests/1.1.0/x64/opensearch-1.1.0-linux-x64.tar.gz",
+                os.path.join("tmp", "tests", "1.1.0", "x64", "opensearch-1.1.0-linux-x64.tar.gz"),
             ),
             call(
                 "maven/org/opensearch/xyz-1.1.0.tar.gz",
-                "/tmp/maven/org/opensearch/xyz-1.1.0.tar.gz",
+                os.path.join("tmp", "maven", "org", "opensearch", "xyz-1.1.0.tar.gz"),
             ),
         ]
         mock_s3_resource.Bucket(bucket_name).download_file.assert_has_calls(calls)
@@ -149,11 +150,11 @@ class TestS3Bucket(unittest.TestCase):
     def test_download_file(self, mock_boto_resource, mock_boto_client):
         expected_sts_response = MockSTSResponse.successful_response()
         mock_boto_client("sts").assume_role.return_value = expected_sts_response
-        file_path = "tests/1.1.0/x64/opensearch-1.1.0-linux-x64.tar.gz"
+        key = "tests/1.1.0/x64/opensearch-1.1.0-linux-x64.tar.gz"
         s3bucket = S3Bucket(bucket_name)
-        s3bucket.download_file(file_path, "/tmp")
+        s3bucket.download_file(key, "tmp")
         calls = [
-            call(file_path, "/tmp/opensearch-1.1.0-linux-x64.tar.gz"),
+            call(key, os.path.join("tmp", "opensearch-1.1.0-linux-x64.tar.gz")),
         ]
         mock_s3_resource.Bucket(bucket_name).download_file.assert_has_calls(calls)
         self.assertTrue(mock_s3_resource.Bucket(bucket_name).download_file.call_count, 1)
@@ -162,10 +163,10 @@ class TestS3Bucket(unittest.TestCase):
     @patch("boto3.resource")
     def test_download_file_failure(self, mock_boto_resource, mock_boto_client):
         mock_boto_client("sts").assume_role.return_value = MockSTSResponse.successful_response()
-        file_path = "tests/1.1.0/x64/opensearch-1.1.0-linux-x64.tar.gz"
+        file_path = os.path.join("tests", "1.1.0", "x64", "opensearch-1.1.0-linux-x64.tar.gz")
         mock_boto_resource("s3").Bucket(bucket_name).download_file.side_effect = ClientError(
             error_response={"Error": {"Code": "403"}}, operation_name="GetObject"
         )
         s3bucket = S3Bucket(bucket_name)
         with self.assertRaises(S3DownloadError):
-            s3bucket.download_file(file_path, "/tmp")
+            s3bucket.download_file(file_path, "tmp")

--- a/tests/test_run_assemble.py
+++ b/tests/test_run_assemble.py
@@ -27,7 +27,7 @@ class TestRunAssemble(unittest.TestCase):
         out, _ = self.capfd.readouterr()
         self.assertTrue(out.startswith("usage:"))
 
-    BUILD_MANIFEST = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
+    BUILD_MANIFEST = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-1.1.0.yml")
 
     @patch("os.chdir")
     @patch("os.makedirs")
@@ -47,6 +47,6 @@ class TestRunAssemble(unittest.TestCase):
         mock_bundle.install_min.assert_called()
         mock_bundle.install_plugins.assert_called()
 
-        mock_bundle.build_tar.assert_called_with("curdir/bundle")
+        mock_bundle.build_tar.assert_called_with(os.path.join("curdir", "bundle"))
 
-        mock_recorder.return_value.write_manifest.assert_has_calls([call("path"), call("curdir/bundle")])  # manifest included in tar
+        mock_recorder.return_value.write_manifest.assert_has_calls([call("path"), call(os.path.join("curdir", "bundle"))])  # manifest included in tar

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -27,7 +27,15 @@ class TestRunBuild(unittest.TestCase):
         out, _ = self.capfd.readouterr()
         self.assertTrue(out.startswith("usage:"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../manifests/1.1.0/opensearch-1.1.0.yml"))
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "manifests",
+            "1.1.0",
+            "opensearch-1.1.0.yml",
+        )
+    )
 
     @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST])
     @patch("run_build.BuildTarget", return_value=MagicMock(output_dir="artifacts"))

--- a/tests/test_run_ci.py
+++ b/tests/test_run_ci.py
@@ -32,7 +32,7 @@ class TestRunCi(unittest.TestCase):
     @patch("argparse._sys.argv", ["run_ci.py", OPENSEARCH_MANIFEST])
     @patch("run_ci.Ci", return_value=MagicMock())
     @patch("run_ci.GitRepository", return_value=MagicMock(working_directory="dummy"))
-    @patch("run_ci.TemporaryDirectory.mkdtemp")
+    @patch("run_ci.TemporaryDirectory")
     def test_main(self, mock_temp, mock_repo, mock_ci, *mocks):
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
 

--- a/tests/test_run_ci.py
+++ b/tests/test_run_ci.py
@@ -32,7 +32,7 @@ class TestRunCi(unittest.TestCase):
     @patch("argparse._sys.argv", ["run_ci.py", OPENSEARCH_MANIFEST])
     @patch("run_ci.Ci", return_value=MagicMock())
     @patch("run_ci.GitRepository", return_value=MagicMock(working_directory="dummy"))
-    @patch("run_ci.TemporaryDirectory")
+    @patch("run_ci.TemporaryDirectory.mkdtemp")
     def test_main(self, mock_temp, mock_repo, mock_ci, *mocks):
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
 

--- a/tests/tests_assemble_workflow/test_bundle.py
+++ b/tests/tests_assemble_workflow/test_bundle.py
@@ -19,33 +19,31 @@ class TestBundle(unittest.TestCase):
 
     def test_bundle(self):
         manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = self.DummyBundle(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertEqual(bundle.min_tarball.name, "OpenSearch")
         self.assertEqual(len(bundle.plugins), 12)
         self.assertEqual(bundle.artifacts_dir, artifacts_path)
         self.assertIsNotNone(bundle.bundle_recorder)
         self.assertEqual(bundle.installed_plugins, [])
-        self.assertTrue(bundle.min_tarball_path.endswith("/opensearch-min-1.1.0-linux-x64.tar.gz"))
+        self.assertTrue(bundle.min_tarball_path.endswith("opensearch-min-1.1.0-linux-x64.tar.gz"))
         self.assertIsNotNone(bundle.archive_path)
 
     def test_bundle_does_not_exist_raises_error(self):
         manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        with self.assertRaisesRegex(
-            FileNotFoundError,
-            "does-not-exist/dist/opensearch-min-1.1.0-linux-x64.tar.gz",
-        ):
+        with self.assertRaises(FileNotFoundError) as ctx:
             self.DummyBundle(
                 BuildManifest.from_path(manifest_path),
-                os.path.join(os.path.dirname(__file__), "data/does-not-exist"),
+                os.path.join(os.path.dirname(__file__), "data", "does-not-exist"),
                 MagicMock(),
             )
+        self.assertTrue("opensearch-min-1.1.0-linux-x64.tar.gz" in str(ctx.exception))
 
     def test_bundle_invalid_archive_raises_error(self):
         manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        with self.assertRaisesRegex(FileNotFoundError, "(/*)$"):
+        with self.assertRaises(FileNotFoundError):
             self.DummyBundle(
                 BuildManifest.from_path(manifest_path),
-                os.path.join(os.path.dirname(__file__), "data/invalid"),
+                os.path.join(os.path.dirname(__file__), "data", "invalid"),
                 MagicMock(),
             )

--- a/tests/tests_assemble_workflow/test_bundle_opensearch.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch.py
@@ -16,14 +16,14 @@ from paths.script_finder import ScriptFinder
 class TestBundleOpenSearch(unittest.TestCase):
     def test_bundle_opensearch(self):
         manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = BundleOpenSearch(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertEqual(bundle.min_tarball.name, "OpenSearch")
         self.assertEqual(len(bundle.plugins), 12)
         self.assertEqual(bundle.artifacts_dir, artifacts_path)
         self.assertIsNotNone(bundle.bundle_recorder)
         self.assertEqual(bundle.installed_plugins, [])
-        self.assertTrue(bundle.min_tarball_path.endswith("/opensearch-min-1.1.0-linux-x64.tar.gz"))
+        self.assertTrue(bundle.min_tarball_path.endswith("opensearch-min-1.1.0-linux-x64.tar.gz"))
         self.assertIsNotNone(bundle.archive_path)
 
     def test_bundle_install_min(self):
@@ -51,7 +51,7 @@ class TestBundleOpenSearch(unittest.TestCase):
         manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         bundle = BundleOpenSearch(
             BuildManifest.from_path(manifest_path),
-            os.path.join(os.path.dirname(__file__), "data/artifacts"),
+            os.path.join(os.path.dirname(__file__), "data", "artifacts"),
             MagicMock(),
         )
 
@@ -61,7 +61,7 @@ class TestBundleOpenSearch(unittest.TestCase):
     @patch("os.path.isfile", return_value=True)
     def test_bundle_install_plugin(self, *mocks):
         manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = BundleOpenSearch(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
 
         plugin = bundle.plugins[0]  # job-scheduler
@@ -73,7 +73,7 @@ class TestBundleOpenSearch(unittest.TestCase):
                 self.assertEqual(mock_copyfile.call_count, 1)
                 self.assertEqual(mock_check_call.call_count, 2)
 
-                install_plugin_bin = os.path.join(bundle.archive_path, "bin/opensearch-plugin")
+                install_plugin_bin = os.path.join(bundle.archive_path, "bin", "opensearch-plugin")
                 mock_check_call.assert_has_calls(
                     [
                         call(
@@ -91,7 +91,7 @@ class TestBundleOpenSearch(unittest.TestCase):
 
     def test_bundle_build_tar(self):
         manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = BundleOpenSearch(
             BuildManifest.from_path(manifest_path),
             artifacts_path,

--- a/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
@@ -16,14 +16,14 @@ from paths.script_finder import ScriptFinder
 class TestBundleOpenSearchDashboards(unittest.TestCase):
     def test_bundle_opensearch_dashboards(self):
         manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml")
-        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = BundleOpenSearchDashboards(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertEqual(bundle.min_tarball.name, "OpenSearch-Dashboards")
         self.assertEqual(len(bundle.plugins), 1)
         self.assertEqual(bundle.artifacts_dir, artifacts_path)
         self.assertIsNotNone(bundle.bundle_recorder)
         self.assertEqual(bundle.installed_plugins, [])
-        self.assertTrue(bundle.min_tarball_path.endswith("/opensearch-dashboards-min-1.1.0-linux-x64.tar.gz"))
+        self.assertTrue(bundle.min_tarball_path.endswith("opensearch-dashboards-min-1.1.0-linux-x64.tar.gz"))
         self.assertIsNotNone(bundle.archive_path)
 
     def test_bundle_install_min(self):
@@ -49,7 +49,7 @@ class TestBundleOpenSearchDashboards(unittest.TestCase):
     @patch("os.path.isfile", return_value=True)
     def test_bundle_install_plugin(self, *mocks):
         manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml")
-        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = BundleOpenSearchDashboards(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
 
         plugin = bundle.plugins[0]  # alertingDashboards
@@ -61,7 +61,7 @@ class TestBundleOpenSearchDashboards(unittest.TestCase):
                 self.assertEqual(mock_copyfile.call_count, 1)
                 self.assertEqual(mock_check_call.call_count, 2)
 
-                install_plugin_bin = os.path.join(bundle.archive_path, "bin/opensearch-dashboards-plugin")
+                install_plugin_bin = os.path.join(bundle.archive_path, "bin", "opensearch-dashboards-plugin")
                 mock_check_call.assert_has_calls(
                     [
                         call(

--- a/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -18,7 +18,7 @@ from system.temporary_directory import TemporaryDirectory
 class TestBundleRecorder(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
-        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
+        manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-1.1.0.yml")
         manifest = BuildManifest.from_path(manifest_path)
         self.bundle_recorder = BundleRecorder(manifest.build, "output_dir", "artifacts_dir")
 
@@ -42,14 +42,14 @@ class TestBundleRecorder(unittest.TestCase):
                     "platform": "linux",
                     "architecture": "x64",
                     "id": "c3ff7a232d25403fa8cc14c97799c323",
-                    "location": "output_dir/opensearch-1.1.0-linux-x64.tar.gz",
+                    "location": os.path.join("output_dir", "opensearch-1.1.0-linux-x64.tar.gz"),
                     "name": "OpenSearch",
                     "version": "1.1.0",
                 },
                 "components": [
                     {
                         "commit_id": "3913d7097934cbfe1fdcf919347f22a597d00b76",
-                        "location": "artifacts_dir/plugins",
+                        "location": os.path.join("artifacts_dir", "plugins"),
                         "name": component.name,
                         "ref": "main",
                         "repository": "https://github.com/opensearch-project/job_scheduler",
@@ -69,7 +69,7 @@ class TestBundleRecorder(unittest.TestCase):
                     "platform": "linux",
                     "architecture": "x64",
                     "id": "c3ff7a232d25403fa8cc14c97799c323",
-                    "location": "output_dir/opensearch-1.1.0-linux-x64.tar.gz",
+                    "location": os.path.join("output_dir", "opensearch-1.1.0-linux-x64.tar.gz"),
                     "name": "OpenSearch",
                     "version": "1.1.0",
                 },
@@ -107,7 +107,7 @@ class TestBundleRecorder(unittest.TestCase):
                     "platform": "linux",
                     "architecture": "x64",
                     "id": "c3ff7a232d25403fa8cc14c97799c323",
-                    "location": "output_dir/opensearch-1.1.0-linux-x64.tar.gz",
+                    "location": os.path.join("output_dir", "opensearch-1.1.0-linux-x64.tar.gz"),
                     "name": "OpenSearch",
                     "version": "1.1.0",
                 },
@@ -150,7 +150,7 @@ class TestBundleRecorder(unittest.TestCase):
 
 class TestBundleRecorderDashboards(unittest.TestCase):
     def setUp(self):
-        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml")
+        manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-dashboards-build-1.1.0.yml")
         manifest = BuildManifest.from_path(manifest_path)
         self.bundle_recorder = BundleRecorder(manifest.build, "output_dir", "artifacts_dir")
 
@@ -174,14 +174,14 @@ class TestBundleRecorderDashboards(unittest.TestCase):
                     "platform": "linux",
                     "architecture": "x64",
                     "id": "c94ebec444a94ada86a230c9297b1d73",
-                    "location": "output_dir/opensearch-dashboards-1.1.0-linux-x64.tar.gz",
+                    "location": os.path.join("output_dir", "opensearch-dashboards-1.1.0-linux-x64.tar.gz"),
                     "name": "OpenSearch Dashboards",
                     "version": "1.1.0",
                 },
                 "components": [
                     {
                         "commit_id": "ae789280740d7000d1f13245019414abeedfc286",
-                        "location": "artifacts_dir/plugins",
+                        "location": os.path.join("artifacts_dir", "plugins"),
                         "name": component.name,
                         "ref": "main",
                         "repository": "https://github.com/opensearch-project/alerting-dashboards-plugin",
@@ -201,7 +201,7 @@ class TestBundleRecorderDashboards(unittest.TestCase):
                     "platform": "linux",
                     "architecture": "x64",
                     "id": "c94ebec444a94ada86a230c9297b1d73",
-                    "location": "output_dir/opensearch-dashboards-1.1.0-linux-x64.tar.gz",
+                    "location": os.path.join("output_dir", "opensearch-dashboards-1.1.0-linux-x64.tar.gz"),
                     "name": "OpenSearch Dashboards",
                     "version": "1.1.0",
                 },
@@ -239,7 +239,7 @@ class TestBundleRecorderDashboards(unittest.TestCase):
                     "platform": "linux",
                     "architecture": "x64",
                     "id": "c94ebec444a94ada86a230c9297b1d73",
-                    "location": "output_dir/opensearch-dashboards-1.1.0-linux-x64.tar.gz",
+                    "location": os.path.join("output_dir", "opensearch-dashboards-1.1.0-linux-x64.tar.gz"),
                     "name": "OpenSearch Dashboards",
                     "version": "1.1.0",
                 },

--- a/tests/tests_assemble_workflow/test_bundles.py
+++ b/tests/tests_assemble_workflow/test_bundles.py
@@ -16,14 +16,14 @@ from manifests.build_manifest import BuildManifest
 
 class TestBundles(unittest.TestCase):
     def test_bundle_opensearch(self):
-        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
-        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-1.1.0.yml")
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = Bundles.create(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertIs(type(bundle), BundleOpenSearch)
 
     def test_bundle_opensearch_dashboards(self):
-        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml")
-        artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
+        manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-dashboards-build-1.1.0.yml")
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = Bundles.create(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertIs(type(bundle), BundleOpenSearchDashboards)
 

--- a/tests/tests_build_workflow/__init__.py
+++ b/tests/tests_build_workflow/__init__.py
@@ -7,4 +7,4 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))

--- a/tests/tests_build_workflow/test_build_args.py
+++ b/tests/tests_build_workflow/test_build_args.py
@@ -14,11 +14,20 @@ from build_workflow.build_args import BuildArgs
 
 class TestBuildArgs(unittest.TestCase):
 
-    BUILD_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/run_build.py"))
+    BUILD_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "run_build.py"))
 
-    BUILD_SH = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../build.sh"))
+    BUILD_SH = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "build.sh"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"))
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "manifests",
+            "1.1.0",
+            "opensearch-1.1.0.yml",
+        )
+    )
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
     def test_manifest(self):

--- a/tests/tests_build_workflow/test_build_recorder.py
+++ b/tests/tests_build_workflow/test_build_recorder.py
@@ -91,10 +91,11 @@ class TestBuildRecorder(unittest.TestCase):
             ),
         )
 
-        recorder.record_artifact("common-utils", "files", "../file1.jar", __file__)
+        recorder.record_artifact("common-utils", "files", os.path.join("..", "file1.jar"), __file__)
 
-        mock_makedirs.assert_called_with("output_dir/..", exist_ok=True)
-        mock_copyfile.assert_called_with(__file__, "output_dir/../file1.jar")
+        output_dir = os.path.join("output_dir", "..")
+        mock_makedirs.assert_called_with(output_dir, exist_ok=True)
+        mock_copyfile.assert_called_with(__file__, os.path.join(output_dir, "file1.jar"))
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")

--- a/tests/tests_build_workflow/test_builder.py
+++ b/tests/tests_build_workflow/test_builder.py
@@ -37,6 +37,7 @@ class TestBuilder(unittest.TestCase):
         self.builder.git_repo.execute.assert_called_with(
             " ".join(
                 [
+                    "bash",
                     os.path.realpath(os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")),
                     "-v 1.0.0",
                     "-p linux",
@@ -61,6 +62,7 @@ class TestBuilder(unittest.TestCase):
         self.builder.git_repo.execute.assert_called_with(
             " ".join(
                 [
+                    "bash",
                     os.path.realpath(os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")),
                     "-v 1.0.0",
                     "-p darwin",

--- a/tests/tests_build_workflow/test_builder.py
+++ b/tests/tests_build_workflow/test_builder.py
@@ -73,10 +73,10 @@ class TestBuilder(unittest.TestCase):
         self.builder.build_recorder.record_component.assert_called_with("component", self.builder.git_repo)
 
     def mock_os_walk(self, artifact_path):
-        if artifact_path.endswith("/checked-out-component/artifacts/core-plugins"):
-            return [["/core-plugins", [], ["plugin1.zip"]]]
-        if artifact_path.endswith("/checked-out-component/artifacts/maven"):
-            return [("/maven", [], ["artifact1.jar"])]
+        if artifact_path.endswith(os.path.join("checked-out-component", "artifacts", "core-plugins")):
+            return [["core-plugins", [], ["plugin1.zip"]]]
+        if artifact_path.endswith(os.path.join("checked-out-component", "artifacts", "maven")):
+            return [("maven", [], ["artifact1.jar"])]
         else:
             return []
 
@@ -90,14 +90,20 @@ class TestBuilder(unittest.TestCase):
                 call(
                     "component",
                     "maven",
-                    os.path.relpath("/maven/artifact1.jar", self.builder.artifacts_path),
-                    "/maven/artifact1.jar",
+                    os.path.relpath(
+                        os.path.join("maven", "artifact1.jar"),
+                        self.builder.artifacts_path,
+                    ),
+                    os.path.join("maven", "artifact1.jar"),
                 ),
                 call(
                     "component",
                     "core-plugins",
-                    os.path.relpath("/core-plugins/plugin1.zip", self.builder.artifacts_path),
-                    "/core-plugins/plugin1.zip",
+                    os.path.relpath(
+                        os.path.join("core-plugins", "plugin1.zip"),
+                        self.builder.artifacts_path,
+                    ),
+                    os.path.join("core-plugins", "plugin1.zip"),
                 ),
             ]
         )

--- a/tests/tests_checkout_workflow/test_checkout_args.py
+++ b/tests/tests_checkout_workflow/test_checkout_args.py
@@ -14,9 +14,18 @@ from checkout_workflow.checkout_args import CheckoutArgs
 
 class TestCheckoutArgs(unittest.TestCase):
 
-    CHECKOUT_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/run_checkout.py"))
+    CHECKOUT_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "run_checkout.py"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"))
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "manifests",
+            "1.1.0",
+            "opensearch-1.1.0.yml",
+        )
+    )
 
     @patch("argparse._sys.argv", [CHECKOUT_PY, OPENSEARCH_MANIFEST])
     def test_manifest(self):

--- a/tests/tests_ci_workflow/test_ci_args.py
+++ b/tests/tests_ci_workflow/test_ci_args.py
@@ -13,11 +13,20 @@ from ci_workflow.ci_args import CiArgs
 
 class TestCiArgs(unittest.TestCase):
 
-    CI_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/run_ci.py"))
+    CI_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "run_ci.py"))
 
-    CI_SH = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../ci.sh"))
+    CI_SH = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "ci.sh"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"))
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "manifests",
+            "1.1.0",
+            "opensearch-1.1.0.yml",
+        )
+    )
 
     @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST])
     def test_manifest(self):

--- a/tests/tests_ci_workflow/test_ci_check_gradle_dependencies.py
+++ b/tests/tests_ci_workflow/test_ci_check_gradle_dependencies.py
@@ -47,7 +47,7 @@ class TestCiCheckGradleDependencies(unittest.TestCase):
         )
 
     def test_loads_tree(self):
-        data_path = os.path.join(os.path.dirname(__file__), "data/job_scheduler_dependencies.txt")
+        data_path = os.path.join(os.path.dirname(__file__), "data", "job_scheduler_dependencies.txt")
         with open(data_path) as f:
             check = self.__mock_dependencies(props=f.read())
             self.assertEqual(

--- a/tests/tests_git/test_git_repository.py
+++ b/tests/tests_git/test_git_repository.py
@@ -37,7 +37,7 @@ class TestGitRepository(unittest.TestCase):
     def test_execute_in_dir(self):
         self.repo.execute("echo $PWD > created.txt", os.path.join(self.repo.dir, "ISSUE_TEMPLATE"))
         self.assertFalse(os.path.isfile(os.path.join(self.repo.dir, "created.txt")))
-        self.assertTrue(os.path.isfile(os.path.join(self.repo.dir, "ISSUE_TEMPLATE/created.txt")))
+        self.assertTrue(os.path.isfile(os.path.join(self.repo.dir, "ISSUE_TEMPLATE", "created.txt")))
 
     @patch("subprocess.check_call")
     def test_execute_silent(self, mock_subprocess):
@@ -76,13 +76,12 @@ class TestGitRepositoryDir(unittest.TestCase):
 
 class TestGitRepositoryWithWorkingDir(unittest.TestCase):
     def test_checkout_into_dir(self):
-        repo = GitRepository(
+        with GitRepository(
             url="https://github.com/opensearch-project/.github",
             ref="163b5acaf6c7d220f800684801bbf2e12f99c797",
             working_subdirectory="ISSUE_TEMPLATE",
-        )
-
-        self.assertEqual(repo.working_directory, os.path.join(repo.dir, "ISSUE_TEMPLATE"))
-
-        pwd = repo.output("pwd")
-        self.assertEqual(pwd, os.path.join(repo.dir, "ISSUE_TEMPLATE"))
+        ) as repo:
+            working_directory = os.path.join(repo.dir, "ISSUE_TEMPLATE")
+            self.assertEqual(repo.working_directory, working_directory)
+            self.assertTrue("ISSUE_TEMPLATE" in repo.output("pwd"))
+        self.assertFalse(os.path.exists(repo.dir))

--- a/tests/tests_manifests/test_build_manifest.py
+++ b/tests/tests_manifests/test_build_manifest.py
@@ -5,6 +5,7 @@
 # compatible open source license.
 
 import os
+import tempfile
 import unittest
 from unittest.mock import mock_open, patch
 
@@ -70,14 +71,15 @@ class TestBuildManifest(unittest.TestCase):
             self.manifest.build.platform,
             self.manifest.build.architecture,
         )
+        dest = os.path.realpath(os.path.join(tempfile.gettempdir(), "xyz"))
         BuildManifest.from_s3(
             "bucket_name",
             self.manifest.build.id,
             self.manifest.build.version,
             self.manifest.build.platform,
             self.manifest.build.architecture,
-            "/xyz",
+            dest,
         )
         self.assertEqual(s3_bucket.download_file.call_count, 1)
-        s3_bucket.download_file.assert_called_with(s3_download_path, "/xyz")
-        os.remove.assert_called_with("/xyz/manifest.yml")
+        s3_bucket.download_file.assert_called_with(s3_download_path, dest)
+        os.remove.assert_called_with(os.path.join(dest, "manifest.yml"))

--- a/tests/tests_manifests/test_bundle_manifest.py
+++ b/tests/tests_manifests/test_bundle_manifest.py
@@ -5,6 +5,7 @@
 # compatible open source license.
 
 import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -79,14 +80,15 @@ class TestBundleManifest(unittest.TestCase):
             self.manifest.build.platform,
             self.manifest.build.architecture,
         )
+        dest = os.path.realpath(os.path.join(tempfile.gettempdir(), "xyz"))
         BundleManifest.from_s3(
             "bucket_name",
             self.manifest.build.id,
             self.manifest.build.version,
             self.manifest.build.platform,
             self.manifest.build.architecture,
-            "/xyz",
+            dest,
         )
         self.assertEqual(s3_bucket.download_file.call_count, 1)
-        s3_bucket.download_file.assert_called_with(s3_download_path, "/xyz")
-        os.remove.assert_called_with("/xyz/manifest.yml")
+        s3_bucket.download_file.assert_called_with(s3_download_path, dest)
+        os.remove.assert_called_with(os.path.join(dest, "manifest.yml"))

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -15,10 +15,10 @@ from manifests.input_manifest import InputManifest
 class TestInputManifest(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
-        self.manifests_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests"))
+        self.manifests_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "manifests"))
 
     def test_1_0(self):
-        path = os.path.join(self.manifests_path, "1.0.0/opensearch-1.0.0.yml")
+        path = os.path.join(self.manifests_path, "1.0.0", "opensearch-1.0.0.yml")
         manifest = InputManifest.from_path(path)
         self.assertEqual(manifest.version, "1.0")
         self.assertEqual(manifest.build.name, "OpenSearch")
@@ -35,7 +35,7 @@ class TestInputManifest(unittest.TestCase):
             self.assertIsInstance(component.ref, str)
 
     def test_1_1(self):
-        path = os.path.join(self.manifests_path, "1.1.0/opensearch-1.1.0.yml")
+        path = os.path.join(self.manifests_path, "1.1.0", "opensearch-1.1.0.yml")
         manifest = InputManifest.from_path(path)
         self.assertEqual(manifest.version, "1.0")
         self.assertEqual(manifest.build.name, "OpenSearch")
@@ -91,7 +91,7 @@ class TestInputManifest(unittest.TestCase):
         self.assertEqual(alerting_component.checks[1].args, "alerting")
 
     def test_to_dict(self):
-        path = os.path.join(self.manifests_path, "1.1.0/opensearch-1.1.0.yml")
+        path = os.path.join(self.manifests_path, "1.1.0", "opensearch-1.1.0.yml")
         manifest = InputManifest.from_path(path)
         data = manifest.to_dict()
         with open(path) as f:

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -12,5 +12,5 @@ from manifests_workflow.input_manifests import InputManifests
 
 class TestInputManifests(unittest.TestCase):
     def test_manifests_path(self):
-        path = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/"))
+        path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "manifests"))
         self.assertEqual(path, InputManifests.manifests_path())

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
@@ -16,7 +16,16 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
     def test_files(self):
         files = InputManifestsOpenSearch.files()
         self.assertTrue(len(files) >= 2)
-        manifest = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"))
+        manifest = os.path.realpath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "..",
+                "manifests",
+                "1.1.0",
+                "opensearch-1.1.0.yml",
+            )
+        )
         self.assertTrue(manifest in files)
 
     @patch("os.makedirs")
@@ -24,10 +33,8 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
     @patch("manifests_workflow.input_manifests.InputManifest.from_path")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearchMin")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearch")
-    @patch("system.temporary_directory.TemporaryDirectory")
     @patch("manifests_workflow.input_manifests.InputManifest")
-    def test_update(self, mock_input_manifest, mock_tmpdir, mock_component_opensearch, mock_component_opensearch_min, mock_input_manifest_from_path, *mocks):
-        mock_tmpdir.__enter__.return_value = "dir"
+    def test_update(self, mock_input_manifest, mock_component_opensearch, mock_component_opensearch_min, mock_input_manifest_from_path, *mocks):
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
         mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
@@ -43,13 +50,15 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
             call(
                 os.path.join(
                     InputManifestsOpenSearch.manifests_path(),
-                    "0.10.0/opensearch-0.10.0.yml",
+                    "0.10.0",
+                    "opensearch-0.10.0.yml",
                 )
             ),
             call(
                 os.path.join(
                     InputManifestsOpenSearch.manifests_path(),
-                    "0.9.0/opensearch-0.9.0.yml",
+                    "0.9.0",
+                    "opensearch-0.9.0.yml",
                 )
             ),
         ]

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
@@ -18,7 +18,11 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
         manifest = os.path.realpath(
             os.path.join(
                 os.path.dirname(__file__),
-                "../../manifests/1.1.0/opensearch-dashboards-1.1.0.yml",
+                "..",
+                "..",
+                "manifests",
+                "1.1.0",
+                "opensearch-dashboards-1.1.0.yml",
             )
         )
         self.assertTrue(manifest in files)
@@ -27,10 +31,8 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
     @patch("os.chdir")
     @patch("manifests_workflow.input_manifests.InputManifest.from_path")
     @patch("manifests_workflow.input_manifests_opensearch_dashboards.ComponentOpenSearchDashboardsMin")
-    @patch("system.temporary_directory.TemporaryDirectory")
     @patch("manifests_workflow.input_manifests.InputManifest")
-    def test_update(self, mock_input_manifest, mock_tmpdir, mock_component_opensearch_min, mock_input_manifest_from_path, *mocks):
-        mock_tmpdir.__enter__.return_value = "dir"
+    def test_update(self, mock_input_manifest, mock_component_opensearch_min, mock_input_manifest_from_path, *mocks):
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch-Dashboards")
         mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
@@ -42,7 +44,8 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
             call(
                 os.path.join(
                     InputManifestsOpenSearchDashboards.manifests_path(),
-                    "0.9.0/opensearch-dashboards-0.9.0.yml",
+                    "0.9.0",
+                    "opensearch-dashboards-0.9.0.yml",
                 )
             )
         ]

--- a/tests/tests_manifests_workflow/test_manifests_args.py
+++ b/tests/tests_manifests_workflow/test_manifests_args.py
@@ -14,7 +14,7 @@ from manifests_workflow.manifests_args import ManifestsArgs
 
 class TestManifestsArgs(unittest.TestCase):
 
-    MANIFESTS_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/manifests.py"))
+    MANIFESTS_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "manifests.py"))
 
     @patch("argparse._sys.argv", [MANIFESTS_PY, "list"])
     def test_action_list(self):

--- a/tests/tests_paths/test_script_finder.py
+++ b/tests/tests_paths/test_script_finder.py
@@ -16,29 +16,29 @@ class TestScriptFinder(unittest.TestCase):
         self.maxDiff = None
         # use root of this repo as the default git checkout directory
         self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
-        self.component_with_scripts = os.path.join(self.data_path, "git/component-with-scripts")
-        self.component_with_scripts_folder = os.path.join(self.data_path, "git/component-with-scripts-folder")
-        self.component_without_scripts = os.path.join(self.data_path, "git/component-without-scripts")
+        self.component_with_scripts = os.path.join(self.data_path, "git", "component-with-scripts")
+        self.component_with_scripts_folder = os.path.join(self.data_path, "git", "component-with-scripts-folder")
+        self.component_without_scripts = os.path.join(self.data_path, "git", "component-without-scripts")
 
     # find_build_script
 
     def test_find_build_script_opensearch_default(self):
         self.assertEqual(
-            os.path.join(ScriptFinder.default_scripts_path, "opensearch/build.sh"),
+            os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh"),
             ScriptFinder.find_build_script("OpenSearch", "invalid", self.component_without_scripts),
             msg="A component without an override resolves to a default.",
         )
 
     def test_find_build_script_opensearch_dashboards_default(self):
         self.assertEqual(
-            os.path.join(ScriptFinder.default_scripts_path, "opensearch-dashboards/build.sh"),
+            os.path.join(ScriptFinder.default_scripts_path, "opensearch-dashboards", "build.sh"),
             ScriptFinder.find_build_script("OpenSearch-Dashboards", "invalid", self.component_without_scripts),
             msg="A component without an override resolves to a default.",
         )
 
     def test_find_build_script_component_override(self):
         self.assertEqual(
-            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/build.sh"),
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "build.sh"),
             ScriptFinder.find_build_script("OpenSearch", "OpenSearch", self.component_without_scripts),
             msg="A component without scripts resolves to a component override.",
         )
@@ -52,14 +52,14 @@ class TestScriptFinder(unittest.TestCase):
 
     def test_find_build_script_component_script_in_folder(self):
         self.assertEqual(
-            os.path.join(self.component_with_scripts_folder, "scripts/build.sh"),
+            os.path.join(self.component_with_scripts_folder, "scripts", "build.sh"),
             ScriptFinder.find_build_script("OpenSearch", "foobar", self.component_with_scripts_folder),
             msg="A component with a scripts folder resolves to a script in that folder.",
         )
 
     def test_find_build_script_component_script_in_folder_with_default(self):
         self.assertEqual(
-            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/build.sh"),
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "build.sh"),
             ScriptFinder.find_build_script("OpenSearch", "OpenSearch", self.component_with_scripts_folder),
             msg="A component with a scripts folder resolves to the override.",
         )
@@ -83,28 +83,28 @@ class TestScriptFinder(unittest.TestCase):
 
     def test_find_integ_test_script_component_override(self):
         self.assertEqual(
-            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"),
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "integtest.sh"),
             ScriptFinder.find_integ_test_script("OpenSearch", self.component_without_scripts),
             msg="A component without scripts resolves to a component override.",
         )
 
     def test_find_integ_test_script_component_script(self):
         self.assertEqual(
-            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"),
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "integtest.sh"),
             ScriptFinder.find_integ_test_script("OpenSearch", self.component_with_scripts),
             msg="A component with a script resolves to the script at the root.",
         )
 
     def test_find_integ_test_script_component_script_in_folder(self):
         self.assertEqual(
-            os.path.join(self.component_with_scripts_folder, "scripts/integtest.sh"),
+            os.path.join(self.component_with_scripts_folder, "scripts", "integtest.sh"),
             ScriptFinder.find_integ_test_script("foobar", self.component_with_scripts_folder),
             msg="A component with a scripts folder resolves to an override.",
         )
 
     def test_find_integ_test_script_component_script_in_folder_with_default(self):
         self.assertEqual(
-            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"),
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "integtest.sh"),
             ScriptFinder.find_integ_test_script("OpenSearch", self.component_with_scripts_folder),
             msg="A component with a scripts folder resolves to a script in that folder.",
         )
@@ -128,7 +128,7 @@ class TestScriptFinder(unittest.TestCase):
 
     def test_find_install_script_component_override(self):
         self.assertEqual(
-            os.path.join(ScriptFinder.component_scripts_path, "k-NN/install.sh"),
+            os.path.join(ScriptFinder.component_scripts_path, "k-NN", "install.sh"),
             ScriptFinder.find_install_script("k-NN"),
             msg="A component without scripts resolves to a component override.",
         )

--- a/tests/tests_paths/test_tree_walker.py
+++ b/tests/tests_paths/test_tree_walker.py
@@ -19,8 +19,16 @@ class TestTreeWalker(unittest.TestCase):
     def test_walk(self):
         paths = sorted(list(itertools.chain(walk(self.data_path))), key=lambda path: path[0])
         self.assertTrue(len(paths), 7)
-        self.assertEqual(paths[0][1], "git/component-with-scripts-folder/scripts/build.sh")
+        self.assertEqual(
+            paths[0][1],
+            os.path.join("git", "component-with-scripts-folder", "scripts", "build.sh"),
+        )
         self.assertEqual(
             paths[0][0],
-            os.path.realpath(os.path.join(self.data_path, "git/component-with-scripts-folder/scripts/build.sh")),
+            os.path.realpath(
+                os.path.join(
+                    self.data_path,
+                    os.path.join("git", "component-with-scripts-folder", "scripts", "build.sh"),
+                )
+            ),
         )

--- a/tests/tests_sign_workflow/test_signer.py
+++ b/tests/tests_sign_workflow/test_signer.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from unittest.mock import MagicMock, call, patch
 
@@ -19,17 +20,17 @@ class TestSigner(unittest.TestCase):
             "something-1.0.0.0.jar",
         ]
         expected = [
-            call("/path/the-jar.jar"),
-            call("/path/the-zip.zip"),
-            call("/path/the-war.war"),
-            call("/path/the-pom.pom"),
-            call("/path/the-module.module"),
-            call("/path/the-tar.tar.gz"),
-            call("/path/something-1.0.0.0.jar"),
+            call(os.path.join("path", "the-jar.jar")),
+            call(os.path.join("path", "the-zip.zip")),
+            call(os.path.join("path", "the-war.war")),
+            call(os.path.join("path", "the-pom.pom")),
+            call(os.path.join("path", "the-module.module")),
+            call(os.path.join("path", "the-tar.tar.gz")),
+            call(os.path.join("path", "something-1.0.0.0.jar")),
         ]
         signer = Signer()
         signer.sign = MagicMock()
-        signer.sign_artifacts(artifacts, "/path")
+        signer.sign_artifacts(artifacts, "path")
         self.assertEqual(signer.sign.call_args_list, expected)
 
     @patch(

--- a/tests/tests_system/test_os.py
+++ b/tests/tests_system/test_os.py
@@ -41,8 +41,8 @@ class TestOs(unittest.TestCase):
 
     # current_platform
     def test_current_platform(self):
-        self.assertTrue(current_platform() in ["linux", "darwin"])
+        self.assertTrue(current_platform() in ["linux", "darwin", "windows"])
 
-    @patch("subprocess.check_output", return_value="Xyz".encode())
+    @patch("subprocess.check_output", return_value="Windows".encode())
     def test_current_platform_lowercase(self, mock_subprocess):
-        self.assertTrue(current_platform() == "xyz")
+        self.assertTrue(current_platform() == "windows")

--- a/tests/tests_system/test_temporary_directory.py
+++ b/tests/tests_system/test_temporary_directory.py
@@ -5,18 +5,30 @@
 # compatible open source license.
 
 import os
+import stat
 import unittest
 
 from system.temporary_directory import TemporaryDirectory
 
 
 class TestTemporaryDirectory(unittest.TestCase):
-    def test_mkdtemp_keep_true(self):
+    def test_keep_true(self):
         with TemporaryDirectory(keep=True) as work_dir:
             self.assertTrue(os.path.exists(work_dir.name))
         self.assertTrue(os.path.exists(work_dir.name))
 
-    def test_mkdtemp_keep_false(self):
+    def test_keep_false(self):
         with TemporaryDirectory() as work_dir:
             self.assertTrue(os.path.exists(work_dir.name))
         self.assertFalse(os.path.exists(work_dir.name))
+
+    def test_remove_readonly(self):
+        with TemporaryDirectory() as work_dir:
+            filename = os.path.join(work_dir.name, "test.txt")
+            with open(filename, "w+") as f:
+                f.write("This is intentionally left blank.")
+            mode = os.stat(filename)[stat.ST_MODE]
+            os.chmod(filename, mode & ~stat.S_IWUSR & ~stat.S_IWGRP & ~stat.S_IWOTH)
+            self.assertTrue(os.path.exists(filename))
+        self.assertFalse(os.path.exists(work_dir.name))
+        self.assertFalse(os.path.exists(filename))

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_bwc_suite.py
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_bwc_suite.py
@@ -9,6 +9,7 @@ import unittest
 from unittest.mock import MagicMock, call, patch
 
 from manifests.bundle_manifest import BundleManifest
+from paths.script_finder import ScriptFinder
 from test_workflow.bwc_test.bwc_test_suite import BwcTestSuite
 
 
@@ -26,10 +27,12 @@ class TestBwcSuite(unittest.TestCase):
         self.bwc_test_suite.execute()
         self.assertEqual(self.bwc_test_suite.component_bwc_tests.call_args_list, expected)
 
-    def test_run_bwctest(self):
-        response = self.bwc_test_suite.run_tests(".", self.manifest.components[1].name)
-        # could find the script but the script exited because `./gradlew` doesn't exist
-        self.assertTrue("default/bwctest.sh" in response[2])  # stderr
+    @patch("test_workflow.bwc_test.bwc_test_suite.execute")
+    def test_run_bwctest(self, mock_execute):
+        mock_execute.return_value = (0, '', '')
+        self.bwc_test_suite.run_tests(".", self.manifest.components[1].name)
+        script = os.path.join(ScriptFinder.default_scripts_path, 'bwctest.sh')
+        mock_execute.assert_called_with(script, '.', True, False)
 
     @patch("test_workflow.bwc_test.bwc_test_suite.TestComponent")
     def test_component_bwctest(self, test_component_mock):
@@ -37,11 +40,11 @@ class TestBwcSuite(unittest.TestCase):
         self.bwc_test_suite.run_tests = MagicMock()
         expected = [
             call(
-                "./" + self.manifest.components[1].name,
+                os.path.join(".", self.manifest.components[1].name),
                 self.manifest.components[1].name,
             )
         ]
 
         self.bwc_test_suite.component_bwc_tests(component)
-        test_component_mock.return_value.checkout.assert_called_with("./" + component.name)
+        test_component_mock.return_value.checkout.assert_called_with(os.path.join(".", component.name))
         self.assertEqual(self.bwc_test_suite.run_tests.call_args_list, expected)

--- a/tests/tests_test_workflow/test_dependency_installer.py
+++ b/tests/tests_test_workflow/test_dependency_installer.py
@@ -11,7 +11,10 @@ class DependencyInstallerTests(unittest.TestCase):
         self.maxDiff = None
         self.manifest_filename = os.path.join(
             os.path.dirname(__file__),
-            "../tests_assemble_workflow/data/opensearch-build-1.1.0.yml",
+            "..",
+            "tests_assemble_workflow",
+            "data",
+            "opensearch-build-1.1.0.yml",
         )
         self.manifest = BuildManifest.from_path(self.manifest_filename)
         with patch("test_workflow.dependency_installer.S3Bucket") as mock_s3_bucket:

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite.py
@@ -38,7 +38,7 @@ class TestIntegSuite(unittest.TestCase):
             test_config,
             self.bundle_manifest,
             self.build_manifest,
-            "/tmpdir",
+            "tmpdir",
             "s3_bucket_name",
             mock_test_recorder,
         )
@@ -52,13 +52,13 @@ class TestIntegSuite(unittest.TestCase):
             [
                 call(
                     "integtest.sh -b localhost -p 9200 -s true -v 1.1.0",
-                    "/tmpdir/job-scheduler",
+                    os.path.join("tmpdir", "job-scheduler"),
                     True,
                     False,
                 ),
                 call(
                     "integtest.sh -b localhost -p 9200 -s false -v 1.1.0",
-                    "/tmpdir/job-scheduler",
+                    os.path.join("tmpdir", "job-scheduler"),
                     True,
                     False,
                 ),
@@ -75,14 +75,21 @@ class TestIntegSuite(unittest.TestCase):
             test_config,
             self.bundle_manifest,
             self.build_manifest,
-            "/tmpdir",
+            "tmpdir",
             "s3_bucket_name",
             mock_test_recorder,
         )
         integ_test_suite.execute()
         mock_dependency_installer.return_value.install_build_dependencies.assert_called_with(
             {"opensearch-job-scheduler": "1.1.0.0"},
-            "/tmpdir/index-management/src/test/resources/job-scheduler",
+            os.path.join(
+                "tmpdir",
+                "index-management",
+                "src",
+                "test",
+                "resources",
+                "job-scheduler",
+            ),
         )
 
     @patch.object(IntegTestSuite, "_IntegTestSuite__setup_cluster_and_execute_test_config")
@@ -95,7 +102,7 @@ class TestIntegSuite(unittest.TestCase):
             test_config,
             self.bundle_manifest,
             self.build_manifest,
-            "/tmpdir",
+            "tmpdir",
             "s3_bucket_name",
             mock_test_recorder,
         )
@@ -112,7 +119,7 @@ class TestIntegSuite(unittest.TestCase):
             test_config,
             self.bundle_manifest,
             self.build_manifest,
-            "/tmpdir",
+            "tmpdir",
             "s3_bucket_name",
             mock_test_recorder,
         )
@@ -130,7 +137,7 @@ class TestIntegSuite(unittest.TestCase):
             test_config,
             self.bundle_manifest,
             invalid_build_manifest,
-            "/tmpdir",
+            "tmpdir",
             "s3_bucket_name",
             mock_test_recorder,
         )
@@ -162,7 +169,7 @@ class TestIntegSuite(unittest.TestCase):
             test_config,
             self.bundle_manifest,
             self.build_manifest,
-            "/tmpdir",
+            "tmpdir",
             "s3_bucket_name",
             mock_test_recorder,
         )
@@ -170,4 +177,11 @@ class TestIntegSuite(unittest.TestCase):
         mock_local_test_cluster.create().__enter__.return_value = "localhost", "9200"
         mock_script_finder.return_value = "integtest.sh"
         integ_test_suite.execute()
-        mock_script_finder.assert_has_calls([call("dashboards-reports", "/tmpdir/dashboards-reports/reports-scheduler")])
+        mock_script_finder.assert_has_calls(
+            [
+                call(
+                    "dashboards-reports",
+                    os.path.join("tmpdir", "dashboards-reports", "reports-scheduler"),
+                )
+            ]
+        )

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster.py
@@ -7,7 +7,6 @@
 import os
 import subprocess
 import sys
-import tempfile
 import unittest
 from unittest.mock import MagicMock, call, mock_open, patch
 
@@ -24,7 +23,7 @@ class LocalTestClusterTests(unittest.TestCase):
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
     def setUp(self, mock_test_recorder):
         self.maxDiff = None
-        self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../../tests_manifests/data"))
+        self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "tests_manifests", "data"))
         self.manifest_filename = os.path.join(self.data_path, "opensearch-bundle-1.1.0.yml")
         self.manifest = BundleManifest.from_path(self.manifest_filename)
         self.work_dir = TemporaryDirectory()
@@ -160,8 +159,8 @@ class LocalTestClusterTests(unittest.TestCase):
     @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.terminate")
     @patch("test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock())
     def test_terminate_process(self, mock_logging, mock_terminate, mock_wait, mock_process):
-        self.local_test_cluster.stdout = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
-        self.local_test_cluster.stderr = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
+        self.local_test_cluster.stdout = None
+        self.local_test_cluster.stderr = None
         self.local_test_cluster.process = self.process
         self.local_test_cluster.terminate_process()
         mock_process.assert_called_once_with(self.process.pid)
@@ -184,8 +183,8 @@ class LocalTestClusterTests(unittest.TestCase):
     @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.terminate")
     @patch("test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock())
     def test_terminate_process_timeout(self, mock_logging, mock_terminate, mock_wait, mock_process):
-        self.local_test_cluster.stdout = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
-        self.local_test_cluster.stderr = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
+        self.local_test_cluster.stdout = None
+        self.local_test_cluster.stderr = None
         mock_wait.side_effect = subprocess.TimeoutExpired(cmd="pass", timeout=1)
         with self.assertRaises(subprocess.TimeoutExpired):
             self.local_test_cluster.process = self.process

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_run_integ_test.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_run_integ_test.py
@@ -35,6 +35,7 @@ class TestRunIntegTest(unittest.TestCase):
     @patch("run_integ_test.GitRepository")
     @patch("run_integ_test.DependencyInstaller")
     @patch("os.chdir")
+    @patch("os.makedirs")
     @patch("run_integ_test.TestSuiteResults")
     @patch.object(BundleManifest, "from_s3")
     @patch.object(BuildManifest, "from_s3")

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -43,7 +43,7 @@ class TestPerfTestCluster(unittest.TestCase):
                 with patch("builtins.open", MagicMock()):
                     with patch("json.load", mock_file):
                         self.perf_test_cluster.create_cluster()
-                        mock_chdir.assert_called_once_with("opensearch-cluster/cdk/single-node/")
+                        mock_chdir.assert_called_once_with(os.path.join("opensearch-cluster", "cdk", "single-node"))
                         self.assertEqual(mock_check_call.call_count, 1)
 
     def test_endpoint(self):
@@ -56,5 +56,5 @@ class TestPerfTestCluster(unittest.TestCase):
         with patch("test_workflow.perf_test.perf_test_cluster.os.chdir") as mock_chdir:
             with patch("subprocess.check_call") as mock_check_call:
                 self.perf_test_cluster.destroy()
-                mock_chdir.assert_called_once_with("current_workspace/opensearch-cluster/cdk/single-node/")
+                mock_chdir.assert_called_once_with(os.path.join("current_workspace", "opensearch-cluster", "cdk", "single-node"))
                 self.assertEqual(mock_check_call.call_count, 1)

--- a/tests/tests_test_workflow/test_test_args.py
+++ b/tests/tests_test_workflow/test_test_args.py
@@ -8,7 +8,7 @@ from test_workflow.test_args import TestArgs
 
 class TestTestArgs(unittest.TestCase):
 
-    ARGS_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/run_bwc_test.py"))
+    ARGS_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "run_bwc_test.py"))
 
     @patch(
         "argparse._sys.argv",


### PR DESCRIPTION
### Description

Fixes tests on Windows:
 
1. Use `os.path.join` vs. concatenating string paths or paths with a `/` separator.
2. Git on windows writes read-only files that cannot be unlinked, use workaround in https://stackoverflow.com/questions/1213706/what-user-do-python-scripts-run-as-in-windows.
3. Fixup load paths in `tests/tests_build_workflow`.
4. Make OpenSearch-min build script work on Windows.

### Issues Resolved

On top of #772. 

Part of #33. 

With this PR and fixes in https://github.com/opensearch-project/OpenSearch/pull/1412 you can successfully build OpenSearch 2.0.0 min with the following manifest.

```
build:
  name: OpenSearch
  version: 2.0.0
components:
  - name: OpenSearch
    repository: https://github.com/dblock/OpenSearch.git
    ref: "fix-windows-build"
    checks:
      - gradle:publish
      - gradle:properties:version
schema-version: '1.0'
```
  
```
$ ./build.sh manifests/2.0.0/opensearch-2.0.0.yml --snapshot

$ find artifacts/dist/
artifacts/dist/
artifacts/dist/opensearch-min-2.0.0-SNAPSHOT-windows-x64.zip
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
