### PR TITLE
Fix: missing env.JOB_NAME parameter to getArtifactRoot.

### DIFF
--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -164,7 +164,7 @@ void build() {
     def baseUrl = buildManifest.getArtifactRootUrl(env.PUBLIC_ARTIFACT_URL, env.JOB_NAME, env.BUILD_NUMBER)
     sh "./assemble.sh builds/manifest.yml --base-url ${baseUrl}"
 
-    def artifactPath = buildManifest.getArtifactRoot(env.BUILD_NUMBER)
+    def artifactPath = buildManifest.getArtifactRoot(env.JOB_NAME, env.BUILD_NUMBER)
     echo "Uploading to s3://${ARTIFACT_BUCKET_NAME}/${artifactPath}"
     withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
         s3Upload(file: 'builds', bucket: "${ARTIFACT_BUCKET_NAME}", path: "${artifactPath}/builds")


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Forgot one place to change the argument.
 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
