### PR TITLE
Refactored TemporaryFile and GitRepository into context managers.

### DIFF
--- a/src/assemble_workflow/bundle.py
+++ b/src/assemble_workflow/bundle.py
@@ -10,10 +10,10 @@ import os
 import shutil
 import subprocess
 import tarfile
-import tempfile
 from abc import ABC, abstractmethod
 
 from paths.script_finder import ScriptFinder
+from system.temporary_directory import TemporaryDirectory
 
 """
 This class is responsible for executing the build of the full bundle and passing results to a bundle recorder.
@@ -34,7 +34,7 @@ class Bundle(ABC):
         self.plugins = self.__get_plugins(build_manifest.components)
         self.artifacts_dir = artifacts_dir
         self.bundle_recorder = bundle_recorder
-        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.tmp_dir = TemporaryDirectory()
         self.installed_plugins = []
         self.min_tarball_path = self._copy_component(self.min_tarball, "dist")
         self.__unpack_min_tarball(self.tmp_dir.name)

--- a/src/git/git_repository.py
+++ b/src/git/git_repository.py
@@ -7,8 +7,9 @@
 import logging
 import os
 import subprocess
-import tempfile
 from pathlib import Path
+
+from system.temporary_directory import TemporaryDirectory
 
 
 class GitRepository:
@@ -22,7 +23,7 @@ class GitRepository:
         self.url = url
         self.ref = ref
         if directory is None:
-            self.temp_dir = tempfile.TemporaryDirectory()
+            self.temp_dir = TemporaryDirectory()
             self.dir = os.path.realpath(self.temp_dir.name)
         else:
             self.temp_dir = None
@@ -40,6 +41,13 @@ class GitRepository:
         self.execute_silent("git checkout FETCH_HEAD", self.dir)
         self.sha = self.output("git rev-parse HEAD", self.dir)
         logging.info(f"Checked out {self.url}@{self.ref} into {self.dir} at {self.sha}")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if self.temp_dir:
+            self.temp_dir.__exit__(exc_type, exc_value, exc_traceback)
 
     @property
     def working_directory(self):

--- a/src/manifests_workflow/component_opensearch.py
+++ b/src/manifests_workflow/component_opensearch.py
@@ -23,17 +23,18 @@ class ComponentOpenSearch(Component):
         snapshot=False,
         working_directory=None,
     ):
-        return ComponentOpenSearch(
-            name,
-            GitRepository(
-                f"https://github.com/opensearch-project/{name}.git",
-                branch,
-                path,
-                working_directory,
-            ),
-            opensearch_version,
-            snapshot,
-        )
+        with GitRepository(
+            f"https://github.com/opensearch-project/{name}.git",
+            branch,
+            path,
+            working_directory,
+        ) as repo:
+            return ComponentOpenSearch(
+                name,
+                repo,
+                opensearch_version,
+                snapshot,
+            )
 
     def __init__(self, name, repo, opensearch_version, snapshot=False):
         super().__init__(name, repo, snapshot)

--- a/src/manifests_workflow/component_opensearch_dashboards_min.py
+++ b/src/manifests_workflow/component_opensearch_dashboards_min.py
@@ -21,14 +21,15 @@ class ComponentOpenSearchDashboardsMin(Component):
 
     @classmethod
     def checkout(self, path, branch="main", snapshot=False):
-        return ComponentOpenSearchDashboardsMin(
-            GitRepository(
-                "https://github.com/opensearch-project/OpenSearch-Dashboards.git",
-                branch,
-                path,
-            ),
-            snapshot,
-        )
+        with GitRepository(
+            "https://github.com/opensearch-project/OpenSearch-Dashboards.git",
+            branch,
+            path,
+        ) as repo:
+            return ComponentOpenSearchDashboardsMin(
+                repo,
+                snapshot,
+            )
 
     @property
     def properties(self):

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -40,7 +40,7 @@ class InputManifests(Manifests):
         known_versions = self.versions
         logging.info(f"Known versions: {known_versions}")
         main_versions = {}
-        with TemporaryDirectory.mkdtemp(keep=keep) as work_dir:
+        with TemporaryDirectory(keep=keep) as work_dir:
             logging.info(f"Checking out components into {work_dir.name}")
             os.chdir(work_dir.name)
 

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -40,16 +40,16 @@ class InputManifests(Manifests):
         known_versions = self.versions
         logging.info(f"Known versions: {known_versions}")
         main_versions = {}
-        with TemporaryDirectory(keep=keep) as work_dir:
-            logging.info(f"Checking out components into {work_dir}")
-            os.chdir(work_dir)
+        with TemporaryDirectory.mkdtemp(keep=keep) as work_dir:
+            logging.info(f"Checking out components into {work_dir.name}")
+            os.chdir(work_dir.name)
 
             # check out and build #main, 1.x, etc.
             branches = min_klass.branches()
             logging.info(f"Checking {self.name} {branches} branches")
             for branch in branches:
                 c = min_klass.checkout(
-                    path=os.path.join(work_dir, f"{self.name.replace(' ', '')}/{branch}"),
+                    path=os.path.join(work_dir.name, f"{self.name.replace(' ', '')}/{branch}"),
                     branch=branch,
                 )
                 version = c.version
@@ -67,7 +67,7 @@ class InputManifests(Manifests):
                     logging.info(f"Checking out {component.name}#main")
                     component = component_klass.checkout(
                         name=component.name,
-                        path=os.path.join(work_dir, component.name),
+                        path=os.path.join(work_dir.name, component.name),
                         version=manifest.build.version,
                         branch="main",
                     )

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -40,7 +40,7 @@ def main():
     output_dir = os.path.join(os.getcwd(), "bundle")
     os.makedirs(output_dir, exist_ok=True)
 
-    with TemporaryDirectory.mkdtemp() as work_dir:
+    with TemporaryDirectory() as work_dir:
         logging.info(f"Bundling {build.name} ({build.architecture}) on {build.platform} into {output_dir} ...")
 
         os.chdir(work_dir.name)

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -10,12 +10,12 @@ import argparse
 import logging
 import os
 import sys
-import tempfile
 
 from assemble_workflow.bundle_recorder import BundleRecorder
 from assemble_workflow.bundles import Bundles
 from manifests.build_manifest import BuildManifest
 from system import console
+from system.temporary_directory import TemporaryDirectory
 
 
 def main():
@@ -40,10 +40,10 @@ def main():
     output_dir = os.path.join(os.getcwd(), "bundle")
     os.makedirs(output_dir, exist_ok=True)
 
-    with tempfile.TemporaryDirectory() as work_dir:
+    with TemporaryDirectory.mkdtemp() as work_dir:
         logging.info(f"Bundling {build.name} ({build.architecture}) on {build.platform} into {output_dir} ...")
 
-        os.chdir(work_dir)
+        os.chdir(work_dir.name)
 
         bundle_recorder = BundleRecorder(build, output_dir, artifacts_dir)
 

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -25,7 +25,7 @@ def main():
     console.configure(level=args.logging_level)
     manifest = InputManifest.from_file(args.manifest)
 
-    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
+    with TemporaryDirectory(keep=args.keep) as work_dir:
         output_dir = os.path.join(os.getcwd(), "artifacts")
 
         logging.info(f"Building in {work_dir.name}")

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -25,12 +25,12 @@ def main():
     console.configure(level=args.logging_level)
     manifest = InputManifest.from_file(args.manifest)
 
-    with TemporaryDirectory(keep=args.keep) as work_dir:
+    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
         output_dir = os.path.join(os.getcwd(), "artifacts")
 
-        logging.info(f"Building in {work_dir}")
+        logging.info(f"Building in {work_dir.name}")
 
-        os.chdir(work_dir)
+        os.chdir(work_dir.name)
 
         target = BuildTarget(
             name=manifest.build.name,
@@ -52,20 +52,19 @@ def main():
                 continue
 
             logging.info(f"Building {component.name}")
-            repo = GitRepository(
+            with GitRepository(
                 component.repository,
                 component.ref,
-                os.path.join(work_dir, component.name),
+                os.path.join(work_dir.name, component.name),
                 component.working_directory,
-            )
-
-            try:
-                builder = Builder(component.name, repo, build_recorder)
-                builder.build(target)
-                builder.export_artifacts()
-            except:
-                logging.error(f"Error building {component.name}, retry with: {args.component_command(component.name)}")
-                raise
+            ) as repo:
+                try:
+                    builder = Builder(component.name, repo, build_recorder)
+                    builder.build(target)
+                    builder.export_artifacts()
+                except:
+                    logging.error(f"Error building {component.name}, retry with: {args.component_command(component.name)}")
+                    raise
 
         build_recorder.write_manifest()
 

--- a/src/run_bwc_test.py
+++ b/src/run_bwc_test.py
@@ -18,8 +18,8 @@ from test_workflow.test_args import TestArgs
 def main():
     args = TestArgs()
     console.configure(level=args.logging_level)
-    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
-        logging.info("Switching to temporary work_dir: f{work_dir.name}")
+    with TemporaryDirectory(keep=args.keep) as work_dir:
+        logging.info(f"Switching to temporary work_dir: {work_dir.name}")
         bundle_manifest = BundleManifest.from_s3(
             args.s3_bucket,
             args.build_id,

--- a/src/run_bwc_test.py
+++ b/src/run_bwc_test.py
@@ -18,16 +18,16 @@ from test_workflow.test_args import TestArgs
 def main():
     args = TestArgs()
     console.configure(level=args.logging_level)
-    with TemporaryDirectory(keep=args.keep) as work_dir:
-        logging.info("Switching to temporary work_dir: " + work_dir)
+    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
+        logging.info("Switching to temporary work_dir: f{work_dir.name}")
         bundle_manifest = BundleManifest.from_s3(
             args.s3_bucket,
             args.build_id,
             args.opensearch_version,
             args.architecture,
-            work_dir,
+            work_dir.name,
         )
-        BwcTestSuite(bundle_manifest, work_dir, args.component, args.keep).execute()
+        BwcTestSuite(bundle_manifest, work_dir.name, args.component, args.keep).execute()
 
 
 if __name__ == "__main__":

--- a/src/run_checkout.py
+++ b/src/run_checkout.py
@@ -22,10 +22,10 @@ def main():
     console.configure(level=args.logging_level)
     manifest = InputManifest.from_file(args.manifest)
 
-    with TemporaryDirectory(keep=True) as work_dir:
-        logging.info(f"Checking out into {work_dir}")
+    with TemporaryDirectory(keep=True).mkdtemp() as work_dir:
+        logging.info(f"Checking out into {work_dir.name}")
 
-        os.chdir(work_dir)
+        os.chdir(work_dir.name)
 
         for component in manifest.components:
 
@@ -33,11 +33,11 @@ def main():
             GitRepository(
                 component.repository,
                 component.ref,
-                os.path.join(work_dir, component.name),
+                os.path.join(work_dir.name, component.name),
                 component.working_directory,
             )
 
-    logging.info(f"Done, checked out into {work_dir}.")
+    logging.info(f"Done, checked out into {work_dir.name}.")
 
 
 if __name__ == "__main__":

--- a/src/run_checkout.py
+++ b/src/run_checkout.py
@@ -22,7 +22,7 @@ def main():
     console.configure(level=args.logging_level)
     manifest = InputManifest.from_file(args.manifest)
 
-    with TemporaryDirectory(keep=True).mkdtemp() as work_dir:
+    with TemporaryDirectory(keep=True) as work_dir:
         logging.info(f"Checking out into {work_dir.name}")
 
         os.chdir(work_dir.name)

--- a/src/run_ci.py
+++ b/src/run_ci.py
@@ -26,7 +26,7 @@ def main():
 
     target = CiTarget(version=manifest.build.version, snapshot=args.snapshot)
 
-    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
+    with TemporaryDirectory(keep=args.keep) as work_dir:
         logging.info(f"Sanity-testing in {work_dir.name}")
 
         os.chdir(work_dir.name)

--- a/src/run_ci.py
+++ b/src/run_ci.py
@@ -26,10 +26,10 @@ def main():
 
     target = CiTarget(version=manifest.build.version, snapshot=args.snapshot)
 
-    with TemporaryDirectory(keep=args.keep) as work_dir:
-        logging.info(f"Sanity-testing in {work_dir}")
+    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
+        logging.info(f"Sanity-testing in {work_dir.name}")
 
-        os.chdir(work_dir)
+        os.chdir(work_dir.name)
 
         logging.info(f"Sanity testing {manifest.build.name}")
 
@@ -40,19 +40,18 @@ def main():
                 continue
 
             logging.info(f"Sanity checking {component.name}")
-            repo = GitRepository(
+            with GitRepository(
                 component.repository,
                 component.ref,
-                os.path.join(work_dir, component.name),
+                os.path.join(work_dir.name, component.name),
                 component.working_directory,
-            )
-
-            try:
-                ci = Ci(component, repo, target)
-                ci.check()
-            except:
-                logging.error(f"Error checking {component.name}, retry with: {args.component_command(component.name)}")
-                raise
+            ) as repo:
+                try:
+                    ci = Ci(component, repo, target)
+                    ci.check()
+                except:
+                    logging.error(f"Error checking {component.name}, retry with: {args.component_command(component.name)}")
+                    raise
 
     logging.info("Done.")
 

--- a/src/run_integ_test.py
+++ b/src/run_integ_test.py
@@ -40,17 +40,17 @@ def main():
     for component in test_manifest.components:
         if component.integ_test is not None:
             integ_test_config[component.name] = component
-    with TemporaryDirectory(keep=args.keep) as work_dir:
-        logging.info("Switching to temporary work_dir: " + work_dir)
-        test_recorder = TestRecorder(args.test_run_id, "integ-test", work_dir)
-        os.chdir(work_dir)
+    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
+        logging.info(f"Switching to temporary work_dir: {work_dir.name}")
+        test_recorder = TestRecorder(args.test_run_id, "integ-test", work_dir.name)
+        os.chdir(work_dir.name)
         bundle_manifest = BundleManifest.from_s3(
             args.s3_bucket,
             args.build_id,
             args.opensearch_version,
             args.platform,
             args.architecture,
-            work_dir,
+            work_dir.name,
         )
         build_manifest = BuildManifest.from_s3(
             args.s3_bucket,
@@ -58,9 +58,9 @@ def main():
             args.opensearch_version,
             args.platform,
             args.architecture,
-            work_dir,
+            work_dir.name,
         )
-        pull_build_repo(work_dir)
+        pull_build_repo(work_dir.name)
         DependencyInstaller(build_manifest.build).install_all_maven_dependencies()
         all_results = TestSuiteResults()
         for component in bundle_manifest.components:
@@ -70,7 +70,7 @@ def main():
                     integ_test_config[component.name],
                     bundle_manifest,
                     build_manifest,
-                    work_dir,
+                    work_dir.name,
                     args.s3_bucket,
                     test_recorder,
                 )

--- a/src/run_integ_test.py
+++ b/src/run_integ_test.py
@@ -40,7 +40,7 @@ def main():
     for component in test_manifest.components:
         if component.integ_test is not None:
             integ_test_config[component.name] = component
-    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
+    with TemporaryDirectory(keep=args.keep) as work_dir:
         logging.info(f"Switching to temporary work_dir: {work_dir.name}")
         test_recorder = TestRecorder(args.test_run_id, "integ-test", work_dir.name)
         os.chdir(work_dir.name)

--- a/src/run_perf_test.py
+++ b/src/run_perf_test.py
@@ -41,7 +41,7 @@ def get_infra_repo_url():
 
 
 def main():
-    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
+    with TemporaryDirectory(keep=args.keep) as work_dir:
         os.chdir(work_dir.name)
         current_workspace = os.path.join(work_dir.name, "infra")
         GitRepository(get_infra_repo_url(), "main", current_workspace)

--- a/src/run_perf_test.py
+++ b/src/run_perf_test.py
@@ -41,9 +41,9 @@ def get_infra_repo_url():
 
 
 def main():
-    with TemporaryDirectory(keep=args.keep) as work_dir:
-        os.chdir(work_dir)
-        current_workspace = os.path.join(work_dir, "infra")
+    with TemporaryDirectory.mkdtemp(keep=args.keep) as work_dir:
+        os.chdir(work_dir.name)
+        current_workspace = os.path.join(work_dir.name, "infra")
         GitRepository(get_infra_repo_url(), "main", current_workspace)
         security = False
         for component in manifest.components:

--- a/src/system/temporary_directory.py
+++ b/src/system/temporary_directory.py
@@ -23,7 +23,3 @@ class TemporaryDirectory:
         else:
             logging.debug(f"Removing {self.name}")
             shutil.rmtree(self.name)
-
-    @classmethod
-    def mkdtemp(cls, keep=False):
-        return cls(keep)

--- a/src/system/temporary_directory.py
+++ b/src/system/temporary_directory.py
@@ -7,16 +7,23 @@
 import logging
 import shutil
 import tempfile
-from contextlib import contextmanager
 
 
-@contextmanager
-def TemporaryDirectory(keep=False):
-    name = tempfile.mkdtemp()
-    try:
-        yield name
-    finally:
-        if keep:
-            logging.info(f"Keeping {name}")
+class TemporaryDirectory:
+    def __init__(self, keep=False):
+        self.keep = keep
+        self.name = tempfile.mkdtemp()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        if self.keep:
+            logging.info(f"Keeping {self.name}")
         else:
-            shutil.rmtree(name)
+            logging.debug(f"Removing {self.name}")
+            shutil.rmtree(self.name)
+
+    @classmethod
+    def mkdtemp(cls, keep=False):
+        return cls(keep)

--- a/tests/test_run_assemble.py
+++ b/tests/test_run_assemble.py
@@ -35,7 +35,7 @@ class TestRunAssemble(unittest.TestCase):
     @patch("argparse._sys.argv", ["run_assemble.py", BUILD_MANIFEST])
     @patch("run_assemble.Bundles", return_value=MagicMock())
     @patch("run_assemble.BundleRecorder", return_value=MagicMock())
-    @patch("tempfile.TemporaryDirectory")
+    @patch("run_assemble.TemporaryDirectory")
     @patch("shutil.copy2")
     def test_main(self, mock_copy, mock_temp, mock_recorder, mock_bundles, *mocks):
         mock_temp.return_value.__enter__.return_value = tempfile.gettempdir()

--- a/tests/test_run_assemble.py
+++ b/tests/test_run_assemble.py
@@ -38,7 +38,7 @@ class TestRunAssemble(unittest.TestCase):
     @patch("run_assemble.TemporaryDirectory")
     @patch("shutil.copy2")
     def test_main(self, mock_copy, mock_temp, mock_recorder, mock_bundles, *mocks):
-        mock_temp.return_value.__enter__.return_value = tempfile.gettempdir()
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
         mock_bundle = MagicMock(archive_path="path")
         mock_bundles.create.return_value = mock_bundle
 

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -33,7 +33,7 @@ class TestRunBuild(unittest.TestCase):
     @patch("run_build.Builder", return_value=MagicMock())
     @patch("run_build.BuildRecorder", return_value=MagicMock())
     @patch("run_build.GitRepository")
-    @patch("run_build.TemporaryDirectory.mkdtemp")
+    @patch("run_build.TemporaryDirectory")
     def test_main(self, mock_temp, mock_repo, mock_recorder, mock_builder, *mocks):
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
         repo = MagicMock(name="dummy")

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -32,10 +32,12 @@ class TestRunBuild(unittest.TestCase):
     @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST])
     @patch("run_build.Builder", return_value=MagicMock())
     @patch("run_build.BuildRecorder", return_value=MagicMock())
-    @patch("run_build.GitRepository", return_value=MagicMock(working_directory="dummy"))
-    @patch("run_build.TemporaryDirectory")
+    @patch("run_build.GitRepository")
+    @patch("run_build.TemporaryDirectory.mkdtemp")
     def test_main(self, mock_temp, mock_repo, mock_recorder, mock_builder, *mocks):
-        mock_temp.return_value.__enter__.return_value = tempfile.gettempdir()
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        repo = MagicMock(name="dummy")
+        mock_repo.return_value.__enter__.return_value = repo
 
         main()
 
@@ -69,11 +71,11 @@ class TestRunBuild(unittest.TestCase):
         # each component is built and its artifacts exported
         mock_builder.assert_has_calls(
             [
-                call("OpenSearch", mock_repo.return_value, mock_recorder.return_value),
-                call("common-utils", mock_repo.return_value, mock_recorder.return_value),
+                call("OpenSearch", repo, mock_recorder.return_value),
+                call("common-utils", repo, mock_recorder.return_value),
                 call(
                     "dashboards-reports",
-                    mock_repo.return_value,
+                    repo,
                     mock_recorder.return_value,
                 ),
             ],

--- a/tests/test_run_checkout.py
+++ b/tests/test_run_checkout.py
@@ -14,7 +14,7 @@ import pytest
 from run_checkout import main
 
 
-class TestRunChecout(unittest.TestCase):
+class TestRunCheckout(unittest.TestCase):
     @pytest.fixture(autouse=True)
     def capfd(self, capfd):
         self.capfd = capfd
@@ -30,10 +30,11 @@ class TestRunChecout(unittest.TestCase):
     OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(os.path.dirname(__file__), "../manifests/1.1.0/opensearch-1.1.0.yml"))
 
     @patch("argparse._sys.argv", ["run_checkout.py", OPENSEARCH_MANIFEST])
-    @patch("run_checkout.GitRepository", return_value=MagicMock(working_directory="dummy"))
-    @patch("run_checkout.TemporaryDirectory")
+    @patch("run_checkout.GitRepository")
+    @patch("run_checkout.TemporaryDirectory.mkdtemp")
     def test_main(self, mock_temp, mock_repo):
-        mock_temp.return_value.__enter__.return_value = tempfile.gettempdir()
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        mock_repo.return_value.__enter__.return_value = MagicMock(working_directory="dummy")
 
         main()
 

--- a/tests/test_run_checkout.py
+++ b/tests/test_run_checkout.py
@@ -31,7 +31,7 @@ class TestRunCheckout(unittest.TestCase):
 
     @patch("argparse._sys.argv", ["run_checkout.py", OPENSEARCH_MANIFEST])
     @patch("run_checkout.GitRepository")
-    @patch("run_checkout.TemporaryDirectory.mkdtemp")
+    @patch("run_checkout.TemporaryDirectory")
     def test_main(self, mock_temp, mock_repo):
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
         mock_repo.return_value.__enter__.return_value = MagicMock(working_directory="dummy")

--- a/tests/test_run_ci.py
+++ b/tests/test_run_ci.py
@@ -32,9 +32,9 @@ class TestRunCi(unittest.TestCase):
     @patch("argparse._sys.argv", ["run_ci.py", OPENSEARCH_MANIFEST])
     @patch("run_ci.Ci", return_value=MagicMock())
     @patch("run_ci.GitRepository", return_value=MagicMock(working_directory="dummy"))
-    @patch("run_ci.TemporaryDirectory")
+    @patch("run_ci.TemporaryDirectory.mkdtemp")
     def test_main(self, mock_temp, mock_repo, mock_ci, *mocks):
-        mock_temp.return_value.__enter__.return_value = tempfile.gettempdir()
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
 
         main()
 

--- a/tests/test_run_ci.py
+++ b/tests/test_run_ci.py
@@ -32,7 +32,7 @@ class TestRunCi(unittest.TestCase):
     @patch("argparse._sys.argv", ["run_ci.py", OPENSEARCH_MANIFEST])
     @patch("run_ci.Ci", return_value=MagicMock())
     @patch("run_ci.GitRepository", return_value=MagicMock(working_directory="dummy"))
-    @patch("run_ci.TemporaryDirectory.mkdtemp")
+    @patch("run_ci.TemporaryDirectory")
     def test_main(self, mock_temp, mock_repo, mock_ci, *mocks):
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
 

--- a/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -78,7 +78,7 @@ class TestBundleRecorder(unittest.TestCase):
         )
 
     def test_write_manifest(self):
-        with TemporaryDirectory.mkdtemp() as dest_dir:
+        with TemporaryDirectory() as dest_dir:
             self.bundle_recorder.write_manifest(dest_dir.name)
             manifest_path = os.path.join(dest_dir.name, "manifest.yml")
             self.assertTrue(os.path.isfile(manifest_path))
@@ -210,7 +210,7 @@ class TestBundleRecorderDashboards(unittest.TestCase):
         )
 
     def test_write_manifest(self):
-        with TemporaryDirectory.mkdtemp() as dest_dir:
+        with TemporaryDirectory() as dest_dir:
             self.bundle_recorder.write_manifest(dest_dir.name)
             manifest_path = os.path.join(dest_dir.name, "manifest.yml")
             self.assertTrue(os.path.isfile(manifest_path))

--- a/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -5,7 +5,6 @@
 # compatible open source license.
 
 import os
-import tempfile
 import unittest
 
 import yaml
@@ -13,6 +12,7 @@ import yaml
 from assemble_workflow.bundle_recorder import BundleRecorder
 from manifests.build_manifest import BuildManifest
 from manifests.bundle_manifest import BundleManifest
+from system.temporary_directory import TemporaryDirectory
 
 
 class TestBundleRecorder(unittest.TestCase):
@@ -78,9 +78,9 @@ class TestBundleRecorder(unittest.TestCase):
         )
 
     def test_write_manifest(self):
-        with tempfile.TemporaryDirectory() as dest_dir:
-            self.bundle_recorder.write_manifest(dest_dir)
-            manifest_path = os.path.join(dest_dir, "manifest.yml")
+        with TemporaryDirectory.mkdtemp() as dest_dir:
+            self.bundle_recorder.write_manifest(dest_dir.name)
+            manifest_path = os.path.join(dest_dir.name, "manifest.yml")
             self.assertTrue(os.path.isfile(manifest_path))
             data = self.bundle_recorder.get_manifest().to_dict()
             with open(manifest_path) as f:
@@ -210,9 +210,9 @@ class TestBundleRecorderDashboards(unittest.TestCase):
         )
 
     def test_write_manifest(self):
-        with tempfile.TemporaryDirectory() as dest_dir:
-            self.bundle_recorder.write_manifest(dest_dir)
-            manifest_path = os.path.join(dest_dir, "manifest.yml")
+        with TemporaryDirectory.mkdtemp() as dest_dir:
+            self.bundle_recorder.write_manifest(dest_dir.name)
+            manifest_path = os.path.join(dest_dir.name, "manifest.yml")
             self.assertTrue(os.path.isfile(manifest_path))
             data = self.bundle_recorder.get_manifest().to_dict()
             with open(manifest_path) as f:

--- a/tests/tests_build_workflow/test_build_recorder.py
+++ b/tests/tests_build_workflow/test_build_recorder.py
@@ -138,7 +138,7 @@ class TestBuildRecorder(unittest.TestCase):
         )
 
     def test_write_manifest(self):
-        with TemporaryDirectory.mkdtemp() as dest_dir:
+        with TemporaryDirectory() as dest_dir:
             mock = self.__mock(snapshot=False)
             mock.target.output_dir = dest_dir.name
             mock.write_manifest()

--- a/tests/tests_build_workflow/test_build_recorder.py
+++ b/tests/tests_build_workflow/test_build_recorder.py
@@ -5,7 +5,6 @@
 # compatible open source license.
 
 import os
-import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -16,6 +15,7 @@ from build_workflow.build_target import BuildTarget
 from build_workflow.opensearch.build_artifact_check_maven import BuildArtifactOpenSearchCheckMaven
 from build_workflow.opensearch.build_artifact_check_plugin import BuildArtifactOpenSearchCheckPlugin
 from manifests.build_manifest import BuildManifest
+from system.temporary_directory import TemporaryDirectory
 
 
 class TestBuildRecorder(unittest.TestCase):
@@ -138,11 +138,11 @@ class TestBuildRecorder(unittest.TestCase):
         )
 
     def test_write_manifest(self):
-        with tempfile.TemporaryDirectory() as dest_dir:
+        with TemporaryDirectory.mkdtemp() as dest_dir:
             mock = self.__mock(snapshot=False)
-            mock.target.output_dir = dest_dir
+            mock.target.output_dir = dest_dir.name
             mock.write_manifest()
-            manifest_path = os.path.join(dest_dir, "manifest.yml")
+            manifest_path = os.path.join(dest_dir.name, "manifest.yml")
             self.assertTrue(os.path.isfile(manifest_path))
             data = mock.get_manifest().to_dict()
             with open(manifest_path) as f:

--- a/tests/tests_git/test_git_repository.py
+++ b/tests/tests_git/test_git_repository.py
@@ -6,11 +6,11 @@
 
 import os
 import subprocess
-import tempfile
 import unittest
 from unittest.mock import patch
 
 from git.git_repository import GitRepository
+from system.temporary_directory import TemporaryDirectory
 
 
 class TestGitRepository(unittest.TestCase):
@@ -24,7 +24,7 @@ class TestGitRepository(unittest.TestCase):
         self.assertEqual(self.repo.url, "https://github.com/opensearch-project/.github")
         self.assertEqual(self.repo.ref, "8ac515431bf24caf92fea9d9b0af3b8f10b88453")
         self.assertEqual(self.repo.sha, "8ac515431bf24caf92fea9d9b0af3b8f10b88453")
-        self.assertIs(type(self.repo.temp_dir), tempfile.TemporaryDirectory)
+        self.assertIs(type(self.repo.temp_dir), TemporaryDirectory)
         self.assertEqual(self.repo.dir, os.path.realpath(self.repo.temp_dir.name))
         self.assertTrue(os.path.isfile(os.path.join(self.repo.dir, "CODE_OF_CONDUCT.md")))
         # was added in the next commit
@@ -58,8 +58,8 @@ class TestGitRepository(unittest.TestCase):
 
 class TestGitRepositoryDir(unittest.TestCase):
     def test_checkout_into_dir(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            subdir = os.path.join(tmpdir, ".github")
+        with TemporaryDirectory() as tmpdir:
+            subdir = os.path.join(tmpdir.name, ".github")
             repo = GitRepository(
                 url="https://github.com/opensearch-project/.github",
                 ref="8ac515431bf24caf92fea9d9b0af3b8f10b88453",

--- a/tests/tests_manifests/test_manifest.py
+++ b/tests/tests_manifests/test_manifest.py
@@ -5,12 +5,12 @@
 # compatible open source license.
 
 import os
-import tempfile
 import unittest
 
 import yaml
 
 from manifests.manifest import Manifest
+from system.temporary_directory import TemporaryDirectory
 
 
 class TestManifest(unittest.TestCase):
@@ -64,8 +64,8 @@ class TestManifest(unittest.TestCase):
         manifest_path = os.path.join(self.data_path, "min.yml")
         manifest = TestManifest.SampleManifest.from_path(manifest_path)
 
-        with tempfile.TemporaryDirectory() as path:
-            output_path = os.path.join(path, "manifest.yml")
+        with TemporaryDirectory() as path:
+            output_path = os.path.join(path.name, "manifest.yml")
             manifest.to_file(output_path)
             self.assertTrue(os.path.isfile(manifest_path))
             with open(output_path) as f:

--- a/tests/tests_system/test_temporary_directory.py
+++ b/tests/tests_system/test_temporary_directory.py
@@ -11,12 +11,12 @@ from system.temporary_directory import TemporaryDirectory
 
 
 class TestTemporaryDirectory(unittest.TestCase):
-    def test_keep_true(self):
-        with TemporaryDirectory(keep=True) as work_dir:
-            self.assertTrue(os.path.exists(work_dir))
-        self.assertTrue(os.path.exists(work_dir))
+    def test_mkdtemp_keep_true(self):
+        with TemporaryDirectory.mkdtemp(keep=True) as work_dir:
+            self.assertTrue(os.path.exists(work_dir.name))
+        self.assertTrue(os.path.exists(work_dir.name))
 
-    def test_keep_false(self):
-        with TemporaryDirectory() as work_dir:
-            self.assertTrue(os.path.exists(work_dir))
-        self.assertFalse(os.path.exists(work_dir))
+    def test_mkdtemp_keep_false(self):
+        with TemporaryDirectory.mkdtemp() as work_dir:
+            self.assertTrue(os.path.exists(work_dir.name))
+        self.assertFalse(os.path.exists(work_dir.name))

--- a/tests/tests_system/test_temporary_directory.py
+++ b/tests/tests_system/test_temporary_directory.py
@@ -12,11 +12,11 @@ from system.temporary_directory import TemporaryDirectory
 
 class TestTemporaryDirectory(unittest.TestCase):
     def test_mkdtemp_keep_true(self):
-        with TemporaryDirectory.mkdtemp(keep=True) as work_dir:
+        with TemporaryDirectory(keep=True) as work_dir:
             self.assertTrue(os.path.exists(work_dir.name))
         self.assertTrue(os.path.exists(work_dir.name))
 
     def test_mkdtemp_keep_false(self):
-        with TemporaryDirectory.mkdtemp() as work_dir:
+        with TemporaryDirectory() as work_dir:
             self.assertTrue(os.path.exists(work_dir.name))
         self.assertFalse(os.path.exists(work_dir.name))

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/__init__.py
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../../src"))

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/__init__.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/__init__.py
@@ -7,4 +7,4 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../../src"))

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster.py
@@ -15,6 +15,7 @@ import requests
 import yaml
 
 from manifests.bundle_manifest import BundleManifest
+from system.temporary_directory import TemporaryDirectory
 from test_workflow.integ_test.local_test_cluster import LocalTestCluster
 from test_workflow.test_cluster import ClusterCreationException
 
@@ -26,7 +27,7 @@ class LocalTestClusterTests(unittest.TestCase):
         self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "../../../tests_manifests/data"))
         self.manifest_filename = os.path.join(self.data_path, "opensearch-bundle-1.1.0.yml")
         self.manifest = BundleManifest.from_path(self.manifest_filename)
-        self.work_dir = tempfile.TemporaryDirectory()
+        self.work_dir = TemporaryDirectory()
         self.process = self.__get_process()
         self.process.returncode = 0
         self.local_test_cluster = LocalTestCluster(
@@ -39,9 +40,6 @@ class LocalTestClusterTests(unittest.TestCase):
             mock_test_recorder,
             "dummy-bucket",
         )
-
-    def tearDown(self):
-        self.work_dir.cleanup()
 
     class MockResponse:
         def __init__(self, text, status_code):

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/__init__.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/__init__.py
@@ -7,4 +7,4 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../../src"))

--- a/tests/tests_test_workflow/test_test_component.py
+++ b/tests/tests_test_workflow/test_test_component.py
@@ -13,7 +13,7 @@ class TestTestComponent(unittest.TestCase):
         )
 
     def test_checkout(self):
-        with TemporaryDirectory.mkdtemp() as tmpdir:
+        with TemporaryDirectory() as tmpdir:
             subdir = os.path.join(tmpdir.name, ".github")
             repo = self.test_component.checkout(subdir)
             self.assertEqual(repo.url, "https://github.com/opensearch-project/.github")

--- a/tests/tests_test_workflow/test_test_component.py
+++ b/tests/tests_test_workflow/test_test_component.py
@@ -1,7 +1,7 @@
 import os
-import tempfile
 import unittest
 
+from system.temporary_directory import TemporaryDirectory
 from test_workflow.test_component import TestComponent
 
 
@@ -13,8 +13,8 @@ class TestTestComponent(unittest.TestCase):
         )
 
     def test_checkout(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            subdir = os.path.join(tmpdir, ".github")
+        with TemporaryDirectory.mkdtemp() as tmpdir:
+            subdir = os.path.join(tmpdir.name, ".github")
             repo = self.test_component.checkout(subdir)
             self.assertEqual(repo.url, "https://github.com/opensearch-project/.github")
             self.assertEqual(repo.ref, "8ac515431bf24caf92fea9d9b0af3b8f10b88453")


### PR DESCRIPTION
### Description

Refactored TemporaryFile and GitRepository into context managers.

On top of #768, extracted from https://github.com/opensearch-project/opensearch-build/pull/767
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
