### PR TITLE
Align bwctest finder on other scripts.

### DIFF
--- a/scripts/components/OpenSearch/bwctest.sh
+++ b/scripts/components/OpenSearch/bwctest.sh
@@ -6,4 +6,4 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-# TODO: This is used by ScriptFinder tests, needs a working integtest.sh for OpenSearch.
+# TODO: This is used by ScriptFinder tests, needs a working bwctest.sh for OpenSearch.

--- a/src/paths/script_finder.py
+++ b/src/paths/script_finder.py
@@ -42,6 +42,17 @@ class ScriptFinder:
         return script
 
     @classmethod
+    def __find_named_script(cls, script_name, component_name, git_dir):
+        paths = [
+            os.path.realpath(os.path.join(cls.component_scripts_path, component_name, script_name)),
+            os.path.realpath(os.path.join(git_dir, script_name)),
+            os.path.realpath(os.path.join(git_dir, "scripts", script_name)),
+            os.path.realpath(os.path.join(cls.default_scripts_path, script_name)),
+        ]
+
+        return cls.__find_script(script_name, paths)
+
+    @classmethod
     def find_build_script(cls, project, component_name, git_dir):
         paths = [
             os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "build.sh")),
@@ -59,17 +70,6 @@ class ScriptFinder:
         return cls.__find_script("build.sh", paths)
 
     @classmethod
-    def find_integ_test_script(cls, component_name, git_dir):
-        paths = [
-            os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "integtest.sh")),
-            os.path.realpath(os.path.join(git_dir, "integtest.sh")),
-            os.path.realpath(os.path.join(git_dir, "scripts", "integtest.sh")),
-            os.path.realpath(os.path.join(cls.default_scripts_path, "integtest.sh")),
-        ]
-
-        return cls.__find_script("integtest.sh", paths)
-
-    @classmethod
     def find_install_script(cls, component_name):
         paths = [
             os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "install.sh")),
@@ -79,12 +79,9 @@ class ScriptFinder:
         return cls.__find_script("install.sh", paths)
 
     @classmethod
-    def find_bwc_test_script(cls, component_name, git_dir):
-        paths = [
-            os.path.realpath(os.path.join(git_dir, "bwctest.sh")),
-            os.path.realpath(os.path.join(git_dir, "scripts", "bwctest.sh")),
-            os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "bwctest.sh")),
-            os.path.realpath(os.path.join(cls.default_scripts_path, "bwctest.sh")),
-        ]
+    def find_integ_test_script(cls, component_name, git_dir):
+        return cls.__find_named_script("integtest.sh", component_name, git_dir)
 
-        return cls.__find_script("bwctest.sh", paths)
+    @classmethod
+    def find_bwc_test_script(cls, component_name, git_dir):
+        return cls.__find_named_script("bwctest.sh", component_name, git_dir)

--- a/tests/tests_paths/data/git/component-with-scripts-folder/scripts/bwctest.sh
+++ b/tests/tests_paths/data/git/component-with-scripts-folder/scripts/bwctest.sh
@@ -1,9 +1,7 @@
-#!/bin/bash
-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-
-# TODO: This is used by ScriptFinder tests, needs a working integtest.sh for OpenSearch.
+#
+# This page intentionally left blank.

--- a/tests/tests_paths/data/git/component-with-scripts/bwctest.sh
+++ b/tests/tests_paths/data/git/component-with-scripts/bwctest.sh
@@ -1,9 +1,7 @@
-#!/bin/bash
-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-
-# TODO: This is used by ScriptFinder tests, needs a working integtest.sh for OpenSearch.
+#
+# This page intentionally left blank.

--- a/tests/tests_paths/test_script_finder.py
+++ b/tests/tests_paths/test_script_finder.py
@@ -140,3 +140,48 @@ class TestScriptFinder(unittest.TestCase):
             "Could not find install.sh script. Looked in .*",
         ):
             ScriptFinder.find_install_script("anything")
+
+    # find_bwc_test_script
+
+    def test_find_bwc_test_script_default(self):
+        self.assertEqual(
+            os.path.join(ScriptFinder.default_scripts_path, "bwctest.sh"),
+            ScriptFinder.find_bwc_test_script("invalid", self.component_without_scripts),
+            msg="A component without an override resolves to a default.",
+        )
+
+    def test_find_bwc_test_script_component_override(self):
+        self.assertEqual(
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "bwctest.sh"),
+            ScriptFinder.find_bwc_test_script("OpenSearch", self.component_without_scripts),
+            msg="A component without scripts resolves to a component override.",
+        )
+
+    def test_find_bwc_test_script_component_script(self):
+        self.assertEqual(
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "bwctest.sh"),
+            ScriptFinder.find_bwc_test_script("OpenSearch", self.component_with_scripts),
+            msg="A component with a script resolves to the script at the root.",
+        )
+
+    def test_find_bwc_test_script_component_script_in_folder(self):
+        self.assertEqual(
+            os.path.join(self.component_with_scripts_folder, "scripts", "bwctest.sh"),
+            ScriptFinder.find_bwc_test_script("foobar", self.component_with_scripts_folder),
+            msg="A component with a scripts folder resolves to an override.",
+        )
+
+    def test_find_bwc_test_script_component_script_in_folder_with_default(self):
+        self.assertEqual(
+            os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "bwctest.sh"),
+            ScriptFinder.find_bwc_test_script("OpenSearch", self.component_with_scripts_folder),
+            msg="A component with a scripts folder resolves to a script in that folder.",
+        )
+
+    @patch("os.path.exists", return_value=False)
+    def test_find_bwc_test_script_does_not_exist(self, *mocks):
+        with self.assertRaisesRegex(
+            ScriptFinder.ScriptNotFoundError,
+            "Could not find bwctest.sh script. Looked in .*",
+        ):
+            ScriptFinder.find_bwc_test_script("anything", self.component_without_scripts)

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_bwc_suite.py
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_bwc_suite.py
@@ -34,13 +34,13 @@ class TestBwcSuite(unittest.TestCase):
     @patch("test_workflow.bwc_test.bwc_test_suite.execute")
     def test_run_bwctest(self, mock_execute):
         mock_execute.return_value = (0, "", "")
-        self.bwc_test_suite.run_tests(".", "OpenSearch")
+        self.bwc_test_suite.run_tests(".", "job-scheduler")
         script = os.path.join(ScriptFinder.default_scripts_path, "bwctest.sh")
         mock_execute.assert_called_with(script, ".", True, False)
 
     @patch("test_workflow.bwc_test.bwc_test_suite.TestComponent")
     def test_component_bwctest(self, test_component_mock):
-        component = self.manifest.components["OpenSearch"]
+        component = self.manifest.components["job-scheduler"]
         self.bwc_test_suite.run_tests = MagicMock()
         expected = [call(os.path.join(".", component.name), component.name)]
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

The order of scripts for bwctests is different than for other scripts, align those, add tests.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
