### PR TITLE
Fix: stage names for gathering messages.

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -147,7 +147,7 @@ pipeline {
                                 ]
                             }
 
-                            def stashed = lib.Messages.new(this).get(['build-x64', 'build-arm64'])
+                            def stashed = lib.Messages.new(this).get(['build-linux-x64', 'post-build (linux-arm64)'])
                             publishNotification(":white_check_mark:", "Successful Build", "\n${stashed}")
                         }
                     }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Regression from https://github.com/opensearch-project/opensearch-build/pull/924/files

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
