### PR TITLE
[Jenkins] add missing slash for base url

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -155,7 +155,7 @@ void assemble() {
     script { manifest = readYaml(file: 'builds/manifest.yml') }
 
     def artifactPath = "${env.JOB_NAME}/${manifest.build.version}/${env.BUILD_NUMBER}/${manifest.build.platform}/${manifest.build.architecture}";
-    def BASE_URL = PUBLIC_ARTIFACT_URL + artifactPath;
+    def BASE_URL = "${PUBLIC_ARTIFACT_URL}/${artifactPath}";
 
     sh "./assemble.sh builds/manifest.yml --base-url ${BASE_URL}"
 

--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -151,7 +151,7 @@ void build() {
     script { manifest = readYaml(file: 'builds/manifest.yml') }
     
     def artifactPath = "${env.JOB_NAME}/${manifest.build.version}/${env.BUILD_NUMBER}/${manifest.build.platform}/${manifest.build.architecture}";
-    def BASE_URL = PUBLIC_ARTIFACT_URL + artifactPath;
+    def BASE_URL = "${PUBLIC_ARTIFACT_URL}/${artifactPath}";
 
     sh "./assemble.sh builds/manifest.yml --base-url ${BASE_URL}"
     


### PR DESCRIPTION
### Description
Add a missing slash for base url in the Jenkinsfiles for OpenSearch
and OpenSearch Dashboards.

No build errors though just ci folder probably looks weird.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/805
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
