### PR TITLE
Enable components to declare compatible platforms.

### DIFF
--- a/manifests/1.1.0/opensearch-1.1.0.yml
+++ b/manifests/1.1.0/opensearch-1.1.0.yml
@@ -54,6 +54,9 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+    platforms:
+      - darwin
+      - linux
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
     ref: "1.1"
@@ -66,6 +69,9 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+    platforms:
+      - darwin
+      - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
     ref: "1.1"

--- a/src/assemble_workflow/bundle.py
+++ b/src/assemble_workflow/bundle.py
@@ -30,8 +30,8 @@ class Bundle(ABC):
         :param artifacts_dir: Dir location where build artifacts can be found locally
         :param bundle_recorder: The bundle recorder that will capture and build a BundleManifest
         """
-        self.min_tarball = self.__get_min_bundle(build_manifest.components)
-        self.plugins = self.__get_plugins(build_manifest.components)
+        self.min_tarball = self.__get_min_bundle(build_manifest.components.values())
+        self.plugins = self.__get_plugins(build_manifest.components.values())
         self.artifacts_dir = artifacts_dir
         self.bundle_recorder = bundle_recorder
         self.tmp_dir = TemporaryDirectory()

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -10,10 +10,7 @@ import sys
 
 
 class BuildArgs:
-    SUPPORTED_PLATFORMS = [
-        "linux",
-        "darwin",
-    ]
+    SUPPORTED_PLATFORMS = ["linux", "darwin", "windows"]
     SUPPORTED_ARCHITECTURES = [
         "x64",
         "arm64",
@@ -43,20 +40,8 @@ class BuildArgs:
             action="store_true",
             help="Do not delete the working temporary directory.",
         )
-        parser.add_argument(
-            "-p",
-            "--platform",
-            type=str,
-            choices=self.SUPPORTED_PLATFORMS,
-            help="Platform to build."
-        )
-        parser.add_argument(
-            "-a",
-            "--architecture",
-            type=str,
-            choices=self.SUPPORTED_ARCHITECTURES,
-            help="Architecture to build."
-        )
+        parser.add_argument("-p", "--platform", type=str, choices=self.SUPPORTED_PLATFORMS, help="Platform to build.")
+        parser.add_argument("-a", "--architecture", type=str, choices=self.SUPPORTED_ARCHITECTURES, help="Architecture to build.")
         parser.add_argument(
             "-v",
             "--verbose",

--- a/src/manifests/build/build_manifest_1_0.py
+++ b/src/manifests/build/build_manifest_1_0.py
@@ -79,26 +79,17 @@ class BuildManifest_1_0(Manifest):
         super().__init__(data)
 
         self.build = self.Build(data["build"])
-        self.components = list(map(lambda entry: self.Component(entry), data.get("components", [])))
+        self.components = BuildManifest_1_0.Components(data.get("components", []))
 
     def __to_dict__(self):
-        return {
-            "schema-version": "1.0",
-            "build": self.build.__to_dict__(),
-            "components": list(map(lambda component: component.__to_dict__(), self.components)),
-        }
+        return {"schema-version": "1.0", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
 
-    def get_component(self, component_name):
-        component = next(
-            iter(filter(lambda comp: comp.name == component_name, self.components)),
-            None,
-        )
-        if component is None:
-            raise BuildManifest_1_0.ComponentNotFoundError(f"{component_name} not found in build manifest.yml")
-        return component
+    class Components(dict):
+        def __init__(self, data):
+            super().__init__(map(lambda component: (component["name"], BuildManifest_1_0.Component(component)), data))
 
-    class ComponentNotFoundError(Exception):
-        pass
+        def to_dict(self):
+            return list(map(lambda component: component.__to_dict__(), self.values()))
 
     class Build:
         def __init__(self, data):

--- a/src/manifests/build/build_manifest_1_1.py
+++ b/src/manifests/build/build_manifest_1_1.py
@@ -80,26 +80,10 @@ class BuildManifest_1_1(Manifest):
         super().__init__(data)
 
         self.build = self.Build(data["build"])
-        self.components = list(map(lambda entry: self.Component(entry), data.get("components", [])))
+        self.components = BuildManifest_1_1.Components(data.get("components", []))
 
     def __to_dict__(self):
-        return {
-            "schema-version": "1.1",
-            "build": self.build.__to_dict__(),
-            "components": list(map(lambda component: component.__to_dict__(), self.components)),
-        }
-
-    def get_component(self, component_name):
-        component = next(
-            iter(filter(lambda comp: comp.name == component_name, self.components)),
-            None,
-        )
-        if component is None:
-            raise BuildManifest_1_1.ComponentNotFoundError(f"{component_name} not found in build manifest.yml")
-        return component
-
-    class ComponentNotFoundError(Exception):
-        pass
+        return {"schema-version": "1.1", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
 
     class Build:
         def __init__(self, data):
@@ -115,6 +99,13 @@ class BuildManifest_1_1(Manifest):
                 "architecture": self.architecture,
                 "id": self.id,
             }
+
+    class Components(dict):
+        def __init__(self, data):
+            super().__init__(map(lambda component: (component["name"], BuildManifest_1_1.Component(component)), data))
+
+        def to_dict(self):
+            return list(map(lambda component: component.__to_dict__(), self.values()))
 
     class Component:
         def __init__(self, data):

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -42,16 +42,9 @@ def main():
 
         build_recorder = BuildRecorder(target)
 
-        logging.info(
-            f"Building {manifest.build.name} ({target.architecture}) into {target.output_dir}"
-        )
+        logging.info(f"Building {manifest.build.name} ({target.architecture}) into {target.output_dir}")
 
-        for component in manifest.components:
-
-            if args.component and args.component != component.name:
-                logging.info(f"Skipping {component.name}")
-                continue
-
+        for component in manifest.components.select(focus=args.component, platform=target.platform):
             logging.info(f"Building {component.name}")
 
             with GitRepository(

--- a/src/run_checkout.py
+++ b/src/run_checkout.py
@@ -25,9 +25,9 @@ def main():
     with TemporaryDirectory(keep=True, chdir=True) as work_dir:
         logging.info(f"Checking out into {work_dir.name}")
 
-        for component in manifest.components:
-
+        for component in manifest.components.select():
             logging.info(f"Checking out {component.name}")
+
             with GitRepository(
                 component.repository,
                 component.ref,

--- a/src/run_ci.py
+++ b/src/run_ci.py
@@ -31,13 +31,9 @@ def main():
 
         logging.info(f"Sanity testing {manifest.build.name}")
 
-        for component in manifest.components:
+        for component in manifest.components.select(focus=args.component):
+            logging.info(f"Sanity testing {component.name}")
 
-            if args.component and args.component != component.name:
-                logging.info(f"Skipping {component.name}")
-                continue
-
-            logging.info(f"Sanity checking {component.name}")
             with GitRepository(
                 component.repository,
                 component.ref,

--- a/src/run_sign.py
+++ b/src/run_sign.py
@@ -38,15 +38,10 @@ def main():
     basepath = os.path.dirname(os.path.abspath(args.manifest.name))
     signer = Signer()
 
-    for component in manifest.components:
-
-        if args.component and args.component != component.name:
-            logging.info(f"Skipping {component.name}")
-            continue
-
+    for component in manifest.components.select(focus=args.component):
         logging.info(f"Signing {component.name}")
-        for artifact_type in component.artifacts:
 
+        for artifact_type in component.artifacts:
             if args.type and args.type != artifact_type:
                 continue
 

--- a/src/test_workflow/integ_test/integ_test_suite.py
+++ b/src/test_workflow/integ_test/integ_test_suite.py
@@ -71,7 +71,7 @@ class IntegTestSuite:
         custom_local_path = os.path.join(self.repo.dir, "src", "test", "resources", "job-scheduler")
         for file in glob.glob(os.path.join(custom_local_path, "opensearch-job-scheduler-*.zip")):
             os.unlink(file)
-        job_scheduler = self.build_manifest.get_component("job-scheduler")
+        job_scheduler = self.build_manifest.components["job-scheduler"]
         DependencyInstaller(self.build_manifest.build).install_build_dependencies({"opensearch-job-scheduler": job_scheduler.version}, custom_local_path)
 
     @staticmethod

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -7,7 +7,7 @@
 import os
 import tempfile
 import unittest
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -37,83 +37,12 @@ class TestRunBuild(unittest.TestCase):
         )
     )
 
-    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST])
-    @patch("run_build.BuildTarget", return_value=MagicMock(output_dir="artifacts"))
-    @patch("run_build.Builder", return_value=MagicMock())
-    @patch("run_build.BuildRecorder", return_value=MagicMock())
-    @patch("run_build.GitRepository")
-    @patch("run_build.TemporaryDirectory")
-    def test_main(self, mock_temp, mock_repo, mock_recorder, mock_builder, mock_target, *mocks):
-        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
-        repo = MagicMock(name="dummy")
-        mock_repo.return_value.__enter__.return_value = repo
-
-        main()
-
-        # each repository is checked out locally
-        mock_repo.assert_has_calls(
-            [
-                call(
-                    "https://github.com/opensearch-project/OpenSearch.git",
-                    "1.1",
-                    os.path.join(tempfile.gettempdir(), "OpenSearch"),
-                    None,
-                ),
-                call(
-                    "https://github.com/opensearch-project/common-utils.git",
-                    "1.1",
-                    os.path.join(tempfile.gettempdir(), "common-utils"),
-                    None,
-                ),
-                call(
-                    "https://github.com/opensearch-project/dashboards-reports.git",
-                    "1.1",
-                    os.path.join(tempfile.gettempdir(), "dashboards-reports"),
-                    "reports-scheduler",
-                ),
-            ],
-            any_order=True,
-        )
-
-        mock_target.assert_called_once_with(
-            name="OpenSearch",
-            version="1.1.0",
-            snapshot=False,
-            platform=None,
-            architecture=None,
-            output_dir=ANY
-        )
-
-        self.assertEqual(mock_repo.call_count, 15)
-
-        # each component is built and its artifacts exported
-        mock_builder.assert_has_calls(
-            [
-                call("OpenSearch", repo, mock_recorder.return_value),
-                call("common-utils", repo, mock_recorder.return_value),
-                call(
-                    "dashboards-reports",
-                    repo,
-                    mock_recorder.return_value,
-                ),
-            ],
-            any_order=True,
-        )
-
-        self.assertEqual(mock_builder.call_count, 15)
-        self.assertEqual(mock_builder.return_value.build.call_count, 15)
-        self.assertEqual(mock_builder.return_value.export_artifacts.call_count, 15)
-
-        # the output manifest is written
-        mock_recorder.return_value.write_manifest.assert_called()
-
     @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "-p", "linux"])
-    @patch("run_build.BuildTarget", return_value=MagicMock(output_dir="artifacts"))
     @patch("run_build.Builder", return_value=MagicMock())
     @patch("run_build.BuildRecorder", return_value=MagicMock())
     @patch("run_build.GitRepository")
     @patch("run_build.TemporaryDirectory")
-    def test_main_platform(self, mock_temp, mock_repo, mock_recorder, mock_builder, mock_target, *mocks):
+    def test_main_platform_linux(self, mock_temp, mock_repo, mock_recorder, mock_builder, *mocks):
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
         repo = MagicMock(name="dummy")
         mock_repo.return_value.__enter__.return_value = repo
@@ -143,15 +72,6 @@ class TestRunBuild(unittest.TestCase):
                 ),
             ],
             any_order=True,
-        )
-
-        mock_target.assert_called_once_with(
-            name="OpenSearch",
-            version="1.1.0",
-            snapshot=False,
-            platform="linux",
-            architecture=None,
-            output_dir=ANY
         )
 
         self.assertEqual(mock_repo.call_count, 15)
@@ -178,73 +98,35 @@ class TestRunBuild(unittest.TestCase):
         mock_recorder.return_value.write_manifest.assert_called()
 
     @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "-p", "darwin"])
+    @patch("run_build.Builder", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.GitRepository")
+    @patch("run_build.TemporaryDirectory")
+    def test_main_platform_darwin(self, mock_temp, mock_repo, mock_recorder, mock_builder, *mocks):
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        mock_repo.return_value.__enter__.return_value = MagicMock(name="dummy")
+        main()
+        self.assertEqual(mock_repo.call_count, 15)
+        self.assertEqual(mock_builder.call_count, 15)
+        self.assertEqual(mock_builder.return_value.build.call_count, 15)
+        self.assertEqual(mock_builder.return_value.export_artifacts.call_count, 15)
+        mock_recorder.return_value.write_manifest.assert_called()
+
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "-p", "windows"])
     @patch("run_build.BuildTarget", return_value=MagicMock(output_dir="artifacts"))
     @patch("run_build.Builder", return_value=MagicMock())
     @patch("run_build.BuildRecorder", return_value=MagicMock())
     @patch("run_build.GitRepository")
     @patch("run_build.TemporaryDirectory")
-    def test_main_platform_darwin(self, mock_temp, mock_repo, mock_recorder, mock_builder, mock_target, *mocks):
+    def test_main_platform_windows(self, mock_temp, mock_repo, mock_recorder, mock_builder, *mocks):
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
-        repo = MagicMock(name="dummy")
-        mock_repo.return_value.__enter__.return_value = repo
-
+        mock_repo.return_value.__enter__.return_value = MagicMock(name="dummy")
         main()
-
-        # each repository is checked out locally
-        mock_repo.assert_has_calls(
-            [
-                call(
-                    "https://github.com/opensearch-project/OpenSearch.git",
-                    "1.1",
-                    os.path.join(tempfile.gettempdir(), "OpenSearch"),
-                    None,
-                ),
-                call(
-                    "https://github.com/opensearch-project/common-utils.git",
-                    "1.1",
-                    os.path.join(tempfile.gettempdir(), "common-utils"),
-                    None,
-                ),
-                call(
-                    "https://github.com/opensearch-project/dashboards-reports.git",
-                    "1.1",
-                    os.path.join(tempfile.gettempdir(), "dashboards-reports"),
-                    "reports-scheduler",
-                ),
-            ],
-            any_order=True,
-        )
-
-        mock_target.assert_called_once_with(
-            name="OpenSearch",
-            version="1.1.0",
-            snapshot=False,
-            platform="darwin",
-            architecture=None,
-            output_dir=ANY
-        )
-
-        self.assertEqual(mock_repo.call_count, 15)
-
-        # each component is built and its artifacts exported
-        mock_builder.assert_has_calls(
-            [
-                call("OpenSearch", repo, mock_recorder.return_value),
-                call("common-utils", repo, mock_recorder.return_value),
-                call(
-                    "dashboards-reports",
-                    repo,
-                    mock_recorder.return_value,
-                ),
-            ],
-            any_order=True,
-        )
-
-        self.assertEqual(mock_builder.call_count, 15)
-        self.assertEqual(mock_builder.return_value.build.call_count, 15)
-        self.assertEqual(mock_builder.return_value.export_artifacts.call_count, 15)
-
-        # the output manifest is written
+        # excludes performance analyzer and k-nn
+        self.assertEqual(mock_repo.call_count, 13)
+        self.assertEqual(mock_builder.call_count, 13)
+        self.assertEqual(mock_builder.return_value.build.call_count, 13)
+        self.assertEqual(mock_builder.return_value.export_artifacts.call_count, 13)
         mock_recorder.return_value.write_manifest.assert_called()
 
     OPENSEARCH_DASHBOARDS_MANIFEST = os.path.realpath(
@@ -263,7 +145,7 @@ class TestRunBuild(unittest.TestCase):
     @patch("run_build.BuildRecorder", return_value=MagicMock())
     @patch("run_build.GitRepository")
     @patch("run_build.TemporaryDirectory")
-    def test_main_with_architecture(self, mock_temp, mock_repo, mock_recorder, mock_builder, mock_target, *mocks):
+    def test_main_with_architecture(self, mock_temp, mock_repo, mock_recorder, mock_builder, *mocks):
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
         repo = MagicMock(name="dummy")
         mock_repo.return_value.__enter__.return_value = repo
@@ -281,15 +163,6 @@ class TestRunBuild(unittest.TestCase):
                 ),
             ],
             any_order=True,
-        )
-
-        mock_target.assert_called_once_with(
-            name="OpenSearch Dashboards",
-            version="1.1.0",
-            snapshot=False,
-            platform=None,
-            architecture="x64",
-            output_dir=ANY
         )
 
         # each component is built and its artifacts exported
@@ -304,12 +177,11 @@ class TestRunBuild(unittest.TestCase):
         mock_recorder.return_value.write_manifest.assert_called()
 
     @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_DASHBOARDS_MANIFEST, "-a", "arm64"])
-    @patch("run_build.BuildTarget", return_value=MagicMock(output_dir="artifacts"))
     @patch("run_build.Builder", return_value=MagicMock())
     @patch("run_build.BuildRecorder", return_value=MagicMock())
     @patch("run_build.GitRepository")
     @patch("run_build.TemporaryDirectory")
-    def test_main_with_architecture_arm64(self, mock_temp, mock_repo, mock_recorder, mock_builder, mock_target, *mocks):
+    def test_main_with_architecture_arm64(self, mock_temp, mock_repo, mock_recorder, mock_builder, *mocks):
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
         repo = MagicMock(name="dummy")
         mock_repo.return_value.__enter__.return_value = repo
@@ -327,15 +199,6 @@ class TestRunBuild(unittest.TestCase):
                 ),
             ],
             any_order=True,
-        )
-
-        mock_target.assert_called_once_with(
-            name="OpenSearch Dashboards",
-            version="1.1.0",
-            snapshot=False,
-            platform=None,
-            architecture="arm64",
-            output_dir=ANY
         )
 
         # each component is built and its artifacts exported

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite.py
@@ -141,9 +141,10 @@ class TestIntegSuite(unittest.TestCase):
             "s3_bucket_name",
             mock_test_recorder,
         )
-        with self.assertRaises(BuildManifest.ComponentNotFoundError) as context:
+        with self.assertRaises(KeyError) as ctx:
             integ_test_suite.execute()
-        self.assertEqual(str(context.exception), "job-scheduler not found in build manifest.yml")
+
+        self.assertEqual(str(ctx.exception), "'job-scheduler'")
         mock_install_build_dependencies.assert_not_called()
 
     def __get_test_config_and_bundle_component(self, component_name):


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

- Enable components to declare compatible platforms, defaults to all.
- Exclude incompatible components during build.
- Raise an error if no components match, e.g. if one specifies `--component=invalid`.
 
### Issues Resolved

- Closes https://github.com/opensearch-project/opensearch-build/issues/811.
- Closes https://github.com/opensearch-project/opensearch-build/issues/657
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
