### PR TITLE
Added Test Publisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ out.txt
 
 /builds/
 /dist/
+/test-results/
 
 /.vscode/

--- a/jenkins/test/testsuite/Jenkinsfile
+++ b/jenkins/test/testsuite/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                 }
             }
             steps {
-                sh "./test.sh ${JOB_NAME} --s3-bucket ${ARTIFACT_BUCKET_NAME} --opensearch-version ${opensearch_version} --build-id ${build_id} --architecture ${architecture} --test-run-id ${test_run_id}"
+                sh "./test.sh integ-test --s3-bucket ${ARTIFACT_BUCKET_NAME} --opensearch-version ${opensearch_version} --build-id ${build_id} --architecture ${architecture} --test-run-id ${test_run_id}"
             }
             post() {
                 always {

--- a/jenkins/test/testsuite/Jenkinsfile
+++ b/jenkins/test/testsuite/Jenkinsfile
@@ -59,6 +59,7 @@ pipeline {
                 }
             }
             steps {
+                sh "pip3 install --upgrade pip"
                 sh "./test.sh integ-test --s3-bucket ${ARTIFACT_BUCKET_NAME} --opensearch-version ${opensearch_version} --build-id ${build_id} --architecture ${architecture} --test-run-id ${test_run_id}"
             }
             post() {

--- a/jenkins/test/testsuite/Jenkinsfile
+++ b/jenkins/test/testsuite/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
             }
             steps {
                 sh "pip3 install --upgrade pip"
-                sh "./test.sh integ-test --s3-bucket ${ARTIFACT_BUCKET_NAME} --opensearch-version ${opensearch_version} --build-id ${build_id} --architecture ${architecture} --test-run-id ${test_run_id}"
+                sh "./test.sh integ-test https://ci.opensearch.org/ci/dbc/bundle-build/${opensearch_version}/${build_id}/linux/${architecture}"
             }
             post() {
                 always {

--- a/jenkins/test/testsuite/Jenkinsfile
+++ b/jenkins/test/testsuite/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
                                             name: 'build_id',
                                             trim: true
                                     ),
+
                                     string(
                                             defaultValue: '',
                                             name: 'architecture',
@@ -31,9 +32,9 @@ pipeline {
                                     ),
                                     string(
                                             defaultValue: '',
-                                            name: 'test_run_id',
+                                            name: 'platform',
                                             trim: true
-                                    ),
+                                    )
                             ])
                     ])
                 }
@@ -59,14 +60,28 @@ pipeline {
                 }
             }
             steps {
-                sh "pip3 install --upgrade pip"
-                sh "./test.sh integ-test https://ci.opensearch.org/ci/dbc/bundle-build/${opensearch_version}/${build_id}/linux/${architecture}"
+                script {
+                    basePath = "https://ci.opensearch.org/ci/dbc/bundle-build/${opensearch_version}/${build_id}/${platform}/${architecture}"
+                    sh "./test.sh ${JOB_NAME} ${basePath} --test-run-id ${env.BUILD_NUMBER}"
+                }
             }
             post() {
                 always {
+                    script {
+                        publish()
+                    }
                     cleanWs disableDeferredWipeout: true, deleteDirs: true
                 }
             }
         }
     }
+}
+
+/** Publishes test results to S3 **/
+void publish() {
+    def artifactPath = "bundle-build/${opensearch_version}/${build_id}/${platform}/${architecture}"
+    withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
+        s3Upload(file: 'test-results', bucket: "${ARTIFACT_BUCKET_NAME}", path: "${artifactPath}/test-results")
+    }
+    echo "Uploaded Test Results to ${artifactPath}/test-results"
 }

--- a/src/run_integ_test.py
+++ b/src/run_integ_test.py
@@ -29,8 +29,10 @@ def main():
     bundle_manifest = BundleManifest.from_urlpath("/".join([args.path.rstrip("/"), "dist/manifest.yml"]))
     build_manifest = BuildManifest.from_urlpath("/".join([args.path.rstrip("/"), "builds/manifest.yml"]))
     dependency_installer = DependencyInstaller(args.path, build_manifest, bundle_manifest)
+    tests_dir = os.path.join(os.getcwd(), "test-results")
+    os.makedirs(tests_dir, exist_ok=True)
     with TemporaryDirectory(keep=args.keep, chdir=True) as work_dir:
-        test_recorder = TestRecorder(args.test_run_id, "integ-test", work_dir.name)
+        test_recorder = TestRecorder(args.test_run_id, "integ-test", tests_dir)
         dependency_installer.install_maven_dependencies()
         all_results = TestSuiteResults()
         for component in bundle_manifest.components.select(focus=args.component):

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -15,10 +15,10 @@ from test_workflow.test_recorder.test_result_data import TestResultData
 
 
 class TestRecorder:
-    def __init__(self, test_run_id, test_type, location):
+    def __init__(self, test_run_id, test_type, tests_dir):
         self.test_run_id = test_run_id
         self.test_type = test_type
-        self.location = os.path.join(location, "test-recorder", "tests", str(self.test_run_id), self.test_type)
+        self.location = os.path.join(tests_dir, str(self.test_run_id), self.test_type)
         os.makedirs(self.location, exist_ok=True)
         logging.info(f"TestRecorder recording logs in {self.location}")
         self.local_cluster_logs = self.LocalClusterLogs(self)


### PR DESCRIPTION
### Description

- Implemented Test Publisher to store result of the test to S3. 
- Path to test-results `bundlebuild/${opensearch_version}/${build_id}/${platform}/${architecture}/test-results/test_run_id/test_type/component`. 
- Added `platform` as a build parameter.
- Fixed run command for Integ Test to execute without S3 dependencies

Ref: https://github.com/opensearch-project/opensearch-build/issues/207 for the discussion.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/341

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
