### PR TITLE
Refactor components into a subclass.

### DIFF
--- a/src/manifests/build/build_manifest_1_0.py
+++ b/src/manifests/build/build_manifest_1_0.py
@@ -4,7 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from manifests.manifest import Manifest
+from manifests.component_manifest import ComponentManifest
 
 """
 A BuildManifest is an immutable view of the outputs from a build step
@@ -35,9 +35,7 @@ components:
 """
 
 
-class BuildManifest_1_0(Manifest):
-    components: list
-
+class BuildManifest_1_0(ComponentManifest):
     SCHEMA = {
         "build": {
             "required": True,
@@ -77,19 +75,14 @@ class BuildManifest_1_0(Manifest):
 
     def __init__(self, data):
         super().__init__(data)
-
         self.build = self.Build(data["build"])
-        self.components = BuildManifest_1_0.Components(data.get("components", []))
 
     def __to_dict__(self):
         return {"schema-version": "1.0", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
 
-    class Components(dict):
-        def __init__(self, data):
-            super().__init__(map(lambda component: (component["name"], BuildManifest_1_0.Component(component)), data))
-
-        def to_dict(self):
-            return list(map(lambda component: component.__to_dict__(), self.values()))
+    class Components(ComponentManifest.Components):
+        def create(self, data):
+            return BuildManifest_1_0.Component(data)
 
     class Build:
         def __init__(self, data):
@@ -103,12 +96,12 @@ class BuildManifest_1_0(Manifest):
                 "name": self.name,
                 "version": self.version,
                 "architecture": self.architecture,
-                "id": self.id,
+                "id": self.id
             }
 
-    class Component:
+    class Component(ComponentManifest.Component):
         def __init__(self, data):
-            self.name = data["name"]
+            super().__init__(data)
             self.repository = data["repository"]
             self.ref = data["ref"]
             self.commit_id = data["commit_id"]

--- a/src/manifests/build/build_manifest_1_0.py
+++ b/src/manifests/build/build_manifest_1_0.py
@@ -81,7 +81,7 @@ class BuildManifest_1_0(ComponentManifest):
         return {"schema-version": "1.0", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
 
     class Components(ComponentManifest.Components):
-        def create(self, data):
+        def __create(self, data):
             return BuildManifest_1_0.Component(data)
 
     class Build:

--- a/src/manifests/build/build_manifest_1_1.py
+++ b/src/manifests/build/build_manifest_1_1.py
@@ -4,7 +4,7 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from manifests.manifest import Manifest
+from manifests.component_manifest import ComponentManifest
 
 """
 A BuildManifest is an immutable view of the outputs from a build step
@@ -36,9 +36,7 @@ components:
 """
 
 
-class BuildManifest_1_1(Manifest):
-    components: list
-
+class BuildManifest_1_1(ComponentManifest):
     SCHEMA = {
         "build": {
             "required": True,
@@ -78,9 +76,7 @@ class BuildManifest_1_1(Manifest):
 
     def __init__(self, data):
         super().__init__(data)
-
         self.build = self.Build(data["build"])
-        self.components = BuildManifest_1_1.Components(data.get("components", []))
 
     def __to_dict__(self):
         return {"schema-version": "1.1", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
@@ -97,19 +93,16 @@ class BuildManifest_1_1(Manifest):
                 "name": self.name,
                 "version": self.version,
                 "architecture": self.architecture,
-                "id": self.id,
+                "id": self.id
             }
 
-    class Components(dict):
-        def __init__(self, data):
-            super().__init__(map(lambda component: (component["name"], BuildManifest_1_1.Component(component)), data))
+    class Components(ComponentManifest.Components):
+        def create(self, data):
+            return BuildManifest_1_1.Component(data)
 
-        def to_dict(self):
-            return list(map(lambda component: component.__to_dict__(), self.values()))
-
-    class Component:
+    class Component(ComponentManifest.Component):
         def __init__(self, data):
-            self.name = data["name"]
+            super().__init__(data)
             self.repository = data["repository"]
             self.ref = data["ref"]
             self.commit_id = data["commit_id"]

--- a/src/manifests/build/build_manifest_1_1.py
+++ b/src/manifests/build/build_manifest_1_1.py
@@ -97,7 +97,7 @@ class BuildManifest_1_1(ComponentManifest):
             }
 
     class Components(ComponentManifest.Components):
-        def create(self, data):
+        def __create(self, data):
             return BuildManifest_1_1.Component(data)
 
     class Component(ComponentManifest.Component):

--- a/src/manifests/build_manifest.py
+++ b/src/manifests/build_manifest.py
@@ -130,7 +130,7 @@ class BuildManifest(ComponentManifest):
 
     class Components(ComponentManifest.Components):
         @classmethod
-        def create(self, data):
+        def __create(self, data):
             return BuildManifest.Component(data)
 
     class Component(ComponentManifest.Component):

--- a/src/manifests/bundle/bundle_manifest_1_0.py
+++ b/src/manifests/bundle/bundle_manifest_1_0.py
@@ -4,10 +4,10 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from manifests.manifest import Manifest
+from manifests.component_manifest import ComponentManifest
 
 
-class BundleManifest_1_0(Manifest):
+class BundleManifest_1_0(ComponentManifest):
     """
     A BundleManifest is an immutable view of the outputs from a assemble step
     The manifest contains information about the bundle that was built (in the `assemble` section),
@@ -60,14 +60,9 @@ class BundleManifest_1_0(Manifest):
     def __init__(self, data):
         super().__init__(data)
         self.build = self.Build(data["build"])
-        self.components = list(map(lambda entry: self.Component(entry), data["components"]))
 
     def __to_dict__(self):
-        return {
-            "schema-version": "1.0",
-            "build": self.build.__to_dict__(),
-            "components": list(map(lambda component: component.__to_dict__(), self.components)),
-        }
+        return {"schema-version": "1.0", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
 
     class Build:
         def __init__(self, data):
@@ -83,12 +78,16 @@ class BundleManifest_1_0(Manifest):
                 "version": self.version,
                 "architecture": self.architecture,
                 "location": self.location,
-                "id": self.id,
+                "id": self.id
             }
 
-    class Component:
+    class Components(ComponentManifest.Components):
+        def create(self, data):
+            return BundleManifest_1_0.Component(data)
+
+    class Component(ComponentManifest.Component):
         def __init__(self, data):
-            self.name = data["name"]
+            super().__init__(data)
             self.repository = data["repository"]
             self.ref = data["ref"]
             self.commit_id = data["commit_id"]
@@ -100,5 +99,5 @@ class BundleManifest_1_0(Manifest):
                 "repository": self.repository,
                 "ref": self.ref,
                 "commit_id": self.commit_id,
-                "location": self.location,
+                "location": self.location
             }

--- a/src/manifests/bundle/bundle_manifest_1_0.py
+++ b/src/manifests/bundle/bundle_manifest_1_0.py
@@ -82,7 +82,7 @@ class BundleManifest_1_0(ComponentManifest):
             }
 
     class Components(ComponentManifest.Components):
-        def create(self, data):
+        def __create(self, data):
             return BundleManifest_1_0.Component(data)
 
     class Component(ComponentManifest.Component):

--- a/src/manifests/bundle_manifest.py
+++ b/src/manifests/bundle_manifest.py
@@ -114,7 +114,7 @@ class BundleManifest(ComponentManifest):
 
     class Components(ComponentManifest.Components):
         @classmethod
-        def create(self, data):
+        def __create(self, data):
             return BundleManifest.Component(data)
 
     class Component(ComponentManifest.Component):

--- a/src/manifests/bundle_manifest.py
+++ b/src/manifests/bundle_manifest.py
@@ -8,10 +8,10 @@ import os
 
 from aws.s3_bucket import S3Bucket
 from manifests.bundle.bundle_manifest_1_0 import BundleManifest_1_0
-from manifests.manifest import Manifest
+from manifests.component_manifest import ComponentManifest
 
 
-class BundleManifest(Manifest):
+class BundleManifest(ComponentManifest):
     """
     A BundleManifest is an immutable view of the outputs from a assemble step
     The manifest contains information about the bundle that was built (in the `assemble` section),
@@ -66,14 +66,9 @@ class BundleManifest(Manifest):
     def __init__(self, data):
         super().__init__(data)
         self.build = self.Build(data["build"])
-        self.components = list(map(lambda entry: self.Component(entry), data["components"]))
 
     def __to_dict__(self):
-        return {
-            "schema-version": "1.1",
-            "build": self.build.__to_dict__(),
-            "components": list(map(lambda component: component.__to_dict__(), self.components)),
-        }
+        return {"schema-version": "1.1", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
 
     @staticmethod
     def from_s3(bucket_name, build_id, opensearch_version, platform, architecture, work_dir=None):
@@ -117,9 +112,14 @@ class BundleManifest(Manifest):
                 "id": self.id,
             }
 
-    class Component:
+    class Components(ComponentManifest.Components):
+        @classmethod
+        def create(self, data):
+            return BundleManifest.Component(data)
+
+    class Component(ComponentManifest.Component):
         def __init__(self, data):
-            self.name = data["name"]
+            super().__init__(data)
             self.repository = data["repository"]
             self.ref = data["ref"]
             self.commit_id = data["commit_id"]
@@ -131,11 +131,8 @@ class BundleManifest(Manifest):
                 "repository": self.repository,
                 "ref": self.ref,
                 "commit_id": self.commit_id,
-                "location": self.location,
+                "location": self.location
             }
 
 
-BundleManifest.VERSIONS = {
-    "1.0": BundleManifest_1_0,
-    "1.1": BundleManifest
-}
+BundleManifest.VERSIONS = {"1.0": BundleManifest_1_0, "1.1": BundleManifest}

--- a/src/manifests/component_manifest.py
+++ b/src/manifests/component_manifest.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import itertools
+import logging
+
+from manifests.manifest import Manifest
+
+
+class ComponentManifest(Manifest):
+    SCHEMA = {"schema-version": {"required": True, "type": "string", "allowed": ["1.0"]}, "components": {"type": "list"}}
+
+    def __init__(self, data):
+        super().__init__(data)
+
+        self.components = self.Components(data.get("components", []))
+
+    def __to_dict__(self):
+        return {"schema-version": "1.0", "components": self.components.to_dict()}
+
+    class Components(dict):
+        def __init__(self, data):
+            super().__init__(map(lambda component: (component["name"], self.create(component)), data))
+
+        @classmethod
+        def create(data):
+            ComponentManifest.Component(data)
+
+        def to_dict(self):
+            return list(map(lambda component: component.__to_dict__(), self.values()))
+
+        def select(self, focus=None):
+            """
+            Select components.
+
+            :param str focus: Choose one component.
+            :return: Collection of components.
+            :raises ValueError: Invalid platform or component name specified.
+            """
+            selected, it = itertools.tee(filter(lambda component: component.matches(focus), self.values()))
+
+            if not any(it):
+                raise ValueError(f"No components matched focus={focus}.")
+
+            return selected
+
+    class Component:
+        def __init__(self, data):
+            self.name = data["name"]
+
+        def __to_dict__(self):
+            return {"name": self.name}
+
+        def matches(self, focus=None, platform=None):
+            matches = ((not focus) or (self.name == focus)) and ((not platform) or (not self.platforms) or (platform in self.platforms))
+
+            if not matches:
+                logging.info(f"Skipping {self.name}")
+
+            return matches

--- a/src/manifests/component_manifest.py
+++ b/src/manifests/component_manifest.py
@@ -23,7 +23,7 @@ class ComponentManifest(Manifest):
 
     class Components(dict):
         def __init__(self, data):
-            super().__init__(map(lambda component: (component["name"], self.create(component)), data))
+            super().__init__(map(lambda component: (component["name"], self.__create(component)), data))
 
         @classmethod
         def create(data):

--- a/src/manifests/input_manifest.py
+++ b/src/manifests/input_manifest.py
@@ -36,10 +36,10 @@ components:
 import itertools
 import logging
 
-from manifests.manifest import Manifest
+from manifests.component_manifest import ComponentManifest
 
 
-class InputManifest(Manifest):
+class InputManifest(ComponentManifest):
     SCHEMA = {
         "schema-version": {"required": True, "type": "string", "allowed": ["1.0"]},
         "build": {
@@ -48,10 +48,7 @@ class InputManifest(Manifest):
             "schema": {
                 "name": {"required": True, "type": "string"},
                 "version": {"required": True, "type": "string"},
-                "patches": {
-                    "type": "list",
-                    "schema": {"type": "string"},
-                },
+                "patches": {"type": "list", "schema": {"type": "string"}},
             },
         },
         "ci": {
@@ -62,7 +59,7 @@ class InputManifest(Manifest):
                     "required": False,
                     "type": "dict",
                     "schema": {"name": {"required": True, "type": "string"}, "args": {"required": False, "type": "string"}},
-                },
+                }
             },
         },
         "components": {
@@ -76,14 +73,8 @@ class InputManifest(Manifest):
                             "ref": {"required": True, "type": "string"},
                             "repository": {"required": True, "type": "string"},
                             "working_directory": {"type": "string"},
-                            "checks": {
-                                "type": "list",
-                                "schema": {"anyof": [{"type": "string"}, {"type": "dict"}]},
-                            },
-                            "platforms": {
-                                "type": "list",
-                                "schema": {"type": "string", "allowed": ["linux", "windows", "darwin"]},
-                            },
+                            "checks": {"type": "list", "schema": {"anyof": [{"type": "string"}, {"type": "dict"}]}},
+                            "platforms": {"type": "list", "schema": {"type": "string", "allowed": ["linux", "windows", "darwin"]}},
                         },
                     },
                     {
@@ -91,10 +82,7 @@ class InputManifest(Manifest):
                         "schema": {
                             "name": {"required": True, "type": "string"},
                             "dist": {"required": True, "type": "string"},
-                            "platforms": {
-                                "type": "list",
-                                "schema": {"type": "string", "allowed": ["linux", "windows", "darwin"]},
-                            },
+                            "platforms": {"type": "list", "schema": {"type": "string", "allowed": ["linux", "windows", "darwin"]}},
                         },
                     },
                 ]
