### PR TITLE
Remove notebooks from project meta

### DIFF
--- a/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
@@ -47,7 +47,7 @@ ARG OPENSEARCH_DASHBOARDS_HOME=/usr/share/opensearch-dashboards
 # Install which to allow running of securityadmin.sh
 RUN yum update -y && yum install -y tar gzip shadow-utils which && yum clean all
 
-# Install notebooks dependencies
+# Install Reporting dependencies
 RUN yum install -y libnss3.so xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc fontconfig freetype && yum clean all
 
 # Create an opensearch-dashboards user, group

--- a/meta/.gitignore
+++ b/meta/.gitignore
@@ -3,7 +3,6 @@
 /alerting/
 /anomaly-detection/
 /asynchronous-search/
-/dashboards-notebooks/
 /dashboards-reports/
 /dashboards-visualizations/
 /index-management/

--- a/meta/.meta
+++ b/meta/.meta
@@ -5,7 +5,6 @@
     "alerting": "git@github.com:opensearch-project/alerting.git",
     "anomaly-detection": "git@github.com:opensearch-project/anomaly-detection.git",
     "asynchronous-search": "git@github.com:opensearch-project/asynchronous-search.git",
-    "dashboards-notebooks": "git@github.com:opensearch-project/dashboards-notebooks",
     "dashboards-reports": "git@github.com:opensearch-project/dashboards-reports.git",
     "dashboards-visualizations": "git@github.com:opensearch-project/dashboards-visualizations.git",
     "index-management": "git@github.com:opensearch-project/index-management.git",


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Notebooks repo is deprecated as it is merged to observability, removing it
 
### Issues Resolved
https://github.com/opensearch-project/dashboards-notebooks/issues/98#issuecomment-967590887
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
