### PR TITLE
Include chromium binary in dashboards-reports artifact

### DIFF
--- a/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
@@ -30,6 +30,8 @@ components:
   repository: https://github.com/opensearch-project/dashboards-reports.git
   working_directory: dashboards-reports
   ref: "1.2"
+  platforms:
+    - linux
 - name: observabilityDashboards
   repository: https://github.com/opensearch-project/trace-analytics.git
   working_directory: dashboards-observability

--- a/scripts/components/reportsDashboards/build.sh
+++ b/scripts/components/reportsDashboards/build.sh
@@ -60,7 +60,6 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
-
 [ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
@@ -97,6 +96,7 @@ echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build)
+# Reporting uses headless chromium to generate reports, which needs to be included in its artifact
 echo "DOWNLOADING CHROMIUM FOR $PLUGIN_NAME"
 mkdir -p ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/opensearch-dashboards/$PLUGIN_NAME
 curl -sLO "$CHROMIUM_URL"

--- a/scripts/components/reportsDashboards/build.sh
+++ b/scripts/components/reportsDashboards/build.sh
@@ -68,12 +68,6 @@ case $PLATFORM in
     linux*)
         PLATFORM="linux"
         ;;
-    darwin*)
-        PLATFORM="macos"
-        ;;
-    windows*)
-        PLATFORM="windows"
-        ;;
     *)
         echo "Unsupported platform: $PLATFORM"
         exit 1
@@ -82,7 +76,7 @@ esac
 
 case $ARCHITECTURE in
     x64|arm64)
-        TARGET="chromium-$PLATFORM-$ARCHITECTURE.zip"
+        CHROMIUM_TARGET="chromium-$PLATFORM-$ARCHITECTURE.zip"
         ;;
     *)
         echo "Unsupported architecture: $ARCHITECTURE"
@@ -90,11 +84,7 @@ case $ARCHITECTURE in
         ;;
 esac
 
-CHROMIUM_URL="https://github.com/opensearch-project/dashboards-reports/releases/download/chromium-1.12.0.0/$TARGET"
-if curl -sI "$CHROMIUM_URL" | grep -q 404; then
-    echo "Unsupported chromium build: $TARGET"
-    exit 1
-fi
+CHROMIUM_URL="https://github.com/opensearch-project/dashboards-reports/releases/download/chromium-1.12.0.0/$CHROMIUM_TARGET"
 
 mkdir -p $OUTPUT/plugins
 # For hybrid plugin it actually resides in 'reportsDashboards/dashboards-reports'
@@ -111,7 +101,7 @@ echo "DOWNLOADING CHROMIUM FOR $PLUGIN_NAME"
 mkdir -p ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/opensearch-dashboards/$PLUGIN_NAME
 curl -sLO "$CHROMIUM_URL"
 echo "PUTTING CHROMIUM INSIDE $PLUGIN_NAME-$VERSION.zip"
-unzip "$TARGET" -d ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/opensearch-dashboards/$PLUGIN_NAME
+unzip "$CHROMIUM_TARGET" -d ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/opensearch-dashboards/$PLUGIN_NAME
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build && zip -ur $PLUGIN_NAME-$VERSION.zip opensearch-dashboards)
 echo "COPY $PLUGIN_NAME.zip"
 cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Include chromium binary in dashboards-reports artifact, binaries are from https://github.com/opensearch-project/dashboards-reports/releases/tag/chromium-1.12.0.0 ([docs](https://github.com/opensearch-project/dashboards-reports/tree/main/dashboards-reports/rendering-engine/headless-chrome))

Limit dashboards-reports dashboards plugin to linux platform only, darwin-arm64 and windows-arm64 chromium binaries are not available yet.
 
### Issues Resolved
#934 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