@@ -130,7 +118,10 @@ class InputManifest(Manifest):
                 self.args = data.get("args", None)
 
             def __to_dict__(self):
-                return {"name": self.name, "args": self.args}
+                return {
+                    "name": self.name,
+                    "args": self.args
+                }
 
     class Build:
         def __init__(self, data):
@@ -139,11 +130,16 @@ class InputManifest(Manifest):
             self.patches = data.get("patches", [])
 
         def __to_dict__(self):
-            return Manifest.compact({"name": self.name, "version": self.version, "patches": self.patches})
+            return {
+                "name": self.name,
+                "version": self.version,
+                "patches": self.patches
+            }
 
-    class Components(dict):
-        def __init__(self, data):
-            super().__init__(map(lambda component: (component["name"], InputManifest.Component._from(component)), data))
+    class Components(ComponentManifest.Components):
+        @classmethod
+        def create(self, data):
+            return InputManifest.Component._from(data)
 
         def select(self, focus=None, platform=None):
             """
@@ -161,16 +157,10 @@ class InputManifest(Manifest):
 
             return selected
 
-        def to_dict(self):
-            return list(map(lambda component: component.__to_dict__(), self.values()))
-
-    class Component:
+    class Component(ComponentManifest.Component):
         def __init__(self, data):
-            self.name = data["name"]
+            super().__init__(data)
             self.platforms = data.get("platforms", None)
-
-        def __to_dict__(self):
-            return Manifest.compact({"name": self.name})
 
         @classmethod
         def _from(self, data):
@@ -198,16 +188,14 @@ class InputManifest(Manifest):
             self.checks = list(map(lambda entry: InputManifest.Check(entry), data.get("checks", [])))
 
         def __to_dict__(self):
-            return Manifest.compact(
-                {
-                    "name": self.name,
-                    "repository": self.repository,
-                    "ref": self.ref,
-                    "working_directory": self.working_directory,
-                    "checks": list(map(lambda check: check.__to_dict__(), self.checks)),
-                    "platforms": self.platforms,
-                }
-            )
+            return {
+                "name": self.name,
+                "repository": self.repository,
+                "ref": self.ref,
+                "working_directory": self.working_directory,
+                "checks": list(map(lambda check: check.__to_dict__(), self.checks)),
+                "platforms": self.platforms,
+            }
 
     class ComponentFromDist(Component):
         def __init__(self, data):
@@ -215,13 +203,11 @@ class InputManifest(Manifest):
             self.dist = data["dist"]
 
         def __to_dict__(self):
-            return Manifest.compact(
-                {
-                    "name": self.name,
-                    "dist": self.dist,
-                    "platforms": self.platforms,
-                }
-            )
+            return {
+                "name": self.name,
+                "dist": self.dist,
+                "platforms": self.platforms
+            }
 
     class Check:
         def __init__(self, data):

--- a/src/manifests/input_manifest.py
+++ b/src/manifests/input_manifest.py
@@ -138,7 +138,7 @@ class InputManifest(ComponentManifest):
 
     class Components(ComponentManifest.Components):
         @classmethod
-        def create(self, data):
+        def __create(self, data):
             return InputManifest.Component._from(data)
 
         def select(self, focus=None, platform=None):

--- a/src/manifests/manifest.py
+++ b/src/manifests/manifest.py
@@ -51,15 +51,17 @@ class Manifest(ABC):
 
     @classmethod
     def compact(cls, d):
-        result = {}
-        for k, v in d.items():
-            if isinstance(v, dict):
-                nested = cls.compact(v)
-                if nested:
-                    result[k] = nested
-            elif v and v != []:
-                result[k] = v
-        return result
+        if isinstance(d, list):
+            return list(map(lambda i: cls.compact(i), d))
+        elif isinstance(d, dict):
+            result = {}
+            for k, v in d.items():
+                v = cls.compact(v)
+                if v and v != []:
+                    result[k] = v
+            return result
+        else:
+            return d
 
     def __to_dict(self):
         return {}

--- a/src/manifests/test_manifest.py
+++ b/src/manifests/test_manifest.py
@@ -66,7 +66,7 @@ class TestManifest(ComponentManifest):
 
     class Components(ComponentManifest.Components):
         @classmethod
-        def create(self, data):
+        def __create(self, data):
             return TestManifest.Component(data)
 
     class Component(ComponentManifest.Component):

--- a/src/manifests/test_manifest.py
+++ b/src/manifests/test_manifest.py
@@ -4,10 +4,10 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from manifests.manifest import Manifest
+from manifests.component_manifest import ComponentManifest
 
 
-class TestManifest(Manifest):
+class TestManifest(ComponentManifest):
     """
     TestManifest contains the test support matrix for any component.
 
