### PR TITLE
Fix: re-add webhook URL when sending notifications.

### DIFF
--- a/tests/jenkins/TestVars.groovy
+++ b/tests/jenkins/TestVars.groovy
@@ -22,6 +22,7 @@ class TestVars extends BuildPipelineTest {
         binding.setVariable('ARTIFACT_BUCKET_NAME', 'artifact-bucket')
         binding.setVariable('AWS_ACCOUNT_PUBLIC', 'account')
         binding.setVariable('STAGE_NAME', 'stage')
+        binding.setVariable('BUILD_NOTICE_WEBHOOK', 'https://web/hook/url')
 
         helper.registerAllowedMethod("s3Upload", [Map])
         helper.registerAllowedMethod("withAWS", [Map, Closure], { args, closure ->

--- a/tests/jenkins/jobs/Vars_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/Vars_Jenkinsfile.txt
@@ -32,9 +32,9 @@ https://ci.opensearch.org/dbc//vars-build/1.1.0/33/linux/x64/dist/manifest.yml})
          Vars_Jenkinsfile.stage(notify, groovy.lang.Closure)
             Vars_Jenkinsfile.script(groovy.lang.Closure)
                Vars_Jenkinsfile.publishNotification({icon=:white_check_mark:, message=Successful Build, extra=extra})
-                  publishNotification.string({credentialsId=BUILD_NOTICE_WEBHOOK, variable=TOKEN})
+                  publishNotification.string({credentialsId=BUILD_NOTICE_WEBHOOK, variable=BUILD_NOTICE_WEBHOOK})
                   publishNotification.withCredentials([null], groovy.lang.Closure)
                      publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark: vars-build [33] Successful Build
 Build: http://jenkins.us-east-1.elb.amazonaws.com/job/vars/42
 Manifest: manifests/2.0.0/opensearch-2.0.0.yml
-extra"}')
+extra"}' "https://web/hook/url")

--- a/vars/publishNotification.groovy
+++ b/vars/publishNotification.groovy
@@ -6,12 +6,13 @@ void call(Map args = [:]) {
         args.extra
     ] - null).join("\n")
 
-    withCredentials([string(credentialsId: 'BUILD_NOTICE_WEBHOOK', variable: 'TOKEN')]) {
+    withCredentials([string(credentialsId: 'BUILD_NOTICE_WEBHOOK', variable: 'BUILD_NOTICE_WEBHOOK')]) {
         sh ([
             args.script ?: 'curl',
             '-XPOST',
             '--header "Content-Type: application/json"',
-            "--data '{\"result_text\":\"${text}\"}'"
+            "--data '{\"result_text\":\"${text}\"}'",
+            "\"${BUILD_NOTICE_WEBHOOK}\""
         ].join(' '))
     }
 }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Notifications aren't being sent. I missed this in #975, now with tests! 
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
