### PR TITLE
Extracted common test code into a BuildPipelineTest base class.

### DIFF
--- a/tests/jenkins/BuildPipelineTest.groovy
+++ b/tests/jenkins/BuildPipelineTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package jenkins.tests
+
+import org.junit.*
+import java.util.*
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
+import com.lesfurets.jenkins.unit.*
+import com.lesfurets.jenkins.unit.declarative.*
+import static org.junit.Assert.*
+import org.yaml.snakeyaml.Yaml
+
+abstract class BuildPipelineTest extends DeclarativePipelineTest {
+    @Override
+    @Before
+    void setUp() {
+        super.setUp()
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('<notNeeded>')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('<notNeeded>')
+                .retriever(projectSource())
+                .build()
+            )
+
+        helper.registerAllowedMethod("readYaml", [Map.class], { args ->
+            return new Yaml().load((args.file as File).text)
+        })
+
+        binding.setVariable('scm', {})
+        
+        helper.registerAllowedMethod("legacySCM", [Closure.class], null)
+        
+        helper.registerAllowedMethod("library", [Map.class], { Map args ->
+            helper.getLibLoader().loadLibrary(args["identifier"])
+            return new LibClassLoader(helper, null)
+        })
+    }
+
+    void testPipeline(String jenkinsScript) {
+        runScript(jenkinsScript)
+        RegressionTestHelper.testNonRegression(helper, jenkinsScript)
+        assertJobStatusSuccess()
+        printCallStack()
+    }
+}

--- a/tests/jenkins/TestBuild.groovy
+++ b/tests/jenkins/TestBuild.groovy
@@ -9,18 +9,11 @@
 package jenkins.tests
 
 import org.junit.*
-import com.lesfurets.jenkins.unit.BasePipelineTest
-import com.lesfurets.jenkins.unit.MethodCall
-import static org.assertj.core.api.Assertions.assertThat
 
