### PR TITLE
Adds index management main to the 1.2 manifest

### DIFF
--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -32,6 +32,12 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
+  - name: index-management
+    repository: https://github.com/opensearch-project/index-management.git
+    ref: "main"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
     ref: "main"

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -71,7 +71,7 @@ class TestInputManifest(unittest.TestCase):
         self.assertEqual(manifest.build.version, "1.2.0")
         self.assertEqual(manifest.ci.image.name, "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028")
         self.assertEqual(manifest.ci.image.args, "-e JAVA_HOME=/usr/lib/jvm/adoptopenjdk-14-hotspot")
-        self.assertEqual(len(manifest.components), 5)
+        self.assertEqual(len(manifest.components), 6)
         self.assertEqual(len(list(manifest.components.select(focus="common-utils"))), 1)
         # opensearch component
         opensearch_component = manifest.components["OpenSearch"]


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

### Description
Adds index management main to the 1.2 build manifest.
 
### Issues Resolved
https://github.com/opensearch-project/index-management/issues/154
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