@@ -42,30 +42,15 @@ class TestManifest(Manifest):
                         "type": "dict",
                         "schema": {
                             "build-dependencies": {"type": "list"},
-                            "test-configs": {
-                                "type": "list",
-                                "allowed": [
-                                    "with-security",
-                                    "without-security",
-                                ],
-                            },
-                            "additional-cluster-configs": {
-                                "type": "dict",
-                            },
+                            "test-configs": {"type": "list", "allowed": ["with-security", "without-security"]},
+                            "additional-cluster-configs": {"type": "dict"},
                         },
                     },
                     "bwc-test": {
                         "type": "dict",
                         "schema": {
                             "build-dependencies": {"type": "list"},
-                            "test-configs": {
-                                "type": "list",
-                                "allowed": [
-                                    "with-security",
-                                    "without-security",
-                                    "with-less-security",
-                                ],
-                            },
+                            "test-configs": {"type": "list", "allowed": ["with-security", "without-security", "with-less-security"]},
                         },
                     },
                 },
@@ -75,34 +60,31 @@ class TestManifest(Manifest):
 
     def __init__(self, data):
         super().__init__(data)
-        self.components = list(map(lambda entry: self.Component(entry), data["components"]))
 
     def __to_dict__(self):
-        return {
-            "schema-version": "1.0",
-            "components": list(map(lambda component: component.__to_dict__(), self.components)),
-        }
+        return {"schema-version": "1.0", "components": self.components.to_dict()}
 
