### PR TITLE
Restore git checkout.

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -122,6 +122,7 @@ pipeline {
             steps {
                 node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
                     script {
+                        git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
                         def inputManifest = lib.InputManifest.new(readYaml(file: "manifests/$INPUT_MANIFEST"))
                         dockerBuild: {
                             build job: 'docker-build',
@@ -162,6 +163,7 @@ pipeline {
 }
 
 void build(platform, architecture) {
+    git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
     sh "./build.sh manifests/$INPUT_MANIFEST -p $platform -a $architecture"
 }
 

--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -117,6 +117,7 @@ pipeline {
             steps {
                 node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
                     script {
+                        git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
                         def inputManifest = lib.InputManifest.new(readYaml(file: "manifests/$INPUT_MANIFEST"))
                         dockerBuild: {
                             build job: 'docker-build',
@@ -157,6 +158,7 @@ pipeline {
 }
 
 void build() {
+    git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
     sh "./build.sh manifests/$INPUT_MANIFEST"
     
     def buildManifest = lib.BuildManifest.new(readYaml(file: 'builds/manifest.yml'))


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Restores git checkout so that manifest files can be found in the workspace.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
