### PR TITLE
Copy the OpenSearch-Dashboards src package to cache for plugin build reuse

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -8,7 +8,7 @@ This document describes steps to onboard a new plugin to release workflow for co
 
 2. Create a `scripts/build.sh` if you have specific requirements that are not covered by the [default build.sh script](/scripts/default/build.sh) and commit it to your repository.
 
-3. Ensure your `build.sh` reads and passes along both `-Dbuild.snapshot=` and `-Dopensearch.version=` flags.  Snapshot builds should produce a -SNAPSHOT tagged artifact for example `opensearch-plugin-1.1.0.0-SNAPSHOT.zip` where a release build of the same component would produce `opensearch-plugin-1.1.0.0.zip`.
+3. Ensure your `build.sh` reads and passes along both `-Dbuild.snapshot=` and `-Dopensearch.version=` flags.  Snapshot builds should produce a -SNAPSHOT tagged artifact for example `opensearch-plugin-1.1.0.0-SNAPSHOT.zip` where a release build of the same component would produce `opensearch-plugin-1.1.0.0.zip`. If building a opensearch-dashboards plugin be sure to have the opensearch-dashboards core already in cache. 
 
 4. Execute `./build.sh` to ensure your component builds and all artifacts are correctly placed into ./artifacts/ with correct output names.
 

--- a/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/scripts/components/OpenSearch-Dashboards/build.sh
@@ -77,6 +77,11 @@ case $ARCHITECTURE in
         ;;
 esac
 
+echo "Copying dashboard to .cache for reuse"
+rm -rf ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/
+mkdir -p ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/
+cp -r . ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/
+
 echo "Building node modules for core"
 yarn osd bootstrap
 

--- a/scripts/components/ganttChartDashboards/build.sh
+++ b/scripts/components/ganttChartDashboards/build.sh
@@ -20,6 +20,20 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_opensearch_dashboards_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        echo "No OpenSearch-Dashboards folder found, trying to load from cache"
+        if [ -d ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from cache"
+            cp -r ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ../../
+        else
+            echo "No correct version OpenSearch-Dashboards found from cache, 
+                please run: ./build.sh manifests/1.1.0/opensearch-dashboards-1.1.0.yml --component=OpenSearch-Dashboards"
+            exit 1
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -67,6 +81,7 @@ PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_opensearch_dashboards_from_cache
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)

--- a/scripts/components/notebooksDashboards/build.sh
+++ b/scripts/components/notebooksDashboards/build.sh
@@ -20,6 +20,20 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_opensearch_dashboards_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        echo "No OpenSearch-Dashboards folder found, trying to load from cache"
+        if [ -d ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from cache"
+            cp -r ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ../../
+        else
+            echo "No correct version OpenSearch-Dashboards found from cache, 
+                please run: ./build.sh manifests/1.1.0/opensearch-dashboards-1.1.0.yml --component=OpenSearch-Dashboards"
+            exit 1
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -67,6 +81,7 @@ PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_opensearch_dashboards_from_cache
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)

--- a/scripts/components/notificationsDashboards/build.sh
+++ b/scripts/components/notificationsDashboards/build.sh
@@ -20,6 +20,20 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_opensearch_dashboards_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        echo "No OpenSearch-Dashboards folder found, trying to load from cache"
+        if [ -d ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from cache"
+            cp -r ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ../../
+        else
+            echo "No correct version OpenSearch-Dashboards found from cache, 
+                please run: ./build.sh manifests/1.1.0/opensearch-dashboards-1.1.0.yml --component=OpenSearch-Dashboards"
+            exit 1
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -67,6 +81,7 @@ PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_opensearch_dashboards_from_cache
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)

--- a/scripts/components/queryWorkbenchDashboards/build.sh
+++ b/scripts/components/queryWorkbenchDashboards/build.sh
@@ -20,6 +20,20 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_opensearch_dashboards_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        echo "No OpenSearch-Dashboards folder found, try to load from cache"
+        if [ -d ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from cache"
+            cp -r ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ../../
+        else
+            echo "No correct version OpenSearch-Dashboards found from cache, 
+                please run: ./build.sh manifests/1.1.0/opensearch-dashboards-1.1.0.yml --component=OpenSearch-Dashboards"
+            exit 1
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -67,6 +81,7 @@ PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_opensearch_dashboards_from_cache
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)

--- a/scripts/components/reportsDashboards/build.sh
+++ b/scripts/components/reportsDashboards/build.sh
@@ -20,6 +20,19 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_opensearch_dashboards_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        echo "No OpenSearch-Dashboards folder found, try to load from cache"
+        if [ -d ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from cache"
+            cp -r ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ../../
+        else
+            echo "No correct version OpenSearch-Dashboards found from cache, please build OpenSearch-Dashboards first"
+            exit 1
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -67,6 +80,7 @@ PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_opensearch_dashboards_from_cache
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -20,6 +20,20 @@ function usage() {
     echo -e "-h help"
 }
 
+function load_opensearch_dashboards_from_cache() {
+    if [ ! -d ../OpenSearch-Dashboards ]; then
+        echo "No OpenSearch-Dashboards folder found, try to load from cache"
+        if [ -d ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ]; then
+            echo "Copy OpenSearch-Dashboards from cache"
+            cp -r ~/.cache/opensearch-project/$VERSION/OpenSearch-Dashboards/ ../
+        else
+            echo "No correct version OpenSearch-Dashboards found from cache, 
+                please run: ./build.sh manifests/1.1.0/opensearch-dashboards-1.1.0.yml --component=OpenSearch-Dashboards"
+            exit 1
+        fi
+    fi
+}
+
 while getopts ":h:v:s:o:p:a:" arg; do
     case $arg in
         h)
@@ -65,6 +79,7 @@ mkdir -p $OUTPUT/plugins
 PLUGIN_NAME=$(basename "$PWD")
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins
 # This makes it so there is a dependency on having Dashboards pulled already.
+load_opensearch_dashboards_from_cache
 cp -r ../$PLUGIN_NAME/ ../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../OpenSearch-Dashboards && yarn osd bootstrap)


### PR DESCRIPTION
### Description
Copy the OpenSearch-Dashboards git package to ~/.cache folder when building the OpenSearch-Dashboards component. Also create the load_dashboard_from_cache function for plugin build to reuse OpenSearch-Dashboards source code. This way allows individual plugin to build independently, https://github.com/opensearch-project/opensearch-build/issues/606

Test:
verify locally that build OpenSearch-Dashboards plugin independently with fetching core from cache run successfully.
ex: ./build.sh manifests/1.1.0/opensearch-dashboards-1.1.0.yml --component=alertingDashboards
 
### Issues Resolved
#812 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
