### PR TITLE
Moved docker build into a stage.

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -129,34 +129,41 @@ pipeline {
                     }
                 }
             }
-            post() {
-                success {
-                    node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
-                        script {
-                            def VERSION = sh(script: 'echo ${INPUT_MANIFEST} | grep -Po "[0-9.]+?(?=.yml)"', returnStdout: true).trim()
-                            sh "echo VERSION:${VERSION} BUILD_NUMBER:${env.BUILD_NUMBER}"
-                            def URL_x64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/x64/dist/opensearch-dashboards-${VERSION}-linux-x64.tar.gz"
-                            def URL_arm64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/arm64/dist/opensearch-dashboards-${VERSION}-linux-arm64.tar.gz"
-                            dockerBuild: {
-                                build job: 'docker-build',
-                                parameters: [
-                                    string(name: 'DOCKER_BUILD_GIT_REPOSITORY', value: 'https://github.com/opensearch-project/opensearch-build'),
-                                    string(name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE', value: 'main'),
-                                    string(name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS', value: "id && pwd && cd docker/release && curl -sSL $URL_x64 -o opensearch-dashboards-x64.tgz && curl -sSL $URL_arm64 -o opensearch-dashboards-arm64.tgz && bash build-image-multi-arch.sh -v ${VERSION} -f ./dockerfiles/opensearch-dashboards.al2.dockerfile -p opensearch-dashboards -a 'x64,arm64' -r opensearchstaging/opensearch-dashboards -t 'opensearch-dashboards-x64.tgz,opensearch-dashboards-arm64.tgz' -n ${env.BUILD_NUMBER}"),
-                                    booleanParam(name: 'IS_STAGING', value: true)
-                                ]
-                            }
-
-                            def stashed = lib.Messages.new(this).get(['build-linux-x64', 'post-build (linux-arm64)'])
-                            publishNotification(":white_check_mark:", "Successful Build", "\n${stashed}")
+        }
+        stage('docker build') {
+            steps {
+                node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                    script {
+                        def VERSION = sh(script: 'echo ${INPUT_MANIFEST} | grep -Po "[0-9.]+?(?=.yml)"', returnStdout: true).trim()
+                        sh "echo VERSION:${VERSION} BUILD_NUMBER:${env.BUILD_NUMBER}"
+                        def URL_x64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/x64/dist/opensearch-dashboards-${VERSION}-linux-x64.tar.gz"
+                        def URL_arm64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/arm64/dist/opensearch-dashboards-${VERSION}-linux-arm64.tar.gz"
+                        dockerBuild: {
+                            build job: 'docker-build',
+                            parameters: [
+                                string(name: 'DOCKER_BUILD_GIT_REPOSITORY', value: 'https://github.com/opensearch-project/opensearch-build'),
+                                string(name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE', value: 'main'),
+                                string(name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS', value: "id && pwd && cd docker/release && curl -sSL $URL_x64 -o opensearch-dashboards-x64.tgz && curl -sSL $URL_arm64 -o opensearch-dashboards-arm64.tgz && bash build-image-multi-arch.sh -v ${VERSION} -f ./dockerfiles/opensearch-dashboards.al2.dockerfile -p opensearch-dashboards -a 'x64,arm64' -r opensearchstaging/opensearch-dashboards -t 'opensearch-dashboards-x64.tgz,opensearch-dashboards-arm64.tgz' -n ${env.BUILD_NUMBER}"),
+                                booleanParam(name: 'IS_STAGING', value: true)
+                            ]
                         }
-                    }
+                    }                
                 }
-                failure {
-                    node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
-                        publishNotification(":warning:", "Failed Build", "")
-                    }
+            }
+        }
+    }
+    post() {
+        success {
+            node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                script {
+                    def stashed = lib.Messages.new(this).get(['build-linux-x64', 'post-build (linux-arm64)'])
+                    publishNotification(":white_check_mark:", "Successful Build", "\n${stashed}")
                 }
+            }
+        }
+        failure {
+            node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                publishNotification(":warning:", "Failed Build", "")
             }
         }
     }

--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -130,34 +130,41 @@ pipeline {
                     }
                 }
             }
