### PR TITLE
Updated alerting-dashboards-plugin ref to 1.2.

### DIFF
--- a/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
@@ -12,7 +12,7 @@ components:
   repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
 - name: alertingDashboards
   repository: https://github.com/opensearch-project/alerting-dashboards-plugin
-  ref: "main"
+  ref: "1.2"
 - name: functionalTestDashboards
   repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
   ref: "main"


### PR DESCRIPTION
Signed-off-by: AWSHurneyt <hurneyt@amazon.com>

### Description
Updated alerting-dashboards-plugin ref to 1.2.
 
### Issues Resolved
[alerting-dashboards-plugin PR 118](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/118)
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
