### PR TITLE
Add support for .lock manifests to avoid building unnecessarily.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ out.txt
 .classpath
 /bin/
 
+/manifests/**/*.yml.lock
+

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The following options are available in `build.sh`.
 |--------------------|-------------------------------------------------------------------------|
 | --snapshot         | Build a snapshot instead of a release artifact, default is `false`.     |
 | --component [name] | Rebuild a single component by name, e.g. `--component common-utils`.    |
-| --keep             | DDo not delete the temporary working directory on both success or error.|
+| --keep             | Do not delete the temporary working directory on both success or error. |
 | -l, --lock         | Generate a stable reference manifest.                                   |
 | -v, --verbose      | Show more verbose output.                                               |
 
@@ -187,22 +187,20 @@ Each component build relies on a `build.sh` script that is used to prepare bundl
 
 ##### Avoiding Rebuilds
 
-Builds can automatically generate a `manifest.lock` file with stable git references by specifying `--lock`. The output can then be reused as input manifest after checking against a collection of prior builds.
+Builds can automatically generate a `manifest.lock` file with stable git references (commit IDs) and build options (platform, architecture and snapshot) by specifying `--lock`. The output can then be reused as input manifest after checking against a collection of prior builds.
 
 ```bash
-PLATFORM=linux
-ARCHITECTURE=x64
 MANIFEST=manifests/1.1.0/opensearch-1.1.0.yml
-SHAS=shas/opensearch/$PLATFORM-$ARCHITECTURE
+SHAS=shas
 
-./build.sh --platform $PLATFORM --architecture $ARCHITECTURE --lock $MANIFEST # generates opensearch-1.1.0.yml.lock
+./build.sh --lock $MANIFEST # generates opensearch-1.1.0.yml.lock
 
 MANIFEST_SHA=$(sha1sum $MANIFEST.lock | cut -f1 -d' ') # generate a checksum of the stable manifest
 
 if test -f "$SHAS/$MANIFEST_SHA.lock"; then
   echo "Skipping $MANIFEST_SHA"
 else
-  ./build.sh --platform $PLATFORM --architecture $ARCHITECTURE $MANIFEST.lock # rebuild using stable references in .lock
+  ./build.sh $MANIFEST.lock # rebuild using stable references in .lock
   mkdir -p $SHAS
   cp $MANIFEST.lock $SHAS/$MANIFEST_SHA.lock # save the stable reference manifest
 fi

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     - [Check Out Source](#check-out-source)
     - [Build from Source](#build-from-source)
       - [Custom Build Scripts](#custom-build-scripts)
+      - [Avoiding Rebuilds](#avoiding-rebuilds)
       - [Patch Releases](#patch-releases)
     - [Assemble the Bundle](#assemble-the-bundle)
       - [Cross-Platform Builds](#cross-platform-builds)
@@ -176,12 +177,17 @@ The following options are available in `build.sh`.
 |--------------------|-------------------------------------------------------------------------|
 | --snapshot         | Build a snapshot instead of a release artifact, default is `false`.     |
 | --component [name] | Rebuild a single component by name, e.g. `--component common-utils`.    |
-| --keep             | Do not delete the temporary working directory on both success or error. |
+| --keep             | Do not generate or use a stable reference manifest.                     |
+| -l, --lock         | Generate and use a stable reference manifest.                           |
 | -v, --verbose      | Show more verbose output.                                               |
 
 ##### Custom Build Scripts
 
 Each component build relies on a `build.sh` script that is used to prepare bundle artifacts for a particular bundle version that takes two arguments: version and target architecture. By default the tool will look for a script in [scripts/components](scripts/components), then in the checked-out repository in `build/build.sh`, then default to a Gradle build implemented in [scripts/default/build.sh](scripts/default/build.sh).
+
+##### Avoiding Rebuilds
+
+Builds can automatically generate `manifest.lock` files with stable git references by specifying `--lock`. If no changes on any repo in the manifest have been made since the last `.lock` file was produced, the build process will exit successfully.
 
 ##### Patch Releases
 

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -32,7 +32,7 @@ class BuildArgs:
             dest="lock",
             action="store_true",
             default=False,
-            help="Generate and use a stable reference manifest."
+            help="Generate a stable reference manifest."
         )
         parser.add_argument(
             "-s",

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -27,6 +27,14 @@ class BuildArgs:
         parser = argparse.ArgumentParser(description="Build an OpenSearch Bundle")
         parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
         parser.add_argument(
+            "-l",
+            "--lock",
+            dest="lock",
+            action="store_true",
+            default=False,
+            help="Generate and use a stable reference manifest."
+        )
+        parser.add_argument(
             "-s",
             "--snapshot",
             action="store_true",
@@ -55,6 +63,7 @@ class BuildArgs:
         args = parser.parse_args()
         self.logging_level = args.logging_level
         self.manifest = args.manifest
+        self.ref_manifest = args.manifest.name + ".lock" if args.lock else None
         self.snapshot = args.snapshot
         self.component = args.component
         self.keep = args.keep

--- a/src/git/git_repository.py
+++ b/src/git/git_repository.py
@@ -55,6 +55,10 @@ class GitRepository:
         else:
             return self.dir
 
+    @classmethod
+    def stable_ref(self, url, ref):
+        return subprocess.check_output(f"git ls-remote {url} {ref}", shell=True).decode().strip().split("\t")
+
     def execute_silent(self, command, cwd=None):
         cwd = cwd or self.working_directory
         logging.info(f'Executing "{command}" in {cwd}')

--- a/src/git/git_repository.py
+++ b/src/git/git_repository.py
@@ -57,7 +57,8 @@ class GitRepository:
 
     @classmethod
     def stable_ref(self, url, ref):
-        return subprocess.check_output(f"git ls-remote {url} {ref}", shell=True).decode().strip().split("\t")
+        results = subprocess.check_output(f"git ls-remote {url} {ref}", shell=True).decode().strip().split("\t")
+        return results if len(results) > 1 else [ref, ref]
 
     def execute_silent(self, command, cwd=None):
         cwd = cwd or self.working_directory

--- a/src/manifests/manifest.py
+++ b/src/manifests/manifest.py
@@ -85,6 +85,11 @@ class Manifest(ABC):
     def __to_dict(self):
         return {}
 
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.to_dict() == other.to_dict()
+        return False
+
     def to_dict(self):
         return Manifest.compact(self.__to_dict__())
 

--- a/src/manifests/manifest.py
+++ b/src/manifests/manifest.py
@@ -76,7 +76,7 @@ class Manifest(ABC):
             result = {}
             for k, v in d.items():
                 v = cls.compact(v)
-                if v:
+                if v or isinstance(v, bool):
                     result[k] = v
             return result
         else:

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -25,6 +25,14 @@ def main():
     manifest = InputManifest.from_file(args.manifest)
     output_dir = os.path.join(os.getcwd(), "builds")
 
+    if args.ref_manifest:
+        manifest = manifest.stable()
+        if os.path.exists(args.ref_manifest) and manifest == InputManifest.from_path(args.ref_manifest):
+            logging.info(f"No changes since {args.ref_manifest}")
+            exit(0)
+        logging.info(f"Writing {args.ref_manifest}")
+        manifest.to_file(args.ref_manifest)
+
     with TemporaryDirectory(keep=args.keep, chdir=True) as work_dir:
         logging.info(f"Building in {work_dir.name}")
 

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -27,11 +27,16 @@ def main():
 
     if args.ref_manifest:
         manifest = manifest.stable()
-        if os.path.exists(args.ref_manifest) and manifest == InputManifest.from_path(args.ref_manifest):
-            logging.info(f"No changes since {args.ref_manifest}")
-            exit(0)
-        logging.info(f"Writing {args.ref_manifest}")
-        manifest.to_file(args.ref_manifest)
+        if os.path.exists(args.ref_manifest):
+            if manifest == InputManifest.from_path(args.ref_manifest):
+                logging.info(f"No changes since {args.ref_manifest}")
+            else:
+                logging.info(f"Updating {args.ref_manifest}")
+                manifest.to_file(args.ref_manifest)
+        else:
+            logging.info(f"Creating {args.ref_manifest}")
+            manifest.to_file(args.ref_manifest)
+        exit(0)
 
     with TemporaryDirectory(keep=args.keep, chdir=True) as work_dir:
         logging.info(f"Building in {work_dir.name}")

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -16,6 +16,7 @@ from build_workflow.build_target import BuildTarget
 from build_workflow.builders import Builders
 from manifests.input_manifest import InputManifest
 from system import console
+from system.os import current_architecture, current_platform
 from system.temporary_directory import TemporaryDirectory
 
 
@@ -26,7 +27,11 @@ def main():
     output_dir = os.path.join(os.getcwd(), "builds")
 
     if args.ref_manifest:
-        manifest = manifest.stable()
+        manifest = manifest.stable(
+            architecture=args.architecture or current_architecture(),
+            platform=args.platform or current_platform(),
+            snapshot=args.snapshot if args.snapshot is not None else False
+        )
         if os.path.exists(args.ref_manifest):
             if manifest == InputManifest.from_path(args.ref_manifest):
                 logging.info(f"No changes since {args.ref_manifest}")
@@ -45,10 +50,10 @@ def main():
             name=manifest.build.name,
             version=manifest.build.version,
             patches=manifest.build.patches,
-            snapshot=args.snapshot,
+            snapshot=args.snapshot if args.snapshot is not None else manifest.build.snapshot,
             output_dir=output_dir,
-            platform=args.platform,
-            architecture=args.architecture,
+            platform=args.platform or manifest.build.platform,
+            architecture=args.architecture or manifest.build.architecture,
         )
 
         os.makedirs(target.output_dir, exist_ok=True)

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -110,31 +110,37 @@ class TestRunBuild(unittest.TestCase):
             main()
 
     @patch("os.path.exists", return_value=True)
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "--lock"])
     @patch("run_build.InputManifest.from_path", return_value=InputManifest.from_path(OPENSEARCH_MANIFEST))
     @patch("run_build.InputManifest.stable", return_value=InputManifest.from_path(OPENSEARCH_MANIFEST))
-    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "--lock"])
-    @patch("run_build.Builders.builder_from", return_value=MagicMock())
-    @patch("run_build.BuildRecorder", return_value=MagicMock())
-    @patch("run_build.TemporaryDirectory")
+    @patch("run_build.InputManifest.to_file")
     @patch("logging.info")
-    def test_main_incremental_without_changes(self, mock_logging, mock_temp, mock_recorder, mock_builder, *mocks):
-        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+    def test_main_manifest_lock_without_changes(self, mock_logging, mock_to_file, *mocks):
         with self.assertRaises(SystemExit):
             main()
-        self.assertEqual(mock_builder.return_value.build.call_count, 0)
+        mock_to_file.assert_not_called()
         mock_logging.assert_called_with(f"No changes since {self.OPENSEARCH_MANIFEST}.lock")
-        mock_recorder.return_value.write_manifest.assert_not_called()
 
     @patch("os.path.exists", return_value=True)
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "--lock"])
     @patch("run_build.InputManifest.from_path", return_value=InputManifest.from_path(OPENSEARCH_MANIFEST))
     @patch("run_build.InputManifest.stable", return_value=InputManifest.from_path(OPENSEARCH_MANIFEST_1_2))
-    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "--lock"])
-    @patch("run_build.Builders.builder_from", return_value=MagicMock())
-    @patch("run_build.BuildRecorder", return_value=MagicMock())
-    @patch("run_build.TemporaryDirectory")
     @patch("run_build.InputManifest.to_file")
-    def test_main_incremental_with_changes(self, mock_to_file, mock_temp, mock_recorder, mock_builder, *mocks):
-        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
-        main()
+    @patch("logging.info")
+    def test_main_manifest_lock_with_changes(self, mock_logging, mock_to_file, *mocks):
+        with self.assertRaises(SystemExit):
+            main()
         mock_to_file.assert_called_with(self.OPENSEARCH_MANIFEST + ".lock")
-        mock_recorder.return_value.write_manifest.assert_called()
+        mock_logging.assert_called_with(f"Updating {self.OPENSEARCH_MANIFEST}.lock")
+
+    @patch("os.path.exists", return_value=False)
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "--lock"])
+    @patch("run_build.InputManifest.from_path", return_value=InputManifest.from_path(OPENSEARCH_MANIFEST))
+    @patch("run_build.InputManifest.stable", return_value=InputManifest.from_path(OPENSEARCH_MANIFEST_1_2))
+    @patch("run_build.InputManifest.to_file")
+    @patch("logging.info")
+    def test_main_manifest_new_lock(self, mock_logging, mock_to_file, *mocks):
+        with self.assertRaises(SystemExit):
+            main()
+        mock_to_file.assert_called_with(self.OPENSEARCH_MANIFEST + ".lock")
+        mock_logging.assert_called_with(f"Creating {self.OPENSEARCH_MANIFEST}.lock")

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from manifests.input_manifest import InputManifest
 from run_build import main
 
 
@@ -27,15 +28,14 @@ class TestRunBuild(unittest.TestCase):
         out, _ = self.capfd.readouterr()
         self.assertTrue(out.startswith("usage:"))
 
-    OPENSEARCH_MANIFEST = os.path.realpath(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "manifests",
-            "1.1.0",
-            "opensearch-1.1.0.yml",
-        )
+    MANIFESTS = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "manifests",
     )
+
+    OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(MANIFESTS, "1.1.0", "opensearch-1.1.0.yml"))
+    OPENSEARCH_MANIFEST_1_2 = os.path.realpath(os.path.join(MANIFESTS, "1.2.0", "opensearch-1.2.0.yml"))
 
     @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "-p", "linux"])
     @patch("run_build.Builders.builder_from", return_value=MagicMock())
@@ -108,3 +108,33 @@ class TestRunBuild(unittest.TestCase):
     def test_main_with_invalid_architecture(self, *mocks):
         with self.assertRaises(SystemExit):
             main()
+
+    @patch("os.path.exists", return_value=True)
+    @patch("run_build.InputManifest.from_path", return_value=InputManifest.from_path(OPENSEARCH_MANIFEST))
+    @patch("run_build.InputManifest.stable", return_value=InputManifest.from_path(OPENSEARCH_MANIFEST))
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "--lock"])
+    @patch("run_build.Builders.builder_from", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.TemporaryDirectory")
+    @patch("logging.info")
+    def test_main_incremental_without_changes(self, mock_logging, mock_temp, mock_recorder, mock_builder, *mocks):
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        with self.assertRaises(SystemExit):
+            main()
+        self.assertEqual(mock_builder.return_value.build.call_count, 0)
+        mock_logging.assert_called_with(f"No changes since {self.OPENSEARCH_MANIFEST}.lock")
+        mock_recorder.return_value.write_manifest.assert_not_called()
+
+    @patch("os.path.exists", return_value=True)
+    @patch("run_build.InputManifest.from_path", return_value=InputManifest.from_path(OPENSEARCH_MANIFEST))
+    @patch("run_build.InputManifest.stable", return_value=InputManifest.from_path(OPENSEARCH_MANIFEST_1_2))
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "--lock"])
+    @patch("run_build.Builders.builder_from", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.TemporaryDirectory")
+    @patch("run_build.InputManifest.to_file")
+    def test_main_incremental_with_changes(self, mock_to_file, mock_temp, mock_recorder, mock_builder, *mocks):
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        main()
+        mock_to_file.assert_called_with(self.OPENSEARCH_MANIFEST + ".lock")
+        mock_recorder.return_value.write_manifest.assert_called()

--- a/tests/tests_build_workflow/test_build_args.py
+++ b/tests/tests_build_workflow/test_build_args.py
@@ -98,3 +98,11 @@ class TestBuildArgs(unittest.TestCase):
             BuildArgs().component_command("component"),
             f"{self.BUILD_SH} {self.OPENSEARCH_MANIFEST} --component component --snapshot",
         )
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--lock"])
+    def test_manifest_lock(self):
+        self.assertEqual(BuildArgs().ref_manifest, TestBuildArgs.OPENSEARCH_MANIFEST + ".lock")
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_manifest_no_lock(self):
+        self.assertIsNone(BuildArgs().ref_manifest)

--- a/tests/tests_git/test_git_repository.py
+++ b/tests/tests_git/test_git_repository.py
@@ -85,3 +85,10 @@ class TestGitRepositoryWithWorkingDir(unittest.TestCase):
             self.assertEqual(repo.working_directory, working_directory)
             self.assertTrue("ISSUE_TEMPLATE" in repo.output("pwd"))
         self.assertFalse(os.path.exists(repo.dir))
+
+
+class TestGitRepositoryClassMethods(unittest.TestCase):
+    @patch("subprocess.check_output")
+    def test_stable_ref(self, mock_output):
+        mock_output.return_value.decode.return_value = "546ab21989a27ae52cd557621ffac77ef4b09530\tHEAD"
+        self.assertEqual(GitRepository.stable_ref("url", "ref"), ["546ab21989a27ae52cd557621ffac77ef4b09530", "HEAD"])

--- a/tests/tests_git/test_git_repository.py
+++ b/tests/tests_git/test_git_repository.py
@@ -90,5 +90,14 @@ class TestGitRepositoryWithWorkingDir(unittest.TestCase):
 class TestGitRepositoryClassMethods(unittest.TestCase):
     @patch("subprocess.check_output")
     def test_stable_ref(self, mock_output):
-        mock_output.return_value.decode.return_value = "546ab21989a27ae52cd557621ffac77ef4b09530\tHEAD"
-        self.assertEqual(GitRepository.stable_ref("url", "ref"), ["546ab21989a27ae52cd557621ffac77ef4b09530", "HEAD"])
+        mock_output.return_value.decode.return_value = "sha\tHEAD"
+        ref, name = GitRepository.stable_ref("https://github.com/opensearch-project/OpenSearch", "sha")
+        self.assertEqual(ref, "sha")
+        self.assertEqual(name, "HEAD")
+
+    @patch("subprocess.check_output")
+    def test_stable_ref_none(self, mock_output):
+        mock_output.return_value.decode.return_value = ""
+        ref, name = GitRepository.stable_ref("https://github.com/opensearch-project/OpenSearch", "sha")
+        self.assertEqual(ref, "sha")
+        self.assertEqual(name, "sha")

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -4,8 +4,10 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import copy
 import os
 import unittest
+from unittest.mock import patch
 
 import yaml
 
@@ -136,3 +138,36 @@ class TestInputManifest(unittest.TestCase):
         self.assertTrue(component.__matches__(focus=None))
         self.assertTrue(component.__matches__(focus="x"))
         self.assertFalse(component.__matches__(focus="y"))
+
+    @patch("subprocess.check_output")
+    def test_stable(self, mock_output):
+        mock_output.return_value.decode.return_value = "updated\tHEAD"
+        path = os.path.join(self.manifests_path, "1.1.0", "opensearch-1.1.0.yml")
+        manifest = InputManifest.from_path(path).stable()
+        opensearch = manifest.components["OpenSearch"]
+        self.assertEqual(opensearch.ref, "updated")
+
+    def test_eq(self):
+        path = os.path.join(self.manifests_path, "1.0.0", "opensearch-1.0.0.yml")
+        manifest1 = InputManifest.from_path(path)
+        manifest2 = InputManifest.from_path(path)
+        self.assertEqual(manifest1, manifest1)
+        self.assertEqual(manifest1, manifest2)
+
+    def test_neq(self):
+        path1 = os.path.join(self.manifests_path, "1.0.0", "opensearch-1.0.0.yml")
+        path2 = os.path.join(self.manifests_path, "1.1.0", "opensearch-1.1.0.yml")
+        manifest1 = InputManifest.from_path(path1)
+        manifest2 = InputManifest.from_path(path2)
+        self.assertNotEqual(manifest1, manifest2)
+
+    def test_neq_update(self):
+        path = os.path.join(self.manifests_path, "1.0.0", "opensearch-1.0.0.yml")
+        manifest1 = InputManifest.from_path(path)
+        manifest2 = copy.deepcopy(manifest1)
+        self.assertEqual(manifest1, manifest2)
+        manifest2.components["name"] = InputManifest.ComponentFromDist({
+            "name": "name",
+            "dist": "dist"
+        })
+        self.assertNotEqual(manifest1, manifest2)

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -147,6 +147,15 @@ class TestInputManifest(unittest.TestCase):
         opensearch = manifest.components["OpenSearch"]
         self.assertEqual(opensearch.ref, "updated")
 
+    @patch("subprocess.check_output")
+    def test_stable_override_build(self, mock_output):
+        mock_output.return_value.decode.return_value = "updated\tHEAD"
+        path = os.path.join(self.manifests_path, "1.1.0", "opensearch-1.1.0.yml")
+        manifest = InputManifest.from_path(path).stable(platform="windows", architecture="arm64", snapshot=True)
+        self.assertEqual(manifest.build.platform, "windows")
+        self.assertEqual(manifest.build.architecture, "arm64")
+        self.assertTrue(manifest.build.snapshot)
+
     def test_eq(self):
         path = os.path.join(self.manifests_path, "1.0.0", "opensearch-1.0.0.yml")
         manifest1 = InputManifest.from_path(path)

--- a/tests/tests_manifests/test_manifest.py
+++ b/tests/tests_manifests/test_manifest.py
@@ -73,6 +73,8 @@ class TestManifest(unittest.TestCase):
         self.assertEqual(Manifest.compact({"x": "y", "z": []}), {"x": "y"})
         self.assertEqual(Manifest.compact({"x": "y", "z": None}), {"x": "y"})
         self.assertEqual(Manifest.compact({"x": "y", "z": {"t": None}}), {"x": "y"})
+        self.assertEqual(Manifest.compact({"x": True}), {"x": True})
+        self.assertEqual(Manifest.compact({"x": False}), {"x": False})
 
     def test_to_file(self):
         manifest_path = os.path.join(self.data_path, "min.yml")

--- a/tests/tests_manifests/test_manifest.py
+++ b/tests/tests_manifests/test_manifest.py
@@ -124,3 +124,10 @@ class TestManifest(unittest.TestCase):
         manifest = TestManifest.SampleManifest.from_url("url")
         self.assertEqual(manifest.version, "3.14")
         mock_urlopen.assert_called_with("url")
+
+    def test_eq(self):
+        manifest_path = os.path.join(self.data_path, "min.yml")
+        manifest1 = TestManifest.SampleManifest.from_path(manifest_path)
+        manifest2 = TestManifest.SampleManifest.from_path(manifest_path)
+        self.assertEqual(manifest1, manifest1)
+        self.assertEqual(manifest1, manifest2)


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Automatically generates a .lock file with stable refs. Subsequent builds will exit early if nothing has changed in either the manifest or any of the repos referenced in the manifest.

We would need to save those lock files across builds in order to take advantage of this system in Jenkins CI. One way would be to commit them. Thoughts @peternied? 

### Issues Resolved

Implements https://github.com/opensearch-project/opensearch-build/issues/675.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
