### PR TITLE
Update K-NN ref to 1.2 in manifest

### DIFF
--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -40,7 +40,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: "main"
+    ref: "1.2"
     platforms:
       - darwin
       - linux


### PR DESCRIPTION
Signed-off-by: Naveen Tatikonda <navtat@amazon.com>

### Description
Updating K-NN ref to 1.2 in manifest 1.2.0 
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/102
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
