### PR TITLE
Align configurations of black and isort.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 160
+target-version = ['py37']
+
+[tool.isort]
+profile = "black"
+line_length = 160

--- a/src/assemble_workflow/bundle.py
+++ b/src/assemble_workflow/bundle.py
@@ -41,9 +41,7 @@ class Bundle(ABC):
 
     def install_min(self):
         post_install_script = ScriptFinder.find_install_script(self.min_tarball.name)
-        self._execute(
-            f'{post_install_script} -a "{self.artifacts_dir}" -o "{self.archive_path}"'
-        )
+        self._execute(f'{post_install_script} -a "{self.artifacts_dir}" -o "{self.archive_path}"')
 
     def install_plugins(self):
         for plugin in self.plugins:
@@ -56,9 +54,7 @@ class Bundle(ABC):
     @abstractmethod
     def install_plugin(self, plugin):
         post_install_script = ScriptFinder.find_install_script(plugin.name)
-        self._execute(
-            f'{post_install_script} -a "{self.artifacts_dir}" -o "{self.archive_path}"'
-        )
+        self._execute(f'{post_install_script} -a "{self.artifacts_dir}" -o "{self.archive_path}"')
 
     def build_tar(self, dest):
         tar_name = self.bundle_recorder.tar_name
@@ -88,9 +84,7 @@ class Bundle(ABC):
             if file.is_dir():
                 return file.path
 
-        raise FileNotFoundError(
-            errno.ENOENT, os.strerror(errno.ENOENT), os.path.join(dest, "*")
-        )
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), os.path.join(dest, "*"))
 
     def __get_rel_path(self, component, component_type):
         return next(iter(component.artifacts.get(component_type, [])), None)
@@ -109,9 +103,7 @@ class Bundle(ABC):
         return [c for c in build_components if "plugins" in c.artifacts]
 
     def __get_min_bundle(self, build_components):
-        min_bundle = next(
-            iter([c for c in build_components if "dist" in c.artifacts]), None
-        )
+        min_bundle = next(iter([c for c in build_components if "dist" in c.artifacts]), None)
         if min_bundle is None:
             raise ValueError('Missing min "dist" in input artifacts.')
         return min_bundle

--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -49,9 +49,7 @@ class BundleRecorder:
     # Assembled bundles are expected to be served from a separate "bundles" folder
     # Example: https://artifacts.opensearch.org/bundles/1.0.0/<build-id
     def __get_tar_location(self):
-        return self.__get_location(
-            "bundles", self.tar_name, os.path.join(self.output_dir, self.tar_name)
-        )
+        return self.__get_location("bundles", self.tar_name, os.path.join(self.output_dir, self.tar_name))
 
     # Build artifacts are expected to be served from a "builds" folder
     # Example: https://artifacts.opensearch.org/builds/1.0.0/<build-id>

--- a/src/assemble_workflow/bundles.py
+++ b/src/assemble_workflow/bundles.py
@@ -5,8 +5,7 @@
 # compatible open source license.
 
 from assemble_workflow.bundle_opensearch import BundleOpenSearch
-from assemble_workflow.bundle_opensearch_dashboards import \
-    BundleOpenSearchDashboards
+from assemble_workflow.bundle_opensearch_dashboards import BundleOpenSearchDashboards
 
 
 class Bundles:

--- a/src/aws/s3_bucket.py
+++ b/src/aws/s3_bucket.py
@@ -26,19 +26,11 @@ class S3Bucket:
         :param role_session_name: the aws role session name
         """
         self.bucket_name = bucket_name
-        self.role_arn = (
-            role_arn if role_arn is not None else os.environ.get(S3Bucket.AWS_ROLE_ARN)
-        )
-        self.role_session_name = (
-            role_session_name
-            if role_session_name is not None
-            else os.environ.get(S3Bucket.AWS_ROLE_SESSION_NAME)
-        )
+        self.role_arn = role_arn if role_arn is not None else os.environ.get(S3Bucket.AWS_ROLE_ARN)
+        self.role_session_name = role_session_name if role_session_name is not None else os.environ.get(S3Bucket.AWS_ROLE_SESSION_NAME)
         # TODO: later use for credential refereshing
         assumed_role_creds = self.__sts_assume_role()
-        self.__s3_client, self.__s3_resource = self.__create_s3_clients(
-            assumed_role_creds
-        )
+        self.__s3_client, self.__s3_resource = self.__create_s3_clients(assumed_role_creds)
 
     def __sts_assume_role(self):
         try:
@@ -79,11 +71,7 @@ class S3Bucket:
         local_dir = Path(dest)
         s3_response = bucket.objects.filter(Prefix=s3_path)
         for obj in s3_response:
-            target = (
-                obj.key
-                if local_dir is None
-                else local_dir / Path(obj.key).relative_to(s3_path)
-            )
+            target = obj.key if local_dir is None else local_dir / Path(obj.key).relative_to(s3_path)
             target.parent.mkdir(parents=True, exist_ok=True)
             if obj.key[-1] == "/":
                 continue

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -17,9 +17,7 @@ class BuildArgs:
 
     def __init__(self):
         parser = argparse.ArgumentParser(description="Build an OpenSearch Bundle")
-        parser.add_argument(
-            "manifest", type=argparse.FileType("r"), help="Manifest file."
-        )
+        parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
         parser.add_argument(
             "-s",
             "--snapshot",
@@ -27,9 +25,7 @@ class BuildArgs:
             default=False,
             help="Build snapshot.",
         )
-        parser.add_argument(
-            "-c", "--component", type=str, help="Rebuild a single component."
-        )
+        parser.add_argument("-c", "--component", type=str, help="Rebuild a single component.")
         parser.add_argument(
             "--keep",
             dest="keep",

--- a/src/build_workflow/build_artifact_checks.py
+++ b/src/build_workflow/build_artifact_checks.py
@@ -4,12 +4,9 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from build_workflow.opensearch.build_artifact_check_maven import \
-    BuildArtifactOpenSearchCheckMaven
-from build_workflow.opensearch.build_artifact_check_plugin import \
-    BuildArtifactOpenSearchCheckPlugin
-from build_workflow.opensearch_dashboards.build_artifact_check_plugin import \
-    BuildArtifactOpenSearchDashboardsCheckPlugin
+from build_workflow.opensearch.build_artifact_check_maven import BuildArtifactOpenSearchCheckMaven
+from build_workflow.opensearch.build_artifact_check_plugin import BuildArtifactOpenSearchCheckPlugin
+from build_workflow.opensearch_dashboards.build_artifact_check_plugin import BuildArtifactOpenSearchDashboardsCheckPlugin
 
 
 class BuildArtifactChecks:
@@ -18,9 +15,7 @@ class BuildArtifactChecks:
             "plugins": BuildArtifactOpenSearchCheckPlugin,
             "maven": BuildArtifactOpenSearchCheckMaven,
         },
-        "OpenSearch Dashboards": {
-            "plugins": BuildArtifactOpenSearchDashboardsCheckPlugin
-        },
+        "OpenSearch Dashboards": {"plugins": BuildArtifactOpenSearchDashboardsCheckPlugin},
     }
 
     @classmethod

--- a/src/build_workflow/build_recorder.py
+++ b/src/build_workflow/build_recorder.py
@@ -27,12 +27,8 @@ class BuildRecorder:
             git_repo.sha,
         )
 
-    def record_artifact(
-        self, component_name, artifact_type, artifact_path, artifact_file
-    ):
-        logging.info(
-            f"Recording {artifact_type} artifact for {component_name}: {artifact_path} (from {artifact_file})"
-        )
+    def record_artifact(self, component_name, artifact_type, artifact_path, artifact_file):
+        logging.info(f"Recording {artifact_type} artifact for {component_name}: {artifact_path} (from {artifact_file})")
         # Ensure the target directory exists
         dest_file = os.path.join(self.target.output_dir, artifact_path)
         dest_dir = os.path.dirname(dest_file)
@@ -42,9 +38,7 @@ class BuildRecorder:
         # Copy the file
         shutil.copyfile(artifact_file, dest_file)
         # Notify the recorder
-        self.build_manifest.append_artifact(
-            component_name, artifact_type, artifact_path
-        )
+        self.build_manifest.append_artifact(component_name, artifact_type, artifact_path)
 
     def get_manifest(self):
         return self.build_manifest.to_manifest()

--- a/src/build_workflow/builder.py
+++ b/src/build_workflow/builder.py
@@ -28,14 +28,10 @@ class Builder:
         self.git_repo = git_repo
         self.build_recorder = build_recorder
         self.output_path = "artifacts"
-        self.artifacts_path = os.path.join(
-            self.git_repo.working_directory, self.output_path
-        )
+        self.artifacts_path = os.path.join(self.git_repo.working_directory, self.output_path)
 
     def build(self, target):
-        build_script = ScriptFinder.find_build_script(
-            target.name, self.component_name, self.git_repo.working_directory
-        )
+        build_script = ScriptFinder.find_build_script(target.name, self.component_name, self.git_repo.working_directory)
         build_command = " ".join(
             [
                 build_script,
@@ -56,12 +52,8 @@ class Builder:
 
     def export_artifacts(self):
         for artifact_type in ["maven", "dist", "plugins", "libs", "core-plugins"]:
-            for dir, dirs, files in os.walk(
-                os.path.join(self.artifacts_path, artifact_type)
-            ):
+            for dir, dirs, files in os.walk(os.path.join(self.artifacts_path, artifact_type)):
                 for file_name in files:
                     absolute_path = os.path.join(dir, file_name)
                     relative_path = os.path.relpath(absolute_path, self.artifacts_path)
-                    self.build_recorder.record_artifact(
-                        self.component_name, artifact_type, relative_path, absolute_path
-                    )
+                    self.build_recorder.record_artifact(self.component_name, artifact_type, relative_path, absolute_path)

--- a/src/build_workflow/opensearch/build_artifact_check_maven.py
+++ b/src/build_workflow/opensearch/build_artifact_check_maven.py
@@ -28,9 +28,7 @@ class BuildArtifactOpenSearchCheckMaven(BuildArtifactCheck):
             ".xml",
             ".zip",
         ]:
-            raise BuildArtifactCheck.BuildArtifactInvalidError(
-                path, f"{ext} is not a valid extension for a maven file"
-            )
+            raise BuildArtifactCheck.BuildArtifactInvalidError(path, f"{ext} is not a valid extension for a maven file")
         if os.path.splitext(path)[1] == ".jar":
             with ZipFile(path, "r") as zip:
                 data = zip.read("META-INF/MANIFEST.MF").decode("UTF-8")
@@ -46,6 +44,4 @@ class BuildArtifactOpenSearchCheckMaven(BuildArtifactCheck):
                     )
                 except PropertiesFile.CheckError as e:
                     raise BuildArtifactCheck.BuildArtifactInvalidError(path, str(e))
-                logging.info(
-                    f'Checked {path} ({properties.get_value("Implementation-Version", "N/A")})'
-                )
+                logging.info(f'Checked {path} ({properties.get_value("Implementation-Version", "N/A")})')

--- a/src/build_workflow/opensearch/build_artifact_check_plugin.py
+++ b/src/build_workflow/opensearch/build_artifact_check_plugin.py
@@ -17,9 +17,7 @@ class BuildArtifactOpenSearchCheckPlugin(BuildArtifactCheck):
         if os.path.splitext(path)[1] != ".zip":
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")
         if not path.endswith(f"-{self.target.component_version}.zip"):
-            raise BuildArtifactCheck.BuildArtifactInvalidError(
-                path, f"Expected filename to include {self.target.component_version}."
-            )
+            raise BuildArtifactCheck.BuildArtifactInvalidError(path, f"Expected filename to include {self.target.component_version}.")
         with ZipFile(path, "r") as zip:
             data = zip.read("plugin-descriptor.properties").decode("UTF-8")
             properties = PropertiesFile(data)

--- a/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
+++ b/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
@@ -17,12 +17,8 @@ class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
     def check(self, path):
         if os.path.splitext(path)[1] != ".zip":
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")
-        opensearch_dashboards_version = re.sub(
-            r"-SNAPSHOT$", "", self.target.opensearch_version
-        )
-        match = re.search(
-            rf"^(\w+)-{opensearch_dashboards_version}.zip$", os.path.basename(path)
-        )
+        opensearch_dashboards_version = re.sub(r"-SNAPSHOT$", "", self.target.opensearch_version)
+        match = re.search(rf"^(\w+)-{opensearch_dashboards_version}.zip$", os.path.basename(path))
         if not match:
             raise BuildArtifactCheck.BuildArtifactInvalidError(
                 path,
@@ -30,18 +26,12 @@ class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
             )
         plugin_name = match.group(1)
         with ZipFile(path, "r") as zip:
-            data = zip.read(
-                f"opensearch-dashboards/{plugin_name}/opensearch_dashboards.json"
-            ).decode("UTF-8")
+            data = zip.read(f"opensearch-dashboards/{plugin_name}/opensearch_dashboards.json").decode("UTF-8")
             config = ConfigFile(data)
             try:
-                component_version = re.sub(
-                    r"-SNAPSHOT$", "", self.target.component_version
-                )
+                component_version = re.sub(r"-SNAPSHOT$", "", self.target.component_version)
                 config.check_value("version", component_version)
-                config.check_value(
-                    "opensearchDashboardsVersion", opensearch_dashboards_version
-                )
+                config.check_value("opensearchDashboardsVersion", opensearch_dashboards_version)
             except ConfigFile.CheckError as e:
                 raise BuildArtifactCheck.BuildArtifactInvalidError(path, e.__str__())
             logging.info(f'Checked {path} ({config.get_value("version", "N/A")})')

--- a/src/checkout_workflow/checkout_args.py
+++ b/src/checkout_workflow/checkout_args.py
@@ -13,9 +13,7 @@ class CheckoutArgs:
 
     def __init__(self):
         parser = argparse.ArgumentParser(description="Checkout an OpenSearch Bundle")
-        parser.add_argument(
-            "manifest", type=argparse.FileType("r"), help="Manifest file."
-        )
+        parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
         parser.add_argument(
             "-v",
             "--verbose",

--- a/src/ci_workflow/ci.py
+++ b/src/ci_workflow/ci.py
@@ -4,12 +4,9 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from ci_workflow.ci_check_gradle_dependencies_opensearch import \
-    CiCheckGradleDependenciesOpenSearchVersion
-from ci_workflow.ci_check_gradle_properties_version import \
-    CiCheckGradlePropertiesVersion
-from ci_workflow.ci_check_gradle_publish_to_maven_local import \
-    CiCheckGradlePublishToMavenLocal
+from ci_workflow.ci_check_gradle_dependencies_opensearch import CiCheckGradleDependenciesOpenSearchVersion
+from ci_workflow.ci_check_gradle_properties_version import CiCheckGradlePropertiesVersion
+from ci_workflow.ci_check_gradle_publish_to_maven_local import CiCheckGradlePublishToMavenLocal
 
 """
 This class is responsible for sanity checking the OpenSearch bundle.
@@ -26,9 +23,7 @@ class Ci:
     class InvalidCheckError(Exception):
         def __init__(self, check):
             self.check = check
