### PR TITLE
Revert "Remove build.sh files moved to common-utils, job-scheduler, and alerting repos. (#945)"

### DIFF
--- a/scripts/components/alerting/build.sh
+++ b/scripts/components/alerting/build.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:p:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+mkdir -p $OUTPUT/plugins
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x ktlint
+
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+
+echo "COPY ${distributions}/*.zip"
+cp ${distributions}/*.zip ./$OUTPUT/plugins
+
+./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x ktlint
+
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./notification/build/libs $OUTPUT/maven/org/opensearch/notification

--- a/scripts/components/common-utils/build.sh
+++ b/scripts/components/common-utils/build.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:p:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+./gradlew build -x test -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./build/libs $OUTPUT/maven/org/opensearch/common-utils

--- a/scripts/components/job-scheduler/build.sh
+++ b/scripts/components/job-scheduler/build.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:s:o:p:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./spi/build/distributions/* $OUTPUT/maven/org/opensearch
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+mkdir -p $OUTPUT/plugins
+cp ./build/distributions/*.zip $OUTPUT/plugins

--- a/tests/tests_build_workflow/test_builder_from_source.py
+++ b/tests/tests_build_workflow/test_builder_from_source.py
@@ -17,7 +17,7 @@ from paths.script_finder import ScriptFinder
 class TestBuilderFromSource(unittest.TestCase):
     def setUp(self):
         self.builder = BuilderFromSource(
-            InputManifest.ComponentFromSource({"name": "OpenSearch", "repository": "url", "ref": "ref"}),
+            InputManifest.ComponentFromSource({"name": "common-utils", "repository": "url", "ref": "ref"}),
             BuildTarget(
                 name="OpenSearch",
                 version="1.1.0",
@@ -28,7 +28,7 @@ class TestBuilderFromSource(unittest.TestCase):
         )
 
     def test_builder(self):
-        self.assertEqual(self.builder.component.name, "OpenSearch")
+        self.assertEqual(self.builder.component.name, "common-utils")
 
     @patch("build_workflow.builder_from_source.GitRepository")
     def test_build(self, mock_git_repo):
@@ -40,7 +40,7 @@ class TestBuilderFromSource(unittest.TestCase):
             " ".join(
                 [
                     "bash",
-                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "build.sh")),
+                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "common-utils", "build.sh")),
                     "-v 1.1.0",
                     "-p linux",
                     "-a x64",
@@ -49,7 +49,7 @@ class TestBuilderFromSource(unittest.TestCase):
                 ]
             )
         )
-        build_recorder.record_component.assert_called_with("OpenSearch", mock_git_repo.return_value)
+        build_recorder.record_component.assert_called_with("common-utils", mock_git_repo.return_value)
 
     @patch("build_workflow.builder_from_source.GitRepository")
     def test_build_snapshot(self, mock_git_repo):
@@ -62,7 +62,7 @@ class TestBuilderFromSource(unittest.TestCase):
             " ".join(
                 [
                     "bash",
-                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "build.sh")),
+                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "common-utils", "build.sh")),
                     "-v 1.1.0",
                     "-p linux",
                     "-a x64",
@@ -71,7 +71,7 @@ class TestBuilderFromSource(unittest.TestCase):
                 ]
             )
         )
-        build_recorder.record_component.assert_called_with("OpenSearch", self.builder.git_repo)
+        build_recorder.record_component.assert_called_with("common-utils", self.builder.git_repo)
 
     def mock_os_walk(self, artifact_path):
         if artifact_path.endswith(os.path.join("dir", "builds", "core-plugins")):
@@ -93,7 +93,7 @@ class TestBuilderFromSource(unittest.TestCase):
         build_recorder.record_artifact.assert_has_calls(
             [
                 call(
-                    "OpenSearch",
+                    "common-utils",
                     "maven",
                     os.path.relpath(
                         os.path.join("maven", "artifact1.jar"),
@@ -102,7 +102,7 @@ class TestBuilderFromSource(unittest.TestCase):
                     os.path.join("maven", "artifact1.jar"),
                 ),
                 call(
-                    "OpenSearch",
+                    "common-utils",
                     "core-plugins",
                     os.path.relpath(
                         os.path.join("core-plugins", "plugin1.zip"),


### PR DESCRIPTION
This reverts commit 481df95511dcdb2b91695e38956f01d900d80dd0.

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Revert the removal of these files until the scripts in each repo are corrected.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
