### PR TITLE
Skip tests for common-utils.

### DIFF
--- a/scripts/components/common-utils/build.sh
+++ b/scripts/components/common-utils/build.sh
@@ -59,7 +59,7 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-./gradlew build -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew build -x test -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 ./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 mkdir -p $OUTPUT/maven/org/opensearch
 cp -r ./build/libs $OUTPUT/maven/org/opensearch/common-utils


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Skip running common-utils tests in distribution assembly.
 
### Issues Resolved

Workaround for common-utils unit tests failing on Windows, which is https://github.com/opensearch-project/common-utils/issues/85.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
