### PR TITLE
Remove performance-analyzer-rca from input manifest

### DIFF
--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -56,11 +56,6 @@ components:
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: "1.2"
-  - name: performance-analyzer-rca
-    repository: https://github.com/opensearch-project/performance-analyzer-rca.git
-    ref: "1.2"
-    checks:
-      - gradle:properties:version
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: "1.2"


### PR DESCRIPTION
Signed-off-by: Sruti Parthiban <partsrut@amazon.com>

### Description
Remove performance-analyzer-rca from the input manifest. 
```performance-analyzer-rca.zip``` is already included in the ```performance-analyzer.zip```
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/894
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