-    class Component:
+    class Components(ComponentManifest.Components):
+        @classmethod
+        def create(self, data):
+            return TestManifest.Component(data)
+
+    class Component(ComponentManifest.Component):
         def __init__(self, data):
-            self.name = data["name"]
+            super().__init__(data)
             self.working_directory = data.get("working-directory", None)
-            self.integ_test = data["integ-test"]
-            self.bwc_test = data["bwc-test"]
+            self.integ_test = data.get("integ-test", None)
+            self.bwc_test = data.get("bwc-test", None)
 
         def __to_dict__(self):
-            return Manifest.compact(
-                {
-                    "name": self.name,
-                    "working-directory": self.working_directory,
-                    "integ-test": self.integ_test,
-                    "bwc-test": self.bwc_test,
-                }
-            )
+            return {
+                "name": self.name,
+                "working-directory": self.working_directory,
+                "integ-test": self.integ_test,
+                "bwc-test": self.bwc_test
+            }
 
 
-TestManifest.VERSIONS = {
-    "1.0": TestManifest
-}
+TestManifest.VERSIONS = {"1.0": TestManifest}
 
 TestManifest.__test__ = False  # type:ignore

--- a/src/manifests_workflow/component.py
+++ b/src/manifests_workflow/component.py
@@ -26,11 +26,9 @@ class Component:
         return branches
 
     def to_dict(self):
