### PR TITLE
Trigger docker image build after successful bundle build dashboards

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -131,6 +131,19 @@ pipeline {
                 success {
                     node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
                         publishNotification(":white_check_mark:", "Successful Build", "\n${getAllJenkinsMessages()}")
+                        def VERSION = sh(script: 'echo ${INPUT_MANIFEST} | grep -Po "[0-9.]+?(?=.yml)"', returnStdout: true).trim()
+                        sh "echo VERSION:${VERSION} BUILD_NUMBER:${env.BUILD_NUMBER}"
+                        def URL_x64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/x64/dist/opensearch-dashboards-${VERSION}-linux-x64.tar.gz"
+                        def URL_arm64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}linux/arm64/dist/opensearch-dashboards-${VERSION}-linux-arm64.tar.gz"
+                        dockerBuild: {
+                            build job: 'docker-build',
+                            parameters: [
+                                string(name: 'DOCKER_BUILD_GIT_REPOSITORY', value: 'https://github.com/opensearch-project/opensearch-build'),
+                                string(name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE', value: 'main'),
+                                string(name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS', value: "id && pwd && cd docker/release && curl -sSL $URL_x64 -o opensearch-dashboards-x64.tgz && curl -sSL $URL_arm64 -o opensearch-dashboards-arm64.tgz && bash build-image-multi-arch.sh -v ${VERSION} -f ./dockerfiles/opensearch-dashboards.al2.dockerfile -p opensearch-dashboards -a 'x64,arm64' -r opensearchstaging/opensearch-dashboards -t 'opensearch-dashboards-x64.tgz,opensearch-dashboards-arm64.tgz' -n ${env.BUILD_NUMBER}"),
+                                booleanParam(name: 'IS_STAGING', value: true)
+                            ]
+                        }
                     }
                 }
                 failure {

--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -135,14 +135,14 @@ pipeline {
                         script {
                             def VERSION = sh(script: 'echo ${INPUT_MANIFEST} | grep -Po "[0-9.]+?(?=.yml)"', returnStdout: true).trim()
                             sh "echo VERSION:$VERSION BUILD_NUMBER:$BUILD_NUMBER"
-                            def URL_x64 = "https://ci.opensearch.org/ci/dbc/bundle-build/$VERSION/$BUILD_NUMBER/linux/x64/dist/opensearch-$VERSION-linux-x64.tar.gz"
-                            def URL_arm64 = "https://ci.opensearch.org/ci/dbc/bundle-build/$VERSION/$BUILD_NUMBER/linux/arm64/dist/opensearch-$VERSION-linux-arm64.tar.gz"
+                            def URL_x64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/x64/dist/opensearch-${VERSION}-linux-x64.tar.gz"
+                            def URL_arm64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/arm64/dist/opensearch-${VERSION}-linux-arm64.tar.gz"
                             dockerBuild: {
                                 build job: 'docker-build',
                                 parameters: [
                                     string(name: 'DOCKER_BUILD_GIT_REPOSITORY', value: 'https://github.com/opensearch-project/opensearch-build'),
                                     string(name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE', value: 'main'),
-                                    string(name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS', value: "id && pwd && cd docker/release && curl -sSL $URL_x64 -o opensearch-x64.tgz && curl -sSL $URL_arm64 -o opensearch-arm64.tgz && bash build-image-multi-arch.sh -v $VERSION -f ./dockerfiles/opensearch.al2.dockerfile -p opensearch -a 'x64,arm64' -r opensearchstaging/opensearch -t 'opensearch-x64.tgz,opensearch-arm64.tgz' -n $BUILD_NUMBER"),
+                                    string(name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS', value: "id && pwd && cd docker/release && curl -sSL $URL_x64 -o opensearch-x64.tgz && curl -sSL $URL_arm64 -o opensearch-arm64.tgz && bash build-image-multi-arch.sh -v ${VERSION} -f ./dockerfiles/opensearch.al2.dockerfile -p opensearch -a 'x64,arm64' -r opensearchstaging/opensearch -t 'opensearch-x64.tgz,opensearch-arm64.tgz' -n ${env.BUILD_NUMBER}"),
                                     booleanParam(name: 'IS_STAGING', value: true)
                                 ]
                             }


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Add docker build trigger after bundle builds dashboards
 
### Issues Resolved
part of #908 for dashboards
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