-            super().__init__(
-                f"Invalid check {check}, must be one of {Ci.CHECKS.keys()}."
-            )
+            super().__init__(f"Invalid check {check}, must be one of {Ci.CHECKS.keys()}.")
 
     def __init__(self, component, git_repo, target):
         """

--- a/src/ci_workflow/ci_args.py
+++ b/src/ci_workflow/ci_args.py
@@ -14,12 +14,8 @@ class CiArgs:
     snapshot: bool
 
     def __init__(self):
-        parser = argparse.ArgumentParser(
-            description="Sanity test the OpenSearch Bundle"
-        )
-        parser.add_argument(
-            "manifest", type=argparse.FileType("r"), help="Manifest file."
-        )
+        parser = argparse.ArgumentParser(description="Sanity test the OpenSearch Bundle")
+        parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
         parser.add_argument(
             "-s",
             "--snapshot",
@@ -27,9 +23,7 @@ class CiArgs:
             default=False,
             help="Build snapshot.",
         )
-        parser.add_argument(
-            "-c", "--component", type=str, help="Rebuild a single component."
-        )
+        parser.add_argument("-c", "--component", type=str, help="Rebuild a single component.")
         parser.add_argument(
             "--keep",
             dest="keep",

--- a/src/ci_workflow/ci_check_gradle_dependencies_opensearch.py
+++ b/src/ci_workflow/ci_check_gradle_dependencies_opensearch.py
@@ -11,9 +11,5 @@ from ci_workflow.ci_check_gradle_dependencies import CiCheckGradleDependencies
 
 class CiCheckGradleDependenciesOpenSearchVersion(CiCheckGradleDependencies):
     def check(self):
-        self.dependencies.check_value(
-            "org.opensearch:opensearch", self.target.opensearch_version
-        )
-        logging.info(
-            f"Checked {self.component.name} OpenSearch dependency ({self.target.opensearch_version})."
-        )
+        self.dependencies.check_value("org.opensearch:opensearch", self.target.opensearch_version)
+        logging.info(f"Checked {self.component.name} OpenSearch dependency ({self.target.opensearch_version}).")

--- a/src/manifests/build_manifest.py
+++ b/src/manifests/build_manifest.py
@@ -85,17 +85,13 @@ class BuildManifest(Manifest):
         super().__init__(data)
 
         self.build = self.Build(data["build"])
-        self.components = list(
-            map(lambda entry: self.Component(entry), data.get("components", []))
-        )
+        self.components = list(map(lambda entry: self.Component(entry), data.get("components", [])))
 
     def __to_dict__(self):
         return {
             "schema-version": "1.2",
             "build": self.build.__to_dict__(),
-            "components": list(
-                map(lambda component: component.__to_dict__(), self.components)
-            ),
+            "components": list(map(lambda component: component.__to_dict__(), self.components)),
         }
 
     def get_component(self, component_name):
@@ -104,24 +100,18 @@ class BuildManifest(Manifest):
             None,
         )
         if component is None:
-            raise BuildManifest.ComponentNotFoundError(
-                f"{component_name} not found in build manifest.yml"
-            )
+            raise BuildManifest.ComponentNotFoundError(f"{component_name} not found in build manifest.yml")
         return component
 
     @staticmethod
-    def get_build_manifest_relative_location(
-        build_id, opensearch_version, platform, architecture
-    ):
+    def get_build_manifest_relative_location(build_id, opensearch_version, platform, architecture):
         # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
         return f"builds/{opensearch_version}/{build_id}/{architecture}/manifest.yml"
 
     @staticmethod
     def from_s3(bucket_name, build_id, opensearch_version, platform, architecture, work_dir=None):
         work_dir = work_dir if not None else str(os.getcwd())
-        manifest_s3_path = BuildManifest.get_build_manifest_relative_location(
-            build_id, opensearch_version, platform, architecture
-        )
+        manifest_s3_path = BuildManifest.get_build_manifest_relative_location(build_id, opensearch_version, platform, architecture)
         S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
         build_manifest = BuildManifest.from_path("manifest.yml")
         os.remove(os.path.realpath(os.path.join(work_dir, "manifest.yml")))

--- a/src/manifests/bundle_manifest.py
+++ b/src/manifests/bundle_manifest.py
@@ -65,38 +65,26 @@ class BundleManifest(Manifest):
     def __init__(self, data):
         super().__init__(data)
         self.build = self.Build(data["build"])
-        self.components = list(
-            map(lambda entry: self.Component(entry), data["components"])
-        )
+        self.components = list(map(lambda entry: self.Component(entry), data["components"]))
 
     def __to_dict__(self):
         return {
             "schema-version": "1.1",
             "build": self.build.__to_dict__(),
-            "components": list(
-                map(lambda component: component.__to_dict__(), self.components)
-            ),
+            "components": list(map(lambda component: component.__to_dict__(), self.components)),
         }
 
     @staticmethod
-    def from_s3(
-        bucket_name, build_id, opensearch_version, platform, architecture, work_dir=None
-    ):
+    def from_s3(bucket_name, build_id, opensearch_version, platform, architecture, work_dir=None):
         work_dir = work_dir if not None else str(os.getcwd())
-        manifest_s3_path = BundleManifest.get_bundle_manifest_relative_location(
-            build_id, opensearch_version, platform, architecture
-        )
+        manifest_s3_path = BundleManifest.get_bundle_manifest_relative_location(build_id, opensearch_version, platform, architecture)
         S3Bucket(bucket_name).download_file(manifest_s3_path, work_dir)
-        bundle_manifest = BundleManifest.from_path(
-            os.path.join(work_dir, "manifest.yml")
-        )
+        bundle_manifest = BundleManifest.from_path(os.path.join(work_dir, "manifest.yml"))
         os.remove(os.path.realpath(os.path.join(work_dir, "manifest.yml")))
         return bundle_manifest
 
     @staticmethod
-    def get_tarball_relative_location(
-        build_id, opensearch_version, platform, architecture
-    ):
+    def get_tarball_relative_location(build_id, opensearch_version, platform, architecture):
         # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
         return f"bundles/{opensearch_version}/{build_id}/{architecture}/opensearch-{opensearch_version}-{platform}-{architecture}.tar.gz"
 
@@ -105,9 +93,7 @@ class BundleManifest(Manifest):
         return f"opensearch-{opensearch_version}-{platform}-{architecture}.tar.gz"
 
     @staticmethod
-    def get_bundle_manifest_relative_location(
-        build_id, opensearch_version, platform, architecture
-    ):
+    def get_bundle_manifest_relative_location(build_id, opensearch_version, platform, architecture):
         # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
         return f"bundles/{opensearch_version}/{build_id}/{architecture}/manifest.yml"
 

--- a/src/manifests/input_manifest.py
+++ b/src/manifests/input_manifest.py
@@ -61,17 +61,13 @@ class InputManifest(Manifest):
         super().__init__(data)
 
         self.build = self.Build(data["build"])
-        self.components = list(
-            map(lambda entry: self.Component(entry), data["components"])
-        )
+        self.components = list(map(lambda entry: self.Component(entry), data["components"]))
 
     def __to_dict__(self):
         return {
             "schema-version": "1.0",
             "build": self.build.__to_dict__(),
-            "components": list(
-                map(lambda component: component.__to_dict__(), self.components)
-            ),
+            "components": list(map(lambda component: component.__to_dict__(), self.components)),
         }
 
     class Build:
@@ -88,9 +84,7 @@ class InputManifest(Manifest):
             self.repository = data["repository"]
             self.ref = data["ref"]
             self.working_directory = data.get("working_directory", None)
-            self.checks = list(
-                map(lambda entry: InputManifest.Check(entry), data.get("checks", []))
-            )
+            self.checks = list(map(lambda entry: InputManifest.Check(entry), data.get("checks", [])))
 
         def __to_dict__(self):
             return Manifest.compact(

--- a/src/manifests/manifest.py
+++ b/src/manifests/manifest.py
@@ -11,9 +11,7 @@ from cerberus import Validator  # type:ignore
 
 
 class Manifest(ABC):
-    SCHEMA = {
-        "schema-version": {"required": True, "type": "string", "empty": False}
-    }
+    SCHEMA = {"schema-version": {"required": True, "type": "string", "empty": False}}
 
     @classmethod
     def from_file(cls, file):

--- a/src/manifests/manifests.py
+++ b/src/manifests/manifests.py
@@ -29,9 +29,7 @@ class Manifests(SortedDict):
 
     @property
     def manifests_path(self):
-        return os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "../../manifests")
-        )
+        return os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests"))
 
     @property
     def versions(self):

--- a/src/manifests/test_manifest.py
+++ b/src/manifests/test_manifest.py
@@ -41,9 +41,7 @@ class TestManifest(Manifest):
                     "integ-test": {
                         "type": "dict",
                         "schema": {
-                            "build-dependencies": {
-                                "type": "list"
-                            },
+                            "build-dependencies": {"type": "list"},
                             "test-configs": {
                                 "type": "list",
                                 "allowed": [
@@ -59,9 +57,7 @@ class TestManifest(Manifest):
                     "bwc-test": {
                         "type": "dict",
                         "schema": {
-                            "build-dependencies": {
-                                "type": "list"
-                            },
+                            "build-dependencies": {"type": "list"},
                             "test-configs": {
                                 "type": "list",
                                 "allowed": [
@@ -79,16 +75,12 @@ class TestManifest(Manifest):
 
     def __init__(self, data):
         super().__init__(data)
-        self.components = list(
-            map(lambda entry: self.Component(entry), data["components"])
-        )
+        self.components = list(map(lambda entry: self.Component(entry), data["components"]))
 
     def __to_dict__(self):
         return {
             "schema-version": "1.0",
-            "components": list(
-                map(lambda component: component.__to_dict__(), self.components)
-            ),
+            "components": list(map(lambda component: component.__to_dict__(), self.components)),
         }
 
     class Component:

--- a/src/manifests_workflow/component.py
+++ b/src/manifests_workflow/component.py
@@ -21,13 +21,7 @@ class Component:
     def branches(self, uri):
         """Return main or any x.y branches."""
         branches = ["main"]
-        remote_branches = (
-            subprocess.check_output(
-                f"git ls-remote {uri} refs/heads/* | cut -f2 | cut -d/ -f3", shell=True
-            )
-            .decode()
-            .split("\n")
-        )
+        remote_branches = subprocess.check_output(f"git ls-remote {uri} refs/heads/* | cut -f2 | cut -d/ -f3", shell=True).decode().split("\n")
         branches.extend(filter(lambda b: re.match(r"[\d]+.[\dx]*", b), remote_branches))
         return branches
 

--- a/src/manifests_workflow/component_opensearch_dashboards_min.py
+++ b/src/manifests_workflow/component_opensearch_dashboards_min.py
@@ -17,9 +17,7 @@ class ComponentOpenSearchDashboardsMin(Component):
 
     @classmethod
     def branches(self):
-        return Component.branches(
-            "https://github.com/opensearch-project/OpenSearch-Dashboards.git"
-        )
+        return Component.branches("https://github.com/opensearch-project/OpenSearch-Dashboards.git")
 
     @classmethod
     def checkout(self, path, branch="main", snapshot=False):

--- a/src/manifests_workflow/component_opensearch_min.py
+++ b/src/manifests_workflow/component_opensearch_min.py
@@ -21,9 +21,7 @@ class ComponentOpenSearchMin(Component):
 
     @classmethod
     def branches(self):
-        return Component.branches(
-            "https://github.com/opensearch-project/OpenSearch.git"
-        )
+        return Component.branches("https://github.com/opensearch-project/OpenSearch.git")
 
     @classmethod
     def versions(self, work_dir=None):
@@ -36,23 +34,17 @@ class ComponentOpenSearchMin(Component):
     @classmethod
     def checkout(self, path, branch="main", snapshot=False):
         return ComponentOpenSearchMin(
-            GitRepository(
-                "https://github.com/opensearch-project/OpenSearch.git", branch, path
-            ),
+            GitRepository("https://github.com/opensearch-project/OpenSearch.git", branch, path),
             snapshot,
         )
 
     def publish_to_maven_local(self):
-        cmd = ComponentOpenSearch.gradle_cmd(
-            "publishToMavenLocal", {"build.snapshot": str(self.snapshot).lower()}
-        )
+        cmd = ComponentOpenSearch.gradle_cmd("publishToMavenLocal", {"build.snapshot": str(self.snapshot).lower()})
         self.git_repo.execute_silent(cmd)
 
     @property
     def properties(self):
-        cmd = ComponentOpenSearch.gradle_cmd(
-            "properties", {"build.snapshot": str(self.snapshot).lower()}
-        )
+        cmd = ComponentOpenSearch.gradle_cmd("properties", {"build.snapshot": str(self.snapshot).lower()})
         return PropertiesFile(self.git_repo.output(cmd))
 
     @property

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -23,16 +23,12 @@ class InputManifests(Manifests):
 
     @classmethod
     def manifests_path(self):
-        return os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "../../manifests")
-        )
+        return os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests"))
 
     @classmethod
     def files(self, name):
         results = []
-        for filename in glob.glob(
-            os.path.join(self.manifests_path(), f"**/{name}-*.yml")
-        ):
+        for filename in glob.glob(os.path.join(self.manifests_path(), f"**/{name}-*.yml")):
             # avoids the -maven manifest
             match = re.search(rf"^{name}-([0-9.]*).yml$", os.path.basename(filename))
             if match:
@@ -53,9 +49,7 @@ class InputManifests(Manifests):
             logging.info(f"Checking {self.name} {branches} branches")
             for branch in branches:
                 c = min_klass.checkout(
-                    path=os.path.join(
-                        work_dir, f"{self.name.replace(' ', '')}/{branch}"
-                    ),
+                    path=os.path.join(work_dir, f"{self.name.replace(' ', '')}/{branch}"),
                     branch=branch,
                 )
                 version = c.version
@@ -84,9 +78,7 @@ class InputManifests(Manifests):
                         if release_version not in main_versions.keys():
                             main_versions[release_version] = []
                         main_versions[release_version].append(component)
-                        logging.info(
-                            f"{component.name}#main is version {release_version} (from {component_version})"
-                        )
+                        logging.info(f"{component.name}#main is version {release_version} (from {component_version})")
 
             # summarize
             logging.info("Found versions on main:")

--- a/src/manifests_workflow/input_manifests_opensearch_dashboards.py
+++ b/src/manifests_workflow/input_manifests_opensearch_dashboards.py
@@ -4,8 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from manifests_workflow.component_opensearch_dashboards_min import \
-    ComponentOpenSearchDashboardsMin
+from manifests_workflow.component_opensearch_dashboards_min import ComponentOpenSearchDashboardsMin
 from manifests_workflow.input_manifests import InputManifests
 
 
@@ -18,6 +17,4 @@ class InputManifestsOpenSearchDashboards(InputManifests):
         return InputManifests.files("opensearch-dashboards")
 
     def update(self, keep=False):
-        super().update(
-            min_klass=ComponentOpenSearchDashboardsMin, component_klass=None, keep=keep
-        )
+        super().update(min_klass=ComponentOpenSearchDashboardsMin, component_klass=None, keep=keep)

--- a/src/manifests_workflow/manifests_args.py
+++ b/src/manifests_workflow/manifests_args.py
@@ -7,18 +7,14 @@
 import argparse
 import logging
 
-from manifests_workflow.input_manifests_opensearch import \
-    InputManifestsOpenSearch
-from manifests_workflow.input_manifests_opensearch_dashboards import \
-    InputManifestsOpenSearchDashboards
+from manifests_workflow.input_manifests_opensearch import InputManifestsOpenSearch
+from manifests_workflow.input_manifests_opensearch_dashboards import InputManifestsOpenSearchDashboards
 
 
 class ManifestsArgs:
     def __init__(self):
         parser = argparse.ArgumentParser(description="Manifest management")
-        parser.add_argument(
-            "action", choices=["list", "update"], help="Operation to perform."
-        )
+        parser.add_argument("action", choices=["list", "update"], help="Operation to perform.")
         parser.add_argument(
             "--type",
             dest="type",

--- a/src/paths/script_finder.py
+++ b/src/paths/script_finder.py
@@ -14,17 +14,9 @@ class ScriptFinder:
             self.paths = paths
             super().__init__(f"Could not find {kind} script. Looked in {paths}.")
 
-    component_scripts_path = os.path.realpath(
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "../../scripts/components"
-        )
-    )
+    component_scripts_path = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../scripts/components"))
 
-    default_scripts_path = os.path.realpath(
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "../../scripts/default"
-        )
-    )
+    default_scripts_path = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../scripts/default"))
 
     """
     ScriptFinder is a helper that abstracts away the details of where to look for build, test and install scripts.
@@ -51,9 +43,7 @@ class ScriptFinder:
     @classmethod
     def find_build_script(cls, project, component_name, git_dir):
         paths = [
-            os.path.realpath(
-                os.path.join(cls.component_scripts_path, component_name, "build.sh")
-            ),
+            os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "build.sh")),
             os.path.realpath(os.path.join(git_dir, "build.sh")),
             os.path.realpath(os.path.join(git_dir, "scripts/build.sh")),
             os.path.realpath(
@@ -70,9 +60,7 @@ class ScriptFinder:
     @classmethod
     def find_integ_test_script(cls, component_name, git_dir):
         paths = [
-            os.path.realpath(
-                os.path.join(cls.component_scripts_path, component_name, "integtest.sh")
-            ),
+            os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "integtest.sh")),
             os.path.realpath(os.path.join(git_dir, "integtest.sh")),
             os.path.realpath(os.path.join(git_dir, "scripts/integtest.sh")),
             os.path.realpath(os.path.join(cls.default_scripts_path, "integtest.sh")),
@@ -83,9 +71,7 @@ class ScriptFinder:
     @classmethod
     def find_install_script(cls, component_name):
         paths = [
-            os.path.realpath(
-                os.path.join(cls.component_scripts_path, component_name, "install.sh")
-            ),
+            os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "install.sh")),
             os.path.realpath(os.path.join(cls.default_scripts_path, "install.sh")),
         ]
 
@@ -96,9 +82,7 @@ class ScriptFinder:
         paths = [
             os.path.realpath(os.path.join(git_dir, "bwctest.sh")),
             os.path.realpath(os.path.join(git_dir, "scripts/bwctest.sh")),
-            os.path.realpath(
-                os.path.join(cls.component_scripts_path, component_name, "bwctest.sh")
-            ),
+            os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "bwctest.sh")),
             os.path.realpath(os.path.join(cls.default_scripts_path, "bwctest.sh")),
         ]
 

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -41,9 +41,7 @@ def main():
     os.makedirs(output_dir, exist_ok=True)
 
     with tempfile.TemporaryDirectory() as work_dir:
-        logging.info(
-            f"Bundling {build.name} ({build.architecture}) on {build.platform} into {output_dir} ..."
-        )
+        logging.info(f"Bundling {build.name} ({build.architecture}) on {build.platform} into {output_dir} ...")
 
         os.chdir(work_dir)
 

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -43,9 +43,7 @@ def main():
 
         build_recorder = BuildRecorder(target)
 
-        logging.info(
-            f"Building {manifest.build.name} ({target.arch}) into {target.output_dir}"
-        )
+        logging.info(f"Building {manifest.build.name} ({target.arch}) into {target.output_dir}")
 
         for component in manifest.components:
 
@@ -66,9 +64,7 @@ def main():
                 builder.build(target)
                 builder.export_artifacts()
             except:
-                logging.error(
-                    f"Error building {component.name}, retry with: {args.component_command(component.name)}"
-                )
+                logging.error(f"Error building {component.name}, retry with: {args.component_command(component.name)}")
                 raise
 
         build_recorder.write_manifest()

--- a/src/run_bwc_test.py
+++ b/src/run_bwc_test.py
@@ -21,7 +21,12 @@ def main():
     with TemporaryDirectory(keep=args.keep) as work_dir:
         logging.info("Switching to temporary work_dir: " + work_dir)
         bundle_manifest = BundleManifest.from_s3(
-            args.s3_bucket, args.build_id, args.opensearch_version, args.architecture, work_dir)
+            args.s3_bucket,
+            args.build_id,
+            args.opensearch_version,
+            args.architecture,
+            work_dir,
+        )
         BwcTestSuite(bundle_manifest, work_dir, args.component, args.keep).execute()
 
 

--- a/src/run_ci.py
+++ b/src/run_ci.py
@@ -51,9 +51,7 @@ def main():
                 ci = Ci(component, repo, target)
                 ci.check()
             except:
-                logging.error(
-                    f"Error checking {component.name}, retry with: {args.component_command(component.name)}"
-                )
+                logging.error(f"Error checking {component.name}, retry with: {args.component_command(component.name)}")
                 raise
 
     logging.info("Done.")

--- a/src/run_integ_test.py
+++ b/src/run_integ_test.py
@@ -34,9 +34,7 @@ def pull_build_repo(work_dir):
 def main():
     args = TestArgs()
     console.configure(level=args.logging_level)
-    test_manifest_path = os.path.join(
-        os.path.dirname(__file__), "test_workflow/config/test_manifest.yml"
-    )
+    test_manifest_path = os.path.join(os.path.dirname(__file__), "test_workflow/config/test_manifest.yml")
     test_manifest = TestManifest.from_path(test_manifest_path)
     integ_test_config = dict()
     for component in test_manifest.components:
@@ -80,10 +78,7 @@ def main():
                 all_results.append(component.name, test_results)
 
             else:
-                logging.info(
-                    "Skipping tests for %s, as it is currently not supported"
-                    % component.name
-                )
+                logging.info("Skipping tests for %s, as it is currently not supported" % component.name)
 
         all_results.log()
 

--- a/src/run_perf_test.py
+++ b/src/run_perf_test.py
@@ -18,9 +18,7 @@ from test_workflow.perf_test.perf_test_suite import PerfTestSuite
 
 
 parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
