### PR TITLE
Fix S3 permissions and jenkins module names

### DIFF
--- a/deployment/lib/artifacts-public-access.ts
+++ b/deployment/lib/artifacts-public-access.ts
@@ -5,10 +5,10 @@ import { CanonicalUserPrincipal, PolicyStatement } from '@aws-cdk/aws-iam';
 import { Code, Function, Runtime } from '@aws-cdk/aws-lambda';
 import { IBucket } from '@aws-cdk/aws-s3';
 import { CfnOutput } from '@aws-cdk/core';
-import { JenkinsArtifactStack } from './jenkins-artifact-stack';
+import { BuildArtifactStack } from './build-artifact-stack';
 
 export class ArtifactsPublicAccess {
-  constructor(stack: JenkinsArtifactStack, buildBucket: IBucket, existingBucketNeedsUpdate: boolean) {
+  constructor(stack: BuildArtifactStack, buildBucket: IBucket, existingBucketNeedsUpdate: boolean) {
     const originAccessIdentity = new OriginAccessIdentity(stack, 'cloudfront-OAI', {
       comment: `OAI for ${buildBucket.bucketName}`,
     });

--- a/deployment/lib/buckets.ts
+++ b/deployment/lib/buckets.ts
@@ -1,12 +1,12 @@
 import { AnyPrincipal, Role } from '@aws-cdk/aws-iam';
 import { Bucket, IBucket } from '@aws-cdk/aws-s3';
 
-import { JenkinsArtifactStack } from './jenkins-artifact-stack';
+import { BuildArtifactStack } from './build-artifact-stack';
 
 export class Buckets {
   readonly BuildBucket: IBucket;
 
-  constructor(stack: JenkinsArtifactStack, buildBucketArn?: string) {
+  constructor(stack: BuildArtifactStack, buildBucketArn?: string) {
     this.BuildBucket = buildBucketArn
       ? Bucket.fromBucketArn(stack, 'BuildBucket', buildBucketArn)
       : new Bucket(stack, 'BuildBucket', {});

--- a/deployment/lib/identities.ts
+++ b/deployment/lib/identities.ts
@@ -37,13 +37,14 @@ export class Identities {
         assumedBy: props.buildAgentPrinciple,
       });
 
-    props.buildBucket.grantPut(buildRole, 'builds/*');
-    props.buildBucket.grantRead(bundleRole, 'builds/*');
+    props.buildBucket.grantPut(buildRole, '*/builds/*');
 
-    props.buildBucket.grantPut(bundleRole, 'dist/*');
-    props.buildBucket.grantRead(testRole, 'dist/*');
+    props.buildBucket.grantRead(bundleRole, '*/builds/*');
+    props.buildBucket.grantPut(bundleRole, '*/builds/*');
+    props.buildBucket.grantPut(bundleRole, '*/dist/*');
 
-    props.buildBucket.grantPut(testRole, 'dist/*/tests/*');
+    props.buildBucket.grantRead(testRole, '*/dist/*');
+    props.buildBucket.grantPut(testRole, '*/dist/*/tests/*');
   }
 
   private static roleFromName(stack: Stack, roleName: string): IRole {


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Fixes S3 permissions since now the upload path includes the jenkins job name as well.
Also fixes jenkins module names that had some indiscrepancy. 
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/798
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
