### PR TITLE
Revert #854 (asynchronous search) until #864 is fixed, update OpenSearch branch.

### DIFF
--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -26,12 +26,6 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
-  - name: asynchronous-search
-    repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: "main"
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
     ref: "main"

--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -10,7 +10,7 @@ build:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: "1.x"
+    ref: "1.2"
     checks:
       - gradle:publish
       - gradle:properties:version

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -78,7 +78,7 @@ class TestInputManifest(unittest.TestCase):
             opensearch_component.repository,
             "https://github.com/opensearch-project/OpenSearch.git",
         )
-        self.assertEqual(opensearch_component.ref, "1.x")
+        self.assertEqual(opensearch_component.ref, "1.2")
         # components
         for component in manifest.components.values():
             self.assertIsInstance(component.ref, str)


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I propose we remove asynchronous-search to unblock builds until #864 is fixed. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
