### PR TITLE
Generalize knn lib install copy

### DIFF
--- a/scripts/components/k-NN/install.sh
+++ b/scripts/components/k-NN/install.sh
@@ -39,4 +39,4 @@ done
 # see https://github.com/opensearch-project/k-NN/issues/80 to make this part of the plugin installer
 echo "Copying libKNN from $ARTIFACTS to $OUTPUT ..."
 mkdir -p "$OUTPUT/plugins/opensearch-knn/knnlib"
-cp "$ARTIFACTS"/libs/libKNN* "$OUTPUT/plugins/opensearch-knn/knnlib"
+cp "$ARTIFACTS"/libs/lib*knn* "$ARTIFACTS"/libs/lib*KNN* "$OUTPUT/plugins/opensearch-knn/knnlib"


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
In the install script, generalize cp to copy any libs with knn or KNN in the title. Recently, the library name was changed from libKNNIndexv2_0_11.so to libopensearchknn.so. To maintain backwards compatibility, we should look for any libraries with "knn" in the name (case insensitive).
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
