### PR TITLE
Unrevert "Update PerformanceAnalyzer refs to 1.2 branch in manifest"

### DIFF
--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -52,12 +52,12 @@ components:
     ref: "1.2"
   - name: performance-analyzer-rca
     repository: https://github.com/opensearch-project/performance-analyzer-rca.git
-    ref: "main"
+    ref: "1.2"
     checks:
       - gradle:properties:version
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: "main"
+    ref: "1.2"
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Reverts opensearch-project/opensearch-build#918

Over the shoulder review by @gaiksaya 