### PR TITLE
Updated index management dashboards manifest reference to 1.2

### DIFF
--- a/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
@@ -21,5 +21,5 @@ components:
   ref: "main"
 - name: indexManagementDashboards
   repository: https://github.com/opensearch-project/index-management-dashboards-plugin
-  ref: "main"
+  ref: "1.2"
 schema-version: '1.0'


### PR DESCRIPTION
Signed-off-by: Eric Lobdell <lobdelle@amazon.com>

### Description
Sets index management dashboards manifest reference to 1.2
 
### Issues Resolved
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/98
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
