### PR TITLE
Update ld_library_path for k-NN in release Dockerfile

### DIFF
--- a/docker/release/dockerfiles/opensearch.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2.dockerfile
@@ -83,8 +83,8 @@ WORKDIR $OPENSEARCH_HOME
 # Set $JAVA_HOME
 RUN echo "export JAVA_HOME=$OPENSEARCH_HOME/jdk" >> /etc/profile.d/java_home.sh
 
-# Copy KNN Lib
-RUN cp -v plugins/opensearch-knn/knnlib/lib*.so /usr/lib
+# Add k-NN lib directory to library loading path variable
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENSEARCH_HOME/plugins/opensearch-knn/knnlib"
 
 # Change user
 USER $UID


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
For k-NN, we needed to package a dependency to openmp in knnlib build directory. This currently works for the tar  install because we [set](https://github.com/opensearch-project/opensearch-build/blob/main/scripts/legacy/tar/linux/opensearch-tar-install.sh#L65) `LD_LIBRARY_PATH` env variable to `plugins/opensearch-knn/knnlib`.

However, this does not work for the release docker image because instead of setting `LD_LIBRARY_PATH`, we copy the lib to /usr/lib. My first attempts to fix this tried to generalize this copy statement to also copy the libomp to /usr/lib. However, this was not working. On x64, it was only looking for the libomp in /usr/lib64 and on arm it was looking for k-NN lib only in /usr/lib.

To simplify, I decided to just replace copy with env set (as is done in the tar install).
 
To test, I built the image on AL2 arm64/x64 machines with:
```
./build-image-single-arch.sh -v 1.2.0 -f ./dockerfiles/opensearch.al2.dockerfile -p opensearch -a  x64 -t opensearch-1.2.0-linux-x64.tar.gz

Step 20/30 : RUN echo "export JAVA_HOME=$OPENSEARCH_HOME/jdk" >> /etc/profile.d/java_home.sh
 ---> Running in daa3e1307696
Removing intermediate container daa3e1307696
 ---> 29b77b9a68a0
Step 21/30 : ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENSEARCH_HOME/plugins/opensearch-knn/knnlib"
 ---> Running in 2f5312236439
Removing intermediate container 2f5312236439
 ---> f8c0b2868d59
Step 22/30 : USER $UID
 ---> Running in aa426ef800aa
Removing intermediate container aa426ef800aa

sudo ./build-image-single-arch.sh -v 1.2.0 -f ./dockerfiles/opensearch.al2.dockerfile -p opensearch -a arm64 -t opensearch-1.2.0-linux-arm64.tar.gz

Step 20/30 : RUN echo "export JAVA_HOME=$OPENSEARCH_HOME/jdk" >> /etc/profile.d/java_home.sh
 ---> Running in 9d816ef75478
Removing intermediate container 9d816ef75478
 ---> af86fcd17db1
Step 21/30 : ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENSEARCH_HOME/plugins/opensearch-knn/knnlib"
 ---> Running in 796dee275ca4
Removing intermediate container 796dee275ca4
 ---> 8694b2004df3
Step 22/30 : USER $UID
 ---> Running in b7f15fa57fb0
Removing intermediate container b7f15fa57fb0
```

I then created a bash session container with the images, ran opensearch-docker-entrypoint.sh, and confirmed knn libs load as expected when knn workload was run. Note - I was running into unrelated problems with security/perf analyzer, so I disabled them in my test.

The tars I used came from build 867, which incorporated https://github.com/opensearch-project/k-NN/pull/175.

### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/174
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
