### PR TITLE
Update echo messages in tar installer

### DIFF
--- a/scripts/legacy/tar/linux/opensearch-tar-install.sh
+++ b/scripts/legacy/tar/linux/opensearch-tar-install.sh
@@ -46,16 +46,14 @@ if echo "$OSTYPE" | grep -qi "darwin"; then
         echo "k-NN libraries found in JAVA_LIBRARY_PATH"
     else
         export JAVA_LIBRARY_PATH=$JAVA_LIBRARY_PATH:$KNN_LIB_DIR
-        echo "k-NN libraries not found in JAVA_LIBRARY_PATH. Updating path..."
-        echo $JAVA_LIBRARY_PATH
+        echo "k-NN libraries not found in JAVA_LIBRARY_PATH. Updating path to: $JAVA_LIBRARY_PATH." 
     fi
 else
     if echo "$LD_LIBRARY_PATH" | grep -q "$KNN_LIB_DIR"; then
         echo "k-NN libraries found in LD_LIBRARY_PATH"
     else
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$KNN_LIB_DIR
-        echo "k-NN libraries not found in LD_LIBRARY_PATH. Updating path..."
-        echo $LD_LIBRARY_PATH
+        echo "k-NN libraries not found in LD_LIBRARY_PATH. Updating path to: $LD_LIBRARY_PATH."
     fi
 fi
 

--- a/scripts/legacy/tar/linux/opensearch-tar-install.sh
+++ b/scripts/legacy/tar/linux/opensearch-tar-install.sh
@@ -40,33 +40,25 @@ if ! grep -q '## OpenSearch Performance Analyzer' $OPENSEARCH_HOME/config/jvm.op
 fi
 echo "done plugins"
 
-##Check KNN lib existence in OpenSearch TAR distribution
-echo "Checking kNN library"
-FILE=`ls $KNN_LIB_DIR/lib*.so`
-if test -f "$FILE"; then
-    echo "FILE EXISTS $FILE"
-else
-    echo "TEST FAILED OR FILE NOT EXIST $FILE"
-fi
-
 ##Set KNN Dylib Path for macOS and *nix systems
 if echo "$OSTYPE" | grep -qi "darwin"; then
     if echo "$JAVA_LIBRARY_PATH" | grep -q "$KNN_LIB_DIR"; then
-        echo "KNN lib path has been set"
+        echo "k-NN libraries found in JAVA_LIBRARY_PATH"
     else
         export JAVA_LIBRARY_PATH=$JAVA_LIBRARY_PATH:$KNN_LIB_DIR
-        echo "KNN lib path not found, set new path"
+        echo "k-NN libraries not found in JAVA_LIBRARY_PATH. Updating path..."
         echo $JAVA_LIBRARY_PATH
     fi
 else
     if echo "$LD_LIBRARY_PATH" | grep -q "$KNN_LIB_DIR"; then
-        echo "KNN lib path has been set"
+        echo "k-NN libraries found in LD_LIBRARY_PATH"
     else
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$KNN_LIB_DIR
-        echo "KNN lib path not found, set new path"
+        echo "k-NN libraries not found in LD_LIBRARY_PATH. Updating path..."
         echo $LD_LIBRARY_PATH
     fi
 fi
 
 ##Start OpenSearch
+echo "Starting OpenSearch"
 exec $OPENSEARCH_HOME/bin/opensearch "$@"


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
This PR cleans up some of the echo messages around the k-NN library to give more accurate information on tar install. I removed the library check because that seems unnecessary. Additionally, I added a message to indicate to the user that OpenSearch is starting.
 
### Issues Resolved
#917 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
