### PR TITLE
Add collapsed usage guide into the release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -8,6 +8,23 @@ labels: untriaged, release, v{{ env.VERSION }}
 
 I noticed that a manifest was automatically created in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}). Please follow the following checklist to make a release.
 
+<details><summary>How to use this issue</summary>
+<p>
+
+## This Release Issue
+This issue captures the state of the OpenSearch release, its assignee is responsible for driving the release.  Please contact them or @mention them on this issue for help.  There are linked issues on components of the release where individual components can be tracked.
+
+## Release Steps
+There are several steps to the release process, these steps are completed as the whole release and components that are behind present risk to the release.  The release owner completes the tasks in this ticket, whereas component owners resolve tasks on their ticket in their repositories.
+
+Steps have completion dates for coordinating efforts between the components of a release; components can start as soon as they are ready far in advance of a future release.
+
+### Component List
+To aid in understanding the state of the release there is a table with status indicating each component state.  This is updated based on the status of the component issues.
+
+</p>
+</details>
+
 ### Preparation
 
 - [ ] Assign this issue to a release owner.


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
![image](https://user-images.githubusercontent.com/2754967/139959205-dbf491f2-590b-4d42-a3c3-6de5241288c2.png) 
See https://github.com/opensearch-project/opensearch-build/issues/567 for this guide in action

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
