### PR TITLE
[Build] fix Dashboards Jenkinsfile with new path and stage

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
                             steps {
                                 script {
                                     build("linux", "arm64")
-                                    zip zipFile: 'buildArtifacts.zip', archive: false, dir: 'artifacts'
+                                    zip zipFile: 'buildArtifacts.zip', archive: false, dir: 'builds'
                                     archiveArtifacts artifacts: 'buildArtifacts.zip', fingerprint: true
                                 }
                             }
@@ -114,7 +114,7 @@ pipeline {
                             steps {
                                 script {
                                     copyArtifacts filter: 'buildArtifacts.zip', fingerprintArtifacts: true, projectName: env.JOB_NAME, selector: specific(env.BUILD_NUMBER)
-                                    unzip zipFile: 'buildArtifacts.zip', dir: './artifacts'
+                                    unzip zipFile: 'buildArtifacts.zip', dir: './builds'
                                     assemble()
                                 }
                             }
@@ -186,7 +186,7 @@ String getAllJenkinsMessages() {
     script {
         // Stages must be explicitly added to prevent overwriting
         // See https://ryan.himmelwright.net/post/jenkins-parallel-stashing/
-        def stages = ['build-linux-x64', 'build-linux-arm64']
+        def stages = ['build-linux-x64', 'post-build (linux-arm64)']
         for (stage in stages) {
             unstash "notifications-${stage}"
         }


### PR DESCRIPTION
### Description
Path was updated for builds so it needed to be archived correctly
for a different stage to build properly. Also, stashed to a
nested stage so the stage name was incorrect for arm64.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
Partial: https://github.com/opensearch-project/opensearch-build/issues/798
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
