### PR TITLE
add dashboards functional test repo into 1.2.0 manifest

### DIFF
--- a/src/test_workflow/dependency_installer.py
+++ b/src/test_workflow/dependency_installer.py
@@ -20,26 +20,19 @@ class DependencyInstaller:
     def __init__(self, build):
         self.build_id = build.id
         self.version = build.version
-        self.arch = build.architecture
+        self.platform = build.platform
+        self.architecture = build.architecture
         self.s3_bucket = S3Bucket(self.ARTIFACT_S3_BUCKET)
-        self.s3_maven_location = (
-            f"builds/{self.version}/{self.build_id}/{self.arch}/maven/org/opensearch"
-        )
-        self.s3_build_location = (
-            f"builds/{self.version}/{self.build_id}/{self.arch}/plugins"
-        )
-        self.maven_local_path = os.path.join(
-            os.path.expanduser("~"), ".m2/repository/org/opensearch/"
-        )
+        self.s3_maven_location = f"builds/{self.version}/{self.build_id}/{self.platform}/{self.architecture}/maven/org/opensearch"
+        self.s3_build_location = f"builds/{self.version}/{self.build_id}/{self.platform}/{self.architecture}/plugins"
+        self.maven_local_path = os.path.join(os.path.expanduser("~"), ".m2/repository/org/opensearch/")
 
     def install_all_maven_dependencies(self):
         """
         Downloads all pre-built maven dependencies from S3 bucket
         """
         logging.info("Downloading all pre-built maven dependencies from s3")
-        self.s3_bucket.download_folder(
-            f"{self.s3_maven_location}", self.maven_local_path
-        )
+        self.s3_bucket.download_folder(f"{self.s3_maven_location}", self.maven_local_path)
         logging.info("Successfully downloaded maven dependencies")
 
     def install_build_dependencies(self, dependency_dict, custom_local_path):


### PR DESCRIPTION
### Description
As part of #604, we are gradually moving our POC work https://github.com/tianleh/opensearch-build/tree/add-test-support into the build repository.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/834
 
### Test
Verified that both build and assemble work!

```
./build.sh manifests/1.2.0/opensearch-dashboards-1.2.0.yml

./assemble.sh builds/manifest.yml 

```

Output of build cmd.

```
2021-10-29 07:34:11 INFO     Executing "git fetch --depth 1 origin main" in /tmp/tmpjsbba8gf/functionalTestDashboards
2021-10-29 07:34:13 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmpjsbba8gf/functionalTestDashboards
2021-10-29 07:34:14 INFO     Executing "git rev-parse HEAD" in /tmp/tmpjsbba8gf/functionalTestDashboards
2021-10-29 07:34:14 INFO     Checked out https://github.com/opensearch-project/opensearch-dashboards-functional-test.git@main into /tmp/tmpjsbba8gf/functionalTestDashboards at 16caeb7d21e0295d3ebbf4a3fcc83ba37b81d86e
2021-10-29 07:34:14 INFO     Executing "bash /usr/share/opensearch/workspace/opensearch-build/scripts/components/functionalTestDashboards/build.sh -v 1.2.0 -p linux -a x64 -s false -o builds" in /tmp/tmpjsbba8gf/functionalTestDashboards
2021-10-29 07:34:14 INFO     Created build manifest /usr/share/opensearch/workspace/opensearch-build/builds/manifest.yml
2021-10-29 07:34:20 INFO     Done.
```

The manifest file in the build folder looks like this.

```
build:
  architecture: x64
  id: ab2d9c5e6fb94817843e855f457c4302
  name: OpenSearch Dashboards
  platform: linux
  version: 1.2.0
components:
- artifacts:
    dist:
    - dist/opensearch-dashboards-min-1.2.0-linux-x64.tar.gz
  commit_id: d8d4aee8e437f2a670ce9963c6c4fc7e4bd4750f
  name: OpenSearch-Dashboards
  ref: main
  repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
  version: 1.2.0.0
- artifacts: {}
  commit_id: 16caeb7d21e0295d3ebbf4a3fcc83ba37b81d86e
  name: functionalTestDashboards
  ref: main
  repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
  version: 1.2.0.0
schema-version: '1.2'

```

The output of the assemble cmd.

```
+ getopts :h:a:o: arg
++ dirname /usr/share/opensearch/workspace/opensearch-build/scripts/components/OpenSearch-Dashboards/install.sh
+ DIR=/usr/share/opensearch/workspace/opensearch-build/scripts/components/OpenSearch-Dashboards
+ echo /usr/share/opensearch/workspace/opensearch-build/scripts/components/OpenSearch-Dashboards
/usr/share/opensearch/workspace/opensearch-build/scripts/components/OpenSearch-Dashboards
+ cd /usr/share/opensearch/workspace/opensearch-build/scripts/components/OpenSearch-Dashboards
+ cp ../../../config/opensearch_dashboards.yml /tmp/tmp34iibspj/opensearch-dashboards-1.2.0-linux-x64/config/
2021-10-29 07:37:50 INFO     Installed plugins: []
2021-10-29 07:38:16 INFO     Published /usr/share/opensearch/workspace/opensearch-build/dist/opensearch-dashboards-1.2.0-linux-x64.tar.gz.
2021-10-29 07:38:17 INFO     Done.
```

The manifest in dist folder is

```
build:
  architecture: x64
  id: ab2d9c5e6fb94817843e855f457c4302
  location: /usr/share/opensearch/workspace/opensearch-build/dist/opensearch-dashboards-1.2.0-linux-x64.tar.gz
  name: OpenSearch Dashboards
  platform: linux
  version: 1.2.0
components:
- commit_id: d8d4aee8e437f2a670ce9963c6c4fc7e4bd4750f
  location: /usr/share/opensearch/workspace/opensearch-build/builds/dist/opensearch-dashboards-min-1.2.0-linux-x64.tar.gz
  name: OpenSearch-Dashboards
  ref: main
  repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
schema-version: '1.1'

```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