-parser.add_argument(
-    "--bundle-manifest", type=argparse.FileType("r"), help="Bundle Manifest file."
-)
+parser.add_argument("--bundle-manifest", type=argparse.FileType("r"), help="Bundle Manifest file.")
 parser.add_argument("--stack", dest="stack", help="Stack name for performance test")
 parser.add_argument("--config", type=argparse.FileType("r"), help="Config file.")
 parser.add_argument(
@@ -45,7 +43,7 @@ def get_infra_repo_url():
 def main():
     with TemporaryDirectory(keep=args.keep) as work_dir:
         os.chdir(work_dir)
-        current_workspace = os.path.join(work_dir, 'infra')
+        current_workspace = os.path.join(work_dir, "infra")
         GitRepository(get_infra_repo_url(), "main", current_workspace)
         security = False
         for component in manifest.components:
@@ -58,9 +56,7 @@ def main():
                 test_cluster_port,
             ):
                 os.chdir(current_workspace)
-                perf_test_suite = PerfTestSuite(
-                    manifest, test_cluster_endpoint, security, current_workspace
-                )
+                perf_test_suite = PerfTestSuite(manifest, test_cluster_endpoint, security, current_workspace)
                 perf_test_suite.execute()
 
 

--- a/src/run_sign.py
+++ b/src/run_sign.py
@@ -18,9 +18,7 @@ from system import console
 
 def main():
     parser = argparse.ArgumentParser(description="Sign artifacts")
-    parser.add_argument(
-        "manifest", type=argparse.FileType("r"), help="Path to local manifest file."
-    )
+    parser.add_argument("manifest", type=argparse.FileType("r"), help="Path to local manifest file.")
     parser.add_argument("--component", nargs="?", help="Component name")
     parser.add_argument("--type", nargs="?", help="Artifact type")
     parser.add_argument(

--- a/src/system/config_file.py
+++ b/src/system/config_file.py
@@ -14,9 +14,7 @@ class ConfigFile:
     class UnexpectedKeyValueError(CheckError):
         def __init__(self, key, expected, current=None):
             super().__init__(
-                f"Expected to have {key}='{expected}', but was '{current}'."
-                if current
-                else f"Expected to have {key}='{expected}', but none was found."
+                f"Expected to have {key}='{expected}', but was '{current}'." if current else f"Expected to have {key}='{expected}', but none was found."
             )
 
     class UnexpectedKeyValuesError(CheckError):

--- a/src/system/execute.py
+++ b/src/system/execute.py
@@ -16,9 +16,7 @@ def execute(command, dir, capture=True, raise_on_failure=True):
     :returns a tuple containing the exit code, stdout, and stderr.
     """
     logging.info(f'Executing "{command}" in {dir}')
-    result = subprocess.run(
-        command, cwd=dir, shell=True, capture_output=capture, text=True
-    )
+    result = subprocess.run(command, cwd=dir, shell=True, capture_output=capture, text=True)
     if raise_on_failure:
         result.check_returncode()
     return (result.returncode, result.stdout, result.stderr)

--- a/src/system/properties_file.py
+++ b/src/system/properties_file.py
@@ -14,9 +14,7 @@ class PropertiesFile(Properties):
     class UnexpectedKeyValueError(CheckError):
         def __init__(self, key, expected, current=None):
             super().__init__(
-                f"Expected to have {key}='{expected}', but was '{current}'."
-                if current
-                else f"Expected to have {key}='{expected}', but none was found."
+                f"Expected to have {key}='{expected}', but was '{current}'." if current else f"Expected to have {key}='{expected}', but none was found."
             )
 
     class UnexpectedKeyValuesError(CheckError):

--- a/src/test_workflow/bwc_test/bwc_test_suite.py
+++ b/src/test_workflow/bwc_test/bwc_test_suite.py
@@ -28,9 +28,7 @@ class BwcTestSuite:
         self.keep = keep
 
     def run_tests(self, work_dir, component_name):
-        script = ScriptFinder.find_bwc_test_script(
-            component_name, work_dir
-        )
+        script = ScriptFinder.find_bwc_test_script(component_name, work_dir)
         cmd = f"{script}"
         (status, stdout, stderr) = execute(cmd, work_dir, True, False)
         return (status, stdout, stderr)

--- a/src/test_workflow/dependency_installer.py
+++ b/src/test_workflow/dependency_installer.py
@@ -25,18 +25,14 @@ class DependencyInstaller:
         self.s3_bucket = S3Bucket(self.ARTIFACT_S3_BUCKET)
         self.s3_maven_location = f"builds/{self.version}/{self.build_id}/{self.platform}/{self.architecture}/maven/org/opensearch"
         self.s3_build_location = f"builds/{self.version}/{self.build_id}/{self.platform}/{self.architecture}/plugins"
-        self.maven_local_path = os.path.join(
-            os.path.expanduser("~"), ".m2/repository/org/opensearch/"
-        )
+        self.maven_local_path = os.path.join(os.path.expanduser("~"), ".m2/repository/org/opensearch/")
 
     def install_all_maven_dependencies(self):
         """
         Downloads all pre-built maven dependencies from S3 bucket
         """
         logging.info("Downloading all pre-built maven dependencies from s3")
-        self.s3_bucket.download_folder(
-            f"{self.s3_maven_location}", self.maven_local_path
-        )
+        self.s3_bucket.download_folder(f"{self.s3_maven_location}", self.maven_local_path)
         logging.info("Successfully downloaded maven dependencies")
 
     def install_build_dependencies(self, dependency_dict, custom_local_path):

--- a/src/test_workflow/integ_test/local_test_cluster.py
+++ b/src/test_workflow/integ_test/local_test_cluster.py
@@ -138,9 +138,7 @@ class LocalTestCluster(TestCluster):
                 logging.info(f"Pinging {url} attempt {attempt}")
                 response = requests.get(url, verify=False, auth=("admin", "admin"))
                 logging.info(f"{response.status_code}: {response.text}")
-                if response.status_code == 200 and (
-                    '"status":"green"' or '"status":"yellow"' in response.text
-                ):
+                if response.status_code == 200 and ('"status":"green"' or '"status":"yellow"' in response.text):
                     logging.info("Service is available")
                     return
             except requests.exceptions.ConnectionError:
@@ -173,13 +171,9 @@ class LocalTestCluster(TestCluster):
                 raise
         finally:
             logging.info(f"Process terminated with exit code {self.process.returncode}")
-            with open(
-                os.path.join(os.path.realpath(self.work_dir), self.stdout.name), "r"
-            ) as stdout:
+            with open(os.path.join(os.path.realpath(self.work_dir), self.stdout.name), "r") as stdout:
                 self.local_cluster_stdout = stdout.read()
-            with open(
-                os.path.join(os.path.realpath(self.work_dir), self.stderr.name), "r"
-            ) as stderr:
+            with open(os.path.join(os.path.realpath(self.work_dir), self.stderr.name), "r") as stderr:
                 self.local_cluster_stderr = stderr.read()
             self.return_code = self.process.returncode
             self.stdout.close()

--- a/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/src/test_workflow/perf_test/perf_test_cluster.py
@@ -11,9 +11,7 @@ class PerfTestCluster(TestCluster):
     Represents a performance test cluster. This class deploys the opensearch bundle with CDK and returns the private IP.
     """
 
-    def __init__(
-        self, bundle_manifest, config, stack_name, security, current_workspace
-    ):
+    def __init__(self, bundle_manifest, config, stack_name, security, current_workspace):
         self.manifest = bundle_manifest
         self.work_dir = "opensearch-cluster/cdk/single-node/"
         self.current_workspace = current_workspace

--- a/src/test_workflow/perf_test/perf_test_suite.py
+++ b/src/test_workflow/perf_test/perf_test_suite.py
@@ -11,23 +11,25 @@ class PerfTestSuite:
 
     def __init__(self, bundle_manifest, endpoint, security, current_workspace):
         self.manifest = bundle_manifest
-        self.work_dir = 'mensor/'
+        self.work_dir = "mensor/"
         self.endpoint = endpoint
         self.security = security
         self.current_workspace = current_workspace
-        self.command = f'pipenv run python test_config.py -i {self.endpoint} -b {self.manifest.build.id}'\
-                       f' -a {self.manifest.build.architecture} -p {self.current_workspace}'
+        self.command = (
+            f"pipenv run python test_config.py -i {self.endpoint} -b {self.manifest.build.id}"
+            f" -a {self.manifest.build.architecture} -p {self.current_workspace}"
+        )
 
     def execute(self):
         try:
             with WorkingDirectory(self.work_dir):
                 dir = os.getcwd()
-                subprocess.check_call('python3 -m pipenv install', cwd=dir, shell=True)
-                subprocess.check_call('pipenv install', cwd=dir, shell=True)
+                subprocess.check_call("python3 -m pipenv install", cwd=dir, shell=True)
+                subprocess.check_call("pipenv install", cwd=dir, shell=True)
 
                 if self.security:
-                    subprocess.check_call(f'{self.command} -s', cwd=dir, shell=True)
+                    subprocess.check_call(f"{self.command} -s", cwd=dir, shell=True)
                 else:
-                    subprocess.check_call(f'{self.command}', cwd=dir, shell=True)
+                    subprocess.check_call(f"{self.command}", cwd=dir, shell=True)
         finally:
             os.chdir(self.current_workspace)

--- a/src/test_workflow/test_args.py
+++ b/src/test_workflow/test_args.py
@@ -32,9 +32,7 @@ class TestArgs:
 
     def __init__(self):
         parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
-        parser.add_argument(
-            "--s3-bucket", type=str, help="S3 bucket name", required=True
-        )
+        parser.add_argument("--s3-bucket", type=str, help="S3 bucket name", required=True)
         parser.add_argument(
             "--opensearch-version",
             type=str,

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -15,7 +15,6 @@ from test_workflow.test_recorder.test_result_data import TestResultData
 
 
 class TestRecorder:
-
     def __init__(self, test_run_id, test_type, location):
         self.test_run_id = test_run_id
         self.test_type = test_type
@@ -27,9 +26,7 @@ class TestRecorder:
         self.test_results_logs = self.TestResultsLogs(self)
 
     def _create_base_folder_structure(self, component_name, component_test_config):
-        dest_directory = os.path.join(self.location,
-                                      str(component_name),
-                                      str(component_test_config))
+        dest_directory = os.path.join(self.location, str(component_name), str(component_test_config))
         os.makedirs(dest_directory, exist_ok=True)
         return os.path.realpath(dest_directory)
 
@@ -45,60 +42,57 @@ class TestRecorder:
             "test_run_id": self.test_run_id,
             "component_name": test_result_data.component_name,
             "test_config": test_result_data.component_test_config,
-            "exit_code": test_result_data.exit_code
+            "exit_code": test_result_data.exit_code,
         }
         with open(os.path.join(output_path, "%s.yml" % test_result_data.component_name), "w") as file:
             yaml.dump(outcome, file)
         return os.path.realpath("%s.yml" % test_result_data.component_name)
 
     class LocalClusterLogs(LogRecorder):
-
         def __init__(self, parent_class):
             self.parent_class = parent_class
 
         def save_test_result_data(self, test_result_data: TestResultData):
-            base = self.parent_class._create_base_folder_structure(test_result_data.component_name,
-                                                                   test_result_data.component_test_config)
+            base = self.parent_class._create_base_folder_structure(test_result_data.component_name, test_result_data.component_test_config)
             dest_directory = os.path.join(base, "local-cluster-logs")
             os.makedirs(dest_directory, exist_ok=True)
             log_files = list(test_result_data.log_files)
             logging.info(
                 f"Recording local cluster logs for {test_result_data.component_name} with test configuration as "
-                f"{test_result_data.component_test_config} at {os.path.realpath(dest_directory)}")
-            self.parent_class._generate_std_files(test_result_data.stdout, test_result_data.stderr,
-                                                  os.path.realpath(dest_directory))
+                f"{test_result_data.component_test_config} at {os.path.realpath(dest_directory)}"
+            )
+            self.parent_class._generate_std_files(
+                test_result_data.stdout,
+                test_result_data.stderr,
+                os.path.realpath(dest_directory),
+            )
             for log_file in log_files:
                 dest_file = os.path.join(dest_directory, os.path.basename(log_file[0]))
                 shutil.copyfile(log_file[0], dest_file)
 
     class RemoteClusterLogs(LogRecorder):
-
         def __init__(self, parent_class):
             self.parent_class = parent_class
 
         def save_test_result_data(self, test_result_data: TestResultData):
-            base = self.parent_class._create_base_folder_structure(test_result_data.component_name,
-                                                                   test_result_data.component_test_config)
+            base = self.parent_class._create_base_folder_structure(test_result_data.component_name, test_result_data.component_test_config)
             dest_directory = os.path.join(base, "remote-cluster-logs")
             os.makedirs(dest_directory, exist_ok=True)
             logging.info(
                 f"Recording remote cluster logs for {test_result_data.component_name} with test configuration as "
-                f"{test_result_data.component_test_config} at {os.path.realpath(dest_directory)}")
+                f"{test_result_data.component_test_config} at {os.path.realpath(dest_directory)}"
+            )
             self.parent_class._generate_yml(test_result_data, dest_directory)
 
     class TestResultsLogs(LogRecorder):
-
         def __init__(self, parent_class):
             self.parent_class = parent_class
 
         def save_test_result_data(self, test_result_data: TestResultData):
-            base = self.parent_class._create_base_folder_structure(test_result_data.component_name,
-                                                                   test_result_data.component_test_config)
+            base = self.parent_class._create_base_folder_structure(test_result_data.component_name, test_result_data.component_test_config)
             dest_directory = os.path.join(base, "test-results")
             os.makedirs(dest_directory, exist_ok=False)
-            logging.info(
-                f"Recording component test results for {test_result_data.component_name} at "
-                f"{os.path.realpath(dest_directory)}")
+            logging.info(f"Recording component test results for {test_result_data.component_name} at " f"{os.path.realpath(dest_directory)}")
             self.parent_class._generate_std_files(test_result_data.stdout, test_result_data.stderr, dest_directory)
             if test_result_data.log_files is not None:
                 results_dir = list(test_result_data.log_files)

