### PR TITLE
fix the issue of starting opensearch

### DIFF
--- a/src/system/process.py
+++ b/src/system/process.py
@@ -23,8 +23,8 @@ class Process:
         if self.started:
             raise ProcessStartedError(self.pid)
 
-        self.stdout = tempfile.NamedTemporaryFile()
-        self.stderr = tempfile.NamedTemporaryFile()
+        self.stdout = tempfile.NamedTemporaryFile(mode="r+")
+        self.stderr = tempfile.NamedTemporaryFile(mode="r+")
 
         self.process = subprocess.Popen(
             command,

--- a/src/test_workflow/integ_test/local_test_cluster.py
+++ b/src/test_workflow/integ_test/local_test_cluster.py
@@ -113,14 +113,12 @@ class LocalTestCluster(TestCluster):
                     return
             except requests.exceptions.ConnectionError:
                 logging.info("Service not available yet")
-                if self.stdout:
+                if self.process_handler.output:
                     logging.info("- stdout:")
-                    with open(os.path.join(self.work_dir, self.stdout.name), "r") as stdout:
-                        logging.info(stdout.read())
-                if self.stderr:
+                    logging.info(self.process_handler.output.read())
+                if self.process_handler.error:
                     logging.info("- stderr:")
-                    with open(os.path.join(self.work_dir, self.stderr.name), "r") as stderr:
-                        logging.info(stderr.read())
+                    logging.info(self.process_handler.error.read())
 
             time.sleep(10)
         raise ClusterCreationException("Cluster is not available after 10 attempts")

--- a/tests/tests_system/test_process.py
+++ b/tests/tests_system/test_process.py
@@ -19,7 +19,9 @@ class TestProcess(unittest.TestCase):
         self.assertTrue(process_handler.started)
         self.assertIsNotNone(process_handler.pid)
         self.assertIsNotNone(process_handler.output)
+        self.assertEqual(process_handler.output.mode, "r+")
         self.assertIsNotNone(process_handler.error)
+        self.assertEqual(process_handler.error.mode, "r+")
 
         return_code, stdout_data, stderr_data = process_handler.terminate()
 


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
fix the issue of starting opensearch. See the related bug issue for details.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/977
 
### Test
Run this command
```
./test.sh integ-test https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/998/linux/x64
```

The output is 

```

2021-11-17 09:46:37 INFO     Skipping integ-tests for OpenSearch, as it is currently not declared in the test manifest
2021-11-17 09:46:37 INFO     Skipping integ-tests for job-scheduler, as it is currently not declared in the test manifest
2021-11-17 09:46:37 INFO     Executing "git init" in /tmp/tmpaonj1nll/alerting
2021-11-17 09:46:37 INFO     Executing "git remote add origin https://github.com/opensearch-project/alerting.git" in /tmp/tmpaonj1nll/alerting
2021-11-17 09:46:37 INFO     Executing "git fetch --depth 1 origin 4374e50f70ab7e8b3fe2a85a3b7b098c9e44d171" in /tmp/tmpaonj1nll/alerting
2021-11-17 09:46:38 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmpaonj1nll/alerting
2021-11-17 09:46:38 INFO     Executing "git rev-parse HEAD" in /tmp/tmpaonj1nll/alerting
2021-11-17 09:46:38 INFO     Checked out https://github.com/opensearch-project/alerting.git@4374e50f70ab7e8b3fe2a85a3b7b098c9e44d171 into /tmp/tmpaonj1nll/alerting at 4374e50f70ab7e8b3fe2a85a3b7b098c9e44d171
2021-11-17 09:46:38 INFO     Additional config found: {'plugins.destination.host.deny_list': ['10.0.0.0/8', '127.0.0.1']}
2021-11-17 09:46:38 INFO     Creating local test cluster in /tmp/tmpaonj1nll/local-test-cluster
2021-11-17 09:46:38 INFO     Downloading bundle
2021-11-17 09:46:38 INFO     Downloading https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/998/linux/x64/dist/opensearch-1.2.0-linux-x64.tar.gz into /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz ...
2021-11-17 09:46:41 INFO     Downloaded bundle to /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:46:41 INFO     Unpacking /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:46:45 INFO     Unpacked /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:46:45 INFO     Started OpenSearch with parent PID 343402
2021-11-17 09:46:45 INFO     Waiting for service to become available
2021-11-17 09:46:45 INFO     Pinging https://localhost:9200/_cluster/health attempt 0
2021-11-17 09:46:45 INFO     Service not available yet
2021-11-17 09:46:45 INFO     - stdout:
2021-11-17 09:46:45 INFO     
2021-11-17 09:46:45 INFO     - stderr:
2021-11-17 09:46:45 INFO     
2021-11-17 09:46:55 INFO     Pinging https://localhost:9200/_cluster/health attempt 1
2021-11-17 09:46:56 INFO     Service not available yet
2021-11-17 09:46:56 INFO     - stdout:
2021-11-17 09:46:56 INFO     
2021-11-17 09:46:56 INFO     - stderr:
2021-11-17 09:46:56 INFO     
2021-11-17 09:47:06 INFO     Pinging https://localhost:9200/_cluster/health attempt 2
/usr/share/opensearch/.local/share/virtualenvs/opensearch-build-B4-P-5sk/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
2021-11-17 09:47:06 INFO     200: {"cluster_name":"opensearch","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"active_primary_shards":1,"active_shards":1,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0}
2021-11-17 09:47:06 INFO     Service is available
2021-11-17 09:47:06 INFO     ===============================================
2021-11-17 09:47:06 INFO     Running integration tests for alerting
2021-11-17 09:47:06 INFO     ===============================================
2021-11-17 09:47:06 INFO     Executing "/usr/share/opensearch/workspace/opensearch-build/scripts/components/alerting/integtest.sh -b localhost -p 9200 -s true -v 1.2.0" in /tmp/tmpaonj1nll/alerting
2021-11-17 09:49:49 INFO     Recording component test results for alerting at /usr/share/opensearch/workspace/opensearch-build/test-results/4e5370355c3d4f239e6945cee5b599c7/integ-test/alerting/with-security/test-results
2021-11-17 09:49:49 INFO     Walking tree from /tmp/tmpaonj1nll/alerting/build/reports/tests/integTest
2021-11-17 09:49:49 INFO     Integration test run failed for component alerting
2021-11-17 09:49:49 INFO     WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jetbrains.kotlin.com.intellij.util.ReflectionUtil (file:/usr/share/opensearch/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.4.31/6451ea797cef544e81f507b0d9959cd97ae09c0/kotlin-compiler-embeddable-1.4.31.jar) to method java.util.ResourceBundle.setParent(java.util.ResourceBundle)
WARNING: Please consider reporting this to the maintainers of org.jetbrains.kotlin.com.intellij.util.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Note: /tmp/tmpaonj1nll/alerting/notification/src/main/java/org/opensearch/alerting/destination/Notification.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

2021-11-17 09:49:49 INFO     Sending SIGKILL to PID 343402
2021-11-17 09:49:49 INFO     Process killed with exit code None
2021-11-17 09:49:49 INFO     Walking tree from /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0/logs
2021-11-17 09:49:49 INFO     Recording local cluster logs for alerting with test configuration as with-security at /usr/share/opensearch/workspace/opensearch-build/test-results/4e5370355c3d4f239e6945cee5b599c7/integ-test/alerting/with-security/local-cluster-logs
2021-11-17 09:49:49 INFO     Additional config found: {'plugins.destination.host.deny_list': ['10.0.0.0/8', '127.0.0.1']}
2021-11-17 09:49:49 INFO     Creating local test cluster in /tmp/tmpaonj1nll/local-test-cluster
2021-11-17 09:49:49 INFO     Downloading bundle
2021-11-17 09:49:49 INFO     Downloading https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/998/linux/x64/dist/opensearch-1.2.0-linux-x64.tar.gz into /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz ...
2021-11-17 09:49:53 INFO     Downloaded bundle to /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:49:53 INFO     Unpacking /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:49:57 INFO     Unpacked /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:49:57 INFO     Started OpenSearch with parent PID 350784
2021-11-17 09:49:57 INFO     Waiting for service to become available
2021-11-17 09:49:57 INFO     Pinging http://localhost:9200/_cluster/health attempt 0
2021-11-17 09:49:57 INFO     Service not available yet
2021-11-17 09:49:57 INFO     - stdout:
2021-11-17 09:49:57 INFO     
2021-11-17 09:49:57 INFO     - stderr:
2021-11-17 09:49:57 INFO     
2021-11-17 09:50:07 INFO     Pinging http://localhost:9200/_cluster/health attempt 1
2021-11-17 09:50:07 INFO     200: {"cluster_name":"opensearch","status":"yellow","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"active_primary_shards":2,"active_shards":2,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":1,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":66.66666666666666}
2021-11-17 09:50:07 INFO     Service is available
2021-11-17 09:50:07 INFO     ===============================================
2021-11-17 09:50:07 INFO     Running integration tests for alerting
2021-11-17 09:50:07 INFO     ===============================================
2021-11-17 09:50:07 INFO     Executing "/usr/share/opensearch/workspace/opensearch-build/scripts/components/alerting/integtest.sh -b localhost -p 9200 -s false -v 1.2.0" in /tmp/tmpaonj1nll/alerting
2021-11-17 09:51:33 INFO     Recording component test results for alerting at /usr/share/opensearch/workspace/opensearch-build/test-results/4e5370355c3d4f239e6945cee5b599c7/integ-test/alerting/without-security/test-results
2021-11-17 09:51:33 INFO     Walking tree from /tmp/tmpaonj1nll/alerting/build/reports/tests/integTest
2021-11-17 09:51:33 INFO     Integration test run failed for component alerting
2021-11-17 09:51:33 INFO     WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jetbrains.kotlin.com.intellij.util.ReflectionUtil (file:/usr/share/opensearch/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.4.31/6451ea797cef544e81f507b0d9959cd97ae09c0/kotlin-compiler-embeddable-1.4.31.jar) to method java.util.ResourceBundle.setParent(java.util.ResourceBundle)
WARNING: Please consider reporting this to the maintainers of org.jetbrains.kotlin.com.intellij.util.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

2021-11-17 09:51:33 INFO     Sending SIGKILL to PID 350784
2021-11-17 09:51:33 INFO     Process killed with exit code None
2021-11-17 09:51:33 INFO     Walking tree from /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0/logs
2021-11-17 09:51:33 INFO     Recording local cluster logs for alerting with test configuration as without-security at /usr/share/opensearch/workspace/opensearch-build/test-results/4e5370355c3d4f239e6945cee5b599c7/integ-test/alerting/without-security/local-cluster-logs
2021-11-17 09:51:33 INFO     Executing "git init" in /tmp/tmpaonj1nll/asynchronous-search
2021-11-17 09:51:33 INFO     Executing "git remote add origin https://github.com/opensearch-project/asynchronous-search.git" in /tmp/tmpaonj1nll/asynchronous-search
2021-11-17 09:51:33 INFO     Executing "git fetch --depth 1 origin cddcd91cf5421dda2cf51bcc61c57f3e9c3fb6b4" in /tmp/tmpaonj1nll/asynchronous-search
2021-11-17 09:51:34 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmpaonj1nll/asynchronous-search
2021-11-17 09:51:34 INFO     Executing "git rev-parse HEAD" in /tmp/tmpaonj1nll/asynchronous-search
2021-11-17 09:51:34 INFO     Checked out https://github.com/opensearch-project/asynchronous-search.git@cddcd91cf5421dda2cf51bcc61c57f3e9c3fb6b4 into /tmp/tmpaonj1nll/asynchronous-search at cddcd91cf5421dda2cf51bcc61c57f3e9c3fb6b4
2021-11-17 09:51:34 INFO     Creating local test cluster in /tmp/tmpaonj1nll/local-test-cluster
2021-11-17 09:51:34 INFO     Downloading bundle
2021-11-17 09:51:34 INFO     Downloading https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/998/linux/x64/dist/opensearch-1.2.0-linux-x64.tar.gz into /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz ...
2021-11-17 09:51:37 INFO     Downloaded bundle to /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:51:37 INFO     Unpacking /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:51:41 INFO     Unpacked /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:51:41 INFO     Started OpenSearch with parent PID 354652
2021-11-17 09:51:41 INFO     Waiting for service to become available
2021-11-17 09:51:41 INFO     Pinging https://localhost:9200/_cluster/health attempt 0
2021-11-17 09:51:41 INFO     Service not available yet
2021-11-17 09:51:41 INFO     - stdout:
2021-11-17 09:51:41 INFO     
2021-11-17 09:51:41 INFO     - stderr:
2021-11-17 09:51:41 INFO     
2021-11-17 09:51:51 INFO     Pinging https://localhost:9200/_cluster/health attempt 1
/usr/share/opensearch/.local/share/virtualenvs/opensearch-build-B4-P-5sk/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
2021-11-17 09:51:51 INFO     200: {"cluster_name":"opensearch","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"active_primary_shards":1,"active_shards":1,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0}
2021-11-17 09:51:51 INFO     Service is available
2021-11-17 09:51:51 INFO     ===============================================
2021-11-17 09:51:51 INFO     Running integration tests for asynchronous-search
2021-11-17 09:51:51 INFO     ===============================================
2021-11-17 09:51:51 INFO     Executing "/usr/share/opensearch/workspace/opensearch-build/scripts/default/integtest.sh -b localhost -p 9200 -s true -v 1.2.0" in /tmp/tmpaonj1nll/asynchronous-search
2021-11-17 09:54:08 INFO     Recording component test results for asynchronous-search at /usr/share/opensearch/workspace/opensearch-build/test-results/4e5370355c3d4f239e6945cee5b599c7/integ-test/asynchronous-search/with-security/test-results
2021-11-17 09:54:08 INFO     Walking tree from /tmp/tmpaonj1nll/asynchronous-search/build/reports/tests/integTest
2021-11-17 09:54:08 INFO     Integration test run failed for component asynchronous-search
2021-11-17 09:54:08 INFO     Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

2021-11-17 09:54:08 INFO     Sending SIGKILL to PID 354652
2021-11-17 09:54:08 INFO     Process killed with exit code None
2021-11-17 09:54:08 INFO     Walking tree from /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0/logs
2021-11-17 09:54:08 INFO     Recording local cluster logs for asynchronous-search with test configuration as with-security at /usr/share/opensearch/workspace/opensearch-build/test-results/4e5370355c3d4f239e6945cee5b599c7/integ-test/asynchronous-search/with-security/local-cluster-logs
2021-11-17 09:54:08 INFO     Creating local test cluster in /tmp/tmpaonj1nll/local-test-cluster
2021-11-17 09:54:08 INFO     Downloading bundle
2021-11-17 09:54:08 INFO     Downloading https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/998/linux/x64/dist/opensearch-1.2.0-linux-x64.tar.gz into /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz ...
2021-11-17 09:54:12 INFO     Downloaded bundle to /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:54:12 INFO     Unpacking /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:54:16 INFO     Unpacked /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:54:16 INFO     Started OpenSearch with parent PID 361010
2021-11-17 09:54:16 INFO     Waiting for service to become available
2021-11-17 09:54:16 INFO     Pinging http://localhost:9200/_cluster/health attempt 0
2021-11-17 09:54:16 INFO     Service not available yet
2021-11-17 09:54:16 INFO     - stdout:
2021-11-17 09:54:16 INFO     
2021-11-17 09:54:16 INFO     - stderr:
2021-11-17 09:54:16 INFO     
2021-11-17 09:54:26 INFO     Pinging http://localhost:9200/_cluster/health attempt 1
2021-11-17 09:54:26 INFO     200: {"cluster_name":"opensearch","status":"yellow","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"active_primary_shards":2,"active_shards":2,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":1,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":66.66666666666666}
2021-11-17 09:54:26 INFO     Service is available
2021-11-17 09:54:26 INFO     ===============================================
2021-11-17 09:54:26 INFO     Running integration tests for asynchronous-search
2021-11-17 09:54:26 INFO     ===============================================
2021-11-17 09:54:26 INFO     Executing "/usr/share/opensearch/workspace/opensearch-build/scripts/default/integtest.sh -b localhost -p 9200 -s false -v 1.2.0" in /tmp/tmpaonj1nll/asynchronous-search
2021-11-17 09:56:25 INFO     Recording component test results for asynchronous-search at /usr/share/opensearch/workspace/opensearch-build/test-results/4e5370355c3d4f239e6945cee5b599c7/integ-test/asynchronous-search/without-security/test-results
2021-11-17 09:56:25 INFO     Walking tree from /tmp/tmpaonj1nll/asynchronous-search/build/reports/tests/integTest
2021-11-17 09:56:25 INFO     Sending SIGKILL to PID 361010
2021-11-17 09:56:25 INFO     Process killed with exit code None
2021-11-17 09:56:25 INFO     Walking tree from /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0/logs
2021-11-17 09:56:25 INFO     Recording local cluster logs for asynchronous-search with test configuration as without-security at /usr/share/opensearch/workspace/opensearch-build/test-results/4e5370355c3d4f239e6945cee5b599c7/integ-test/asynchronous-search/without-security/local-cluster-logs
2021-11-17 09:56:25 INFO     Executing "git init" in /tmp/tmpaonj1nll/index-management
2021-11-17 09:56:25 INFO     Executing "git remote add origin https://github.com/opensearch-project/index-management.git" in /tmp/tmpaonj1nll/index-management
2021-11-17 09:56:25 INFO     Executing "git fetch --depth 1 origin 99aa9923046122e9e95d47559ce97c9d9be1cb86" in /tmp/tmpaonj1nll/index-management
2021-11-17 09:56:26 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmpaonj1nll/index-management
2021-11-17 09:56:26 INFO     Executing "git rev-parse HEAD" in /tmp/tmpaonj1nll/index-management
2021-11-17 09:56:26 INFO     Checked out https://github.com/opensearch-project/index-management.git@99aa9923046122e9e95d47559ce97c9d9be1cb86 into /tmp/tmpaonj1nll/index-management at 99aa9923046122e9e95d47559ce97c9d9be1cb86
2021-11-17 09:56:26 INFO     Downloading https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/998/linux/x64/builds/plugins/opensearch-job-scheduler-1.2.0.0.zip into /tmp/tmpaonj1nll/index-management/src/test/resources/job-scheduler/opensearch-job-scheduler-1.2.0.0.zip ...
2021-11-17 09:56:26 INFO     Additional config found: {'path.repo': ['/tmp']}
2021-11-17 09:56:26 INFO     Creating local test cluster in /tmp/tmpaonj1nll/local-test-cluster
2021-11-17 09:56:26 INFO     Downloading bundle
2021-11-17 09:56:26 INFO     Downloading https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/998/linux/x64/dist/opensearch-1.2.0-linux-x64.tar.gz into /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz ...
2021-11-17 09:56:29 INFO     Downloaded bundle to /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:56:29 INFO     Unpacking /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:56:34 INFO     Unpacked /tmp/tmpaonj1nll/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-17 09:56:34 INFO     Started OpenSearch with parent PID 367060
2021-11-17 09:56:34 INFO     Waiting for service to become available
2021-11-17 09:56:34 INFO     Pinging https://localhost:9200/_cluster/health attempt 0
2021-11-17 09:56:34 INFO     Service not available yet
2021-11-17 09:56:34 INFO     - stdout:
2021-11-17 09:56:34 INFO     
2021-11-17 09:56:34 INFO     - stderr:
2021-11-17 09:56:34 INFO     
2021-11-17 09:56:44 INFO     Pinging https://localhost:9200/_cluster/health attempt 1
/usr/share/opensearch/.local/share/virtualenvs/opensearch-build-B4-P-5sk/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
2021-11-17 09:56:44 INFO     200: {"cluster_name":"opensearch","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"active_primary_shards":1,"active_shards":1,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0}
2021-11-17 09:56:44 INFO     Service is available
2021-11-17 09:56:44 INFO     ===============================================
2021-11-17 09:56:44 INFO     Running integration tests for index-management
2021-11-17 09:56:44 INFO     ===============================================
2021-11-17 09:56:44 INFO     Executing "/usr/share/opensearch/workspace/opensearch-build/scripts/default/integtest.sh -b localhost -p 9200 -s true -v 1.2.0" in /tmp/tmpaonj1nll/index-management

```


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
