### PR TITLE
Move parameters out of a stage.

### DIFF
--- a/jenkins/docker/Jenkinsfile
+++ b/jenkins/docker/Jenkinsfile
@@ -1,42 +1,34 @@
 pipeline {
     options {
-        timeout(time: 3, unit: 'HOURS') 
+        timeout(time: 3, unit: 'HOURS')
     }
     agent none
+    parameters {
+        string(
+            defaultValue: 'https://github.com/opensearch-project/opensearch-build',
+            name: 'DOCKER_BUILD_GIT_REPOSITORY',
+            description: 'The git repository name that contains dockerfiles and the docker build script.',
+            trim: true
+        )
+        string(
+            defaultValue: 'main',
+            name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE',
+            description: 'The git reference (branch/tag/commit_id) of above repository.',
+            trim: true
+        )
+        string(
+            defaultValue: 'bash docker/ci/build-image-multi-arch.sh -v <TAG_NAME> -f <DOCKERFILE PATH>',
+            name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS',
+            description: 'The script path of the docker build script, assuming you are already in root dir of DOCKER_BUILD_GIT_REPOSITORY.',
+            trim: true
+        )
+        booleanParam(
+            defaultValue: true,
+            name: 'IS_STAGING',
+            description: 'Are we pushing docker images to staging (opensearchstaging) or production (opensearchproject) account.'
+        )
+    }
     stages {
-        stage('parameters') {
-            steps {
-                script {
-                    properties([
-                            parameters([
-                                    string(
-                                            defaultValue: 'https://github.com/opensearch-project/opensearch-build',
-                                            name: 'DOCKER_BUILD_GIT_REPOSITORY',
-                                            description: 'The git repository name that contains dockerfiles and the docker build script',
-                                            trim: true
-                                    ),
-                                    string(
-                                            defaultValue: 'main',
-                                            name: 'DOCKER_BUILD_GIT_REPOSITORY_REFERENCE',
-                                            description: 'The git reference (branch/tag/commit_id) of above repository',
-                                            trim: true
-                                    ),
-                                    string(
-                                            defaultValue: 'bash docker/ci/build-image-multi-arch.sh -v <TAG_NAME> -f <DOCKERFILE PATH>',
-                                            name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS',
-                                            description: 'The script path of the docker build script, assuming you are already in root dir of DOCKER_BUILD_GIT_REPOSITORY',
-                                            trim: true
-                                    ),
-                                    booleanParam(
-                                            defaultValue: true,
-                                            name: 'IS_STAGING',
-                                            description: 'Are we pushing docker images to staging (opensearchstaging) or production (opensearchproject) account'
-                                    )
-                            ])
-                    ])
-                }
-            }
-        }
         stage('docker-build') {
             agent {
                 docker {
@@ -50,7 +42,7 @@ pipeline {
                 script {
                     git url: "$DOCKER_BUILD_GIT_REPOSITORY", branch: "$DOCKER_BUILD_GIT_REPOSITORY_REFERENCE"
                     def CREDENTIAL_ID = "jenkins-staging-docker-staging-credential"
-                    if (env.IS_STAGING == "false"){
+                    if (env.IS_STAGING == "false") {
                         CREDENTIAL_ID = "jenkins-staging-docker-prod-token"
                         sh "echo Switch to Production"
                     }

--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -3,29 +3,21 @@ lib = library(identifier: "jenkins@current", retriever: legacySCM(scm))
 pipeline {
     agent none
     triggers {
-      parameterizedCron '''
-        H */2 * * * %INPUT_MANIFEST=1.2.0/opensearch-dashboards-1.2.0.yml
-      '''
+        parameterizedCron '''
+            H */2 * * * %INPUT_MANIFEST=1.2.0/opensearch-dashboards-1.2.0.yml
+        '''
+    }
+    parameters {
+        string(
+            name: 'INPUT_MANIFEST',
+            description: 'Input manifest under the manifests folder, e.g. 2.0.0/opensearch-dashboards-2.0.0.yml.',
+            trim: true
+        )
     }
     options {
         buildDiscarder(logRotator(artifactNumToKeepStr: '1'))
     }
     stages {
-        stage('parameters') {
-            steps {
-                script {
-                    properties([
-                            parameters([
-                                    string(
-                                            defaultValue: '',
-                                            name: 'INPUT_MANIFEST',
-                                            trim: true
-                                    )
-                            ])
-                    ])
-                }
-            }
-        }
         stage('detect Docker image + args to use for the build') {
             agent {
                 docker {
@@ -144,7 +136,7 @@ pipeline {
                                 booleanParam(name: 'IS_STAGING', value: true)
                             ]
                         }
-                    }                
+                    }
                 }
             }
         }

--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -3,27 +3,19 @@ lib = library(identifier: "jenkins@current", retriever: legacySCM(scm))
 pipeline {
     agent none
     triggers {
-      parameterizedCron '''
-        H */2 * * * %INPUT_MANIFEST=1.2.0/opensearch-1.2.0.yml
-        H 1 * * * %INPUT_MANIFEST=2.0.0/opensearch-2.0.0.yml
-      '''
+        parameterizedCron '''
+            H */2 * * * %INPUT_MANIFEST=1.2.0/opensearch-1.2.0.yml
+            H 1 * * * %INPUT_MANIFEST=2.0.0/opensearch-2.0.0.yml
+        '''
+    }
+    parameters {
+        string(
+            name: 'INPUT_MANIFEST',
+            description: 'Input manifest under the manifests folder, e.g. 2.0.0/opensearch-2.0.0.yml.',
+            trim: true
+        )
     }
     stages {
-        stage('parameters') {
-            steps {
-                script {
-                    properties([
-                            parameters([
-                                    string(
-                                            defaultValue: '',
-                                            name: 'INPUT_MANIFEST',
-                                            trim: true
-                                    )
-                            ])
-                    ])
-                }
-            }
-        }
         stage('detect Docker image + args to use for the build') {
             agent {
                 docker {

--- a/tests/jenkins/jobs/Build_Jenkinsfile
+++ b/tests/jenkins/jobs/Build_Jenkinsfile
@@ -4,22 +4,14 @@ lib = library(identifier: "jenkins@current", retriever: legacySCM(scm))
 
 pipeline {
     agent none
+    parameters {
+        string(
+            name: 'INPUT_MANIFEST',
+            description: 'Input manifest under the manifests folder, e.g. 2.0.0/opensearch-2.0.0.yml.',
+            trim: true
+        )
+    }
     stages {
-        stage('parameters') {
-            steps {
-                script {
-                    properties([
-                            parameters([
-                                    string(
-                                            defaultValue: '2.0.0/opensearch-2.0.0.yml',
-                                            name: 'INPUT_MANIFEST',
-                                            trim: true
-                                    )
-                            ])
-                    ])
-                }
-            }
-        }
         stage('detect Docker image + args to use for the build') {
             agent {
                 docker {


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I am not sure why parameters even work inside a stage, but reading https://www.jenkins.io/doc/book/pipeline/syntax/ parameters can be written in a simpler way at a `pipeline` level. 

```
parameters {
  param1
  param2
  ...
}
```

Looks the same from my test config.

![Screen Shot 2021-11-18 at 2 22 03 PM](https://user-images.githubusercontent.com/542335/142482834-4cd75ef2-7a32-4ed5-befb-6310e5e7924a.png)


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