-            post() {
-                success {
-                    node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
-                        script {
-                            def VERSION = sh(script: 'echo ${INPUT_MANIFEST} | grep -Po "[0-9.]+?(?=.yml)"', returnStdout: true).trim()
-                            sh "echo VERSION:${VERSION} BUILD_NUMBER:${env.BUILD_NUMBER}"
-                            def URL_x64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/x64/dist/opensearch-${VERSION}-linux-x64.tar.gz"
-                            def URL_arm64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/arm64/dist/opensearch-${VERSION}-linux-arm64.tar.gz"
-                            dockerBuild: {
-                                build job: 'docker-build',
-                                parameters: [
-                                    string(name: 'DOCKER_BUILD_GIT_REPOSITORY', value: 'https://github.com/opensearch-project/opensearch-build'),
-                                    string(name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE', value: 'main'),
-                                    string(name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS', value: "id && pwd && cd docker/release && curl -sSL $URL_x64 -o opensearch-x64.tgz && curl -sSL $URL_arm64 -o opensearch-arm64.tgz && bash build-image-multi-arch.sh -v ${VERSION} -f ./dockerfiles/opensearch.al2.dockerfile -p opensearch -a 'x64,arm64' -r opensearchstaging/opensearch -t 'opensearch-x64.tgz,opensearch-arm64.tgz' -n ${env.BUILD_NUMBER}"),
-                                    booleanParam(name: 'IS_STAGING', value: true)
-                                ]
-                            }
-                            
-                            def stashed = lib.Messages.new(this).get(['build-x64', 'build-arm64'])
-                            publishNotification(":white_check_mark:", "Successful Build", "\n${stashed}")
+        }
+        stage('docker build') {
+            steps {
+                node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                    script {
+                        def VERSION = sh(script: 'echo ${INPUT_MANIFEST} | grep -Po "[0-9.]+?(?=.yml)"', returnStdout: true).trim()
+                        sh "echo VERSION:${VERSION} BUILD_NUMBER:${env.BUILD_NUMBER}"
+                        def URL_x64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/x64/dist/opensearch-${VERSION}-linux-x64.tar.gz"
+                        def URL_arm64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/arm64/dist/opensearch-${VERSION}-linux-arm64.tar.gz"
+                        dockerBuild: {
+                            build job: 'docker-build',
+                            parameters: [
+                                string(name: 'DOCKER_BUILD_GIT_REPOSITORY', value: 'https://github.com/opensearch-project/opensearch-build'),
+                                string(name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE', value: 'main'),
+                                string(name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS', value: "id && pwd && cd docker/release && curl -sSL $URL_x64 -o opensearch-x64.tgz && curl -sSL $URL_arm64 -o opensearch-arm64.tgz && bash build-image-multi-arch.sh -v ${VERSION} -f ./dockerfiles/opensearch.al2.dockerfile -p opensearch -a 'x64,arm64' -r opensearchstaging/opensearch -t 'opensearch-x64.tgz,opensearch-arm64.tgz' -n ${env.BUILD_NUMBER}"),
+                                booleanParam(name: 'IS_STAGING', value: true)
+                            ]
                         }
                     }
                 }
-                failure {
-                    node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
-                        publishNotification(":warning:", "Failed Build", "")
-                    }
+            }
+        }
+    }
+    post() {
+        success {
+            node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                script {
+                    def stashed = lib.Messages.new(this).get(['build-x64', 'build-arm64'])
+                    publishNotification(":white_check_mark:", "Successful Build", "\n${stashed}")
                 }
+            }
+        }
+        failure {
+            node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                publishNotification(":warning:", "Failed Build", "")
             }
         }
     }

--- a/tests/jenkins/jobs/Build_Jenkinsfile
+++ b/tests/jenkins/jobs/Build_Jenkinsfile
@@ -126,26 +126,34 @@ pipeline {
                     }
                 }
             }
-            post() {
-                success {
-                    node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
-                        script {
-                            def VERSION = sh(script: 'echo ${INPUT_MANIFEST} | grep -Po "[0-9.]+?(?=.yml)"', returnStdout: true).trim()
-                            sh "echo VERSION:$VERSION BUILD_NUMBER:$BUILD_NUMBER"
-                            def URL_x64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/x64/dist/opensearch-${VERSION}-linux-x64.tar.gz"
-                            def URL_arm64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/arm64/dist/opensearch-${VERSION}-linux-arm64.tar.gz"
-                            def s = "id && pwd && cd docker/release && curl -sSL $URL_x64 -o opensearch-x64.tgz && curl -sSL $URL_arm64 -o opensearch-arm64.tgz && bash build-image-multi-arch.sh -v ${VERSION} -f ./dockerfiles/opensearch.al2.dockerfile -p opensearch -a 'x64,arm64' -r opensearchstaging/opensearch -t 'opensearch-x64.tgz,opensearch-arm64.tgz' -n ${env.BUILD_NUMBER}"
-                            echo "dockerBuild:${s}"
-                            def stashed = lib.Messages.new(this).get(['build-x64', 'build-arm64'])
-                            publishNotification(":white_check_mark:", "Successful Build", "\n${stashed}")
-                        }
+        }
+        stage('docker build') {
+            steps {
+                node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                    script {
+                        def VERSION = sh(script: 'echo ${INPUT_MANIFEST} | grep -Po "[0-9.]+?(?=.yml)"', returnStdout: true).trim()
+                        sh "echo VERSION:$VERSION BUILD_NUMBER:$BUILD_NUMBER"
+                        def URL_x64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/x64/dist/opensearch-${VERSION}-linux-x64.tar.gz"
+                        def URL_arm64 = "${PUBLIC_ARTIFACT_URL}/${env.JOB_NAME}/${VERSION}/${env.BUILD_NUMBER}/linux/arm64/dist/opensearch-${VERSION}-linux-arm64.tar.gz"
+                        def s = "id && pwd && cd docker/release && curl -sSL $URL_x64 -o opensearch-x64.tgz && curl -sSL $URL_arm64 -o opensearch-arm64.tgz && bash build-image-multi-arch.sh -v ${VERSION} -f ./dockerfiles/opensearch.al2.dockerfile -p opensearch -a 'x64,arm64' -r opensearchstaging/opensearch -t 'opensearch-x64.tgz,opensearch-arm64.tgz' -n ${env.BUILD_NUMBER}"
+                        echo "dockerBuild:${s}"
                     }
                 }
-                failure {
-                    node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
-                        publishNotification(":warning:", "Failed Build", "")
-                    }
+            }
+        }
+    }
+    post() {
+        success {
+            node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                script {
+                    def stashed = lib.Messages.new(this).get(['build-x64', 'build-arm64'])
+                    publishNotification(":white_check_mark:", "Successful Build", "\n${stashed}")
                 }
+            }
+        }
+        failure {
+            node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                publishNotification(":warning:", "Failed Build", "")
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Followup on https://github.com/opensearch-project/opensearch-build/pull/928 and https://github.com/opensearch-project/opensearch-build/pull/929/files#r746192714.

Jenkins will abort execution of subsequent pipelines on failure AFAIK, unless [you tell it not to](https://newbedev.com/scripted-jenkins-pipeline-continue-on-fail), so there's no need to have the docker build stage on success. Moved the docker build stage after the parallel build stage and moved the `post` stage to the pipeline level from the build stages. 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
