### PR TITLE
Use concurrency when copy/download files

### DIFF
--- a/tests/tests_test_workflow/test_dependency_installer.py
+++ b/tests/tests_test_workflow/test_dependency_installer.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, patch
 
 from manifests.build_manifest import BuildManifest
 from manifests.bundle_manifest import BundleManifest
@@ -13,16 +13,26 @@ class DependencyInstallerTests(unittest.TestCase):
     DIST_MANIFEST_LOCAL = os.path.join(DATA, "local", "dist", "manifest.yml")
     DIST_MANIFEST_REMOTE = os.path.join(DATA, "remote", "dist", "manifest.yml")
 
+    @patch("concurrent.futures.ThreadPoolExecutor", return_value=MagicMock())
     @patch("os.makedirs")
     @patch("shutil.copyfile")
     @patch("urllib.request.urlretrieve")
-    def test_install_maven_dependencies_local(self, mock_request, mock_copyfile, mock_makedirs):
+    def test_install_maven_dependencies_local(self, mock_request, mock_copyfile, mock_makedirs, mock_threadpool):
+        def submit_and_run(callable, source, dest):
+            # Filter down the actual calls to make analyzing failures easier
+            if 'alerting-notification-1.2.0.0.jar' in source:
+                return callable(source, dest)
+            return None
+        mock_threadpool.return_value.__enter__().submit.side_effect = submit_and_run
         dependency_installer = DependencyInstaller(
             self.DATA,
             BuildManifest.from_path(self.BUILD_MANIFEST),
             BundleManifest.from_path(self.DIST_MANIFEST_LOCAL)
         )
         dependency_installer.install_maven_dependencies()
+        self.assertEqual(mock_threadpool.call_count, 4)
+        self.assertEqual(mock_threadpool().__enter__().submit.call_count, 2375)
+
         mock_makedirs.assert_called_with(
             os.path.realpath(
                 os.path.join(
@@ -32,25 +42,30 @@ class DependencyInstallerTests(unittest.TestCase):
             exist_ok=True
         )
         mock_request.assert_not_called()
-        mock_copyfile.assert_has_calls(
-            [
-                call(
-                    os.path.join(self.DATA, "builds", "maven", "org", "opensearch", "notification", "alerting-notification-1.2.0.0.jar"),
-                    os.path.join(dependency_installer.maven_local_path, "org", "opensearch", "notification", "alerting-notification-1.2.0.0.jar"),
-                )
-            ]
+        mock_copyfile.assert_called_with(
+            os.path.join(self.DATA, "builds", "maven", "org", "opensearch", "notification", "alerting-notification-1.2.0.0.jar"),
+            os.path.realpath(os.path.join(dependency_installer.maven_local_path, "org", "opensearch", "notification", "alerting-notification-1.2.0.0.jar"))
         )
 
+    @patch("concurrent.futures.ThreadPoolExecutor", return_value=MagicMock())
     @patch("os.makedirs")
     @patch("shutil.copyfile")
     @patch("urllib.request.urlretrieve")
-    def test_install_maven_dependencies_remote(self, mock_request, mock_copyfile, mock_makedirs):
+    def test_install_maven_dependencies_remote(self, mock_request, mock_copyfile, mock_makedirs, mock_threadpool):
+        def submit_and_run(callable, source, dest):
+            # Filter down the actual calls to make analyzing failures easier
+            if 'alerting-notification-1.2.0.0.jar' in source:
+                return callable(source, dest)
+            return None
+        mock_threadpool.return_value.__enter__().submit.side_effect = submit_and_run
         dependency_installer = DependencyInstaller(
             "https://ci.opensearch.org/x/y",
             BuildManifest.from_path(self.BUILD_MANIFEST),
             BundleManifest.from_path(self.DIST_MANIFEST_REMOTE)
         )
         dependency_installer.install_maven_dependencies()
+        self.assertEqual(mock_threadpool.call_count, 4)
+        self.assertEqual(mock_threadpool().__enter__().submit.call_count, 2375)
         mock_makedirs.assert_called_with(
             os.path.realpath(
                 os.path.join(
@@ -60,13 +75,9 @@ class DependencyInstallerTests(unittest.TestCase):
             exist_ok=True
         )
         mock_copyfile.assert_not_called()
-        mock_request.assert_has_calls(
-            [
-                call(
-                    "https://ci.opensearch.org/x/y/builds/maven/org/opensearch/notification/alerting-notification-1.2.0.0.jar",
-                    os.path.join(dependency_installer.maven_local_path, "org", "opensearch", "notification", "alerting-notification-1.2.0.0.jar"),
-                )
-            ]
+        mock_request.assert_called_with(
+            "https://ci.opensearch.org/x/y/builds/maven/org/opensearch/notification/alerting-notification-1.2.0.0.jar",
+            os.path.realpath(os.path.join(dependency_installer.maven_local_path, "org", "opensearch", "notification", "alerting-notification-1.2.0.0.jar"))
         )
 
     @patch("os.makedirs")


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Speed up downloads / copying by using a threadpool
 
### Tested
Add profiling code to the area where the concurrency is getting added, run ` ./test.sh integ-test https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1048/linux/x64` from my cloud desktop, download only

- Existing code `Elapsed time: 260.8771 seconds`
- PR code `Elapsed time: 22.4884 seconds`

That is an order of magnitude faster, clear winner to me.

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