--- a/src/test_workflow/test_recorder/test_result_data.py
+++ b/src/test_workflow/test_recorder/test_result_data.py
@@ -20,6 +20,7 @@ class TestResultData:
     stderr: A string containing the stderr stream from the test process.
     log_files: A generator that yields tuples containing test cluster log files, in the form (absolute_path, relative_path).
     """
+
     component_name: str
     component_test_config: str
     exit_code: int

--- a/src/test_workflow/test_result/test_result.py
+++ b/src/test_workflow/test_result/test_result.py
@@ -12,7 +12,7 @@ class TestResult:
         return "PASS" if self.status == 0 else "FAIL"
 
     def __str__(self):
-        return '| {:20s} | {:20s} | {:5s} | {:4d} |'.format(self.component, self.config, self.__test_result, self.status)
+        return "| {:20s} | {:20s} | {:5s} | {:4d} |".format(self.component, self.config, self.__test_result, self.status)
 
     def __logger(self):
         return logging.info if self.status == 0 else logging.error

--- a/tests/test_aws/test_s3_bucket.py
+++ b/tests/test_aws/test_s3_bucket.py
@@ -29,12 +29,8 @@ class MockS3Response:
             MockS3Response.ObjectSummary(bucket_name, "tests/"),
             MockS3Response.ObjectSummary(bucket_name, "tests/1.1.0/"),
             MockS3Response.ObjectSummary(bucket_name, "tests/1.1.0/x64/"),
-            MockS3Response.ObjectSummary(
-                bucket_name, "tests/1.1.0/x64/opensearch-1.1.0-linux-x64.tar.gz"
-            ),
-            MockS3Response.ObjectSummary(
-                bucket_name, "maven/org/opensearch/xyz-1.1.0.tar.gz"
-            ),
+            MockS3Response.ObjectSummary(bucket_name, "tests/1.1.0/x64/opensearch-1.1.0-linux-x64.tar.gz"),
+            MockS3Response.ObjectSummary(bucket_name, "maven/org/opensearch/xyz-1.1.0.tar.gz"),
         ]
         mock_s3_resource.Bucket(bucket_name).objects.filter.return_value = response
         return mock_s3_resource
@@ -91,9 +87,7 @@ class TestS3Bucket(unittest.TestCase):
             call(
                 "s3",
                 aws_access_key_id=expected_sts_response["Credentials"]["AccessKeyId"],
-                aws_secret_access_key=expected_sts_response["Credentials"][
-                    "SecretAccessKey"
-                ],
+                aws_secret_access_key=expected_sts_response["Credentials"]["SecretAccessKey"],
                 aws_session_token=expected_sts_response["Credentials"]["SessionToken"],
             ),
         ]
@@ -101,18 +95,14 @@ class TestS3Bucket(unittest.TestCase):
         mock_boto_resource.assert_called_once_with(
             "s3",
             aws_access_key_id=expected_sts_response["Credentials"]["AccessKeyId"],
-            aws_secret_access_key=expected_sts_response["Credentials"][
-                "SecretAccessKey"
-            ],
+            aws_secret_access_key=expected_sts_response["Credentials"]["SecretAccessKey"],
             aws_session_token=expected_sts_response["Credentials"]["SessionToken"],
         )
 
     @patch("boto3.client")
     def test_s3_bucket_obj_sts_error(self, mock_boto_client):
         expected_sts_response = MockSTSResponse.successful_response()
-        mock_boto_client("sts").assume_role.side_effect = ClientError(
-            error_response={"Error": {"Code": "403"}}, operation_name="AssumeRole"
-        )
+        mock_boto_client("sts").assume_role.side_effect = ClientError(error_response={"Error": {"Code": "403"}}, operation_name="AssumeRole")
         mock_boto_client("sts").assume_role.return_value = expected_sts_response
         with self.assertRaises(STSError):
             S3Bucket(bucket_name)
@@ -152,9 +142,7 @@ class TestS3Bucket(unittest.TestCase):
             ),
         ]
         mock_s3_resource.Bucket(bucket_name).download_file.assert_has_calls(calls)
-        self.assertTrue(
-            mock_s3_resource.Bucket(bucket_name).download_file.call_count, 2
-        )
+        self.assertTrue(mock_s3_resource.Bucket(bucket_name).download_file.call_count, 2)
 
     @patch("boto3.client")
     @patch("boto3.resource", side_effect=MockS3Response.mock_list_objects_response)
@@ -168,20 +156,14 @@ class TestS3Bucket(unittest.TestCase):
             call(file_path, "/tmp/opensearch-1.1.0-linux-x64.tar.gz"),
         ]
         mock_s3_resource.Bucket(bucket_name).download_file.assert_has_calls(calls)
-        self.assertTrue(
-            mock_s3_resource.Bucket(bucket_name).download_file.call_count, 1
-        )
+        self.assertTrue(mock_s3_resource.Bucket(bucket_name).download_file.call_count, 1)
 
     @patch("boto3.client")
     @patch("boto3.resource")
     def test_download_file_failure(self, mock_boto_resource, mock_boto_client):
-        mock_boto_client(
-            "sts"
-        ).assume_role.return_value = MockSTSResponse.successful_response()
+        mock_boto_client("sts").assume_role.return_value = MockSTSResponse.successful_response()
         file_path = "tests/1.1.0/x64/opensearch-1.1.0-linux-x64.tar.gz"
-        mock_boto_resource("s3").Bucket(
-            bucket_name
-        ).download_file.side_effect = ClientError(
+        mock_boto_resource("s3").Bucket(bucket_name).download_file.side_effect = ClientError(
             error_response={"Error": {"Code": "403"}}, operation_name="GetObject"
         )
         s3bucket = S3Bucket(bucket_name)

--- a/tests/test_run_assemble.py
+++ b/tests/test_run_assemble.py
@@ -27,9 +27,7 @@ class TestRunAssemble(unittest.TestCase):
         out, _ = self.capfd.readouterr()
         self.assertTrue(out.startswith("usage:"))
 
-    BUILD_MANIFEST = os.path.join(
-        os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-    )
+    BUILD_MANIFEST = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
 
     @patch("os.chdir")
     @patch("os.makedirs")
@@ -51,6 +49,4 @@ class TestRunAssemble(unittest.TestCase):
 
         mock_bundle.build_tar.assert_called_with("curdir/bundle")
 
-        mock_recorder.return_value.write_manifest.assert_has_calls(
-            [call("path"), call("curdir/bundle")]  # manifest included in tar
-        )
+        mock_recorder.return_value.write_manifest.assert_has_calls([call("path"), call("curdir/bundle")])  # manifest included in tar

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -27,11 +27,7 @@ class TestRunBuild(unittest.TestCase):
         out, _ = self.capfd.readouterr()
         self.assertTrue(out.startswith("usage:"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(
-        os.path.join(
-            os.path.dirname(__file__), "../manifests/1.1.0/opensearch-1.1.0.yml"
-        )
-    )
+    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../manifests/1.1.0/opensearch-1.1.0.yml"))
 
     @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST])
     @patch("run_build.Builder", return_value=MagicMock())
@@ -74,9 +70,7 @@ class TestRunBuild(unittest.TestCase):
         mock_builder.assert_has_calls(
             [
                 call("OpenSearch", mock_repo.return_value, mock_recorder.return_value),
-                call(
-                    "common-utils", mock_repo.return_value, mock_recorder.return_value
-                ),
+                call("common-utils", mock_repo.return_value, mock_recorder.return_value),
                 call(
                     "dashboards-reports",
                     mock_repo.return_value,

--- a/tests/test_run_checkout.py
+++ b/tests/test_run_checkout.py
@@ -27,16 +27,10 @@ class TestRunChecout(unittest.TestCase):
         out, _ = self.capfd.readouterr()
         self.assertTrue(out.startswith("usage:"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(
-        os.path.join(
-            os.path.dirname(__file__), "../manifests/1.1.0/opensearch-1.1.0.yml"
-        )
-    )
+    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../manifests/1.1.0/opensearch-1.1.0.yml"))
 
     @patch("argparse._sys.argv", ["run_checkout.py", OPENSEARCH_MANIFEST])
-    @patch(
-        "run_checkout.GitRepository", return_value=MagicMock(working_directory="dummy")
-    )
+    @patch("run_checkout.GitRepository", return_value=MagicMock(working_directory="dummy"))
     @patch("run_checkout.TemporaryDirectory")
     def test_main(self, mock_temp, mock_repo):
         mock_temp.return_value.__enter__.return_value = tempfile.gettempdir()

--- a/tests/test_run_ci.py
+++ b/tests/test_run_ci.py
@@ -27,11 +27,7 @@ class TestRunCi(unittest.TestCase):
         out, _ = self.capfd.readouterr()
         self.assertTrue(out.startswith("usage:"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(
-        os.path.join(
-            os.path.dirname(__file__), "../manifests/1.1.0/opensearch-1.1.0.yml"
-        )
-    )
+    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../manifests/1.1.0/opensearch-1.1.0.yml"))
 
     @patch("argparse._sys.argv", ["run_ci.py", OPENSEARCH_MANIFEST])
     @patch("run_ci.Ci", return_value=MagicMock())

--- a/tests/test_run_manifests.py
+++ b/tests/test_run_manifests.py
@@ -51,9 +51,7 @@ class TestRunManifests(unittest.TestCase):
         "manifests_workflow.manifests_args.InputManifestsOpenSearchDashboards",
         return_value=MagicMock(),
     )
-    def test_main_update(
-        self, mock_manifests_opensearch_dashboards, mock_manifests_opensearch, *mocks
-    ):
+    def test_main_update(self, mock_manifests_opensearch_dashboards, mock_manifests_opensearch, *mocks):
         main()
         mock_manifests_opensearch_dashboards.return_value.update.assert_called()
         mock_manifests_opensearch.return_value.update.assert_called()

--- a/tests/test_run_sign.py
+++ b/tests/test_run_sign.py
@@ -51,6 +51,4 @@ class TestRunSign(unittest.TestCase):
                 )
             ]
         )
-        mock_signer.return_value.sign_artifacts.assert_has_calls(
-            [call(["plugins/opensearch-index-management-1.1.0.0.zip"], self.DATA_PATH)]
-        )
+        mock_signer.return_value.sign_artifacts.assert_has_calls([call(["plugins/opensearch-index-management-1.1.0.0.zip"], self.DATA_PATH)])

--- a/tests/tests_assemble_workflow/test_bundle.py
+++ b/tests/tests_assemble_workflow/test_bundle.py
@@ -18,27 +18,19 @@ class TestBundle(unittest.TestCase):
             pass
 
     def test_bundle(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-        bundle = self.DummyBundle(
-            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
-        )
+        bundle = self.DummyBundle(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertEqual(bundle.min_tarball.name, "OpenSearch")
         self.assertEqual(len(bundle.plugins), 12)
         self.assertEqual(bundle.artifacts_dir, artifacts_path)
         self.assertIsNotNone(bundle.bundle_recorder)
         self.assertEqual(bundle.installed_plugins, [])
-        self.assertTrue(
-            bundle.min_tarball_path.endswith("/opensearch-min-1.1.0-linux-x64.tar.gz")
-        )
+        self.assertTrue(bundle.min_tarball_path.endswith("/opensearch-min-1.1.0-linux-x64.tar.gz"))
         self.assertIsNotNone(bundle.archive_path)
 
     def test_bundle_does_not_exist_raises_error(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         with self.assertRaisesRegex(
             FileNotFoundError,
             "does-not-exist/dist/opensearch-min-1.1.0-linux-x64.tar.gz",
@@ -50,9 +42,7 @@ class TestBundle(unittest.TestCase):
             )
 
     def test_bundle_invalid_archive_raises_error(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         with self.assertRaisesRegex(FileNotFoundError, "(/*)$"):
             self.DummyBundle(
                 BuildManifest.from_path(manifest_path),

--- a/tests/tests_assemble_workflow/test_bundle_opensearch.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch.py
@@ -15,31 +15,21 @@ from paths.script_finder import ScriptFinder
 
 class TestBundleOpenSearch(unittest.TestCase):
     def test_bundle_opensearch(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-        bundle = BundleOpenSearch(
-            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
-        )
+        bundle = BundleOpenSearch(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertEqual(bundle.min_tarball.name, "OpenSearch")
         self.assertEqual(len(bundle.plugins), 12)
         self.assertEqual(bundle.artifacts_dir, artifacts_path)
         self.assertIsNotNone(bundle.bundle_recorder)
         self.assertEqual(bundle.installed_plugins, [])
-        self.assertTrue(
-            bundle.min_tarball_path.endswith("/opensearch-min-1.1.0-linux-x64.tar.gz")
-        )
+        self.assertTrue(bundle.min_tarball_path.endswith("/opensearch-min-1.1.0-linux-x64.tar.gz"))
         self.assertIsNotNone(bundle.archive_path)
 
     def test_bundle_install_min(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-        bundle = BundleOpenSearch(
-            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
-        )
+        bundle = BundleOpenSearch(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
 
         with patch("subprocess.check_call") as mock_check_call:
             bundle.install_min()
@@ -58,9 +48,7 @@ class TestBundleOpenSearch(unittest.TestCase):
 
     @patch.object(BundleOpenSearch, "install_plugin")
     def test_bundle_install_plugins(self, mocks_bundle):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         bundle = BundleOpenSearch(
             BuildManifest.from_path(manifest_path),
             os.path.join(os.path.dirname(__file__), "data/artifacts"),
@@ -72,13 +60,9 @@ class TestBundleOpenSearch(unittest.TestCase):
 
     @patch("os.path.isfile", return_value=True)
     def test_bundle_install_plugin(self, *mocks):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-        bundle = BundleOpenSearch(
-            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
-        )
+        bundle = BundleOpenSearch(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
 
         plugin = bundle.plugins[0]  # job-scheduler
 
@@ -89,9 +73,7 @@ class TestBundleOpenSearch(unittest.TestCase):
                 self.assertEqual(mock_copyfile.call_count, 1)
                 self.assertEqual(mock_check_call.call_count, 2)
 
-                install_plugin_bin = os.path.join(
-                    bundle.archive_path, "bin/opensearch-plugin"
-                )
+                install_plugin_bin = os.path.join(bundle.archive_path, "bin/opensearch-plugin")
                 mock_check_call.assert_has_calls(
                     [
                         call(
@@ -108,9 +90,7 @@ class TestBundleOpenSearch(unittest.TestCase):
                 )
 
     def test_bundle_build_tar(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
         bundle = BundleOpenSearch(
             BuildManifest.from_path(manifest_path),
@@ -124,7 +104,5 @@ class TestBundleOpenSearch(unittest.TestCase):
             with patch("shutil.copyfile") as mock_copyfile:
                 bundle.build_tar(os.path.dirname(__file__))
                 mock_tarfile_open.assert_called_with("opensearch.tar", "w:gz")
-                mock_tarfile_add.assert_called_with(
-                    os.path.join(bundle.tmp_dir.name, "bundle"), arcname="bundle"
-                )
+                mock_tarfile_add.assert_called_with(os.path.join(bundle.tmp_dir.name, "bundle"), arcname="bundle")
                 self.assertEqual(mock_copyfile.call_count, 1)

--- a/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
@@ -8,41 +8,28 @@ import os
 import unittest
 from unittest.mock import MagicMock, call, patch
 
-from assemble_workflow.bundle_opensearch_dashboards import \
-    BundleOpenSearchDashboards
+from assemble_workflow.bundle_opensearch_dashboards import BundleOpenSearchDashboards
 from manifests.build_manifest import BuildManifest
 from paths.script_finder import ScriptFinder
 
 
 class TestBundleOpenSearchDashboards(unittest.TestCase):
     def test_bundle_opensearch_dashboards(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml")
         artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-        bundle = BundleOpenSearchDashboards(
-            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
-        )
+        bundle = BundleOpenSearchDashboards(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertEqual(bundle.min_tarball.name, "OpenSearch-Dashboards")
         self.assertEqual(len(bundle.plugins), 1)
         self.assertEqual(bundle.artifacts_dir, artifacts_path)
         self.assertIsNotNone(bundle.bundle_recorder)
         self.assertEqual(bundle.installed_plugins, [])
-        self.assertTrue(
-            bundle.min_tarball_path.endswith(
-                "/opensearch-dashboards-min-1.1.0-linux-x64.tar.gz"
-            )
-        )
+        self.assertTrue(bundle.min_tarball_path.endswith("/opensearch-dashboards-min-1.1.0-linux-x64.tar.gz"))
         self.assertIsNotNone(bundle.archive_path)
 
     def test_bundle_install_min(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml")
         artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-        bundle = BundleOpenSearchDashboards(
-            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
-        )
+        bundle = BundleOpenSearchDashboards(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
 
         with patch("subprocess.check_call") as mock_check_call:
             bundle.install_min()
@@ -61,13 +48,9 @@ class TestBundleOpenSearchDashboards(unittest.TestCase):
 
     @patch("os.path.isfile", return_value=True)
     def test_bundle_install_plugin(self, *mocks):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml")
         artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-        bundle = BundleOpenSearchDashboards(
-            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
-        )
+        bundle = BundleOpenSearchDashboards(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
 
         plugin = bundle.plugins[0]  # alertingDashboards
 
@@ -78,9 +61,7 @@ class TestBundleOpenSearchDashboards(unittest.TestCase):
                 self.assertEqual(mock_copyfile.call_count, 1)
                 self.assertEqual(mock_check_call.call_count, 2)
 
-                install_plugin_bin = os.path.join(
-                    bundle.archive_path, "bin/opensearch-dashboards-plugin"
-                )
+                install_plugin_bin = os.path.join(bundle.archive_path, "bin/opensearch-dashboards-plugin")
                 mock_check_call.assert_has_calls(
                     [
                         call(

--- a/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -18,13 +18,9 @@ from manifests.bundle_manifest import BundleManifest
 class TestBundleRecorder(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         manifest = BuildManifest.from_path(manifest_path)
-        self.bundle_recorder = BundleRecorder(
-            manifest.build, "output_dir", "artifacts_dir"
-        )
+        self.bundle_recorder = BundleRecorder(manifest.build, "output_dir", "artifacts_dir")
 
     def test_record_component(self):
         component = BuildManifest.Component(
@@ -131,9 +127,7 @@ class TestBundleRecorder(unittest.TestCase):
     def test_get_location_scenarios(self):
         def get_location(public_url):
             self.bundle_recorder.public_url = public_url
-            return self.bundle_recorder._BundleRecorder__get_location(
-                "builds", "dir1/dir2/file", "/tmp/builds/foo/dir1/dir2/file"
-            )
+            return self.bundle_recorder._BundleRecorder__get_location("builds", "dir1/dir2/file", "/tmp/builds/foo/dir1/dir2/file")
 
         # No public URL - Fallback to ABS Path
         self.assertEqual(get_location(None), "/tmp/builds/foo/dir1/dir2/file")
@@ -151,20 +145,14 @@ class TestBundleRecorder(unittest.TestCase):
         )
 
     def test_tar_name(self):
-        self.assertEqual(
-            self.bundle_recorder.tar_name, "opensearch-1.1.0-linux-x64.tar.gz"
-        )
+        self.assertEqual(self.bundle_recorder.tar_name, "opensearch-1.1.0-linux-x64.tar.gz")
 
 
 class TestBundleRecorderDashboards(unittest.TestCase):
     def setUp(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml")
         manifest = BuildManifest.from_path(manifest_path)
-        self.bundle_recorder = BundleRecorder(
-            manifest.build, "output_dir", "artifacts_dir"
-        )
+        self.bundle_recorder = BundleRecorder(manifest.build, "output_dir", "artifacts_dir")
 
     def test_record_component(self):
         component = BuildManifest.Component(
@@ -271,9 +259,7 @@ class TestBundleRecorderDashboards(unittest.TestCase):
     def test_get_location_scenarios(self):
         def get_location(public_url):
             self.bundle_recorder.public_url = public_url
-            return self.bundle_recorder._BundleRecorder__get_location(
-                "builds", "dir1/dir2/file", "/tmp/builds/foo/dir1/dir2/file"
-            )
+            return self.bundle_recorder._BundleRecorder__get_location("builds", "dir1/dir2/file", "/tmp/builds/foo/dir1/dir2/file")
 
         # No public URL - Fallback to ABS Path
         self.assertEqual(get_location(None), "/tmp/builds/foo/dir1/dir2/file")

--- a/tests/tests_assemble_workflow/test_bundles.py
+++ b/tests/tests_assemble_workflow/test_bundles.py
@@ -9,31 +9,22 @@ import unittest
 from unittest.mock import MagicMock
 
 from assemble_workflow.bundle_opensearch import BundleOpenSearch
-from assemble_workflow.bundle_opensearch_dashboards import \
-    BundleOpenSearchDashboards
+from assemble_workflow.bundle_opensearch_dashboards import BundleOpenSearchDashboards
 from assemble_workflow.bundles import Bundles
 from manifests.build_manifest import BuildManifest
 
 
 class TestBundles(unittest.TestCase):
     def test_bundle_opensearch(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-build-1.1.0.yml")
         artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-        bundle = Bundles.create(
-            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
-        )
+        bundle = Bundles.create(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertIs(type(bundle), BundleOpenSearch)
 
     def test_bundle_opensearch_dashboards(self):
-        manifest_path = os.path.join(
-            os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml"
-        )
+        manifest_path = os.path.join(os.path.dirname(__file__), "data/opensearch-dashboards-build-1.1.0.yml")
         artifacts_path = os.path.join(os.path.dirname(__file__), "data/artifacts")
-        bundle = Bundles.create(
-            BuildManifest.from_path(manifest_path), artifacts_path, MagicMock()
-        )
+        bundle = Bundles.create(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertIs(type(bundle), BundleOpenSearchDashboards)
 
     def test_bundle_opensearch_invalid(self):

--- a/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_maven.py
+++ b/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_maven.py
@@ -10,19 +10,14 @@ from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
 from build_workflow.build_target import BuildTarget
-from build_workflow.opensearch.build_artifact_check_maven import \
-    BuildArtifactOpenSearchCheckMaven
+from build_workflow.opensearch.build_artifact_check_maven import BuildArtifactOpenSearchCheckMaven
 
 
 class TestBuildArtifactOpenSearchCheckMaven(unittest.TestCase):
     @contextmanager
     def __mock(self, props="", snapshot=True):
-        with patch(
-            "build_workflow.opensearch.build_artifact_check_maven.ZipFile"
-        ) as mock_zipfile:
-            mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = (
-                props
-            )
+        with patch("build_workflow.opensearch.build_artifact_check_maven.ZipFile") as mock_zipfile:
+            mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = props
             yield BuildArtifactOpenSearchCheckMaven(
                 BuildTarget(
                     build_id="1",
@@ -43,7 +38,7 @@ class TestBuildArtifactOpenSearchCheckMaven(unittest.TestCase):
             mock.check("valid.jar")
 
     def test_record_maven_artifact_after_checking_maven_version_properties_snapshot(
-        self
+        self,
     ):
         with self.__mock("Implementation-Version: 1.1.0.0-SNAPSHOT") as mock:
             mock.check("valid.jar")

--- a/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_plugin.py
+++ b/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_plugin.py
@@ -10,19 +10,14 @@ from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
 from build_workflow.build_target import BuildTarget
-from build_workflow.opensearch.build_artifact_check_plugin import \
-    BuildArtifactOpenSearchCheckPlugin
+from build_workflow.opensearch.build_artifact_check_plugin import BuildArtifactOpenSearchCheckPlugin
 
 
 class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
     @contextmanager
     def __mock(self, props="", snapshot=True):
-        with patch(
-            "build_workflow.opensearch.build_artifact_check_plugin.ZipFile"
-        ) as mock_zipfile:
-            mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = (
-                props
-            )
+        with patch("build_workflow.opensearch.build_artifact_check_plugin.ZipFile") as mock_zipfile:
+            mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = props
             yield BuildArtifactOpenSearchCheckPlugin(
                 BuildTarget(
                     build_id="1",

--- a/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
+++ b/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
@@ -10,19 +10,14 @@ from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
 from build_workflow.build_target import BuildTarget
-from build_workflow.opensearch_dashboards.build_artifact_check_plugin import \
-    BuildArtifactOpenSearchDashboardsCheckPlugin
+from build_workflow.opensearch_dashboards.build_artifact_check_plugin import BuildArtifactOpenSearchDashboardsCheckPlugin
 
 
 class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
     @contextmanager
     def __mock(self, props={}, snapshot=True):
-        with patch(
-            "build_workflow.opensearch_dashboards.build_artifact_check_plugin.ZipFile"
-        ) as mock_zipfile:
-            mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = (
-                props
-            )
+        with patch("build_workflow.opensearch_dashboards.build_artifact_check_plugin.ZipFile") as mock_zipfile:
+            mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = props
             yield BuildArtifactOpenSearchDashboardsCheckPlugin(
                 BuildTarget(
                     build_id="1",
@@ -71,7 +66,5 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             )
 
     def test_check_plugin_version_properties(self, *mocks):
-        with self.__mock(
-            {"opensearchDashboardsVersion": "1.1.0", "version": "1.1.0.0"}
-        ) as mock:
+        with self.__mock({"opensearchDashboardsVersion": "1.1.0", "version": "1.1.0.0"}) as mock:
             mock.check("valid-1.1.0.zip")

--- a/tests/tests_build_workflow/test_build_args.py
+++ b/tests/tests_build_workflow/test_build_args.py
@@ -14,19 +14,11 @@ from build_workflow.build_args import BuildArgs
 
 class TestBuildArgs(unittest.TestCase):
 
-    BUILD_PY = os.path.realpath(
-        os.path.join(os.path.dirname(__file__), "../../src/run_build.py")
-    )
+    BUILD_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/run_build.py"))
 
-    BUILD_SH = os.path.realpath(
-        os.path.join(os.path.dirname(__file__), "../../build.sh")
-    )
+    BUILD_SH = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../build.sh"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(
-        os.path.join(
-            os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"
-        )
-    )
+    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"))
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
     def test_manifest(self):

--- a/tests/tests_build_workflow/test_build_artifact_checks.py
+++ b/tests/tests_build_workflow/test_build_artifact_checks.py
@@ -9,12 +9,9 @@ from unittest.mock import patch
 
 from build_workflow.build_artifact_checks import BuildArtifactChecks
 from build_workflow.build_target import BuildTarget
-from build_workflow.opensearch.build_artifact_check_maven import \
-    BuildArtifactOpenSearchCheckMaven
-from build_workflow.opensearch.build_artifact_check_plugin import \
-    BuildArtifactOpenSearchCheckPlugin
-from build_workflow.opensearch_dashboards.build_artifact_check_plugin import \
-    BuildArtifactOpenSearchDashboardsCheckPlugin
+from build_workflow.opensearch.build_artifact_check_maven import BuildArtifactOpenSearchCheckMaven
+from build_workflow.opensearch.build_artifact_check_plugin import BuildArtifactOpenSearchCheckPlugin
+from build_workflow.opensearch_dashboards.build_artifact_check_plugin import BuildArtifactOpenSearchDashboardsCheckPlugin
 
 
 class TestBuildArtifactChecks(unittest.TestCase):

--- a/tests/tests_build_workflow/test_build_recorder.py
+++ b/tests/tests_build_workflow/test_build_recorder.py
@@ -13,10 +13,8 @@ import yaml
 
 from build_workflow.build_recorder import BuildRecorder
 from build_workflow.build_target import BuildTarget
-from build_workflow.opensearch.build_artifact_check_maven import \
-    BuildArtifactOpenSearchCheckMaven
-from build_workflow.opensearch.build_artifact_check_plugin import \
-    BuildArtifactOpenSearchCheckPlugin
+from build_workflow.opensearch.build_artifact_check_maven import BuildArtifactOpenSearchCheckMaven
+from build_workflow.opensearch.build_artifact_check_plugin import BuildArtifactOpenSearchCheckPlugin
 from manifests.build_manifest import BuildManifest
 
 
@@ -106,9 +104,7 @@ class TestBuildRecorder(unittest.TestCase):
         recorder.record_component("security", MagicMock())
 
         with patch.object(BuildArtifactOpenSearchCheckPlugin, "check") as mock_check:
-            recorder.record_artifact(
-                "security", "plugins", "../file1.zip", "invalid.file"
-            )
+            recorder.record_artifact("security", "plugins", "../file1.zip", "invalid.file")
 
         mock_check.assert_called_with("invalid.file")
 
@@ -183,9 +179,7 @@ class TestBuildRecorder(unittest.TestCase):
                 sha="3913d7097934cbfe1fdcf919347f22a597d00b76",
             ),
         )
-        mock.record_artifact(
-            "security", "plugins", "../file1.zip", "valid-1.1.0.0-SNAPSHOT.zip"
-        )
+        mock.record_artifact("security", "plugins", "../file1.zip", "valid-1.1.0.0-SNAPSHOT.zip")
         manifest_dict = mock.get_manifest().to_dict()
         self.assertEqual(manifest_dict["build"]["version"], "1.1.0-SNAPSHOT")
         self.assertEqual(manifest_dict["components"][0]["version"], "1.1.0.0-SNAPSHOT")

--- a/tests/tests_build_workflow/test_build_target.py
+++ b/tests/tests_build_workflow/test_build_target.py
@@ -13,9 +13,7 @@ from build_workflow.build_target import BuildTarget
 
 class TestBuildTarget(unittest.TestCase):
     def test_output_dir(self):
-        self.assertEqual(
-            BuildTarget(version="1.1.0", arch="x86").output_dir, "artifacts"
-        )
+        self.assertEqual(BuildTarget(version="1.1.0", arch="x86").output_dir, "artifacts")
 
     def test_build_id_hex(self):
         self.assertEqual(len(BuildTarget(version="1.1.0", arch="x86").build_id), 32)
@@ -25,9 +23,7 @@ class TestBuildTarget(unittest.TestCase):
         self.assertEqual(BuildTarget(version="1.1.0", arch="x86").build_id, "id")
 
     def test_build_id_from_arg(self):
-        self.assertEqual(
-            BuildTarget(version="1.1.0", arch="x86", build_id="id").build_id, "id"
-        )
+        self.assertEqual(BuildTarget(version="1.1.0", arch="x86", build_id="id").build_id, "id")
 
     def test_opensearch_version(self):
         self.assertEqual(
@@ -58,6 +54,4 @@ class TestBuildTarget(unittest.TestCase):
         self.assertEqual(BuildTarget(version="1.1.0", snapshot=False).arch, "value")
 
     def test_arch_value(self):
-        self.assertEqual(
-            BuildTarget(version="1.1.0", arch="value", snapshot=False).arch, "value"
-        )
+        self.assertEqual(BuildTarget(version="1.1.0", arch="value", snapshot=False).arch, "value")

--- a/tests/tests_build_workflow/test_builder.py
+++ b/tests/tests_build_workflow/test_builder.py
@@ -37,11 +37,7 @@ class TestBuilder(unittest.TestCase):
         self.builder.git_repo.execute.assert_called_with(
             " ".join(
                 [
-                    os.path.realpath(
-                        os.path.join(
-                            ScriptFinder.default_scripts_path, "opensearch", "build.sh"
-                        )
-                    ),
+                    os.path.realpath(os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")),
                     "-v 1.0.0",
                     "-p linux",
                     "-a x64",
@@ -50,9 +46,7 @@ class TestBuilder(unittest.TestCase):
                 ]
             )
         )
-        self.builder.build_recorder.record_component.assert_called_with(
-            "component", self.builder.git_repo
-        )
+        self.builder.build_recorder.record_component.assert_called_with("component", self.builder.git_repo)
 
     def test_build_snapshot(self):
         self.builder.build(
@@ -67,11 +61,7 @@ class TestBuilder(unittest.TestCase):
         self.builder.git_repo.execute.assert_called_with(
             " ".join(
                 [
-                    os.path.realpath(
-                        os.path.join(
-                            ScriptFinder.default_scripts_path, "opensearch", "build.sh"
-                        )
-                    ),
+                    os.path.realpath(os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")),
                     "-v 1.0.0",
                     "-p darwin",
                     "-a x64",
@@ -80,9 +70,7 @@ class TestBuilder(unittest.TestCase):
                 ]
             )
         )
-        self.builder.build_recorder.record_component.assert_called_with(
-            "component", self.builder.git_repo
-        )
+        self.builder.build_recorder.record_component.assert_called_with("component", self.builder.git_repo)
 
     def mock_os_walk(self, artifact_path):
         if artifact_path.endswith("/checked-out-component/artifacts/core-plugins"):
@@ -102,17 +90,13 @@ class TestBuilder(unittest.TestCase):
                 call(
                     "component",
                     "maven",
-                    os.path.relpath(
-                        "/maven/artifact1.jar", self.builder.artifacts_path
-                    ),
+                    os.path.relpath("/maven/artifact1.jar", self.builder.artifacts_path),
                     "/maven/artifact1.jar",
                 ),
                 call(
                     "component",
                     "core-plugins",
-                    os.path.relpath(
-                        "/core-plugins/plugin1.zip", self.builder.artifacts_path
-                    ),
+                    os.path.relpath("/core-plugins/plugin1.zip", self.builder.artifacts_path),
                     "/core-plugins/plugin1.zip",
                 ),
             ]

--- a/tests/tests_checkout_workflow/test_checkout_args.py
+++ b/tests/tests_checkout_workflow/test_checkout_args.py
@@ -14,15 +14,9 @@ from checkout_workflow.checkout_args import CheckoutArgs
 
 class TestCheckoutArgs(unittest.TestCase):
 
-    CHECKOUT_PY = os.path.realpath(
-        os.path.join(os.path.dirname(__file__), "../../src/run_checkout.py")
-    )
+    CHECKOUT_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/run_checkout.py"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(
-        os.path.join(
-            os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"
-        )
-    )
+    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"))
 
     @patch("argparse._sys.argv", [CHECKOUT_PY, OPENSEARCH_MANIFEST])
     def test_manifest(self):

--- a/tests/tests_ci_workflow/test_ci.py
+++ b/tests/tests_ci_workflow/test_ci.py
@@ -12,9 +12,7 @@ from ci_workflow.ci import Ci
 
 class TestCi(unittest.TestCase):
     def setUp(self):
-        self.ci = Ci(
-            "component", MagicMock(dir="/tmp/checked-out-component"), MagicMock()
-        )
+        self.ci = Ci("component", MagicMock(dir="/tmp/checked-out-component"), MagicMock())
 
     def test_ci(self):
         self.assertEqual(self.ci.component, "component")

--- a/tests/tests_ci_workflow/test_ci_args.py
+++ b/tests/tests_ci_workflow/test_ci_args.py
@@ -13,17 +13,11 @@ from ci_workflow.ci_args import CiArgs
 
 class TestCiArgs(unittest.TestCase):
 
-    CI_PY = os.path.realpath(
-        os.path.join(os.path.dirname(__file__), "../../src/run_ci.py")
-    )
+    CI_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/run_ci.py"))
 
     CI_SH = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../ci.sh"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(
-        os.path.join(
-            os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"
-        )
-    )
+    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"))
 
     @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST])
     def test_manifest(self):

--- a/tests/tests_ci_workflow/test_ci_check_gradle_dependencies.py
+++ b/tests/tests_ci_workflow/test_ci_check_gradle_dependencies.py
@@ -47,9 +47,7 @@ class TestCiCheckGradleDependencies(unittest.TestCase):
         )
 
     def test_loads_tree(self):
-        data_path = os.path.join(
-            os.path.dirname(__file__), "data/job_scheduler_dependencies.txt"
-        )
+        data_path = os.path.join(os.path.dirname(__file__), "data/job_scheduler_dependencies.txt")
         with open(data_path) as f:
             check = self.__mock_dependencies(props=f.read())
             self.assertEqual(
@@ -57,23 +55,15 @@ class TestCiCheckGradleDependencies(unittest.TestCase):
                 "1.1.0-SNAPSHOT",
             )
             self.assertEqual(
-                check.dependencies.get_value(
-                    "org.opensearch:opensearch/org.opensearch:opensearch-core"
-                ),
+                check.dependencies.get_value("org.opensearch:opensearch/org.opensearch:opensearch-core"),
                 "1.1.0-SNAPSHOT",
             )
+            self.assertEqual(check.dependencies.get_value("com.puppycrawl.tools:checkstyle"), "8.29")
             self.assertEqual(
-                check.dependencies.get_value("com.puppycrawl.tools:checkstyle"), "8.29"
-            )
-            self.assertEqual(
-                check.dependencies.get_value(
-                    "com.puppycrawl.tools:checkstyle/antlr:antlr"
-                ),
+                check.dependencies.get_value("com.puppycrawl.tools:checkstyle/antlr:antlr"),
                 "2.7.7",
             )
             self.assertEqual(
-                check.dependencies.get_value(
-                    "com.puppycrawl.tools:checkstyle/commons-beanutils:commons-beanutils/commons-collections:commons-collections"
-                ),
+                check.dependencies.get_value("com.puppycrawl.tools:checkstyle/commons-beanutils:commons-beanutils/commons-collections:commons-collections"),
                 "3.2.2",
             )

--- a/tests/tests_ci_workflow/test_ci_check_gradle_dependencies_opensearch.py
+++ b/tests/tests_ci_workflow/test_ci_check_gradle_dependencies_opensearch.py
@@ -7,8 +7,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from ci_workflow.ci_check_gradle_dependencies_opensearch import \
-    CiCheckGradleDependenciesOpenSearchVersion
+from ci_workflow.ci_check_gradle_dependencies_opensearch import CiCheckGradleDependenciesOpenSearchVersion
 from ci_workflow.ci_target import CiTarget
 from system.properties_file import PropertiesFile
 

--- a/tests/tests_ci_workflow/test_ci_check_gradle_properties.py
+++ b/tests/tests_ci_workflow/test_ci_check_gradle_properties.py
@@ -26,9 +26,7 @@ class TestCiCheckGradleProperties(unittest.TestCase):
             target=CiTarget(version="1.1.0", snapshot=False),
         )
 
-        git_repo.output.assert_called_once_with(
-            "./gradlew properties -Dopensearch.version=1.1.0 -Dbuild.snapshot=false"
-        )
+        git_repo.output.assert_called_once_with("./gradlew properties -Dopensearch.version=1.1.0 -Dbuild.snapshot=false")
 
     def test_executes_gradle_properties_snapshot(self):
         git_repo = MagicMock()
@@ -40,6 +38,4 @@ class TestCiCheckGradleProperties(unittest.TestCase):
             target=CiTarget(version="1.1.0", snapshot=True),
         )
 
-        git_repo.output.assert_called_once_with(
-            "./gradlew properties -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true"
-        )
+        git_repo.output.assert_called_once_with("./gradlew properties -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true")

--- a/tests/tests_ci_workflow/test_ci_check_gradle_properties_version.py
+++ b/tests/tests_ci_workflow/test_ci_check_gradle_properties_version.py
@@ -7,8 +7,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from ci_workflow.ci_check_gradle_properties_version import \
-    CiCheckGradlePropertiesVersion
+from ci_workflow.ci_check_gradle_properties_version import CiCheckGradlePropertiesVersion
 from ci_workflow.ci_target import CiTarget
 from manifests.input_manifest import InputManifest
 from system.properties_file import PropertiesFile
@@ -16,9 +15,7 @@ from system.properties_file import PropertiesFile
 
 class TestCiCheckGradlePropertiesVersion(unittest.TestCase):
     def __mock_check(self, props=None, component=None, snapshot=True):
-        with patch.object(
-            CiCheckGradlePropertiesVersion, "_CiCheckGradleProperties__get_properties"
-        ) as mock_properties:
+        with patch.object(CiCheckGradlePropertiesVersion, "_CiCheckGradleProperties__get_properties") as mock_properties:
             mock_properties.return_value = PropertiesFile(props)
             return CiCheckGradlePropertiesVersion(
                 component=component or MagicMock(),
@@ -48,9 +45,7 @@ class TestCiCheckGradlePropertiesVersion(unittest.TestCase):
     def test_component_version_opensearch(self):
         check = self.__mock_check(
             props={"version": "1.1.0.0-SNAPSHOT"},
-            component=InputManifest.Component(
-                {"name": "OpenSearch", "repository": "", "ref": ""}
-            ),
+            component=InputManifest.Component({"name": "OpenSearch", "repository": "", "ref": ""}),
         )
 
         self.assertEqual(check.checked_version, "1.1.0-SNAPSHOT")
@@ -66,9 +61,7 @@ class TestCiCheckGradlePropertiesVersion(unittest.TestCase):
     def test_component_version(self):
         check = self.__mock_check(
             props={"version": "1.1.0-SNAPSHOT"},
-            component=InputManifest.Component(
-                {"name": "Plugin", "repository": "", "ref": ""}
-            ),
+            component=InputManifest.Component({"name": "Plugin", "repository": "", "ref": ""}),
         )
 
         self.assertEqual(check.checked_version, "1.1.0.0-SNAPSHOT")

--- a/tests/tests_ci_workflow/test_ci_check_gradle_publish_to_maven_local.py
+++ b/tests/tests_ci_workflow/test_ci_check_gradle_publish_to_maven_local.py
@@ -7,8 +7,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from ci_workflow.ci_check_gradle_publish_to_maven_local import \
-    CiCheckGradlePublishToMavenLocal
+from ci_workflow.ci_check_gradle_publish_to_maven_local import CiCheckGradlePublishToMavenLocal
 from ci_workflow.ci_target import CiTarget
 
 
@@ -20,9 +19,7 @@ class TestCiCheckGradlePublishToMavenLocal(unittest.TestCase):
             target=CiTarget(version="1.1.0", snapshot=False),
         )
         check.check()
-        check.git_repo.execute.assert_called_once_with(
-            "./gradlew publishToMavenLocal -Dopensearch.version=1.1.0 -Dbuild.snapshot=false"
-        )
+        check.git_repo.execute.assert_called_once_with("./gradlew publishToMavenLocal -Dopensearch.version=1.1.0 -Dbuild.snapshot=false")
 
     def test_executes_gradle_command_snapshot(self):
         check = CiCheckGradlePublishToMavenLocal(
@@ -31,6 +28,4 @@ class TestCiCheckGradlePublishToMavenLocal(unittest.TestCase):
             target=CiTarget(version="1.1.0", snapshot=True),
         )
         check.check()
-        check.git_repo.execute.assert_called_once_with(
-            "./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true"
-        )
+        check.git_repo.execute.assert_called_once_with("./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT -Dbuild.snapshot=true")

--- a/tests/tests_ci_workflow/test_ci_target.py
+++ b/tests/tests_ci_workflow/test_ci_target.py
@@ -11,9 +11,7 @@ from ci_workflow.ci_target import CiTarget
 
 class TestCiTarget(unittest.TestCase):
     def test_opensearch_version(self):
-        self.assertEqual(
-            CiTarget(version="1.1.0", snapshot=False).opensearch_version, "1.1.0"
-        )
+        self.assertEqual(CiTarget(version="1.1.0", snapshot=False).opensearch_version, "1.1.0")
 
     def test_opensearch_version_snapshot(self):
         self.assertEqual(
@@ -22,9 +20,7 @@ class TestCiTarget(unittest.TestCase):
         )
 
     def test_component_version(self):
-        self.assertEqual(
-            CiTarget(version="1.1.0", snapshot=False).component_version, "1.1.0.0"
-        )
+        self.assertEqual(CiTarget(version="1.1.0", snapshot=False).component_version, "1.1.0.0")
 
     def test_component_version_snapshot(self):
         self.assertEqual(

--- a/tests/tests_git/test_git_repository.py
+++ b/tests/tests_git/test_git_repository.py
@@ -26,9 +26,7 @@ class TestGitRepository(unittest.TestCase):
         self.assertEqual(self.repo.sha, "8ac515431bf24caf92fea9d9b0af3b8f10b88453")
         self.assertIs(type(self.repo.temp_dir), tempfile.TemporaryDirectory)
         self.assertEqual(self.repo.dir, os.path.realpath(self.repo.temp_dir.name))
-        self.assertTrue(
-            os.path.isfile(os.path.join(self.repo.dir, "CODE_OF_CONDUCT.md"))
-        )
+        self.assertTrue(os.path.isfile(os.path.join(self.repo.dir, "CODE_OF_CONDUCT.md")))
         # was added in the next commit
         self.assertFalse(os.path.exists(os.path.join(self.repo.dir, "CONTRIBUTING.md")))
 
@@ -37,13 +35,9 @@ class TestGitRepository(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(self.repo.dir, "created.txt")))
 
     def test_execute_in_dir(self):
-        self.repo.execute(
-            "echo $PWD > created.txt", os.path.join(self.repo.dir, "ISSUE_TEMPLATE")
-        )
+        self.repo.execute("echo $PWD > created.txt", os.path.join(self.repo.dir, "ISSUE_TEMPLATE"))
         self.assertFalse(os.path.isfile(os.path.join(self.repo.dir, "created.txt")))
-        self.assertTrue(
-            os.path.isfile(os.path.join(self.repo.dir, "ISSUE_TEMPLATE/created.txt"))
-        )
+        self.assertTrue(os.path.isfile(os.path.join(self.repo.dir, "ISSUE_TEMPLATE/created.txt")))
 
     @patch("subprocess.check_call")
     def test_execute_silent(self, mock_subprocess):
@@ -59,9 +53,7 @@ class TestGitRepository(unittest.TestCase):
     @patch("subprocess.check_output")
     def test_output(self, mock_subprocess):
         self.repo.output("echo hello")
-        subprocess.check_output.assert_called_with(
-            "echo hello", cwd=self.repo.dir, shell=True
-        )
+        subprocess.check_output.assert_called_with("echo hello", cwd=self.repo.dir, shell=True)
 
 
 class TestGitRepositoryDir(unittest.TestCase):
@@ -79,9 +71,7 @@ class TestGitRepositoryDir(unittest.TestCase):
             self.assertEqual(repo.sha, "8ac515431bf24caf92fea9d9b0af3b8f10b88453")
             self.assertIsNone(repo.temp_dir)
             self.assertEqual(repo.dir, subdir)
-            self.assertTrue(
-                os.path.isfile(os.path.join(repo.dir, "CODE_OF_CONDUCT.md"))
-            )
+            self.assertTrue(os.path.isfile(os.path.join(repo.dir, "CODE_OF_CONDUCT.md")))
 
 
 class TestGitRepositoryWithWorkingDir(unittest.TestCase):

--- a/tests/tests_manifests/test_build_manifest.py
+++ b/tests/tests_manifests/test_build_manifest.py
@@ -15,12 +15,8 @@ from manifests.build_manifest import BuildManifest
 
 class TestBuildManifest(unittest.TestCase):
     def setUp(self):
-        self.data_path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "data")
-        )
-        self.manifest_filename = os.path.join(
-            self.data_path, "opensearch-build-1.1.0.yml"
-        )
+        self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
+        self.manifest_filename = os.path.join(self.data_path, "opensearch-build-1.1.0.yml")
         self.manifest = BuildManifest.from_path(self.manifest_filename)
 
     def test_build(self):
@@ -36,9 +32,7 @@ class TestBuildManifest(unittest.TestCase):
             opensearch_component.repository,
             "https://github.com/opensearch-project/OpenSearch.git",
         )
-        self.assertEqual(
-            opensearch_component.commit_id, "b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583"
-        )
+        self.assertEqual(opensearch_component.commit_id, "b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583")
         self.assertEqual(opensearch_component.ref, "1.x")
         self.assertEqual(
             sorted(opensearch_component.artifacts.keys()),
@@ -51,14 +45,10 @@ class TestBuildManifest(unittest.TestCase):
             self.assertEqual(yaml.safe_load(f), data)
 
     def test_get_manifest_relative_location(self):
-        actual = BuildManifest.get_build_manifest_relative_location(
-            "25", "1.1.0", "linux", "x64"
-        )
+        actual = BuildManifest.get_build_manifest_relative_location("25", "1.1.0", "linux", "x64")
         # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
         expected = "builds/1.1.0/25/x64/manifest.yml"
-        self.assertEqual(
-            actual, expected, "the manifest relative location is not as expected"
-        )
+        self.assertEqual(actual, expected, "the manifest relative location is not as expected")
 
     def test_get_component(self):
         component_name = "index-management"

--- a/tests/tests_manifests/test_bundle_manifest.py
+++ b/tests/tests_manifests/test_bundle_manifest.py
@@ -15,21 +15,15 @@ from manifests.bundle_manifest import BundleManifest
 
 class TestBundleManifest(unittest.TestCase):
     def setUp(self):
-        self.data_path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "data")
-        )
-        self.manifest_filename = os.path.join(
-            self.data_path, "opensearch-bundle-1.1.0.yml"
-        )
+        self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
+        self.manifest_filename = os.path.join(self.data_path, "opensearch-bundle-1.1.0.yml")
         self.manifest = BundleManifest.from_path(self.manifest_filename)
 
     def test_build(self):
         self.assertEqual(self.manifest.version, "1.1")
         self.assertEqual(self.manifest.build.name, "OpenSearch")
         self.assertEqual(self.manifest.build.version, "1.1.0")
-        self.assertEqual(
-            self.manifest.build.location, "bundle/opensearch-1.1.0-linux-x64.tar.gz"
-        )
+        self.assertEqual(self.manifest.build.location, "bundle/opensearch-1.1.0-linux-x64.tar.gz")
         self.assertEqual(self.manifest.build.platform, "linux")
         self.assertEqual(self.manifest.build.architecture, "x64")
         self.assertEqual(len(self.manifest.components), 13)
@@ -57,22 +51,16 @@ class TestBundleManifest(unittest.TestCase):
             self.assertEqual(yaml.safe_load(f), data)
 
     def test_get_manifest_relative_location(self):
-        actual = BundleManifest.get_bundle_manifest_relative_location(
-            "25", "1.1.0", "linux", "x64"
-        )
+        actual = BundleManifest.get_bundle_manifest_relative_location("25", "1.1.0", "linux", "x64")
         # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
         expected = "bundles/1.1.0/25/x64/manifest.yml"
-        self.assertEqual(
-            actual, expected, "the manifest relative location is not as expected"
-        )
+        self.assertEqual(actual, expected, "the manifest relative location is not as expected")
 
     def test_get_tarball_relative_location(self):
         actual = BundleManifest.get_tarball_relative_location("25", "1.1.0", "darwin", "x64")
         # TODO: use platform, https://github.com/opensearch-project/opensearch-build/issues/669
         expected = "bundles/1.1.0/25/x64/opensearch-1.1.0-darwin-x64.tar.gz"
-        self.assertEqual(
-            actual, expected, "the tarball relative location is not as expected"
-        )
+        self.assertEqual(actual, expected, "the tarball relative location is not as expected")
 
     def test_get_tarball_name(self):
         actual = BundleManifest.get_tarball_name("1.1.0", "darwin", "x64")

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -15,9 +15,7 @@ from manifests.input_manifest import InputManifest
 class TestInputManifest(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
-        self.manifests_path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "../../manifests")
-        )
+        self.manifests_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests"))
 
     def test_1_0(self):
         path = os.path.join(self.manifests_path, "1.0.0/opensearch-1.0.0.yml")
@@ -55,9 +53,7 @@ class TestInputManifest(unittest.TestCase):
         for component in manifest.components:
             self.assertIsInstance(component.ref, str)
         # alerting component checks
-        alerting_component = next(
-            c for c in manifest.components if c.name == "alerting"
-        )
+        alerting_component = next(c for c in manifest.components if c.name == "alerting")
         self.assertIsNotNone(alerting_component)
         self.assertEqual(len(alerting_component.checks), 2)
         for check in alerting_component.checks:

--- a/tests/tests_manifests/test_manifests.py
+++ b/tests/tests_manifests/test_manifests.py
@@ -20,37 +20,27 @@ class TestManifests(unittest.TestCase):
             super().__init__(klass, glob.glob(manifest_filenames))
 
     def test_latest(self):
-        manifests = TestManifests.WildcardManifests(
-            BuildManifest, "opensearch-build-*.yml"
-        )
+        manifests = TestManifests.WildcardManifests(BuildManifest, "opensearch-build-*.yml")
         latest_manifest = manifests.latest
         self.assertEqual(latest_manifest.build.version, max(manifests.keys()))
 
     def test_latest_no_manifests(self):
-        manifests = TestManifests.WildcardManifests(
-            BuildManifest, "does-not-exist*.yml"
-        )
+        manifests = TestManifests.WildcardManifests(BuildManifest, "does-not-exist*.yml")
         with self.assertRaises(RuntimeError) as context:
             manifests.latest
         self.assertEqual("No manifests found", str(context.exception))
 
     def test_build_manifests(self):
-        manifests = TestManifests.WildcardManifests(
-            BuildManifest, "opensearch-build-*.yml"
-        )
+        manifests = TestManifests.WildcardManifests(BuildManifest, "opensearch-build-*.yml")
         self.assertTrue(len(manifests) >= 2)
 
     def test_invalid_filename(self):
         with self.assertRaises(ValueError) as context:
             TestManifests.WildcardManifests(BuildManifest, "invalid-schema-version.yml")
-        self.assertEqual(
-            "Invalid file: invalid-schema-version.yml", str(context.exception)
-        )
+        self.assertEqual("Invalid file: invalid-schema-version.yml", str(context.exception))
 
     def test_versions(self):
-        manifests = TestManifests.WildcardManifests(
-            BuildManifest, "opensearch-build-*.yml"
-        )
+        manifests = TestManifests.WildcardManifests(BuildManifest, "opensearch-build-*.yml")
         versions = manifests.versions
         self.assertTrue("1.1.0" in versions)
         self.assertTrue("1.2.0" in versions)

--- a/tests/tests_manifests/test_test_manifest.py
+++ b/tests/tests_manifests/test_test_manifest.py
@@ -15,12 +15,8 @@ from manifests.test_manifest import TestManifest
 class TestTestManifest(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
-        self.data_path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "data")
-        )
-        self.manifest_filename = os.path.join(
-            self.data_path, "opensearch-test-1.1.0.yml"
-        )
+        self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
+        self.manifest_filename = os.path.join(self.data_path, "opensearch-test-1.1.0.yml")
         self.manifest = TestManifest.from_path(self.manifest_filename)
 
     def test_component(self):
@@ -35,20 +31,14 @@ class TestTestManifest(unittest.TestCase):
                 ],
             },
         )
-        self.assertEqual(
-            component.bwc_test, {"test-configs": ["with-security", "without-security"]}
-        )
+        self.assertEqual(component.bwc_test, {"test-configs": ["with-security", "without-security"]})
 
     def test_component_with_working_directory(self):
         component = self.manifest.components[1]
         self.assertEqual(component.name, "dashboards-reports")
         self.assertEqual(component.working_directory, "reports-scheduler")
-        self.assertEqual(
-            component.integ_test, {"test-configs": ["without-security"]}
-        )
-        self.assertEqual(
-            component.bwc_test, {"test-configs": ["without-security"]}
-        )
+        self.assertEqual(component.integ_test, {"test-configs": ["without-security"]})
+        self.assertEqual(component.bwc_test, {"test-configs": ["without-security"]})
 
     def test_to_dict(self):
         data = self.manifest.to_dict()

--- a/tests/tests_manifests_workflow/test_component_opensearch.py
+++ b/tests/tests_manifests_workflow/test_component_opensearch.py
@@ -41,9 +41,7 @@ class TestComponentOpenSearch(unittest.TestCase):
         )
 
     def test_gradle_cmd_target(self):
-        self.assertEqual(
-            ComponentOpenSearch.gradle_cmd("properties"), "./gradlew properties"
-        )
+        self.assertEqual(ComponentOpenSearch.gradle_cmd("properties"), "./gradlew properties")
 
     def test_gradle_cmd_prop(self):
         self.assertEqual(
@@ -53,8 +51,6 @@ class TestComponentOpenSearch(unittest.TestCase):
 
     def test_gradle_cmd_props(self):
         self.assertEqual(
-            ComponentOpenSearch.gradle_cmd(
-                "properties", {"build.snapshot": "false", "opensearch.version": "1.0"}
-            ),
+            ComponentOpenSearch.gradle_cmd("properties", {"build.snapshot": "false", "opensearch.version": "1.0"}),
             "./gradlew properties -Dbuild.snapshot=false -Dopensearch.version=1.0",
         )

--- a/tests/tests_manifests_workflow/test_component_opensearch_dashboards_min.py
+++ b/tests/tests_manifests_workflow/test_component_opensearch_dashboards_min.py
@@ -8,20 +8,15 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from git.git_repository import GitRepository
-from manifests_workflow.component_opensearch_dashboards_min import \
-    ComponentOpenSearchDashboardsMin
+from manifests_workflow.component_opensearch_dashboards_min import ComponentOpenSearchDashboardsMin
 from system.config_file import ConfigFile
 
 
 class TestComponentOpenSearchDashboardsMin(unittest.TestCase):
     @patch("subprocess.check_output")
     def test_branches(self, mock):
-        mock.return_value = "\n".join(
-            ["main", "1.x", "1.21", "20.1", "something", "else"]
-        ).encode()
-        self.assertEqual(
-            ComponentOpenSearchDashboardsMin.branches(), ["main", "1.x", "1.21", "20.1"]
-        )
+        mock.return_value = "\n".join(["main", "1.x", "1.21", "20.1", "something", "else"]).encode()
+        self.assertEqual(ComponentOpenSearchDashboardsMin.branches(), ["main", "1.x", "1.21", "20.1"])
         mock.assert_called_with(
             "git ls-remote https://github.com/opensearch-project/OpenSearch-Dashboards.git refs/heads/* | cut -f2 | cut -d/ -f3",
             shell=True,
@@ -37,17 +32,13 @@ class TestComponentOpenSearchDashboardsMin(unittest.TestCase):
     @patch.object(ConfigFile, "from_file")
     def test_version(self, mock_config):
         mock_config.return_value = ConfigFile('{"version":"2.1"}')
-        component = ComponentOpenSearchDashboardsMin(
-            MagicMock(working_directory="path")
-        )
+        component = ComponentOpenSearchDashboardsMin(MagicMock(working_directory="path"))
         self.assertEqual(component.version, "2.1")
 
     @patch.object(ConfigFile, "from_file")
     def test_properties(self, mock_config):
         mock_config.return_value = ConfigFile('{"version":"2.1"}')
-        component = ComponentOpenSearchDashboardsMin(
-            MagicMock(working_directory="path")
-        )
+        component = ComponentOpenSearchDashboardsMin(MagicMock(working_directory="path"))
         self.assertEqual(component.properties.get_value("version"), "2.1")
 
     @patch.object(ConfigFile, "from_file")

--- a/tests/tests_manifests_workflow/test_component_opensearch_min.py
+++ b/tests/tests_manifests_workflow/test_component_opensearch_min.py
@@ -14,12 +14,8 @@ from manifests_workflow.component_opensearch_min import ComponentOpenSearchMin
 class TestComponentOpenSearchMin(unittest.TestCase):
     @patch("subprocess.check_output")
     def test_branches(self, mock):
-        mock.return_value = "\n".join(
-            ["main", "1.x", "1.21", "20.1", "something", "else"]
-        ).encode()
-        self.assertEqual(
-            ComponentOpenSearchMin.branches(), ["main", "1.x", "1.21", "20.1"]
-        )
+        mock.return_value = "\n".join(["main", "1.x", "1.21", "20.1", "something", "else"]).encode()
+        self.assertEqual(ComponentOpenSearchMin.branches(), ["main", "1.x", "1.21", "20.1"])
         mock.assert_called_with(
             "git ls-remote https://github.com/opensearch-project/OpenSearch.git refs/heads/* | cut -f2 | cut -d/ -f3",
             shell=True,
@@ -35,9 +31,7 @@ class TestComponentOpenSearchMin(unittest.TestCase):
     def test_publish_to_maven_local(self):
         component = ComponentOpenSearchMin(MagicMock())
         component.publish_to_maven_local()
-        component.git_repo.execute_silent.assert_called_with(
-            "./gradlew publishToMavenLocal -Dbuild.snapshot=false"
-        )
+        component.git_repo.execute_silent.assert_called_with("./gradlew publishToMavenLocal -Dbuild.snapshot=false")
 
     def test_version(self):
         repo = MagicMock()

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -12,7 +12,5 @@ from manifests_workflow.input_manifests import InputManifests
 
 class TestInputManifests(unittest.TestCase):
     def test_manifests_path(self):
-        path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "../../manifests/")
-        )
+        path = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/"))
         self.assertEqual(path, InputManifests.manifests_path())

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
@@ -9,19 +9,14 @@ import unittest
 from unittest.mock import MagicMock, call, patch
 
 from manifests.input_manifest import InputManifest
-from manifests_workflow.input_manifests_opensearch import \
-    InputManifestsOpenSearch
+from manifests_workflow.input_manifests_opensearch import InputManifestsOpenSearch
 
 
 class TestInputManifestsOpenSearch(unittest.TestCase):
     def test_files(self):
         files = InputManifestsOpenSearch.files()
         self.assertTrue(len(files) >= 2)
-        manifest = os.path.realpath(
-            os.path.join(
-                os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"
-            )
-        )
+        manifest = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../manifests/1.1.0/opensearch-1.1.0.yml"))
         self.assertTrue(manifest in files)
 
     @patch("os.makedirs")
@@ -31,15 +26,7 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearch")
     @patch("system.temporary_directory.TemporaryDirectory")
     @patch("manifests_workflow.input_manifests.InputManifest")
-    def test_update(
-        self,
-        mock_input_manifest,
-        mock_tmpdir,
-        mock_component_opensearch,
-        mock_component_opensearch_min,
-        mock_input_manifest_from_path,
-        *mocks
-    ):
+    def test_update(self, mock_input_manifest, mock_tmpdir, mock_component_opensearch, mock_component_opensearch_min, mock_input_manifest_from_path, *mocks):
         mock_tmpdir.__enter__.return_value = "dir"
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
         mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
@@ -47,11 +34,7 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
         mock_component_opensearch.return_value = MagicMock(name="common-utils")
         mock_component_opensearch.checkout.return_value = MagicMock(version="0.10.0")
         mock_input_manifest_from_path.return_value = MagicMock(
-            components=[
-                InputManifest.Component(
-                    {"name": "common-utils", "repository": "git", "ref": "ref"}
-                )
-            ]
+            components=[InputManifest.Component({"name": "common-utils", "repository": "git", "ref": "ref"})]
         )
         manifests = InputManifestsOpenSearch()
         manifests.update()

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
@@ -8,8 +8,7 @@ import os
 import unittest
 from unittest.mock import MagicMock, call, patch
 
-from manifests_workflow.input_manifests_opensearch_dashboards import \
-    InputManifestsOpenSearchDashboards
+from manifests_workflow.input_manifests_opensearch_dashboards import InputManifestsOpenSearchDashboards
 
 
 class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
@@ -26,26 +25,13 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
 
     @patch("os.makedirs")
     @patch("os.chdir")
-    @patch(
-        "manifests_workflow.input_manifests.InputManifest.from_path"
-    )
-    @patch(
-        "manifests_workflow.input_manifests_opensearch_dashboards.ComponentOpenSearchDashboardsMin"
-    )
+    @patch("manifests_workflow.input_manifests.InputManifest.from_path")
+    @patch("manifests_workflow.input_manifests_opensearch_dashboards.ComponentOpenSearchDashboardsMin")
     @patch("system.temporary_directory.TemporaryDirectory")
     @patch("manifests_workflow.input_manifests.InputManifest")
-    def test_update(
-        self,
-        mock_input_manifest,
-        mock_tmpdir,
-        mock_component_opensearch_min,
-        mock_input_manifest_from_path,
-        *mocks
-    ):
+    def test_update(self, mock_input_manifest, mock_tmpdir, mock_component_opensearch_min, mock_input_manifest_from_path, *mocks):
         mock_tmpdir.__enter__.return_value = "dir"
-        mock_component_opensearch_min.return_value = MagicMock(
-            name="OpenSearch-Dashboards"
-        )
+        mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch-Dashboards")
         mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
         mock_input_manifest_from_path.return_value = MagicMock(components=[])

--- a/tests/tests_manifests_workflow/test_manifests_args.py
+++ b/tests/tests_manifests_workflow/test_manifests_args.py
@@ -14,9 +14,7 @@ from manifests_workflow.manifests_args import ManifestsArgs
 
 class TestManifestsArgs(unittest.TestCase):
 
-    MANIFESTS_PY = os.path.realpath(
-        os.path.join(os.path.dirname(__file__), "../../src/manifests.py")
-    )
+    MANIFESTS_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/manifests.py"))
 
     @patch("argparse._sys.argv", [MANIFESTS_PY, "list"])
     def test_action_list(self):

--- a/tests/tests_paths/test_script_finder.py
+++ b/tests/tests_paths/test_script_finder.py
@@ -15,74 +15,52 @@ class TestScriptFinder(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
         # use root of this repo as the default git checkout directory
-        self.data_path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "data")
-        )
-        self.component_with_scripts = os.path.join(
-            self.data_path, "git/component-with-scripts"
-        )
-        self.component_with_scripts_folder = os.path.join(
-            self.data_path, "git/component-with-scripts-folder"
-        )
-        self.component_without_scripts = os.path.join(
-            self.data_path, "git/component-without-scripts"
-        )
+        self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
+        self.component_with_scripts = os.path.join(self.data_path, "git/component-with-scripts")
+        self.component_with_scripts_folder = os.path.join(self.data_path, "git/component-with-scripts-folder")
+        self.component_without_scripts = os.path.join(self.data_path, "git/component-without-scripts")
 
     # find_build_script
 
     def test_find_build_script_opensearch_default(self):
         self.assertEqual(
             os.path.join(ScriptFinder.default_scripts_path, "opensearch/build.sh"),
-            ScriptFinder.find_build_script(
-                "OpenSearch", "invalid", self.component_without_scripts
-            ),
+            ScriptFinder.find_build_script("OpenSearch", "invalid", self.component_without_scripts),
             msg="A component without an override resolves to a default.",
         )
 
     def test_find_build_script_opensearch_dashboards_default(self):
         self.assertEqual(
-            os.path.join(
-                ScriptFinder.default_scripts_path, "opensearch-dashboards/build.sh"
-            ),
-            ScriptFinder.find_build_script(
-                "OpenSearch-Dashboards", "invalid", self.component_without_scripts
-            ),
+            os.path.join(ScriptFinder.default_scripts_path, "opensearch-dashboards/build.sh"),
+            ScriptFinder.find_build_script("OpenSearch-Dashboards", "invalid", self.component_without_scripts),
             msg="A component without an override resolves to a default.",
         )
 
     def test_find_build_script_component_override(self):
         self.assertEqual(
             os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/build.sh"),
-            ScriptFinder.find_build_script(
-                "OpenSearch", "OpenSearch", self.component_without_scripts
-            ),
+            ScriptFinder.find_build_script("OpenSearch", "OpenSearch", self.component_without_scripts),
             msg="A component without scripts resolves to a component override.",
         )
 
     def test_find_build_script_component_script(self):
         self.assertEqual(
             os.path.join(self.component_with_scripts, "build.sh"),
-            ScriptFinder.find_build_script(
-                "OpenSearch", "foobar", self.component_with_scripts
-            ),
+            ScriptFinder.find_build_script("OpenSearch", "foobar", self.component_with_scripts),
             msg="A component with a script resolves to the script at the root.",
         )
 
     def test_find_build_script_component_script_in_folder(self):
         self.assertEqual(
             os.path.join(self.component_with_scripts_folder, "scripts/build.sh"),
-            ScriptFinder.find_build_script(
-                "OpenSearch", "foobar", self.component_with_scripts_folder
-            ),
+            ScriptFinder.find_build_script("OpenSearch", "foobar", self.component_with_scripts_folder),
             msg="A component with a scripts folder resolves to a script in that folder.",
         )
 
     def test_find_build_script_component_script_in_folder_with_default(self):
         self.assertEqual(
             os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/build.sh"),
-            ScriptFinder.find_build_script(
-                "OpenSearch", "OpenSearch", self.component_with_scripts_folder
-            ),
+            ScriptFinder.find_build_script("OpenSearch", "OpenSearch", self.component_with_scripts_folder),
             msg="A component with a scripts folder resolves to the override.",
         )
 
@@ -92,60 +70,42 @@ class TestScriptFinder(unittest.TestCase):
             ScriptFinder.ScriptNotFoundError,
             "Could not find build.sh script. Looked in .*",
         ):
-            ScriptFinder.find_build_script(
-                "OpenSearch", "anything", self.component_without_scripts
-            )
+            ScriptFinder.find_build_script("OpenSearch", "anything", self.component_without_scripts)
 
     # find_integ_test_script
 
     def test_find_integ_test_script_default(self):
         self.assertEqual(
             os.path.join(ScriptFinder.default_scripts_path, "integtest.sh"),
-            ScriptFinder.find_integ_test_script(
-                "invalid", self.component_without_scripts
-            ),
+            ScriptFinder.find_integ_test_script("invalid", self.component_without_scripts),
             msg="A component without an override resolves to a default.",
         )
 
     def test_find_integ_test_script_component_override(self):
         self.assertEqual(
-            os.path.join(
-                ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"
-            ),
-            ScriptFinder.find_integ_test_script(
-                "OpenSearch", self.component_without_scripts
-            ),
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"),
+            ScriptFinder.find_integ_test_script("OpenSearch", self.component_without_scripts),
             msg="A component without scripts resolves to a component override.",
         )
 
     def test_find_integ_test_script_component_script(self):
         self.assertEqual(
-            os.path.join(
-                ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"
-            ),
-            ScriptFinder.find_integ_test_script(
-                "OpenSearch", self.component_with_scripts
-            ),
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"),
+            ScriptFinder.find_integ_test_script("OpenSearch", self.component_with_scripts),
             msg="A component with a script resolves to the script at the root.",
         )
 
     def test_find_integ_test_script_component_script_in_folder(self):
         self.assertEqual(
             os.path.join(self.component_with_scripts_folder, "scripts/integtest.sh"),
-            ScriptFinder.find_integ_test_script(
-                "foobar", self.component_with_scripts_folder
-            ),
+            ScriptFinder.find_integ_test_script("foobar", self.component_with_scripts_folder),
             msg="A component with a scripts folder resolves to an override.",
         )
 
     def test_find_integ_test_script_component_script_in_folder_with_default(self):
         self.assertEqual(
-            os.path.join(
-                ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"
-            ),
-            ScriptFinder.find_integ_test_script(
-                "OpenSearch", self.component_with_scripts_folder
-            ),
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch/integtest.sh"),
+            ScriptFinder.find_integ_test_script("OpenSearch", self.component_with_scripts_folder),
             msg="A component with a scripts folder resolves to a script in that folder.",
         )
 
@@ -155,9 +115,7 @@ class TestScriptFinder(unittest.TestCase):
             ScriptFinder.ScriptNotFoundError,
             "Could not find integtest.sh script. Looked in .*",
         ):
-            ScriptFinder.find_integ_test_script(
-                "anything", self.component_without_scripts
-            )
+            ScriptFinder.find_integ_test_script("anything", self.component_without_scripts)
 
     # find_install_script
 

--- a/tests/tests_paths/test_tree_walker.py
+++ b/tests/tests_paths/test_tree_walker.py
@@ -14,23 +14,13 @@ from paths.tree_walker import walk
 class TestTreeWalker(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
-        self.data_path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "data")
-        )
+        self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
 
     def test_walk(self):
-        paths = sorted(
-            list(itertools.chain(walk(self.data_path))), key=lambda path: path[0]
-        )
+        paths = sorted(list(itertools.chain(walk(self.data_path))), key=lambda path: path[0])
         self.assertTrue(len(paths), 7)
-        self.assertEqual(
-            paths[0][1], "git/component-with-scripts-folder/scripts/build.sh"
-        )
+        self.assertEqual(paths[0][1], "git/component-with-scripts-folder/scripts/build.sh")
         self.assertEqual(
             paths[0][0],
-            os.path.realpath(
-                os.path.join(
-                    self.data_path, "git/component-with-scripts-folder/scripts/build.sh"
-                )
-            ),
+            os.path.realpath(os.path.join(self.data_path, "git/component-with-scripts-folder/scripts/build.sh")),
         )

--- a/tests/tests_sign_workflow/test_signer.py
+++ b/tests/tests_sign_workflow/test_signer.py
@@ -46,18 +46,10 @@ class TestSigner(unittest.TestCase):
     def test_signer_verify(self, mock_repo):
         signer = Signer()
         signer.verify("/path/the-jar.jar.asc")
-        mock_repo.assert_has_calls(
-            [call().execute("gpg --verify-files /path/the-jar.jar.asc")]
-        )
+        mock_repo.assert_has_calls([call().execute("gpg --verify-files /path/the-jar.jar.asc")])
 
     @patch("sign_workflow.signer.GitRepository")
     def test_signer_sign(self, mock_repo):
         signer = Signer()
         signer.sign("/path/the-jar.jar")
-        mock_repo.assert_has_calls(
-            [
-                call().execute(
-                    "./opensearch-signer-client -i /path/the-jar.jar -o /path/the-jar.jar.asc -p pgp"
-                )
-            ]
-        )
+        mock_repo.assert_has_calls([call().execute("./opensearch-signer-client -i /path/the-jar.jar -o /path/the-jar.jar.asc -p pgp")])

--- a/tests/tests_system/test_config_file.py
+++ b/tests/tests_system/test_config_file.py
@@ -32,17 +32,13 @@ class TestConfigFile(unittest.TestCase):
         f = ConfigFile({"key": "value"})
         with self.assertRaises(ConfigFile.UnexpectedKeyValueError) as err:
             f.check_value("key", "invalid")
-        self.assertEqual(
-            str(err.exception), "Expected to have key='invalid', but was 'value'."
-        )
+        self.assertEqual(str(err.exception), "Expected to have key='invalid', but was 'value'.")
 
     def test_check_value_none_found(self):
         f = ConfigFile()
         with self.assertRaises(ConfigFile.UnexpectedKeyValueError) as err:
             f.check_value("invalid", "value")
-        self.assertEqual(
-            str(err.exception), "Expected to have invalid='value', but none was found."
-        )
+        self.assertEqual(str(err.exception), "Expected to have invalid='value', but none was found.")
 
     def test_check_value_in(self):
         f = ConfigFile({"key": "value"})

--- a/tests/tests_system/test_execute.py
+++ b/tests/tests_system/test_execute.py
@@ -12,26 +12,20 @@ from system.execute import execute
 
 class TestExecute(unittest.TestCase):
     def test_execute_status_capture_true_raise_false(self):
-        (status, stdout, stderr) = execute(
-            "echo output && exit 128", "/", capture=True, raise_on_failure=False
-        )  # (128, 'output', '')
+        (status, stdout, stderr) = execute("echo output && exit 128", "/", capture=True, raise_on_failure=False)  # (128, 'output', '')
         self.assertEqual(status, 128)
         self.assertEqual(stdout.strip(), "output")
         self.assertEqual(stderr.strip(), "")
 
     def test_execute_status_capture_false_raise_false(self):
-        (status, stdout, stderr) = execute(
-            "echo output && exit 128", "/", capture=False, raise_on_failure=False
-        )  # (128, None, None)
+        (status, stdout, stderr) = execute("echo output && exit 128", "/", capture=False, raise_on_failure=False)  # (128, None, None)
         self.assertEqual(status, 128)
         self.assertEqual(stdout, None)
         self.assertEqual(stderr, None)
 
     def test_execute_status_capture_true_raise_True(self):
         with self.assertRaises(subprocess.CalledProcessError) as context:
-            (status, stdout, stderr) = execute(
-                "echo output && exit 128", "/", capture=True, raise_on_failure=True
-            )  # (128, 'error', '')
+            (status, stdout, stderr) = execute("echo output && exit 128", "/", capture=True, raise_on_failure=True)  # (128, 'error', '')
         self.assertEqual(
             "Command 'echo output && exit 128' returned non-zero exit status 128.",
             str(context.exception),

--- a/tests/tests_system/test_properties_file.py
+++ b/tests/tests_system/test_properties_file.py
@@ -28,17 +28,13 @@ class TestPropertiesFile(unittest.TestCase):
         f = PropertiesFile({"key": "value"})
         with self.assertRaises(PropertiesFile.UnexpectedKeyValueError) as err:
             f.check_value("key", "invalid")
-        self.assertEqual(
-            str(err.exception), "Expected to have key='invalid', but was 'value'."
-        )
+        self.assertEqual(str(err.exception), "Expected to have key='invalid', but was 'value'.")
 
     def test_check_value_none_found(self):
         f = PropertiesFile()
         with self.assertRaises(PropertiesFile.UnexpectedKeyValueError) as err:
             f.check_value("invalid", "value")
-        self.assertEqual(
-            str(err.exception), "Expected to have invalid='value', but none was found."
-        )
+        self.assertEqual(str(err.exception), "Expected to have invalid='value', but none was found.")
 
     def test_check_value_in(self):
         f = PropertiesFile({"key": "value"})

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_bwc_suite.py
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_bwc_suite.py
@@ -16,9 +16,7 @@ class TestBwcSuite(unittest.TestCase):
     def setUp(self):
         os.chdir(os.path.dirname(__file__))
         self.manifest = BundleManifest.from_path("data/test_manifest.yaml")
-        self.bwc_test_suite = BwcTestSuite(
-            manifest=self.manifest, work_dir=".", component=None, keep=False
-        )
+        self.bwc_test_suite = BwcTestSuite(manifest=self.manifest, work_dir=".", component=None, keep=False)
 
     def test_execute(self):
         expected = []
@@ -26,9 +24,7 @@ class TestBwcSuite(unittest.TestCase):
             expected.append(call(component))
         self.bwc_test_suite.component_bwc_tests = MagicMock()
         self.bwc_test_suite.execute()
-        self.assertEqual(
-            self.bwc_test_suite.component_bwc_tests.call_args_list, expected
-        )
+        self.assertEqual(self.bwc_test_suite.component_bwc_tests.call_args_list, expected)
 
     def test_run_bwctest(self):
         response = self.bwc_test_suite.run_tests(".", self.manifest.components[1].name)
@@ -47,7 +43,5 @@ class TestBwcSuite(unittest.TestCase):
         ]
 
         self.bwc_test_suite.component_bwc_tests(component)
-        test_component_mock.return_value.checkout.assert_called_with(
-            "./" + component.name
-        )
+        test_component_mock.return_value.checkout.assert_called_with("./" + component.name)
         self.assertEqual(self.bwc_test_suite.run_tests.call_args_list, expected)

--- a/tests/tests_test_workflow/test_dependency_installer.py
+++ b/tests/tests_test_workflow/test_dependency_installer.py
@@ -36,9 +36,7 @@ class DependencyInstallerTests(unittest.TestCase):
     def test_install_build_dependencies(self, mock_os_makedirs):
         s3_bucket = self.mock_s3_bucket.return_value
         dependencies = dict({"opensearch-job-scheduler": "1.1.0.0"})
-        self.dependency_installer.install_build_dependencies(
-            dependencies, os.path.dirname(__file__)
-        )
+        self.dependency_installer.install_build_dependencies(dependencies, os.path.dirname(__file__))
         self.assertEqual(s3_bucket.download_file.call_count, 1)
         s3_bucket.download_file.assert_has_calls(
             [
@@ -48,6 +46,4 @@ class DependencyInstallerTests(unittest.TestCase):
                 )
             ]
         )
-        mock_os_makedirs.assert_called_once_with(
-            os.path.dirname(__file__), exist_ok=True
-        )
+        mock_os_makedirs.assert_called_once_with(os.path.dirname(__file__), exist_ok=True)

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite.py
@@ -12,10 +12,7 @@ from git.git_repository import GitRepository
 from manifests.build_manifest import BuildManifest
 from manifests.bundle_manifest import BundleManifest
 from manifests.test_manifest import TestManifest
-from test_workflow.integ_test.integ_test_suite import (DependencyInstaller,
-                                                       IntegTestSuite,
-                                                       InvalidTestConfigError,
-                                                       ScriptFinder)
+from test_workflow.integ_test.integ_test_suite import DependencyInstaller, IntegTestSuite, InvalidTestConfigError, ScriptFinder
 
 
 @patch("os.makedirs")
@@ -34,12 +31,8 @@ class TestIntegSuite(unittest.TestCase):
     @patch("test_workflow.integ_test.integ_test_suite.execute")
     @patch("test_workflow.integ_test.integ_test_suite.LocalTestCluster")
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
-    def test_execute_with_multiple_test_configs(
-            self, mock_test_recorder, mock_local_test_cluster, mock_system_execute, mock_script_finder, *mock
-    ):
-        test_config, component = self.__get_test_config_and_bundle_component(
-            "job-scheduler"
-        )
+    def test_execute_with_multiple_test_configs(self, mock_test_recorder, mock_local_test_cluster, mock_system_execute, mock_script_finder, *mock):
+        test_config, component = self.__get_test_config_and_bundle_component("job-scheduler")
         integ_test_suite = IntegTestSuite(
             component,
             test_config,
@@ -47,7 +40,7 @@ class TestIntegSuite(unittest.TestCase):
             self.build_manifest,
             "/tmpdir",
             "s3_bucket_name",
-            mock_test_recorder
+            mock_test_recorder,
         )
         mock_system_execute.return_value = 200, "success", "failure"
         mock_local_test_cluster.create().__enter__.return_value = "localhost", "9200"
@@ -68,19 +61,15 @@ class TestIntegSuite(unittest.TestCase):
                     "/tmpdir/job-scheduler",
                     True,
                     False,
-                )
+                ),
             ]
         )
 
-    @patch.object(
-        IntegTestSuite, "_IntegTestSuite__setup_cluster_and_execute_test_config"
-    )
+    @patch.object(IntegTestSuite, "_IntegTestSuite__setup_cluster_and_execute_test_config")
     @patch("test_workflow.integ_test.integ_test_suite.DependencyInstaller")
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
     def test_execute_with_build_dependencies(self, mock_test_recorder, mock_dependency_installer, *mock):
-        test_config, component = self.__get_test_config_and_bundle_component(
-            "index-management"
-        )
+        test_config, component = self.__get_test_config_and_bundle_component("index-management")
         integ_test_suite = IntegTestSuite(
             component,
             test_config,
@@ -88,7 +77,7 @@ class TestIntegSuite(unittest.TestCase):
             self.build_manifest,
             "/tmpdir",
             "s3_bucket_name",
-            mock_test_recorder
+            mock_test_recorder,
         )
         integ_test_suite.execute()
         mock_dependency_installer.return_value.install_build_dependencies.assert_called_with(
@@ -96,17 +85,11 @@ class TestIntegSuite(unittest.TestCase):
             "/tmpdir/index-management/src/test/resources/job-scheduler",
         )
 
-    @patch.object(
-        IntegTestSuite, "_IntegTestSuite__setup_cluster_and_execute_test_config"
-    )
+    @patch.object(IntegTestSuite, "_IntegTestSuite__setup_cluster_and_execute_test_config")
     @patch.object(DependencyInstaller, "install_build_dependencies")
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
-    def test_execute_without_build_dependencies(
-            self, mock_test_recorder, mock_install_build_dependencies, *mock
-    ):
-        test_config, component = self.__get_test_config_and_bundle_component(
-            "job-scheduler"
-        )
+    def test_execute_without_build_dependencies(self, mock_test_recorder, mock_install_build_dependencies, *mock):
+        test_config, component = self.__get_test_config_and_bundle_component("job-scheduler")
         integ_test_suite = IntegTestSuite(
             component,
             test_config,
@@ -114,22 +97,16 @@ class TestIntegSuite(unittest.TestCase):
             self.build_manifest,
             "/tmpdir",
             "s3_bucket_name",
-            mock_test_recorder
+            mock_test_recorder,
         )
         integ_test_suite.execute()
         mock_install_build_dependencies.assert_not_called()
 
-    @patch.object(
-        IntegTestSuite, "_IntegTestSuite__setup_cluster_and_execute_test_config"
-    )
+    @patch.object(IntegTestSuite, "_IntegTestSuite__setup_cluster_and_execute_test_config")
     @patch.object(DependencyInstaller, "install_build_dependencies")
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
-    def test_execute_with_unsupported_build_dependencies(
-            self, mock_test_recorder, mock_install_build_dependencies, *mock
-    ):
-        test_config, component = self.__get_test_config_and_bundle_component(
-            "anomaly-detection"
-        )
+    def test_execute_with_unsupported_build_dependencies(self, mock_test_recorder, mock_install_build_dependencies, *mock):
+        test_config, component = self.__get_test_config_and_bundle_component("anomaly-detection")
         integ_test_suite = IntegTestSuite(
             component,
             test_config,
@@ -137,7 +114,7 @@ class TestIntegSuite(unittest.TestCase):
             self.build_manifest,
             "/tmpdir",
             "s3_bucket_name",
-            mock_test_recorder
+            mock_test_recorder,
         )
         with self.assertRaises(InvalidTestConfigError):
             integ_test_suite.execute()
@@ -145,15 +122,9 @@ class TestIntegSuite(unittest.TestCase):
 
     @patch.object(DependencyInstaller, "install_build_dependencies")
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
-    def test_execute_with_missing_job_scheduler(
-            self, mock_test_recorder, mock_install_build_dependencies, *mock
-    ):
-        invalid_build_manifest = BuildManifest.from_path(
-            "data/build_manifest_missing_components.yml"
-        )
-        test_config, component = self.__get_test_config_and_bundle_component(
-            "index-management"
-        )
+    def test_execute_with_missing_job_scheduler(self, mock_test_recorder, mock_install_build_dependencies, *mock):
+        invalid_build_manifest = BuildManifest.from_path("data/build_manifest_missing_components.yml")
+        test_config, component = self.__get_test_config_and_bundle_component("index-management")
         integ_test_suite = IntegTestSuite(
             component,
             test_config,
@@ -161,13 +132,11 @@ class TestIntegSuite(unittest.TestCase):
             invalid_build_manifest,
             "/tmpdir",
             "s3_bucket_name",
-            mock_test_recorder
+            mock_test_recorder,
         )
         with self.assertRaises(BuildManifest.ComponentNotFoundError) as context:
             integ_test_suite.execute()
-        self.assertEqual(
-            str(context.exception), "job-scheduler not found in build manifest.yml"
-        )
+        self.assertEqual(str(context.exception), "job-scheduler not found in build manifest.yml")
         mock_install_build_dependencies.assert_not_called()
 
     def __get_test_config_and_bundle_component(self, component_name):
@@ -186,12 +155,8 @@ class TestIntegSuite(unittest.TestCase):
     @patch("test_workflow.integ_test.integ_test_suite.execute")
     @patch("test_workflow.integ_test.integ_test_suite.LocalTestCluster")
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
-    def test_execute_with_working_directory(
-            self, mock_test_recorder, mock_local_test_cluster, mock_system_execute, mock_script_finder, *mock
-    ):
-        test_config, component = self.__get_test_config_and_bundle_component(
-            "dashboards-reports"
-        )
+    def test_execute_with_working_directory(self, mock_test_recorder, mock_local_test_cluster, mock_system_execute, mock_script_finder, *mock):
+        test_config, component = self.__get_test_config_and_bundle_component("dashboards-reports")
         integ_test_suite = IntegTestSuite(
             component,
             test_config,
@@ -199,17 +164,10 @@ class TestIntegSuite(unittest.TestCase):
             self.build_manifest,
             "/tmpdir",
             "s3_bucket_name",
-            mock_test_recorder
+            mock_test_recorder,
         )
         mock_system_execute.return_value = 200, "success", "failure"
         mock_local_test_cluster.create().__enter__.return_value = "localhost", "9200"
         mock_script_finder.return_value = "integtest.sh"
         integ_test_suite.execute()
-        mock_script_finder.assert_has_calls(
-            [
-                call(
-                    'dashboards-reports',
-                    '/tmpdir/dashboards-reports/reports-scheduler'
-                )
-            ]
-        )
+        mock_script_finder.assert_has_calls([call("dashboards-reports", "/tmpdir/dashboards-reports/reports-scheduler")])

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster.py
@@ -23,12 +23,8 @@ class LocalTestClusterTests(unittest.TestCase):
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
     def setUp(self, mock_test_recorder):
         self.maxDiff = None
-        self.data_path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "../../../tests_manifests/data")
-        )
-        self.manifest_filename = os.path.join(
-            self.data_path, "opensearch-bundle-1.1.0.yml"
-        )
+        self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../../tests_manifests/data"))
+        self.manifest_filename = os.path.join(self.data_path, "opensearch-bundle-1.1.0.yml")
         self.manifest = BundleManifest.from_path(self.manifest_filename)
         self.work_dir = tempfile.TemporaryDirectory()
         self.process = self.__get_process()
@@ -90,9 +86,7 @@ class LocalTestClusterTests(unittest.TestCase):
             stdout=self.local_test_cluster.stdout,
             stderr=self.local_test_cluster.stderr,
         )
-        yaml.dump.assert_called_once_with(
-            {"script.context.field.max_compilations_rate": "1000/1m"}
-        )
+        yaml.dump.assert_called_once_with({"script.context.field.max_compilations_rate": "1000/1m"})
 
     def test_endpoint(self):
         self.assertEqual(self.local_test_cluster.endpoint(), "localhost")
@@ -126,9 +120,7 @@ class LocalTestClusterTests(unittest.TestCase):
         self.local_test_cluster.download()
         os.chdir.assert_called_once_with(work_dir_path)
         s3_bucket.download_file.assert_called_once_with(s3_path, work_dir_path)
-        subprocess.check_call.assert_called_once_with(
-            f"tar -xzf {bundle_name}", shell=True
-        )
+        subprocess.check_call.assert_called_once_with(f"tar -xzf {bundle_name}", shell=True)
 
     @patch("requests.get", side_effect=__mock_response)
     def test_wait_for_service(self, mock_requests):
@@ -160,9 +152,7 @@ class LocalTestClusterTests(unittest.TestCase):
                 verify=False,
                 auth=("admin", "admin"),
             )
-        self.assertEqual(
-            str(err.exception), "Cluster is not available after 10 attempts"
-        )
+        self.assertEqual(str(err.exception), "Cluster is not available after 10 attempts")
 
     @patch(
         "test_workflow.integ_test.local_test_cluster.psutil.Process",
@@ -170,18 +160,10 @@ class LocalTestClusterTests(unittest.TestCase):
     )
     @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.wait")
     @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.terminate")
-    @patch(
-        "test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock()
-    )
-    def test_terminate_process(
-        self, mock_logging, mock_terminate, mock_wait, mock_process
-    ):
-        self.local_test_cluster.stdout = tempfile.NamedTemporaryFile(
-            dir=self.local_test_cluster.work_dir
-        )
-        self.local_test_cluster.stderr = tempfile.NamedTemporaryFile(
-            dir=self.local_test_cluster.work_dir
-        )
+    @patch("test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock())
+    def test_terminate_process(self, mock_logging, mock_terminate, mock_wait, mock_process):
+        self.local_test_cluster.stdout = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
+        self.local_test_cluster.stderr = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
         self.local_test_cluster.process = self.process
         self.local_test_cluster.terminate_process()
         mock_process.assert_called_once_with(self.process.pid)
@@ -202,18 +184,10 @@ class LocalTestClusterTests(unittest.TestCase):
     )
     @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.wait")
     @patch("test_workflow.integ_test.local_test_cluster.subprocess.Popen.terminate")
-    @patch(
-        "test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock()
-    )
-    def test_terminate_process_timeout(
-        self, mock_logging, mock_terminate, mock_wait, mock_process
-    ):
-        self.local_test_cluster.stdout = tempfile.NamedTemporaryFile(
-            dir=self.local_test_cluster.work_dir
-        )
-        self.local_test_cluster.stderr = tempfile.NamedTemporaryFile(
-            dir=self.local_test_cluster.work_dir
-        )
+    @patch("test_workflow.integ_test.local_test_cluster.logging", return_value=MagicMock())
+    def test_terminate_process_timeout(self, mock_logging, mock_terminate, mock_wait, mock_process):
+        self.local_test_cluster.stdout = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
+        self.local_test_cluster.stderr = tempfile.NamedTemporaryFile(dir=self.local_test_cluster.work_dir)
         mock_wait.side_effect = subprocess.TimeoutExpired(cmd="pass", timeout=1)
         with self.assertRaises(subprocess.TimeoutExpired):
             self.local_test_cluster.process = self.process

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_run_integ_test.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_run_integ_test.py
@@ -39,14 +39,7 @@ class TestRunIntegTest(unittest.TestCase):
     @patch.object(BundleManifest, "from_s3")
     @patch.object(BuildManifest, "from_s3")
     @patch("run_integ_test.IntegTestSuite")
-    def test_run_integ_test(
-        self,
-        mock_integ_test_suite,
-        mock_build_from_s3,
-        mock_bundle_from_s3,
-        mock_results,
-        *mock
-    ):
+    def test_run_integ_test(self, mock_integ_test_suite, mock_build_from_s3, mock_bundle_from_s3, mock_results, *mock):
         """
         test_manifest.yml has 8 plugin components listed for integration tests. This test ensures all get executed
         as part of integration test job.
