### PR TITLE
Lower Java version to 11 for OpenSearch 1.3.0.

### DIFF
--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -1,11 +1,15 @@
+schema-version: '1.0'
 build:
   name: OpenSearch
   version: 1.3.0
+ci:
+  image:
+     name: "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028"
+     args: "-e JAVA_HOME=/opt/java/openjdk-11"
 components:
-- checks:
-  - gradle:publish
-  - gradle:properties:version
-  name: OpenSearch
-  ref: 1.x
+- name: OpenSearch
+  ref: '1.x'
   repository: https://github.com/opensearch-project/OpenSearch.git
-schema-version: '1.0'
+  checks:
+    - gradle:publish
+    - gradle:properties:version


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

We've lowered the JDK for OpenSearch to 11 in https://github.com/opensearch-project/OpenSearch/pull/940. 

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-build/issues/74.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
