### PR TITLE
Update the example comment for artifacts location after renaming

### DIFF
--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -46,13 +46,13 @@ class BundleRecorder:
             return self.__get_public_url_path(folder_name, rel_path)
         return abs_path
 
-    # Assembled bundles are expected to be served from a separate "bundles" folder
-    # Example: https://artifacts.opensearch.org/bundles/1.0.0/<build-id
+    # Assembled output are expected to be served from a separate "dist" folder
+    # Example: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/build-id/linux/x64/dist/
     def __get_package_location(self):
         return self.__get_location("dist", self.package_name, os.path.join(self.output_dir, self.package_name))
 
     # Build artifacts are expected to be served from a "builds" folder
-    # Example: https://artifacts.opensearch.org/builds/1.0.0/<build-id>
+    # Example: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/build-id/linux/x64/builds/
     def __get_component_location(self, component_rel_path):
         abs_path = os.path.join(self.artifacts_dir, component_rel_path)
         return self.__get_location("builds", component_rel_path, abs_path)


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Since we changed the format of URL for artifacts, this PR update the example comment for the URL location. 
 
### Issues Resolved
#353 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
