### PR TITLE
Fix assigning variable for detecting platform

### DIFF
--- a/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/scripts/components/OpenSearch-Dashboards/build.sh
@@ -57,7 +57,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
-[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 # Assemble distribution artifact

--- a/scripts/components/OpenSearch-Dashboards/install.sh
+++ b/scripts/components/OpenSearch-Dashboards/install.sh
@@ -64,7 +64,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$SNAPSHOT" ] && SNAPSHOT="false"
-[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 ## Setup default config

--- a/scripts/components/OpenSearch/build.sh
+++ b/scripts/components/OpenSearch/build.sh
@@ -75,7 +75,7 @@ cp -r ./build/local-test-repo/org/opensearch "${OUTPUT}"/maven/org
 # Assemble distribution artifact
 # see https://github.com/opensearch-project/OpenSearch/blob/main/settings.gradle#L34 for other distribution targets
 
-[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 case $PLATFORM in

--- a/scripts/components/OpenSearch/install.sh
+++ b/scripts/components/OpenSearch/install.sh
@@ -64,7 +64,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$SNAPSHOT" ] && SNAPSHOT="false"
-[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 ## Copy the tar installation script into the bundle

--- a/scripts/components/performance-analyzer/install.sh
+++ b/scripts/components/performance-analyzer/install.sh
@@ -64,7 +64,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$SNAPSHOT" ] && SNAPSHOT="false"
-[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 ## Setup Performance Analyzer Agent

--- a/scripts/default/install.sh
+++ b/scripts/default/install.sh
@@ -64,7 +64,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$SNAPSHOT" ] && SNAPSHOT="false"
-[ -z "$PLATFORM" ] && PLATFORM=`uname -s` | awk '{print tolower($0)}'
+[ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 exit 0


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Found in https://github.com/opensearch-project/opensearch-build/issues/934#issuecomment-965653497.
Seems like the original implementation will pipe `PLATFORM` assignment output to awk (not very sure what the syntax would do, but `$PLATFORM` will always be empty). Use `$(...)` for variable assignments.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
