### PR TITLE
Fixing missing slash in path

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -135,7 +135,7 @@ pipeline {
                             def VERSION = sh(script: 'echo ${INPUT_MANIFEST} | grep -Po "[0-9.]+?(?=.yml)"', returnStdout: true).trim()
                             sh "echo VERSION:${VERSION} BUILD_NUMBER:${env.BUILD_NUMBER}"
                             def URL_x64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/x64/dist/opensearch-dashboards-${VERSION}-linux-x64.tar.gz"
-                            def URL_arm64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}linux/arm64/dist/opensearch-dashboards-${VERSION}-linux-arm64.tar.gz"
+                            def URL_arm64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/arm64/dist/opensearch-dashboards-${VERSION}-linux-arm64.tar.gz"
                             dockerBuild: {
                                 build job: 'docker-build',
                                 parameters: [


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Looking at the generated URLs, which we should remove, here is a quick fix to make sure the path is resolved properly for arm builds.

#### Without the change the urls generated
```
https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.2.0/361/linux/x64/dist/opensearch-dashboards-1.2.0-linux-x64.tar.gz
https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.2.0/361linux/arm64/dist/opensearch-dashboards-1.2.0-linux-arm64.tar.gz
```

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