-        return Manifest.compact(
-            {
-                "name": self.name,
-                "repository": self.git_repo.url,
-                "ref": self.git_repo.ref,
-                "checks": self.checks,
-            }
-        )
+        return Manifest.compact({
+            "name": self.name,
+            "repository": self.git_repo.url,
+            "ref": self.git_repo.ref,
+            "checks": self.checks
+        })

--- a/src/run_perf_test.py
+++ b/src/run_perf_test.py
@@ -21,12 +21,7 @@ parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
 parser.add_argument("--bundle-manifest", type=argparse.FileType("r"), help="Bundle Manifest file.")
 parser.add_argument("--stack", dest="stack", help="Stack name for performance test")
 parser.add_argument("--config", type=argparse.FileType("r"), help="Config file.")
-parser.add_argument(
-    "--keep",
-    dest="keep",
-    action="store_true",
-    help="Do not delete the working temporary directory.",
-)
+parser.add_argument("--keep", dest="keep", action="store_true", help="Do not delete the working temporary directory.")
 args = parser.parse_args()
 
 manifest = BundleManifest.from_file(args.bundle_manifest)
@@ -45,15 +40,12 @@ def main():
         current_workspace = os.path.join(work_dir.name, "infra")
         with GitRepository(get_infra_repo_url(), "main", current_workspace):
             security = False