@@ -69,14 +62,7 @@ class TestRunIntegTest(unittest.TestCase):
     @patch.object(BundleManifest, "from_s3")
     @patch.object(BuildManifest, "from_s3")
     @patch("run_integ_test.IntegTestSuite")
-    def test_run_integ_test_failure(
-        self,
-        mock_integ_test_suite,
-        mock_build_from_s3,
-        mock_bundle_from_s3,
-        mock_results,
-        *mock
-    ):
+    def test_run_integ_test_failure(self, mock_integ_test_suite, mock_build_from_s3, mock_bundle_from_s3, mock_results, *mock):
         """
         test_manifest.yml has 8 plugin components listed for integration tests. This test ensures all get executed
         as part of integration test job.

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -14,9 +14,7 @@ from test_workflow.perf_test.perf_test_cluster import PerfTestCluster
 
 class TestPerfTestCluster(unittest.TestCase):
     def setUp(self):
-        self.data_path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "data")
-        )
+        self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
         self.manifest_filename = os.path.join(self.data_path, "bundle_manifest.yaml")
         self.manifest = BundleManifest.from_path(self.manifest_filename)
         self.stack_name = "stack"
@@ -45,9 +43,7 @@ class TestPerfTestCluster(unittest.TestCase):
                 with patch("builtins.open", MagicMock()):
                     with patch("json.load", mock_file):
                         self.perf_test_cluster.create_cluster()
-                        mock_chdir.assert_called_once_with(
-                            "opensearch-cluster/cdk/single-node/"
-                        )
+                        mock_chdir.assert_called_once_with("opensearch-cluster/cdk/single-node/")
                         self.assertEqual(mock_check_call.call_count, 1)
 
     def test_endpoint(self):

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_suite.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_suite.py
@@ -14,9 +14,7 @@ from test_workflow.perf_test.perf_test_suite import PerfTestSuite
 
 class TestPerfTestSuite(unittest.TestCase):
     def setUp(self):
-        self.data_path = os.path.realpath(
-            os.path.join(os.path.dirname(__file__), "data")
-        )
+        self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
         self.manifest_filename = os.path.join(self.data_path, "bundle_manifest.yaml")
         self.manifest = BundleManifest.from_path(self.manifest_filename)
         self.endpoint = None

--- a/tests/tests_test_workflow/test_test_args.py
+++ b/tests/tests_test_workflow/test_test_args.py
@@ -8,9 +8,7 @@ from test_workflow.test_args import TestArgs
 
 class TestTestArgs(unittest.TestCase):
 
-    ARGS_PY = os.path.realpath(
-        os.path.join(os.path.dirname(__file__), "../../src/run_bwc_test.py")
-    )
+    ARGS_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../src/run_bwc_test.py"))
 
     @patch(
         "argparse._sys.argv",

--- a/tests/tests_test_workflow/test_test_result/test_test_component_results.py
+++ b/tests/tests_test_workflow/test_test_result/test_test_component_results.py
@@ -1,7 +1,6 @@
 import unittest
 
-from test_workflow.test_result.test_component_results import \
-    TestComponentResults
+from test_workflow.test_result.test_component_results import TestComponentResults
 
 
 class TestTestResultsComponent(unittest.TestCase):


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Adds a pyproject.toml with black and isort configurations aligned, and on the same line length as flake8. With this change one does not attempt to auto-correct the other. Ran the auto-formatter on all of the source once which is all the other changes.
  
Extracted from https://github.com/opensearch-project/opensearch-build/pull/767.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
