### PR TITLE
Added put permission for test-results

### DIFF
--- a/deployment/lib/identities.ts
+++ b/deployment/lib/identities.ts
@@ -45,6 +45,7 @@ export class Identities {
 
     props.buildBucket.grantRead(testRole, '*/dist/*');
     props.buildBucket.grantPut(testRole, '*/dist/*/tests/*');
+    props.buildBucket.grantPut(testRole, '*/test-results/*');
   }
 
   private static roleFromName(stack: Stack, roleName: string): IRole {


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Coming from https://github.com/opensearch-project/opensearch-build/issues/207#issuecomment-961390837. Added put permission for test-results to publish the results of integration test on S3.  Required for https://github.com/opensearch-project/opensearch-build/issues/341
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
