### PR TITLE
Fix daily manifests workflow.

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -45,6 +45,7 @@ class InputManifests(Manifests):
 
             # check out and build #main, 1.x, etc.
             branches = min_klass.branches()
+
             logging.info(f"Checking {self.name} {branches} branches")
             for branch in branches:
                 c = min_klass.checkout(
@@ -59,7 +60,8 @@ class InputManifests(Manifests):
             if component_klass is not None:
                 # components can increment their own version first without incrementing min
                 manifest = self.latest
-                for component in manifest.components:
+                logging.info(f"Examining components in the latest manifest of {manifest.build.name} ({manifest.build.version})")
+                for component in manifest.components.values():
                     if component.name == self.name:
                         continue
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

The daily manifests workflow, which finds new versions of OpenSearch and OpenSearch Dashboards, has [started failing](https://github.com/opensearch-project/opensearch-build/runs/4062588693?check_suite_focus=true) after https://github.com/opensearch-project/opensearch-build/pull/817 in which `manifest.components` has become a dictionary. It was caught in unit tests because we mock the entire input manifest class.

- Added `.values()` when iterating over components.
- Added a `logging.info` to say which component is being looked at.
- Added a regression test that uses the actual latest OpenSearch manifest.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
