### PR TITLE
Small bookkeeping

### DIFF
--- a/src/manifests/build/build_manifest_1_0.py
+++ b/src/manifests/build/build_manifest_1_0.py
@@ -78,7 +78,11 @@ class BuildManifest_1_0(ComponentManifest):
         self.build = self.Build(data["build"])
 
     def __to_dict__(self):
-        return {"schema-version": "1.0", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
+        return {
+            "schema-version": "1.0",
+            "build": self.build.__to_dict__(),
+            "components": self.components.to_dict()
+        }
 
     class Components(ComponentManifest.Components):
         def __create(self, data):

--- a/src/manifests/build/build_manifest_1_0.py
+++ b/src/manifests/build/build_manifest_1_0.py
@@ -81,11 +81,11 @@ class BuildManifest_1_0(ComponentManifest):
         return {
             "schema-version": "1.0",
             "build": self.build.__to_dict__(),
-            "components": self.components.to_dict()
+            "components": self.components.__to_dict__()
         }
 
     class Components(ComponentManifest.Components):
-        def __create(self, data):
+        def __create__(self, data):
             return BuildManifest_1_0.Component(data)
 
     class Build:

--- a/src/manifests/build/build_manifest_1_1.py
+++ b/src/manifests/build/build_manifest_1_1.py
@@ -82,7 +82,7 @@ class BuildManifest_1_1(ComponentManifest):
         return {
             "schema-version": "1.1",
             "build": self.build.__to_dict__(),
-            "components": self.components.to_dict()
+            "components": self.components.__to_dict__()
         }
 
     class Build:
@@ -101,7 +101,7 @@ class BuildManifest_1_1(ComponentManifest):
             }
 
     class Components(ComponentManifest.Components):
-        def __create(self, data):
+        def __create__(self, data):
             return BuildManifest_1_1.Component(data)
 
     class Component(ComponentManifest.Component):

--- a/src/manifests/build/build_manifest_1_1.py
+++ b/src/manifests/build/build_manifest_1_1.py
@@ -79,7 +79,11 @@ class BuildManifest_1_1(ComponentManifest):
         self.build = self.Build(data["build"])
 
     def __to_dict__(self):
