### PR TITLE
Lock 1.1.0 manifest with tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -66,6 +66,7 @@ __Replace with OpenSearch wide initiatives to improve quality and consistency.__
 ### Post Release
 
 - [ ] Create [release tags](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging) for each component.
+- [ ] Replace refs in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}) with tags.
 - [ ] Update [this template](./release_template.md) with any new or missed steps.
 - [ ] Conduct a postmortem, and publish its results.
 

--- a/manifests/1.1.0/opensearch-1.1.0.yml
+++ b/manifests/1.1.0/opensearch-1.1.0.yml
@@ -6,51 +6,51 @@ build:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: "1.1"
+    ref: 1.1.0
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: "1.1"
+    ref: 1.1.0.0
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:properties:version    
       - gradle:dependencies:opensearch.version
   - name: performance-analyzer-rca
     repository: https://github.com/opensearch-project/performance-analyzer-rca.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:properties:version
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -59,13 +59,13 @@ components:
       - linux
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -74,26 +74,26 @@ components:
       - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: "1.1"
+    ref: 1.1.0.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: "1.1"
+    ref: 1.1.0.0
     working_directory: "reports-scheduler"
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: dashboards-notebooks
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-    ref: "1.1"
+    ref: 1.1.0.0
     working_directory: "opensearch-notebooks"
     checks:
       - gradle:properties:version

--- a/tests/test_run_checkout.py
+++ b/tests/test_run_checkout.py
@@ -43,19 +43,19 @@ class TestRunCheckout(unittest.TestCase):
             [
                 call(
                     "https://github.com/opensearch-project/OpenSearch.git",
-                    "1.1",
+                    "1.1.0",
                     os.path.join(tempfile.gettempdir(), "OpenSearch"),
                     None,
                 ),
                 call(
                     "https://github.com/opensearch-project/common-utils.git",
-                    "1.1",
+                    "1.1.0.0",
                     os.path.join(tempfile.gettempdir(), "common-utils"),
                     None,
                 ),
                 call(
                     "https://github.com/opensearch-project/dashboards-reports.git",
-                    "1.1",
+                    "1.1.0.0",
                     os.path.join(tempfile.gettempdir(), "dashboards-reports"),
                     "reports-scheduler",
                 ),

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -48,7 +48,7 @@ class TestInputManifest(unittest.TestCase):
             opensearch_component.repository,
             "https://github.com/opensearch-project/OpenSearch.git",
         )
-        self.assertEqual(opensearch_component.ref, "1.1")
+        self.assertEqual(opensearch_component.ref, "1.1.0")
         # components
         for component in manifest.components.values():
             self.assertIsInstance(component.ref, str)


### PR DESCRIPTION
### Description

Since we incremented the version of OpenSearch on the 1.1 branch CI started failing because of a version mismatch, as expected. Lock the manifest of the released version to use tags.

Performance analyzer RCA is missing a tag, I opened https://github.com/opensearch-project/performance-analyzer-rca/issues/85. I am not sure what the right rev is as I cannot find it in the bundle manifest. This is odd. CI will pass once that's resolved.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
