### PR TITLE
Remove duplicate build command

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -152,8 +152,6 @@ void build(platform, architecture) {
 void assemble() {
     git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
 
-    sh "./build.sh manifests/$INPUT_MANIFEST"
-
     script { manifest = readYaml(file: 'builds/manifest.yml') }
 
     def artifactPath = "${env.JOB_NAME}/${manifest.build.version}/${env.BUILD_NUMBER}/${manifest.build.platform}/${manifest.build.architecture}";


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
There were duplicate commands on running `build.sh` in opensearch-dashboards `Jenkinsfile` when resolving conflicts. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
