### PR TITLE
Update pip in Centos 7 CI Dockerfile

### DIFF
--- a/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
@@ -115,6 +115,7 @@ RUN ln -sfn /usr/local/bin/python3.7 /usr/bin/python3 && \
 
 # Add k-NN Library dependencies
 RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack -y
+RUN pip3 install pip==21.3.1
 RUN pip3 install cmake==3.21.3
 
 # Change User


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
cmake was unable to be installed with pip on centos 7 arm docker image. Following a similar [stackoverflow](https://stackoverflow.com/questions/43452203/error-when-installing-cmake-for-python-windows) thread, upgrading pip to 21.3.1 fixes this issue.

Confirmed image build is working on both x64 and arm.

### Issues Resolved
#824 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