-            for component in manifest.components:
+            for component in manifest.components.values():
                 if component.name == "security":
                     security = True
 
             with WorkingDirectory(current_workspace):
-                with PerfTestCluster.create(manifest, config, args.stack, security, current_workspace) as (
-                    test_cluster_endpoint,
-                    test_cluster_port,
-                ):
+                with PerfTestCluster.create(manifest, config, args.stack, security, current_workspace) as (test_cluster_endpoint, test_cluster_port):
                     perf_test_suite = PerfTestSuite(manifest, test_cluster_endpoint, security, current_workspace)
                     perf_test_suite.execute()
 

--- a/src/test_workflow/bwc_test/bwc_test_suite.py
+++ b/src/test_workflow/bwc_test/bwc_test_suite.py
@@ -44,7 +44,7 @@ class BwcTestSuite:
 
     def execute(self):
         # For each component, check out the git repo and run `bwctest.sh`
-        for component in self.manifest.components:
+        for component in self.manifest.components.values():
             if self.component is None or self.component == component.name:
                 # TODO: Store and report test results, send notification via {console_output}
                 self.component_bwc_tests(component)

--- a/tests/tests_manifests/test_bundle_manifest.py
+++ b/tests/tests_manifests/test_bundle_manifest.py
@@ -30,20 +30,11 @@ class TestBundleManifest(unittest.TestCase):
         self.assertEqual(len(self.manifest.components), 13)
 
     def test_component(self):
