### PR TITLE
rename stdout_data and stderr_data

### DIFF
--- a/src/system/process.py
+++ b/src/system/process.py
@@ -53,19 +53,19 @@ class Process:
         logging.info(f"Process killed with exit code {self.process.returncode}")
 
         if self.stdout:
-            self.stdout_data = self.stdout.read()
+            self.stdout_termination_data = self.stdout.read()
             self.stdout.close()
             self.stdout = None
 
         if self.stderr:
-            self.stderr_data = self.stderr.read()
+            self.stderr_termination_data = self.stderr.read()
             self.stderr.close()
             self.stderr = None
 
         self.return_code = self.process.returncode
         self.process = None
 
-        return self.return_code, self.stdout_data, self.stderr_data
+        return self.return_code, self.stdout_termination_data, self.stderr_termination_data
 
     @property
     def started(self):

--- a/src/system/process.py
+++ b/src/system/process.py
@@ -18,6 +18,8 @@ class Process:
         self.process = None
         self.stdout = None
         self.stderr = None
+        self.__stdout_data__ = None
+        self.__stderr_data__ = None
 
     def start(self, command, cwd):
         if self.started:
@@ -53,19 +55,19 @@ class Process:
         logging.info(f"Process killed with exit code {self.process.returncode}")
 
         if self.stdout:
-            self.stdout_termination_data = self.stdout.read()
+            self.__stdout_data__ = self.stdout.read()
             self.stdout.close()
             self.stdout = None
 
         if self.stderr:
-            self.stderr_termination_data = self.stderr.read()
+            self.__stderr_data__ = self.stderr.read()
             self.stderr.close()
             self.stderr = None
 
         self.return_code = self.process.returncode
         self.process = None
 
-        return self.return_code, self.stdout_termination_data, self.stderr_termination_data
+        return self.return_code
 
     @property
     def started(self):
@@ -76,12 +78,12 @@ class Process:
         return self.process.pid if self.started else None
 
     @property
-    def output(self):
-        return self.stdout
+    def stdout_data(self):
+        return self.stdout.read() if self.stdout else self.__stdout_data__
 
     @property
-    def error(self):
-        return self.stderr
+    def stderr_data(self):
+        return self.stderr.read() if self.stderr else self.__stderr_data__
 
 
 class ProcessStartedError(Exception):

--- a/src/test_workflow/integ_test/local_test_cluster.py
+++ b/src/test_workflow/integ_test/local_test_cluster.py
@@ -113,15 +113,16 @@ class LocalTestCluster(TestCluster):
                     return
             except requests.exceptions.ConnectionError:
                 logging.info("Service not available yet")
-                if self.process_handler.output:
-                    logging.info("- stdout:")
-                    logging.info(self.process_handler.output.read())
-                if self.process_handler.error:
-                    logging.info("- stderr:")
-                    logging.info(self.process_handler.error.read())
+                logging.info("- stdout:")
+                logging.info(self.process_handler.stdout_data)
+
+                logging.info("- stderr:")
+                logging.info(self.process_handler.stderr_data)
 
             time.sleep(10)
         raise ClusterCreationException("Cluster is not available after 10 attempts")
 
     def terminate_process(self):
-        self.return_code, self.local_cluster_stdout, self.local_cluster_stderr = self.process_handler.terminate()
+        self.return_code = self.process_handler.terminate()
+        self.local_cluster_stdout = self.process_handler.stdout_data
+        self.local_cluster_stderr = self.process_handler.stderr_data

--- a/tests/tests_system/test_process.py
+++ b/tests/tests_system/test_process.py
@@ -23,11 +23,11 @@ class TestProcess(unittest.TestCase):
         self.assertIsNotNone(process_handler.error)
         self.assertEqual(process_handler.error.mode, "r+")
 
-        return_code, stdout_data, stderr_data = process_handler.terminate()
+        return_code, stdout_termination_data, stderr_termination_data = process_handler.terminate()
 
         self.assertIsNone(return_code)
-        self.assertIsNotNone(stdout_data)
-        self.assertIsNotNone(stderr_data)
+        self.assertIsNotNone(stdout_termination_data)
+        self.assertIsNotNone(stderr_termination_data)
 
         self.assertFalse(process_handler.started)
         self.assertIsNone(process_handler.pid)

--- a/tests/tests_system/test_process.py
+++ b/tests/tests_system/test_process.py
@@ -4,7 +4,9 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import tempfile
 import unittest
+from unittest.mock import call, patch
 
 from system.process import Process, ProcessNotStartedError, ProcessStartedError
 
@@ -18,21 +20,24 @@ class TestProcess(unittest.TestCase):
 
         self.assertTrue(process_handler.started)
         self.assertIsNotNone(process_handler.pid)
-        self.assertIsNotNone(process_handler.output)
-        self.assertEqual(process_handler.output.mode, "r+")
-        self.assertIsNotNone(process_handler.error)
-        self.assertEqual(process_handler.error.mode, "r+")
+        self.assertIsNotNone(process_handler.stdout_data)
+        self.assertIsNotNone(process_handler.stderr_data)
 
-        return_code, stdout_termination_data, stderr_termination_data = process_handler.terminate()
+        return_code = process_handler.terminate()
 
         self.assertIsNone(return_code)
-        self.assertIsNotNone(stdout_termination_data)
-        self.assertIsNotNone(stderr_termination_data)
+        self.assertIsNotNone(process_handler.stdout_data)
+        self.assertIsNotNone(process_handler.stderr_data)
 
         self.assertFalse(process_handler.started)
         self.assertIsNone(process_handler.pid)
-        self.assertIsNone(process_handler.output)
-        self.assertIsNone(process_handler.error)
+
+    @patch.object(tempfile, 'NamedTemporaryFile')
+    def test_file_open_mode(self, mock_tempfile):
+        process_handler = Process()
+        process_handler.start("./tests/tests_system/data/wait_for_input.sh", ".")
+
+        tempfile.NamedTemporaryFile.assert_has_calls([call(mode="r+"), call(mode="r+")])
 
     def test_start_twice(self):
         process_handler = Process()


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
This is a follow up to address one comment from https://github.com/opensearch-project/opensearch-build/pull/978/files about variable name. 
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
