### PR TITLE
Fix: retry command substitution on Windows.

### DIFF
--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -6,7 +6,6 @@
 
 import argparse
 import logging
-import os
 import sys
 
 
@@ -76,7 +75,7 @@ class BuildArgs:
         self.keep = args.keep
         self.platform = args.platform
         self.architecture = args.architecture
-        self.script_path = sys.argv[0].replace(os.path.sep + os.path.join("src", "run_build.py"), f"{os.path.sep}build.sh")
+        self.script_path = sys.argv[0].replace("/src/run_build.py", "/build.sh")
 
     def component_command(self, name):
         return " ".join(

--- a/src/ci_workflow/ci_args.py
+++ b/src/ci_workflow/ci_args.py
@@ -6,7 +6,6 @@
 
 import argparse
 import logging
-import os
 import sys
 
 
@@ -46,7 +45,7 @@ class CiArgs:
         self.component = args.component
         self.keep = args.keep
         self.logging_level = args.logging_level
-        self.script_path = sys.argv[0].replace(os.path.sep + os.path.join("src", "run_ci.py"), f"{os.path.sep}ci.sh")
+        self.script_path = sys.argv[0].replace("/src/run_ci.py", "/ci.sh")
 
     def component_command(self, name):
         return " ".join(

--- a/tests/tests_build_workflow/test_build_args.py
+++ b/tests/tests_build_workflow/test_build_args.py
@@ -14,9 +14,9 @@ from build_workflow.build_args import BuildArgs
 
 class TestBuildArgs(unittest.TestCase):
 
-    BUILD_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "run_build.py"))
+    BUILD_PY = "./src/run_build.py"
 
-    BUILD_SH = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "build.sh"))
+    BUILD_SH = "./build.sh"
 
     OPENSEARCH_MANIFEST = os.path.realpath(
         os.path.join(
@@ -83,8 +83,6 @@ class TestBuildArgs(unittest.TestCase):
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
     def test_script_path(self):
-        self.assertTrue(os.path.isfile(self.BUILD_PY))
-        self.assertTrue(os.path.isfile(self.BUILD_SH))
         self.assertEqual(BuildArgs().script_path, self.BUILD_SH)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])

--- a/tests/tests_ci_workflow/test_ci_args.py
+++ b/tests/tests_ci_workflow/test_ci_args.py
@@ -13,9 +13,9 @@ from ci_workflow.ci_args import CiArgs
 
 class TestCiArgs(unittest.TestCase):
 
-    CI_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "run_ci.py"))
+    CI_PY = "./src/run_ci.py"
 
-    CI_SH = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "ci.sh"))
+    CI_SH = "./ci.sh"
 
     OPENSEARCH_MANIFEST = os.path.realpath(
         os.path.join(
@@ -58,8 +58,6 @@ class TestCiArgs(unittest.TestCase):
 
     @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
     def test_script_path(self):
-        self.assertTrue(os.path.isfile(self.CI_PY))
-        self.assertTrue(os.path.isfile(self.CI_SH))
         self.assertEqual(CiArgs().script_path, self.CI_SH)
 
     @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST])


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Before:

```
2021-10-25 23:27:37 ERROR    Error building common-utils, retry with: ./src/run_build.py manifests/1.1.0/opensearch-1.1.0.yml --component common-utils --snapshot
```

After:

```
2021-10-26 00:23:48 ERROR    Error building common-utils, retry with: ./build.sh manifests/1.1.0/opensearch-1.1.0.yml --component common-utils --snapshot
```

On Windows, because we always run under bash the paths in these messages are unix, not Windows.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
