### PR TITLE
Extract Jenkins messages into a shared library.

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -1,3 +1,6 @@
+library identifier: 'addJenkinsMessage@current', retriever: legacySCM(scm)
+library identifier: 'getJenkinsMessages@current', retriever: legacySCM(scm)
+
 pipeline {
     agent none
     triggers {
@@ -130,7 +133,8 @@ pipeline {
             post() {
                 success {
                     node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
-                        publishNotification(":white_check_mark:", "Successful Build", "\n${getAllJenkinsMessages()}")
+                        messages = getJenkinsMessages(['build-x64', 'build-arm64'])
+                        publishNotification(":white_check_mark:", "Successful Build", "\n${messages}")
                     }
                 }
                 failure {
@@ -164,43 +168,12 @@ void assemble() {
         s3Upload(file: "dist", bucket: "${ARTIFACT_BUCKET_NAME}", path: "${artifactPath}/dist")
     }
 
-    addJenkinsMessage("${BASE_URL}/builds/manifest.yml\n" +
-                      "${BASE_URL}/dist/manifest.yml")
+    addJenkinsMessage("${STAGE_NAME}", "${BASE_URL}/builds/manifest.yml\n${BASE_URL}/dist/manifest.yml")
 }
 
 /** Publishes a notification to a slack instance*/
 void publishNotification(icon, msg, extra) {
     withCredentials([string(credentialsId: 'BUILD_NOTICE_WEBHOOK', variable: 'TOKEN')]) {
         sh("""curl -XPOST --header "Content-Type: application/json" --data '{"result_text": "$icon ${env.JOB_NAME} [${env.BUILD_NUMBER}] $msg ${env.BUILD_URL}\nManifest: ${INPUT_MANIFEST} $extra"}' """ + "$TOKEN")
-    }
-}
-
-/** Add a message to the jenkins queue */
-void addJenkinsMessage(message) {
-    writeFile(file: "notifications/${STAGE_NAME}.msg", text: message)
-    stash(includes: "notifications/*" , name: "notifications-${STAGE_NAME}")
-}
-
-/** Load all message in the jenkins queue and append them with a leading newline into a mutli-line string */
-String getAllJenkinsMessages() {
-    script {
-        // Stages must be explicitly added to prevent overwriting
-        // See https://ryan.himmelwright.net/post/jenkins-parallel-stashing/
-        def stages = ['build-linux-x64', 'post-build (linux-arm64)']
-        for (stage in stages) {
-            unstash "notifications-${stage}"
-        }
-
-        def files = findFiles(excludes: '', glob: 'notifications/*')
-        def data = ""
-        for (file in files) {
-            data = data + "\n" + readFile (file: file.path)
-        }
-
-        // Delete all the notifications from the workspace
-        dir('notifications') {
-            deleteDir()
-        }
-        return data
     }
 }

--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -1,3 +1,6 @@
+library identifier: 'addJenkinsMessage@current', retriever: legacySCM(scm)
+library identifier: 'getJenkinsMessages@current', retriever: legacySCM(scm)
+
 pipeline {
     agent none
     triggers {
@@ -131,7 +134,8 @@ pipeline {
             post() {
                 success {
                     node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
-                        publishNotification(":white_check_mark:", "Successful Build", "\n${getAllJenkinsMessages()}")
+                        messages = getJenkinsMessages(['build-x64', 'build-arm64'])
+                        publishNotification(":white_check_mark:", "Successful Build", "\n${messages}")
                     }
                 }
                 failure {
@@ -161,44 +165,12 @@ void build() {
         s3Upload(file: "dist", bucket: "${ARTIFACT_BUCKET_NAME}", path: "${artifactPath}/dist")
     }
 
-    addJenkinsMessage("${BASE_URL}/builds/manifest.yml\n" +
-                      "${BASE_URL}/dist/manifest.yml")
-
+    addJenkinsMessage("${STAGE_NAME}", "${BASE_URL}/builds/manifest.yml\n${BASE_URL}/dist/manifest.yml")
 }
 
 /** Publishes a notification to a slack instance*/
 void publishNotification(icon, msg, extra) {
     withCredentials([string(credentialsId: 'BUILD_NOTICE_WEBHOOK', variable: 'TOKEN')]) {
         sh("""curl -XPOST --header "Content-Type: application/json" --data '{"result_text": "$icon ${env.JOB_NAME} [${env.BUILD_NUMBER}] $msg ${env.BUILD_URL}\nManifest: ${INPUT_MANIFEST} $extra"}' """ + "$TOKEN")
-    }
-}
-
-/** Add a message to the jenkins queue */
-void addJenkinsMessage(message) {
-    writeFile(file: "notifications/${STAGE_NAME}.msg", text: message)
-    stash(includes: "notifications/*" , name: "notifications-${STAGE_NAME}")
-}
-
-/** Load all message in the jenkins queue and append them with a leading newline into a mutli-line string */
-String getAllJenkinsMessages() {
-    script {
-        // Stages must be explicitly added to prevent overwriting
-        // See https://ryan.himmelwright.net/post/jenkins-parallel-stashing/
-        def stages = ['build-x64', 'build-arm64']
-        for (stage in stages) {
-            unstash "notifications-${stage}"
-        }
-
-        def files = findFiles(excludes: '', glob: 'notifications/*')
-        def data = ""
-        for (file in files) {
-            data = data + "\n" + readFile (file: file.path)
-        }
-
-        // Delete all the notifications from the workspace
-        dir('notifications') {
-            deleteDir()
-        }
-        return data
     }
 }

--- a/vars/README.md
+++ b/vars/README.md
@@ -1,0 +1,1 @@
+Jenkins shared libraries, cannot be moved.

--- a/vars/addJenkinsMessage.groovy
+++ b/vars/addJenkinsMessage.groovy
@@ -1,0 +1,5 @@
+/** Add a message to the jenkins queue */
+def call(String stage, String message) {
+    writeFile(file: "notifications/${stage}.msg", text: message)
+    stash(includes: "notifications/*" , name: "notifications-${stage}")
+}

--- a/vars/addJenkinsMessage.groovy
+++ b/vars/addJenkinsMessage.groovy
@@ -1,5 +1,5 @@
 /** Add a message to the jenkins queue */
 def call(String stage, String message) {
-    writeFile(file: "notifications/${stage}.msg", text: message)
-    stash(includes: "notifications/*" , name: "notifications-${stage}")
+    writeFile(file: "messages/${stage}.msg", text: message)
+    stash(includes: "messages/*" , name: "messages-${stage}")
 }

--- a/vars/getJenkinsMessages.groovy
+++ b/vars/getJenkinsMessages.groovy
@@ -1,0 +1,20 @@
+/** Load all message in the jenkins queue and append them with a leading newline into a mutli-line string */
+String call(ArrayList stages) {
+    // Stages must be explicitly added to prevent overwriting
+    // See https://ryan.himmelwright.net/post/jenkins-parallel-stashing/
+    for (stage in stages) {
+        unstash "notifications-${stage}"
+    }
+
+    def files = findFiles(excludes: '', glob: 'notifications/*')
+    def data = ""
+    for (file in files) {
+        data = data + "\n" + readFile (file: file.path)
+    }
+
+    // Delete all the notifications from the workspace
+    dir('notifications') {
+        deleteDir()
+    }
+    return data
+}

--- a/vars/getJenkinsMessages.groovy
+++ b/vars/getJenkinsMessages.groovy
@@ -3,17 +3,17 @@ String call(ArrayList stages) {
     // Stages must be explicitly added to prevent overwriting
     // See https://ryan.himmelwright.net/post/jenkins-parallel-stashing/
     for (stage in stages) {
-        unstash "notifications-${stage}"
+        unstash "messages-${stage}"
     }
 
-    def files = findFiles(excludes: '', glob: 'notifications/*')
+    def files = findFiles(excludes: '', glob: 'messages/*')
     def data = ""
     for (file in files) {
         data = data + "\n" + readFile (file: file.path)
     }
 
-    // Delete all the notifications from the workspace
-    dir('notifications') {
+    // Delete all the messages from the workspace
+    dir('messages') {
         deleteDir()
     }
     return data

--- a/vars/notifySlack.groovy
+++ b/vars/notifySlack.groovy
@@ -1,3 +1,0 @@
-def call() {
-    echo "Inside notifySlack"
-}

--- a/vars/notifySlack.groovy
+++ b/vars/notifySlack.groovy
@@ -1,0 +1,3 @@
+def call() {
+    echo "Inside notifySlack"
+}


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Before writing more copy-paste code in Jenkinsfiles for https://github.com/opensearch-project/opensearch-build/pull/904 I thought I'd try to refactor some existing Jenkinsfile code. This PR extracts messages into two shared libraries.

Jenkins libraries live in `vars` by convention. Workarounds suggest doing `git init` in the subfolder and using that, but I couldn't get it to work. There also seems to be [hints at a `libraryPath` option](https://github.com/jenkinsci/workflow-cps-global-lib-plugin/blob/8984698474fdfbef2cb921fb0febb55d22668ba7/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java#L82), but I wasn't able to set it anywhere.

I have an example running in our private staging Jenkins instance under `job/dblock-refactor-jenkinsfile` if you want to take a look at a successful run.
 
### Issues Resolved

Beginning of https://github.com/opensearch-project/opensearch-build/issues/731

### Relevant Links

- https://stackoverflow.com/questions/46213913/load-jenkins-pipeline-shared-library-from-same-repository
- https://code-held.com/2020/01/22/jenkins-local-shared-library/

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
