### PR TITLE
Future proof install scripts by passing platform and architecture through.

### DIFF
--- a/scripts/components/OpenSearch/install.sh
+++ b/scripts/components/OpenSearch/install.sh
@@ -12,20 +12,41 @@ function usage() {
     echo "Usage: $0 [args]"
     echo ""
     echo "Arguments:"
-    echo -e "-a ARTIFACTS\t[Required] Location of build artifacts."
-    echo -e "-o OUTPUT\t[Required] Output path."
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, default is 'uname -s'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, default is 'uname -m'."
+    echo -e "-f ARTIFACTS\t[Optional] Location of build artifacts."
+    echo -e "-o OUTPUT\t[Optional] Output path."
     echo -e "-h help"
 }
 
-while getopts ":h:a:o:" arg; do
+while getopts ":h:v:s:o:p:a:f:" arg; do
     case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
         o)
             OUTPUT=$OPTARG
             ;;
-        a)
-            ARTIFACTS=$OPTARG
+        p)
+            PLATFORM=$OPTARG
             ;;
-        h)
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        f)
+            ARTIFACTS=$ARTIFACTS
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
             usage
             exit 1
             ;;
@@ -35,6 +56,16 @@ while getopts ":h:a:o:" arg; do
             ;;
     esac
 done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: missing version."
+    usage
+    exit 1
+fi
+
+[ -z "$SNAPSHOT" ] && SNAPSHOT="false"
+[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 ## Copy the tar installation script into the bundle
 (

--- a/scripts/components/k-NN/install.sh
+++ b/scripts/components/k-NN/install.sh
@@ -12,20 +12,41 @@ function usage() {
     echo "Usage: $0 [args]"
     echo ""
     echo "Arguments:"
-    echo -e "-a ARTIFACTS\t[Required] Location of build artifacts."
-    echo -e "-o OUTPUT\t[Required] Output path."
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, default is 'uname -s'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, default is 'uname -m'."
+    echo -e "-f ARTIFACTS\t[Optional] Location of build artifacts."
+    echo -e "-o OUTPUT\t[Optional] Output path."
     echo -e "-h help"
 }
 
-while getopts ":h:a:o:" arg; do
+while getopts ":h:v:s:o:p:a:f:" arg; do
     case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
         o)
             OUTPUT=$OPTARG
             ;;
-        a)
-            ARTIFACTS=$OPTARG
+        p)
+            PLATFORM=$OPTARG
             ;;
-        h)
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        f)
+            ARTIFACTS=$ARTIFACTS
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
             usage
             exit 1
             ;;
@@ -35,6 +56,16 @@ while getopts ":h:a:o:" arg; do
             ;;
     esac
 done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: missing version."
+    usage
+    exit 1
+fi
+
+[ -z "$SNAPSHOT" ] && SNAPSHOT="false"
+[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 # see https://github.com/opensearch-project/k-NN/issues/80 to make this part of the plugin installer
 echo "Copying libKNN from $ARTIFACTS to $OUTPUT ..."

--- a/scripts/default/install.sh
+++ b/scripts/default/install.sh
@@ -12,22 +12,43 @@ function usage() {
     echo "Usage: $0 [args]"
     echo ""
     echo "Arguments:"
-    echo -e "-a ARTIFACTS\t[Required] Location of build artifacts."
-    echo -e "-o OUTPUT\t[Required] Output path."
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, default is 'uname -s'."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, default is 'uname -m'."
+    echo -e "-f ARTIFACTS\t[Optional] Location of build artifacts."
+    echo -e "-o OUTPUT\t[Optional] Output path."
     echo -e "-h help"
 }
 
-while getopts ":h:a:o:" arg; do
+while getopts ":h:v:s:o:p:a:f:" arg; do
     case $arg in
         h)
             usage
             exit 1
             ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
         o)
             OUTPUT=$OPTARG
             ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
         a)
-            ARTIFACTS=$OPTARG
+            ARCHITECTURE=$OPTARG
+            ;;
+        f)
+            ARTIFACTS=$ARTIFACTS
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
             ;;
         ?)
             echo "Invalid option: -${arg}"
@@ -35,3 +56,15 @@ while getopts ":h:a:o:" arg; do
             ;;
     esac
 done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: missing version."
