### PR TITLE
Fix extra folder copied into job-scheduler-spi path.

### DIFF
--- a/scripts/components/alerting/build.sh
+++ b/scripts/components/alerting/build.sh
@@ -76,4 +76,4 @@ cp ${distributions}/*.zip ./$OUTPUT/plugins
 ./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 mkdir -p $OUTPUT/maven/org/opensearch
-cp -r ./build/local-staging-repo/org/opensearch/notification $OUTPUT/maven/org/opensearch/notification
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch

--- a/scripts/components/common-utils/build.sh
+++ b/scripts/components/common-utils/build.sh
@@ -63,4 +63,4 @@ fi
 ./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 ./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 mkdir -p $OUTPUT/maven/org/opensearch
-cp -r ./build/local-staging-repo/org/opensearch/common-utils $OUTPUT/maven/org/opensearch/common-utils
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch

--- a/scripts/components/job-scheduler/build.sh
+++ b/scripts/components/job-scheduler/build.sh
@@ -64,8 +64,8 @@ fi
 
 ./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 ./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
-mkdir -p $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
-cp -r ./build/local-staging-repo/org/opensearch/opensearch-job-scheduler-spi $OUTPUT/maven/org/opensearch/opensearch-job-scheduler-spi
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch
 
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts


### PR DESCRIPTION
Updates common-utils and alerting to use wildcard to ignore if this
folder already exists.

Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
job-scheduler-spi was copying an extra folder name into the path because the directory already existed.
This corrects the path and ignores if the folder already exists.

```
[handalm@dev-dsk-handalm-2a-849e7644 maven]$ tree
.
└── org
    └── opensearch
        └── opensearch-job-scheduler-spi
            ├── 1.2.0.0
            │   ├── opensearch-job-scheduler-spi-1.2.0.0.jar
            │   ├── opensearch-job-scheduler-spi-1.2.0.0.jar.md5
            │   ├── opensearch-job-scheduler-spi-1.2.0.0.jar.sha1
            │   ├── opensearch-job-scheduler-spi-1.2.0.0.jar.sha256
            │   ├── opensearch-job-scheduler-spi-1.2.0.0.jar.sha512
            │   ├── opensearch-job-scheduler-spi-1.2.0.0-javadoc.jar
            │   ├── opensearch-job-scheduler-spi-1.2.0.0-javadoc.jar.md5
            │   ├── opensearch-job-scheduler-spi-1.2.0.0-javadoc.jar.sha1
            │   ├── opensearch-job-scheduler-spi-1.2.0.0-javadoc.jar.sha256
            │   ├── opensearch-job-scheduler-spi-1.2.0.0-javadoc.jar.sha512
            │   ├── opensearch-job-scheduler-spi-1.2.0.0.pom
            │   ├── opensearch-job-scheduler-spi-1.2.0.0.pom.md5
            │   ├── opensearch-job-scheduler-spi-1.2.0.0.pom.sha1
            │   ├── opensearch-job-scheduler-spi-1.2.0.0.pom.sha256
            │   ├── opensearch-job-scheduler-spi-1.2.0.0.pom.sha512
            │   ├── opensearch-job-scheduler-spi-1.2.0.0-sources.jar
            │   ├── opensearch-job-scheduler-spi-1.2.0.0-sources.jar.md5
            │   ├── opensearch-job-scheduler-spi-1.2.0.0-sources.jar.sha1
            │   ├── opensearch-job-scheduler-spi-1.2.0.0-sources.jar.sha256
            │   └── opensearch-job-scheduler-spi-1.2.0.0-sources.jar.sha512
            ├── maven-metadata.xml
            ├── maven-metadata.xml.md5
            ├── maven-metadata.xml.sha1
            ├── maven-metadata.xml.sha256
            └── maven-metadata.xml.sha512
```
 
### Issues Resolved
https://github.com/opensearch-project/job-scheduler/issues/101
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
