### PR TITLE
Fix epel-release install error for CI AL2 Dockerfile

### DIFF
--- a/docker/ci/dockerfiles/ci-runner.al2.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.al2.dockerfile
@@ -29,7 +29,7 @@ RUN yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GC
 RUN yum install -y libnss3.so xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc fontconfig freetype && yum clean all
 
 # Add k-NN Library dependencies
-RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack -y
+RUN amazon-linux-extras install epel -y && yum install openblas-static lapack -y
 RUN pip3 install cmake==3.21.3
 
 # Add Yarn dependencies


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
In #810, I added openblas install in both the centos 7 and al2 ci docker images. This package comes from epel-release repo. After testing centos, I copied logic to AL2 dockerfile. However, [for AL2](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-enable-epel/), installation process for epel-release is different. This PR fixes the install of epel-release.

I tested to make sure it works by building the docker image from the updated docker file and then running `./build.sh manifests/1.2.0/opensearch-1.2.0.yml --snapshot` from within a container of the image.

Here is output:
```
./build.sh manifests/1.2.0/opensearch-1.2.0.yml --snapshot
Installing dependencies in . ...
Warning: the environment variable LANG is not set!
We recommend setting this in ~/.profile (or equivalent) for proper expected behavior.
Creating a virtualenv for this project...
Pipfile: /usr/share/opensearch/opensearch-build/Pipfile
Using /usr/bin/python3.7m (3.7.10) to create virtualenv...
⠴ Creating virtual environment...created virtual environment CPython3.7.10.final.0-64 in 351ms
  creator CPython3Posix(dest=/usr/share/opensearch/.local/share/virtualenvs/opensearch-build-s8w2UhEw, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/usr/share/opensearch/.local/share/virtualenv)
    added seed packages: pip==21.3.1, setuptools==58.3.0, wheel==0.37.0
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

✔ Successfully created virtual environment!
Virtualenv location: /usr/share/opensearch/.local/share/virtualenvs/opensearch-build-s8w2UhEw
Installing dependencies from Pipfile.lock (9310b0)...
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 52/52 — 00:00:18
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Running ./src/run_build.py manifests/1.2.0/opensearch-1.2.0.yml --snapshot ...
2021-10-27 17:31:03 INFO     Building in /tmp/tmp2lozz8aj
2021-10-27 17:31:03 INFO     Building OpenSearch (x64) into /usr/share/opensearch/opensearch-build/builds
2021-10-27 17:31:03 INFO     Building OpenSearch
2021-10-27 17:31:03 INFO     Executing "git init" in /tmp/tmp2lozz8aj/OpenSearch
2021-10-27 17:31:03 INFO     Executing "git remote add origin https://github.com/opensearch-project/OpenSearch.git" in /tmp/tmp2lozz8aj/OpenSearch
2021-10-27 17:31:03 INFO     Executing "git fetch --depth 1 origin 1.x" in /tmp/tmp2lozz8aj/OpenSearch
2021-10-27 17:31:06 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmp2lozz8aj/OpenSearch
2021-10-27 17:31:07 INFO     Executing "git rev-parse HEAD" in /tmp/tmp2lozz8aj/OpenSearch
....
[100%] Linking CXX shared library release/libopensearchknn.so
[100%] Built target opensearchknn
+ cd /tmp/tmp2lozz8aj/k-NN
+ cp ./jni/release/libopensearchknn.so ./builds/libs
+ ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=1.2.0-SNAPSHOT -Dbuild.snapshot=true
To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: https://docs.gradle.org/6.6.1/userguide/gradle_daemon.html.
Daemon will be stopped at the end of the build stopping after processing
```

 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
