### PR TITLE
Update build scripts for common-utils, alerting, and job-scheduler to properly generate cksums and copy the correct dependencies.

### DIFF
--- a/scripts/components/alerting/build.sh
+++ b/scripts/components/alerting/build.sh
@@ -73,6 +73,7 @@ echo "COPY ${distributions}/*.zip"
 cp ${distributions}/*.zip ./$OUTPUT/plugins
 
 ./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -x ktlint
+./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 mkdir -p $OUTPUT/maven/org/opensearch
-cp -r ./notification/build/libs $OUTPUT/maven/org/opensearch/notification
+cp -r ./build/local-staging-repo/org/opensearch/notification $OUTPUT/maven/org/opensearch/notification

--- a/scripts/components/common-utils/build.sh
+++ b/scripts/components/common-utils/build.sh
@@ -61,5 +61,6 @@ fi
 
 ./gradlew build -x test -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 ./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 mkdir -p $OUTPUT/maven/org/opensearch
-cp -r ./build/libs $OUTPUT/maven/org/opensearch/common-utils
+cp -r ./build/local-staging-repo/org/opensearch/common-utils $OUTPUT/maven/org/opensearch/common-utils

--- a/scripts/components/job-scheduler/build.sh
+++ b/scripts/components/job-scheduler/build.sh
@@ -63,8 +63,9 @@ fi
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
 ./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-mkdir -p $OUTPUT/maven/org/opensearch
-cp -r ./spi/build/distributions/* $OUTPUT/maven/org/opensearch
+./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
+mkdir -p $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
+cp -r ./build/local-staging-repo/org/opensearch/opensearch-job-scheduler-spi $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
 
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Update build scripts for common-utils, alerting, and job-scheduler until the scripts in those repos are corrected.

This is a quick fix for the build until the following PRs are merged and backported.
https://github.com/opensearch-project/common-utils/pull/95
https://github.com/opensearch-project/job-scheduler/pull/99
https://github.com/opensearch-project/alerting/pull/240

Issues:
#943 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
