### PR TITLE
Upgrade dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,15 @@ dependencies {
     compile group: 'com.lesfurets', name:'jenkins-pipeline-unit', version: '1.12'
     compile group: 'com.cloudbees', name: 'groovy-cps', version: '1.12'
     compile group: 'org.yaml', name: 'snakeyaml', version: '1.29'
+    compile group: 'junit', name: 'junit', version: '4.13.2'
+}
+
+configurations {
+    all {
+        resolutionStrategy {
+            force group: 'org.jenkins-ci.main', name: 'jenkins-core', version: '2.319'
+        }
+    }
 }
 
 sourceSets {


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

This upgrades one of the dependencies to appease Whitesource complaining about CVEs and resolves 100+ issues. It does re-add another library with a new CVE. We could merge this and reduce the count, but we do need to be doing these fixes upstream, https://github.com/jenkinsci/JenkinsPipelineUnit/issues/436
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
