### PR TITLE
[Jenkins] update docker image for dashboards

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
             agent {
                 docker {
                     label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
-                    image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdk14-node10.24.1-cypress6.9.1-20211005'
+                    image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028'
                     alwaysPull true
                 }
             }

--- a/tests/test_run_manifests.py
+++ b/tests/test_run_manifests.py
@@ -32,12 +32,17 @@ class TestRunManifests(unittest.TestCase):
 
         mock_logging.info.assert_has_calls(
             [
-                call("OpenSearch 1.0.0"),
-                call("OpenSearch 1.0.1"),
-                call("OpenSearch 1.1.0"),
-                call("OpenSearch 1.1.1"),
-                call("OpenSearch 1.2.0"),
-                call("OpenSearch 2.0.0"),
+                call('OpenSearch 1.0.0'),
+                call('OpenSearch 1.0.1'),
+                call('OpenSearch 1.1.0'),
+                call('OpenSearch 1.1.1'),
+                call('OpenSearch 1.2.0'),
+                call('OpenSearch 1.3.0'),
+                call('OpenSearch 2.0.0'),
+                call('OpenSearch Dashboards 1.0.1'),
+                call('OpenSearch Dashboards 1.1.0'),
+                call('OpenSearch Dashboards 1.2.0'),
+                call('Done.'),
             ]
         )
 


### PR DESCRIPTION
### Description
Build was breaking. Update docker image for OpenSearch Dashboards like how OpenSearch was updated here: https://github.com/opensearch-project/opensearch-build/pull/832. Also updated the broken unit test.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