-        opensearch_min_component = self.manifest.components[0]
+        opensearch_min_component = self.manifest.components["OpenSearch"]
         self.assertEqual(opensearch_min_component.name, "OpenSearch")
-        self.assertEqual(
-            opensearch_min_component.location,
-            "artifacts/dist/opensearch-min-1.1.0-linux-x64.tar.gz",
-        )
-        self.assertEqual(
-            opensearch_min_component.repository,
-            "https://github.com/opensearch-project/OpenSearch.git",
-        )
-        self.assertEqual(
-            opensearch_min_component.commit_id,
-            "b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583",
-        )
+        self.assertEqual(opensearch_min_component.location, "artifacts/dist/opensearch-min-1.1.0-linux-x64.tar.gz")
+        self.assertEqual(opensearch_min_component.repository, "https://github.com/opensearch-project/OpenSearch.git")
+        self.assertEqual(opensearch_min_component.commit_id, "b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583")
         self.assertEqual(opensearch_min_component.ref, "1.1")
 
     def test_to_dict(self):
@@ -75,19 +66,11 @@ class TestBundleManifest(unittest.TestCase):
     def test_from_s3(self, mock_s3_bucket, *mocks):
         s3_bucket = mock_s3_bucket.return_value
         s3_download_path = BundleManifest.get_bundle_manifest_relative_location(
-            self.manifest.build.id,
-            self.manifest.build.version,
-            self.manifest.build.platform,
-            self.manifest.build.architecture,
+            self.manifest.build.id, self.manifest.build.version, self.manifest.build.platform, self.manifest.build.architecture
         )
         dest = os.path.realpath(os.path.join(tempfile.gettempdir(), "xyz"))
         BundleManifest.from_s3(
-            "bucket_name",
-            self.manifest.build.id,
-            self.manifest.build.version,
-            self.manifest.build.platform,
-            self.manifest.build.architecture,
-            dest,
+            "bucket_name", self.manifest.build.id, self.manifest.build.version, self.manifest.build.platform, self.manifest.build.architecture, dest
         )
         self.assertEqual(s3_bucket.download_file.call_count, 1)
         s3_bucket.download_file.assert_called_with(s3_download_path, dest)
@@ -96,9 +79,5 @@ class TestBundleManifest(unittest.TestCase):
     def test_versions(self):
         self.assertTrue(len(BundleManifest.VERSIONS))
         for version in BundleManifest.VERSIONS:
-            manifest = BundleManifest.from_path(
-                os.path.join(
-                    self.data_path, "bundle", f"opensearch-bundle-schema-version-{version}.yml"
-                )
-            )
+            manifest = BundleManifest.from_path(os.path.join(self.data_path, "bundle", f"opensearch-bundle-schema-version-{version}.yml"))
             self.assertEqual(version, manifest.version)

--- a/tests/tests_manifests/test_component_manifest.py
+++ b/tests/tests_manifests/test_component_manifest.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from abc import abstractmethod
+
+from manifests.component_manifest import ComponentManifest
+
+
+class TestComponentManifest(unittest.TestCase):
+    class UnitTestManifest(ComponentManifest):
+        class Components(ComponentManifest.Components):
+            @abstractmethod
+            def create(self, data):
+                return TestComponentManifest.UnitTestManifest.Component(data)
+
+        class Component(ComponentManifest.Component):
+            pass
+
+    def test_select(self):
+        manifest = TestComponentManifest.UnitTestManifest({
+            "schema-version": "1.0",
+            "components": [
+                {"name": "one"},
+                {"name": "two"}
+            ]
+        })
+
+        self.assertEqual(len(list(manifest.components.select(focus=None))), 2)
+        self.assertEqual(len(list(manifest.components.select(focus="one"))), 1)
+        self.assertEqual(next(manifest.components.select(focus="two")).name, "two")