+    usage
+    exit 1
+fi
+
+[ -z "$SNAPSHOT" ] && SNAPSHOT="false"
+[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
+
+exit 0

--- a/src/assemble_workflow/bundle.py
+++ b/src/assemble_workflow/bundle.py
@@ -42,10 +42,27 @@ class Bundle(ABC):
         self.tmp_dir = TemporaryDirectory(keep=keep)
         self.min_dist = self.__get_min_dist(build_manifest.components.values())
         self.installed_plugins = []
+        self.build = build_manifest.build
 
     def install_min(self):
-        post_install_script = ScriptFinder.find_install_script(self.min_dist.name)
-        self._execute(f'bash {post_install_script} -a "{self.artifacts_dir}" -o "{self.min_dist.archive_path}"')
+        install_script = ScriptFinder.find_install_script(self.min_dist.name)
+        install_command = " ".join(
+            [
+                "bash",
+                install_script,
+                "-v",
+                self.build.version,
+                "-p",
+                self.build.platform,
+                "-a",
+                self.build.architecture,
+                "-f",
+                self.artifacts_dir,
+                "-o",
+                self.min_dist.archive_path,
+            ]
+        )
+        self._execute(install_command)
 
     def install_plugins(self):
         for plugin in self.plugins:
@@ -57,8 +74,24 @@ class Bundle(ABC):
 
     @abstractmethod
     def install_plugin(self, plugin):
-        post_install_script = ScriptFinder.find_install_script(plugin.name)
-        self._execute(f'bash {post_install_script} -a "{self.artifacts_dir}" -o "{self.min_dist.archive_path}"')
+        install_script = ScriptFinder.find_install_script(plugin.name)
+        install_command = " ".join(
+            [
+                "bash",
+                install_script,
+                "-v",
+                self.build.version,
+                "-p",
+                self.build.platform,
+                "-a",
+                self.build.architecture,
+                "-f",
+                self.artifacts_dir,
+                "-o",
+                self.min_dist.archive_path,
+            ]
+        )
+        self._execute(install_command)
 
     def package(self, dest):
         self.min_dist.build(self.bundle_recorder.package_name, dest)

--- a/tests/tests_assemble_workflow/test_bundle_opensearch.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch.py
@@ -41,7 +41,19 @@ class TestBundleOpenSearch(unittest.TestCase):
             mock_check_call.assert_has_calls(
                 [
                     call(
-                        f'bash {ScriptFinder.find_install_script("OpenSearch")} -a "{artifacts_path}" -o "{bundle.min_dist.archive_path}"',
+                        " ".join(
+                            [
+                                "bash",
+                                ScriptFinder.find_install_script("OpenSearch"),
+                                "-v 1.1.0",
+                                "-p linux",
+                                "-a x64",
+                                "-f",
+                                artifacts_path,
+                                "-o",
+                                bundle.min_dist.archive_path,
+                            ]
+                        ),
                         cwd=bundle.min_dist.archive_path,
                         shell=True,
                     ),
@@ -85,7 +97,19 @@ class TestBundleOpenSearch(unittest.TestCase):
                             shell=True,
                         ),
                         call(
-                            f'bash {ScriptFinder.find_install_script("opensearch-job-scheduler")} -a "{artifacts_path}" -o "{bundle.min_dist.archive_path}"',
+                            " ".join(
+                                [
+                                    "bash",
+                                    ScriptFinder.find_install_script("opensearch-job-scheduler"),
+                                    "-v 1.1.0",
+                                    "-p linux",
+                                    "-a x64",
+                                    "-f",
+                                    artifacts_path,
+                                    "-o",
+                                    bundle.min_dist.archive_path,
+                                ]
+                            ),
                             cwd=bundle.min_dist.archive_path,
                             shell=True,
                         ),

--- a/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
@@ -38,7 +38,19 @@ class TestBundleOpenSearchDashboards(unittest.TestCase):
             mock_check_call.assert_has_calls(
                 [
                     call(
-                        f'bash {ScriptFinder.find_install_script("OpenSearch-Dashboards")} -a "{artifacts_path}" -o "{bundle.min_dist.archive_path}"',
+                        " ".join(
+                            [
+                                "bash",
+                                ScriptFinder.find_install_script("OpenSearch-Dashboards"),
+                                "-v 1.1.0",
+                                "-p linux",
+                                "-a x64",
+                                "-f",
+                                artifacts_path,
+                                "-o",
+                                bundle.min_dist.archive_path,
+                            ]
+                        ),
                         cwd=bundle.min_dist.archive_path,
                         shell=True,
                     ),
@@ -69,8 +81,19 @@ class TestBundleOpenSearchDashboards(unittest.TestCase):
                             shell=True,
                         ),
                         call(
-                            f'bash {ScriptFinder.find_install_script("alertingDashboards-1.1.0.zip")} -a '
-                            f'"{artifacts_path}" -o "{bundle.min_dist.archive_path}"',
+                            " ".join(
+                                [
+                                    "bash",
+                                    ScriptFinder.find_install_script("alertingDashboards"),
+                                    "-v 1.1.0",
+                                    "-p linux",
+                                    "-a x64",
+                                    "-f",
+                                    artifacts_path,
+                                    "-o",
+                                    bundle.min_dist.archive_path,
+                                ]
+                            ),
                             cwd=bundle.min_dist.archive_path,
                             shell=True,
                         ),


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Change the arguments for install scripts to include platform and architecture <strike>before we spread them in repos</strike>.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