-class TestBuild extends BasePipelineTest {
-    def jenkinsScript = "tests/jenkins/jobs/build.groovy"
-
-    @Override
-    @Before
-    void setUp() throws Exception {
-        super.setUp()
+class TestBuild extends BuildPipelineTest {
+    @Test
+    @Ignore // TODO: needs fix for https://github.com/jenkinsci/JenkinsPipelineUnit/issues/419 and docker declarations
+    void testBuild() {
+        super.testPipeline("tests/jenkins/jobs/Build_Jenkinsfile")
     }
-
-    // TODO: needs fix for https://github.com/jenkinsci/JenkinsPipelineUnit/issues/419
 }

--- a/tests/jenkins/TestBuildManifest.groovy
+++ b/tests/jenkins/TestBuildManifest.groovy
@@ -9,42 +9,10 @@
 package jenkins.tests
 
 import org.junit.*
-import java.util.*
-import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
-import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
-import com.lesfurets.jenkins.unit.*
-import com.lesfurets.jenkins.unit.declarative.*
-import static org.junit.Assert.*
-import org.yaml.snakeyaml.Yaml
 
-class TestBuildManifest extends DeclarativePipelineTest {
-    def jenkinsScript = "tests/jenkins/jobs/BuildManifest_Jenkinsfile"
-
-    @Override
-    @Before
-    void setUp() throws Exception {
-        super.setUp()
-
-        helper.registerSharedLibrary(
-            library().name('jenkins')
-                .defaultVersion('<notNeeded>')
-                .allowOverride(true)
-                .implicit(true)
-                .targetPath('<notNeeded>')
-                .retriever(projectSource())
-                .build()
-            )
-
-        helper.registerAllowedMethod("readYaml", [Map.class], { args ->
-            return new Yaml().load((args.file as File).text)
-        })
-    }
-
+class TestBuildManifest extends BuildPipelineTest {
     @Test
-    void testBuildManifest() throws Exception {
-        runScript(jenkinsScript)
-        RegressionTestHelper.testNonRegression(helper, jenkinsScript)
-        assertJobStatusSuccess()
-        printCallStack()
+    void testBuildManifest() {
+        super.testPipeline("tests/jenkins/jobs/BuildManifest_Jenkinsfile")
     }
 }

--- a/tests/jenkins/TestHello.groovy
+++ b/tests/jenkins/TestHello.groovy
@@ -9,23 +9,10 @@
 package jenkins.tests
 
 import org.junit.*
-import com.lesfurets.jenkins.unit.*
-import static org.assertj.core.api.Assertions.*
 
-class TestHello extends BasePipelineTest {
-    def jenkinsScript = "tests/jenkins/jobs/Hello_Jenkinsfile"
-
-    @Override
-    @Before
-    void setUp() throws Exception {
-        super.setUp()
-    }
-
+class TestHello extends BuildPipelineTest {
     @Test
     void testHello() {
-        runScript(jenkinsScript)
-        RegressionTestHelper.testNonRegression(helper, jenkinsScript)
-        assertJobStatusSuccess()
-        printCallStack()
+        super.testPipeline("tests/jenkins/jobs/Hello_Jenkinsfile")
     }
 }

--- a/tests/jenkins/TestInputManifest.groovy
+++ b/tests/jenkins/TestInputManifest.groovy
@@ -9,42 +9,10 @@
 package jenkins.tests
 
 import org.junit.*
-import java.util.*
-import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
-import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
-import com.lesfurets.jenkins.unit.*
-import com.lesfurets.jenkins.unit.declarative.*
-import static org.junit.Assert.*
-import org.yaml.snakeyaml.Yaml
 
-class TestInputManifest extends DeclarativePipelineTest {
-    def jenkinsScript = "tests/jenkins/jobs/InputManifest_Jenkinsfile"
-
-    @Override
-    @Before
-    void setUp() throws Exception {
-        super.setUp()
-
-        helper.registerSharedLibrary(
-            library().name('jenkins')
-                .defaultVersion('<notNeeded>')
-                .allowOverride(true)
-                .implicit(true)
-                .targetPath('<notNeeded>')
-                .retriever(projectSource())
-                .build()
-            )
-
-        helper.registerAllowedMethod("readYaml", [Map.class], { args ->
-            return new Yaml().load((args.file as File).text)
-        })
-    }
-
+class TestInputManifest extends BuildPipelineTest {
     @Test
-    void testInputManifest() throws Exception {
-        runScript(jenkinsScript)
-        RegressionTestHelper.testNonRegression(helper, jenkinsScript)
-        assertJobStatusSuccess()
-        printCallStack()
+    void testInputManifest() {
+        super.testPipeline("tests/jenkins/jobs/InputManifest_Jenkinsfile")
     }
 }

--- a/tests/jenkins/TestMessages.groovy
+++ b/tests/jenkins/TestMessages.groovy
@@ -10,38 +10,18 @@ package jenkins.tests
 
 import org.junit.*
 import java.util.*
-import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
-import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
-import com.lesfurets.jenkins.unit.*
-import com.lesfurets.jenkins.unit.declarative.*
-import static org.junit.Assert.*
 
-class TestMessages extends DeclarativePipelineTest {
-    def jenkinsScript = "tests/jenkins/jobs/Messages_Jenkinsfile"
-
+class TestMessages extends BuildPipelineTest {
     @Override
     @Before
-    void setUp() throws Exception {
+    void setUp() {
         super.setUp()
 
-        helper.registerAllowedMethod('findFiles', [Map.class], null)
-        
-        helper.registerSharedLibrary(
-            library().name('jenkins')
-                .defaultVersion('<notNeeded>')
-                .allowOverride(true)
-                .implicit(true)
-                .targetPath('<notNeeded>')
-                .retriever(projectSource())
-                .build()
-            )
+        helper.registerAllowedMethod('findFiles', [Map.class], null)       
     }
 
     @Test
-    void testMessages() throws Exception {
-        runScript(jenkinsScript)
-        RegressionTestHelper.testNonRegression(helper, jenkinsScript)
-        assertJobStatusSuccess()
-        printCallStack()
+    public void testMessages() {
+        super.testPipeline("tests/jenkins/jobs/Messages_Jenkinsfile")
     }
 }

--- a/tests/jenkins/TestParallelMessages.groovy
+++ b/tests/jenkins/TestParallelMessages.groovy
@@ -9,50 +9,20 @@
 package jenkins.tests
 
 import org.junit.*
-import static org.junit.Assert.*
 import java.util.*
-import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
-import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
-import com.lesfurets.jenkins.unit.LibClassLoader
-import com.lesfurets.jenkins.unit.declarative.*
-import com.lesfurets.jenkins.unit.MethodCall
-import static org.assertj.core.api.Assertions.assertThat
 
-class TestParallelMessages extends DeclarativePipelineTest {
-    def jenkinsScript = "tests/jenkins/jobs/ParallelMessages_Jenkinsfile"
-
+class TestParallelMessages extends BuildPipelineTest {
     @Override
     @Before
-    void setUp() throws Exception {
+    void setUp() {
         super.setUp()
 
         helper.registerAllowedMethod('findFiles', [Map.class], null)
-        
-        helper.registerSharedLibrary(
-            library().name('jenkins')
-                .defaultVersion('<notNeeded>')
-                .allowOverride(true)
-                .implicit(true)
-                .targetPath('<notNeeded>')
-                .retriever(projectSource())
-                .build()
-            )
     }
 
     @Test
     @Ignore // raises MissingMethodException on docker agent declaration, need to upgrade jenkins-pipeline-unit which has new problems
-    void testParallelMessages() throws Exception {
-        binding.setVariable('scm', {})
-        helper.registerAllowedMethod("legacySCM", [Closure.class], null)
-        
-        helper.registerAllowedMethod("library", [Map.class], { Map args ->
-            helper.getLibLoader().loadLibrary(args["identifier"])
-            return new LibClassLoader(helper, null)
-        })
-
-        runScript(jenkinsScript)
-
-        assertJobStatusSuccess()
-        printCallStack()
+    void testParallelMessages() {
+        super.testPipeline("tests/jenkins/jobs/ParallelMessages_Jenkinsfile")
     }
 }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Extracted from https://github.com/opensearch-project/opensearch-build/pull/975. There's quite a bit of code duplication growing in Jenkins pipeline unit tests that all ultimately are trying to do some basic setup, then run a Jenkins pipeline to produce a .txt file that contains all inputs and outputs, that can be examined for correctness and compared to for future regressions. With this change the shortest version of this test becomes:

```groovy
package jenkins

import org.junit.*
import java.util.*

class TestMessages extends BuildPipelineTest {
    @Test
    public void testPipeline() {
        super.testPipeline("tests/jenkins/jobs/Pipeline_Jenkinsfile")
    }
}
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