--- a/tests/tests_manifests/test_component_manifest.py
+++ b/tests/tests_manifests/test_component_manifest.py
@@ -14,7 +14,7 @@ class TestComponentManifest(unittest.TestCase):
     class UnitTestManifest(ComponentManifest):
         class Components(ComponentManifest.Components):
             @abstractmethod
-            def create(self, data):
+            def __create(self, data):
                 return TestComponentManifest.UnitTestManifest.Component(data)
 
         class Component(ComponentManifest.Component):

--- a/tests/tests_manifests/test_test_manifest.py
+++ b/tests/tests_manifests/test_test_manifest.py
@@ -20,21 +20,13 @@ class TestTestManifest(unittest.TestCase):
         self.manifest = TestManifest.from_path(self.manifest_filename)
 
     def test_component(self):
-        component = self.manifest.components[0]
+        component = self.manifest.components["index-management"]
         self.assertEqual(component.name, "index-management")
-        self.assertEqual(
-            component.integ_test,
-            {
-                "test-configs": [
-                    "with-security",
-                    "without-security",
-                ],
-            },
-        )
+        self.assertEqual(component.integ_test, {"test-configs": ["with-security", "without-security"]})
         self.assertEqual(component.bwc_test, {"test-configs": ["with-security", "without-security"]})
 
     def test_component_with_working_directory(self):
-        component = self.manifest.components[1]
+        component = self.manifest.components["dashboards-reports"]
         self.assertEqual(component.name, "dashboards-reports")
         self.assertEqual(component.working_directory, "reports-scheduler")
         self.assertEqual(component.integ_test, {"test-configs": ["without-security"]})
@@ -48,9 +40,5 @@ class TestTestManifest(unittest.TestCase):
     def test_versions(self):
         self.assertTrue(len(TestManifest.VERSIONS))
         for version in TestManifest.VERSIONS:
-            manifest = TestManifest.from_path(
-                os.path.join(
-                    self.data_path, "test", f"opensearch-test-schema-version-{version}.yml"
-                )
-            )
+            manifest = TestManifest.from_path(os.path.join(self.data_path, "test", f"opensearch-test-schema-version-{version}.yml"))
             self.assertEqual(version, manifest.version)

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_bwc_suite.py
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_bwc_suite.py
@@ -21,7 +21,7 @@ class TestBwcSuite(unittest.TestCase):
 
     def test_execute(self):
         expected = []
-        for component in self.manifest.components:
+        for component in self.manifest.components.values():
             expected.append(call(component))
         self.bwc_test_suite.component_bwc_tests = MagicMock()
         self.bwc_test_suite.execute()
@@ -29,21 +29,16 @@ class TestBwcSuite(unittest.TestCase):
 
     @patch("test_workflow.bwc_test.bwc_test_suite.execute")
     def test_run_bwctest(self, mock_execute):
-        mock_execute.return_value = (0, '', '')
-        self.bwc_test_suite.run_tests(".", self.manifest.components[1].name)
-        script = os.path.join(ScriptFinder.default_scripts_path, 'bwctest.sh')
-        mock_execute.assert_called_with(script, '.', True, False)
+        mock_execute.return_value = (0, "", "")
+        self.bwc_test_suite.run_tests(".", "OpenSearch")
+        script = os.path.join(ScriptFinder.default_scripts_path, "bwctest.sh")
+        mock_execute.assert_called_with(script, ".", True, False)
 
     @patch("test_workflow.bwc_test.bwc_test_suite.TestComponent")
     def test_component_bwctest(self, test_component_mock):
-        component = self.manifest.components[1]
+        component = self.manifest.components["OpenSearch"]
         self.bwc_test_suite.run_tests = MagicMock()
-        expected = [
-            call(
-                os.path.join(".", self.manifest.components[1].name),
-                self.manifest.components[1].name,
-            )
-        ]
+        expected = [call(os.path.join(".", component.name), component.name)]
 
         self.bwc_test_suite.component_bwc_tests(component)
         test_component_mock.return_value.checkout.assert_called_with(os.path.join(".", component.name))


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Refactor a collection of components into a `Components` and `ComponentsManifest` base classes and use it everywhere. Makes it a lot easier to make a manifest with components that can be selected based on input options.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