-        return {"schema-version": "1.1", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
+        return {
+            "schema-version": "1.1",
+            "build": self.build.__to_dict__(),
+            "components": self.components.to_dict()
+        }
 
     class Build:
         def __init__(self, data):

--- a/src/manifests/build_manifest.py
+++ b/src/manifests/build_manifest.py
@@ -91,11 +91,14 @@ class BuildManifest(ComponentManifest):
 
     def __init__(self, data):
         super().__init__(data)
-
         self.build = self.Build(data["build"])
 
     def __to_dict__(self):
-        return {"schema-version": "1.2", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
+        return {
+            "schema-version": "1.2",
+            "build": self.build.__to_dict__(),
+            "components": self.components.to_dict()
+        }
 
     @staticmethod
     def get_build_manifest_relative_location(build_id, opensearch_version, platform, architecture):

--- a/src/manifests/build_manifest.py
+++ b/src/manifests/build_manifest.py
@@ -97,7 +97,7 @@ class BuildManifest(ComponentManifest):
         return {
             "schema-version": "1.2",
             "build": self.build.__to_dict__(),
-            "components": self.components.to_dict()
+            "components": self.components.__to_dict__()
         }
 
     @staticmethod
@@ -133,7 +133,7 @@ class BuildManifest(ComponentManifest):
 
     class Components(ComponentManifest.Components):
         @classmethod
-        def __create(self, data):
+        def __create__(self, data):
             return BuildManifest.Component(data)
 
     class Component(ComponentManifest.Component):

--- a/src/manifests/bundle/bundle_manifest_1_0.py
+++ b/src/manifests/bundle/bundle_manifest_1_0.py
@@ -62,7 +62,11 @@ class BundleManifest_1_0(ComponentManifest):
         self.build = self.Build(data["build"])
 
     def __to_dict__(self):
-        return {"schema-version": "1.0", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
+        return {
+            "schema-version": "1.0",
+            "build": self.build.__to_dict__(),
+            "components": self.components.to_dict()
+        }
 
     class Build:
         def __init__(self, data):

--- a/src/manifests/bundle/bundle_manifest_1_0.py
+++ b/src/manifests/bundle/bundle_manifest_1_0.py
@@ -65,7 +65,7 @@ class BundleManifest_1_0(ComponentManifest):
         return {
             "schema-version": "1.0",
             "build": self.build.__to_dict__(),
-            "components": self.components.to_dict()
+            "components": self.components.__to_dict__()
         }
 
     class Build:
@@ -86,7 +86,7 @@ class BundleManifest_1_0(ComponentManifest):
             }
 
     class Components(ComponentManifest.Components):
-        def __create(self, data):
+        def __create__(self, data):
             return BundleManifest_1_0.Component(data)
 
     class Component(ComponentManifest.Component):

--- a/src/manifests/bundle_manifest.py
+++ b/src/manifests/bundle_manifest.py
@@ -71,7 +71,7 @@ class BundleManifest(ComponentManifest):
         return {
             "schema-version": "1.1",
             "build": self.build.__to_dict__(),
-            "components": self.components.to_dict()
+            "components": self.components.__to_dict__()
         }
 
     @staticmethod
@@ -118,7 +118,7 @@ class BundleManifest(ComponentManifest):
 
     class Components(ComponentManifest.Components):
         @classmethod
-        def __create(self, data):
+        def __create__(self, data):
             return BundleManifest.Component(data)
 
     class Component(ComponentManifest.Component):

--- a/src/manifests/bundle_manifest.py
+++ b/src/manifests/bundle_manifest.py
@@ -68,7 +68,11 @@ class BundleManifest(ComponentManifest):
         self.build = self.Build(data["build"])
 
     def __to_dict__(self):
-        return {"schema-version": "1.1", "build": self.build.__to_dict__(), "components": self.components.to_dict()}
+        return {
+            "schema-version": "1.1",
+            "build": self.build.__to_dict__(),
+            "components": self.components.to_dict()
+        }
 
     @staticmethod
     def from_s3(bucket_name, build_id, opensearch_version, platform, architecture, work_dir=None):

--- a/src/manifests/component_manifest.py
+++ b/src/manifests/component_manifest.py
@@ -11,7 +11,14 @@ from manifests.manifest import Manifest
 
 
 class ComponentManifest(Manifest):
-    SCHEMA = {"schema-version": {"required": True, "type": "string", "allowed": ["1.0"]}, "components": {"type": "list"}}
+    SCHEMA = {
+        "schema-version": {
+            "required": True, "type": "string", "allowed": ["1.0"]
+        },
+        "components": {
+            "type": "list"
+        }
+    }
 
     def __init__(self, data):
         super().__init__(data)
@@ -19,7 +26,10 @@ class ComponentManifest(Manifest):
         self.components = self.Components(data.get("components", []))
 
     def __to_dict__(self):
-        return {"schema-version": "1.0", "components": self.components.to_dict()}
+        return {
+            "schema-version": "1.0",
+            "components": self.components.to_dict()
+        }
 
     class Components(dict):
         def __init__(self, data):

--- a/src/manifests/component_manifest.py
+++ b/src/manifests/component_manifest.py
@@ -28,18 +28,18 @@ class ComponentManifest(Manifest):
     def __to_dict__(self):
         return {
             "schema-version": "1.0",
-            "components": self.components.to_dict()
+            "components": self.components.__to_dict__()
         }
 
     class Components(dict):
         def __init__(self, data):
-            super().__init__(map(lambda component: (component["name"], self.__create(component)), data))
+            super().__init__(map(lambda component: (component["name"], self.__create__(component)), data))
 
         @classmethod
-        def create(data):
+        def __create__(data):
             ComponentManifest.Component(data)
 
-        def to_dict(self):
+        def __to_dict__(self):
             return list(map(lambda component: component.__to_dict__(), self.values()))
 
         def select(self, focus=None):
@@ -50,7 +50,7 @@ class ComponentManifest(Manifest):
             :return: Collection of components.
             :raises ValueError: Invalid platform or component name specified.
             """
-            selected, it = itertools.tee(filter(lambda component: component.matches(focus), self.values()))
+            selected, it = itertools.tee(filter(lambda component: component.__matches__(focus), self.values()))
 
             if not any(it):
                 raise ValueError(f"No components matched focus={focus}.")
@@ -64,7 +64,7 @@ class ComponentManifest(Manifest):
         def __to_dict__(self):
             return {"name": self.name}
 
-        def matches(self, focus=None, platform=None):
+        def __matches__(self, focus=None, platform=None):
             matches = ((not focus) or (self.name == focus)) and ((not platform) or (not self.platforms) or (platform in self.platforms))
 
             if not matches:

--- a/src/manifests/input_manifest.py
+++ b/src/manifests/input_manifest.py
@@ -102,7 +102,7 @@ class InputManifest(ComponentManifest):
             "schema-version": "1.0",
             "build": self.build.__to_dict__(),
             "ci": None if self.ci is None else self.ci.__to_dict__(),
-            "components": self.components.to_dict(),
+            "components": self.components.__to_dict__(),
         }
 
     class Ci:
@@ -138,7 +138,7 @@ class InputManifest(ComponentManifest):
 
     class Components(ComponentManifest.Components):
         @classmethod
-        def __create(self, data):
+        def __create__(self, data):
             return InputManifest.Component._from(data)
 
         def select(self, focus=None, platform=None):
@@ -150,7 +150,7 @@ class InputManifest(ComponentManifest):
             :return: Collection of components.
             :raises ValueError: Invalid platform or component name specified.
             """
-            selected, it = itertools.tee(filter(lambda component: component.matches(focus, platform), self.values()))
+            selected, it = itertools.tee(filter(lambda component: component.__matches__(focus, platform), self.values()))
 
             if not any(it):
                 raise ValueError(f"No components matched focus={focus}, platform={platform}.")
@@ -171,7 +171,7 @@ class InputManifest(ComponentManifest):
             else:
                 raise ValueError(f"Invalid component data: {data}")
 
-        def matches(self, focus=None, platform=None):
+        def __matches__(self, focus=None, platform=None):
             matches = ((not focus) or (self.name == focus)) and ((not platform) or (not self.platforms) or (platform in self.platforms))
 
             if not matches:

--- a/src/manifests/manifest.py
+++ b/src/manifests/manifest.py
@@ -62,7 +62,7 @@ class Manifest(ABC):
             result = {}
             for k, v in d.items():
                 v = cls.compact(v)
-                if v and v != []:
+                if v:
                     result[k] = v
             return result
         else:

--- a/src/manifests/manifest.py
+++ b/src/manifests/manifest.py
@@ -13,7 +13,12 @@ from cerberus import Validator  # type:ignore
 
 
 class Manifest(ABC):
-    SCHEMA = {"schema-version": {"required": True, "type": "string", "empty": False}}
+    SCHEMA = {
+        "schema-version": {
+            "required": True, "type": "string", "empty": False
+        }
+    }
+
     VERSIONS: Optional[Dict] = None
 
     @classmethod

--- a/src/manifests/test_manifest.py
+++ b/src/manifests/test_manifest.py
@@ -62,7 +62,10 @@ class TestManifest(ComponentManifest):
         super().__init__(data)
 
     def __to_dict__(self):
-        return {"schema-version": "1.0", "components": self.components.to_dict()}
+        return {
+            "schema-version": "1.0",
+            "components": self.components.to_dict()
+        }
 
     class Components(ComponentManifest.Components):
         @classmethod

--- a/src/manifests/test_manifest.py
+++ b/src/manifests/test_manifest.py
@@ -64,12 +64,12 @@ class TestManifest(ComponentManifest):
     def __to_dict__(self):
         return {
             "schema-version": "1.0",
-            "components": self.components.to_dict()
+            "components": self.components.__to_dict__()
         }
 
     class Components(ComponentManifest.Components):
         @classmethod
-        def __create(self, data):
+        def __create__(self, data):
             return TestManifest.Component(data)
 
     class Component(ComponentManifest.Component):

--- a/src/test_workflow/bwc_test/bwc_test_suite.py
+++ b/src/test_workflow/bwc_test/bwc_test_suite.py
@@ -44,7 +44,6 @@ class BwcTestSuite:
 
     def execute(self):
         # For each component, check out the git repo and run `bwctest.sh`
-        for component in self.manifest.components.values():
-            if self.component is None or self.component == component.name:
-                # TODO: Store and report test results, send notification via {console_output}
-                self.component_bwc_tests(component)
+        for component in self.manifest.components.select(focus=self.component):
+            # TODO: Store and report test results, send notification via {console_output}
+            self.component_bwc_tests(component)

--- a/test.sh
+++ b/test.sh
@@ -19,7 +19,7 @@ case $1 in
   "$DIR/run.sh" "$DIR/src/run_bwc_test.py" "${@:2}"
   ;;
   *)
-  echo "Invalid Test suite"
+  echo "Invalid test suite, run ./test.sh integ-test|bwc-test."
   exit 1
   ;;
 esac

--- a/tests/tests_manifests/test_build_manifest.py
+++ b/tests/tests_manifests/test_build_manifest.py
@@ -105,10 +105,10 @@ class TestBuildManifest(unittest.TestCase):
         self.assertEqual(str(ctx.exception), "No components matched focus=x.")
 
     def test_component_matches(self):
-        self.assertTrue(BuildManifest.Component({"name": "x", "repository": "", "ref": "", "commit_id": "", "version": ""}).matches())
+        self.assertTrue(BuildManifest.Component({"name": "x", "repository": "", "ref": "", "commit_id": "", "version": ""}).__matches__())
 
     def test_component_matches_focus(self):
         component = BuildManifest.Component({"name": "x", "repository": "", "ref": "", "commit_id": "", "version": ""})
-        self.assertTrue(component.matches(focus=None))
-        self.assertTrue(component.matches(focus="x"))
-        self.assertFalse(component.matches(focus="y"))
+        self.assertTrue(component.__matches__(focus=None))
+        self.assertTrue(component.__matches__(focus="x"))
+        self.assertFalse(component.__matches__(focus="y"))

--- a/tests/tests_manifests/test_component_manifest.py
+++ b/tests/tests_manifests/test_component_manifest.py
@@ -14,7 +14,7 @@ class TestComponentManifest(unittest.TestCase):
     class UnitTestManifest(ComponentManifest):
         class Components(ComponentManifest.Components):
             @abstractmethod
-            def __create(self, data):
+            def __create__(self, data):
                 return TestComponentManifest.UnitTestManifest.Component(data)
 
         class Component(ComponentManifest.Component):

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -120,19 +120,19 @@ class TestInputManifest(unittest.TestCase):
             self.assertEqual(len(list(manifest.components.select(focus="k-NN", platform="windows"))), 0)
         self.assertEqual(str(ctx.exception), "No components matched focus=k-NN, platform=windows.")
 
-    def test_component_matches(self):
-        self.assertTrue(InputManifest.Component({"name": "x", "repository": "", "ref": ""}).matches())
+    def test_component___matches__(self):
+        self.assertTrue(InputManifest.Component({"name": "x", "repository": "", "ref": ""}).__matches__())
 
-    def test_component_matches_platform(self):
+    def test_component___matches_platform__(self):
         data = {"name": "x", "repository": "", "ref": ""}
-        self.assertTrue(InputManifest.Component(data).matches(platform=None))
-        self.assertTrue(InputManifest.Component(data).matches(platform="x"))
-        self.assertTrue(InputManifest.Component({**data, "platforms": ["linux"]}).matches(platform="linux"))
-        self.assertTrue(InputManifest.Component({**data, "platforms": ["linux", "windows"]}).matches(platform="linux"))
-        self.assertFalse(InputManifest.Component({**data, "platforms": ["linux"]}).matches(platform="x"))
+        self.assertTrue(InputManifest.Component(data).__matches__(platform=None))
+        self.assertTrue(InputManifest.Component(data).__matches__(platform="x"))
+        self.assertTrue(InputManifest.Component({**data, "platforms": ["linux"]}).__matches__(platform="linux"))
+        self.assertTrue(InputManifest.Component({**data, "platforms": ["linux", "windows"]}).__matches__(platform="linux"))
+        self.assertFalse(InputManifest.Component({**data, "platforms": ["linux"]}).__matches__(platform="x"))
 
-    def test_component_matches_focus(self):
+    def test_component___matches_focus__(self):
         component = InputManifest.Component({"name": "x", "repository": "", "ref": ""})
-        self.assertTrue(component.matches(focus=None))
-        self.assertTrue(component.matches(focus="x"))
-        self.assertFalse(component.matches(focus="y"))
+        self.assertTrue(component.__matches__(focus=None))
+        self.assertTrue(component.__matches__(focus="x"))
+        self.assertFalse(component.__matches__(focus="y"))


### PR DESCRIPTION
### Description

- Fixup method names that don't need to be public.
- Avoid calling `.to_dict` that calls `Manifest.compact` within another `.to_dict` call, replace `components.to_dict` by `components.__to_dict__`.
- Simplify integ-test runner, use `components.select` where available and get rid of an extra configuration dictionary that is confusing.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
