### PR TITLE
Implement service class for OpenSearch Dashboards

### DIFF
--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -11,10 +11,8 @@ import tarfile
 import requests
 import yaml
 
-from paths.tree_walker import walk
 from system.process import Process
 from test_workflow.integ_test.service import Service
-from test_workflow.test_recorder.test_result_data import TestResultData
 
 
 class ServiceOpenSearch(Service):
@@ -75,22 +73,6 @@ class ServiceOpenSearch(Service):
         url = self.url("/_cluster/health")
         logging.info(f"Pinging {url}")
         return requests.get(url, verify=False, auth=("admin", "admin"))
-
-    def terminate(self):
-        if not self.process_handler.started:
-            logging.info("Local test cluster is not started")
-            return
-
-        self.return_code = self.process_handler.terminate()
-
-        self.__test_result_data()
-
-    def __test_result_data(self):
-        log_files = walk(os.path.join(self.install_dir, "logs"))
-        test_result_data = TestResultData(
-            self.component_name, self.component_test_config, self.return_code, self.process_handler.stdout_data, self.process_handler.stderr_data, log_files
-        )
-        self.save_logs.save_test_result_data(test_result_data)
 
     def __add_plugin_specific_config(self, additional_config):
         with open(self.opensearch_yml_dir, "a") as yamlfile:

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -12,10 +12,8 @@ import tarfile
 import requests
 import yaml
 
-from paths.tree_walker import walk
 from system.process import Process
 from test_workflow.integ_test.service import Service
-from test_workflow.test_recorder.test_result_data import TestResultData
 
 
 class ServiceOpenSearchDashboards(Service):
@@ -84,22 +82,6 @@ class ServiceOpenSearchDashboards(Service):
         url = self.url("/api/status")
         logging.info(f"Pinging {url}")
         return requests.get(url, verify=False, auth=("kibanaserver", "kibanaserver") if self.security_enabled else None)
-
-    def terminate(self):
-        if not self.process_handler.started:
-            logging.info("OpenSearch Dashboards service is not started")
-            return
-
-        self.return_code = self.process_handler.terminate()
-
-        self.__test_result_data()
-
-    def __test_result_data(self):
-        log_files = walk(os.path.join(self.install_dir, "logs"))
-        test_result_data = TestResultData(
-            self.component_name, self.component_test_config, self.return_code, self.process_handler.stdout_data, self.process_handler.stderr_data, log_files
-        )
-        self.save_logs.save_test_result_data(test_result_data)
 
     def __add_plugin_specific_config(self, additional_config):
         with open(self.opensearch_dashboards_yml_dir, "a") as yamlfile:

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -72,8 +72,8 @@ class ServiceOpenSearchDashboards(Service):
         logging.info(f"Downloaded bundle to {os.path.realpath(bundle_name)}")
 
         logging.info(f"Unpacking {bundle_name}")
-        bundle_tar = tarfile.open(bundle_name, 'r')
-        bundle_tar.extractall(self.work_dir)
+        with tarfile.open(bundle_name, 'r') as bundle_tar:
+            bundle_tar.extractall(self.work_dir)
 
         logging.info(f"Unpacked {bundle_name}")
 

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import logging
+import os
+import subprocess
+import tarfile
+
+import requests
+import yaml
+
+from paths.tree_walker import walk
+from system.process import Process
+from test_workflow.integ_test.service import Service
+from test_workflow.test_recorder.test_result_data import TestResultData
+
+
+class ServiceOpenSearchDashboards(Service):
+    def __init__(
+        self,
+        manifest,
+        component_name,
+        component_test_config,
+        additional_cluster_config,
+        security_enabled,
+        dependency_installer,
+        save_logs,
+        work_dir
+    ):
+        self.manifest = manifest
+        self.component_name = component_name
+        self.component_test_config = component_test_config
+
+        self.additional_cluster_config = additional_cluster_config
+        self.security_enabled = security_enabled
+        self.dependency_installer = dependency_installer
+        self.save_logs = save_logs
+        self.work_dir = work_dir
+
+        self.install_dir = os.path.join(
+            self.work_dir, f"opensearch-dashboards-{self.manifest.build.version}-{self.manifest.build.platform}-{self.manifest.build.architecture}")
+        self.process_handler = Process()
+
+    def start(self):
+        logging.info(f"Starting OpenSearch Dashboards service from {self.work_dir}")
+        self.__download()
+
+        self.opensearch_dashboards_yml_dir = os.path.join(self.install_dir, "config", "opensearch_dashboards.yml")
+        self.executable_dir = os.path.join(self.install_dir, "bin")
+
+        if not self.security_enabled:
+            self.__remove_security()
+
+        if self.additional_cluster_config:
+            self.__add_plugin_specific_config(self.additional_cluster_config)
+
+        self.process_handler.start("./opensearch-dashboards", self.executable_dir)
+        logging.info(f"Started OpenSearch Dashboards with parent PID {self.process_handler.pid}")
+
+    def __remove_security(self):
+        subprocess.check_call("./opensearch-dashboards-plugin remove securityDashboards", cwd=self.executable_dir, shell=True)
+
+        with open(self.opensearch_dashboards_yml_dir, "w") as yamlfile:
+            yamlfile.close()
+
+    def __download(self):
+        logging.info("Downloading OpenSearch Dashboards bundle")
+        bundle_name = self.dependency_installer.download_dist(self.work_dir)
+        logging.info(f"Downloaded bundle to {os.path.realpath(bundle_name)}")
+
+        logging.info(f"Unpacking {bundle_name}")
+        bundle_tar = tarfile.open(bundle_name, 'r')
+        bundle_tar.extractall(self.work_dir)
+
+        logging.info(f"Unpacked {bundle_name}")
+
+    def url(self, path=""):
+        return f'http://{self.endpoint()}:{self.port()}{path}'
+
+    def get_service_response(self):
+        url = self.url("/api/status")
+        logging.info(f"Pinging {url}")
+        return requests.get(url, verify=False, auth=("kibanaserver", "kibanaserver") if self.security_enabled else None)
+
+    def terminate(self):
+        if not self.process_handler.started:
+            logging.info("OpenSearch Dashboards service is not started")
+            return
+
+        self.return_code = self.process_handler.terminate()
+
+        self.__test_result_data()
+
+    def __test_result_data(self):
+        log_files = walk(os.path.join(self.install_dir, "logs"))
+        test_result_data = TestResultData(
+            self.component_name, self.component_test_config, self.return_code, self.process_handler.stdout_data, self.process_handler.stderr_data, log_files
+        )
+        self.save_logs.save_test_result_data(test_result_data)
+
+    def __add_plugin_specific_config(self, additional_config):
+        with open(self.opensearch_dashboards_yml_dir, "a") as yamlfile:
+            yamlfile.write(yaml.dump(additional_config))
+
+    def endpoint(self):
+        return "localhost"
+
+    def port(self):
+        return 5601

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
@@ -126,8 +126,8 @@ class ServiceOpenSearchTests(unittest.TestCase):
     @patch('test_workflow.integ_test.service_opensearch.Process.started', new_callable=PropertyMock, return_value=True)
     @patch('test_workflow.integ_test.service_opensearch.Process.stdout_data', new_callable=PropertyMock, return_value="test stdout_data")
     @patch('test_workflow.integ_test.service_opensearch.Process.stderr_data', new_callable=PropertyMock, return_value="test stderr_data")
-    @patch("test_workflow.integ_test.service_opensearch.walk")
-    @patch("test_workflow.integ_test.service_opensearch.TestResultData")
+    @patch("test_workflow.integ_test.service.walk")
+    @patch("test_workflow.integ_test.service.TestResultData")
     def test_terminate(
         self,
         mock_test_result_data,

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -4,7 +4,6 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import logging
 import os
 import unittest
 from unittest.mock import MagicMock, PropertyMock, mock_open, patch
@@ -75,7 +74,6 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open)
     @patch("tarfile.open")
     def test_start_without_security(self, mock_tarfile_open, mock_file, mock_pid, mock_process, mock_check_call):
-        logging.info(locals())
 
         mock_dependency_installer = MagicMock()
 

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import logging
+import os
+import unittest
+from unittest.mock import MagicMock, PropertyMock, mock_open, patch
+
+from manifests.bundle_manifest import BundleManifest
+from test_workflow.integ_test.service_opensearch_dashboards import ServiceOpenSearchDashboards
+
+
+class ServiceOpenSearchDashboardsTests(unittest.TestCase):
+    DATA = os.path.join(os.path.dirname(__file__), "data")
+    BUNDLE_MANIFEST = os.path.join(DATA, "bundle_manifest.yml")
+
+    def setUp(self):
+        self.bundle_manifest = BundleManifest.from_path(self.BUNDLE_MANIFEST)
+        self.component_name = "sql"
+        self.work_dir = "test_work_dir"
+        self.additional_cluster_config = {"script.context.field.max_compilations_rate": "1000/1m"}
+        self.component_test_config = "test_config"
+        self.dependency_installer = ""
+        self.save_logs = ""
+
+    @patch("test_workflow.integ_test.service_opensearch_dashboards.Process.start")
+    @patch('test_workflow.integ_test.service_opensearch_dashboards.Process.pid', new_callable=PropertyMock, return_value=12345)
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("yaml.dump")
+    @patch("tarfile.open")
+    def test_start(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process):
+
+        mock_dependency_installer = MagicMock()
+
+        service = ServiceOpenSearchDashboards(
+            self.bundle_manifest,
+            self.component_name,
+            self.component_test_config,
+            self.additional_cluster_config,
+            True,
+            mock_dependency_installer,
+            self.save_logs,
+            self.work_dir
+        )
+
+        bundle_full_name = "test_bundle_name"
+        mock_dependency_installer.download_dist.return_value = bundle_full_name
+
+        mock_bundle_tar = MagicMock()
+        mock_tarfile_open.return_value.__enter__.return_value = mock_bundle_tar
+
+        mock_dump_result = MagicMock()
+        mock_dump.return_value = mock_dump_result
+
+        # call the target test function
+        service.start()
+
+        mock_dependency_installer.download_dist.called_once_with(self.work_dir)
+        mock_tarfile_open.assert_called_once_with(bundle_full_name, "r")
+        mock_bundle_tar.extractall.assert_called_once_with(self.work_dir)
+
+        mock_file.assert_called_once_with(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "config", "opensearch_dashboards.yml"), "a")
+        mock_dump.assert_called_once_with(self.additional_cluster_config)
+        mock_file.return_value.write.assert_called_once_with(mock_dump_result)
+
+        mock_process.assert_called_once_with("./opensearch-dashboards", os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "bin"))
+        self.assertEqual(mock_pid.call_count, 1)
+
+    @patch("subprocess.check_call")
+    @patch("test_workflow.integ_test.service_opensearch_dashboards.Process.start")
+    @patch('test_workflow.integ_test.service_opensearch_dashboards.Process.pid', new_callable=PropertyMock, return_value=12345)
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("tarfile.open")
+    def test_start_without_security(self, mock_tarfile_open, mock_file, mock_pid, mock_process, mock_check_call):
+        logging.info(locals())
+
+        mock_dependency_installer = MagicMock()
+
+        service = ServiceOpenSearchDashboards(
+            self.bundle_manifest,
+            self.component_name,
+            self.component_test_config,
+            {},
+            False,
+            mock_dependency_installer,
+            self.save_logs,
+            self.work_dir
+        )
+
+        bundle_full_name = "test_bundle_name"
+        mock_dependency_installer.download_dist.return_value = bundle_full_name
+
+        mock_bundle_tar = MagicMock()
+        mock_tarfile_open.return_value.__enter__.return_value = mock_bundle_tar
+
+        # call the target test function
+        service.start()
+
+        mock_check_call.assert_called_once_with(
+            "./opensearch-dashboards-plugin remove securityDashboards",
+            cwd=os.path.join("test_work_dir", "opensearch-dashboards-1.1.0-linux-x64", "bin"),
+            shell=True
+        )
+
+        mock_file.assert_called_once_with(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "config", "opensearch_dashboards.yml"), "w")
+        mock_file.return_value.close.assert_called_once()
+
+    def test_endpoint_port_url(self):
+        service = ServiceOpenSearchDashboards(
+            self.bundle_manifest,
+            self.component_name,
+            self.component_test_config,
+            self.additional_cluster_config,
+            True,
+            self.dependency_installer,
+            self.save_logs,
+            self.work_dir
+        )
+
+        self.assertEqual(service.endpoint(), "localhost")
+        self.assertEqual(service.port(), 5601)
+        self.assertEqual(service.url(), "http://localhost:5601")
+
+    @patch("requests.get")
+    @patch.object(ServiceOpenSearchDashboards, "url")
+    def test_get_service_response_with_security(self, mock_url, mock_requests_get):
+        service = ServiceOpenSearchDashboards(
+            self.bundle_manifest,
+            self.component_name,
+            self.component_test_config,
+            self.additional_cluster_config,
+            True,
+            self.dependency_installer,
+            self.save_logs,
+            self.work_dir
+        )
+
+        mock_url_result = MagicMock()
+        mock_url.return_value = mock_url_result
+
+        service.get_service_response()
+
+        mock_url.assert_called_once_with("/api/status")
+        mock_requests_get.assert_called_once_with(mock_url_result, verify=False, auth=("kibanaserver", "kibanaserver"))
+
+    @patch("requests.get")
+    @patch.object(ServiceOpenSearchDashboards, "url")
+    def test_get_service_response_without_security(self, mock_url, mock_requests_get):
+        service = ServiceOpenSearchDashboards(
+            self.bundle_manifest,
+            self.component_name,
+            self.component_test_config,
+            self.additional_cluster_config,
+            False,
+            self.dependency_installer,
+            self.save_logs,
+            self.work_dir
+        )
+
+        mock_url_result = MagicMock()
+        mock_url.return_value = mock_url_result
+
+        service.get_service_response()
+
+        mock_url.assert_called_once_with("/api/status")
+        mock_requests_get.assert_called_once_with(mock_url_result, auth=None, verify=False)


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
Implement ServiceOpenSearchDashboards. Currently it only has the functional part. **Still in progress to add unit test.**
 
### Issues Resolved
closes https://github.com/opensearch-project/opensearch-build/issues/1080
 
### Test
Manually switch LocalTestCluster to run this service. Below are the successful service ready checks.

With security
```
successfully ping 5601 with security

Running ./src/run_integ_test.py . ...
2021-11-23 04:33:43 INFO     Loading ./src/test_workflow/config/test_manifest.yml
2021-11-23 04:33:43 INFO     Loading /usr/share/opensearch/workspace/opensearch-build/dist/manifest.yml
2021-11-23 04:33:43 INFO     Loading /usr/share/opensearch/workspace/opensearch-build/builds/manifest.yml
2021-11-23 04:33:43 INFO     TestRecorder recording logs in /usr/share/opensearch/workspace/opensearch-build/test-results/4c110c451d554faab922c2a1bf085011/integ-test
2021-11-23 04:33:43 INFO     Executing "git init" in /tmp/tmp1df06t5a/functionalTestDashboards
2021-11-23 04:33:43 INFO     Executing "git remote add origin https://github.com/opensearch-project/opensearch-dashboards-functional-test.git" in /tmp/tmp1df06t5a/functionalTestDashboards
2021-11-23 04:33:43 INFO     Executing "git fetch --depth 1 origin e5c2326b3bfe098ca8820d13133703539cbaa790" in /tmp/tmp1df06t5a/functionalTestDashboards
2021-11-23 04:33:45 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmp1df06t5a/functionalTestDashboards
2021-11-23 04:33:46 INFO     Executing "git rev-parse HEAD" in /tmp/tmp1df06t5a/functionalTestDashboards
2021-11-23 04:33:46 INFO     Checked out https://github.com/opensearch-project/opensearch-dashboards-functional-test.git@e5c2326b3bfe098ca8820d13133703539cbaa790 into /tmp/tmp1df06t5a/functionalTestDashboards at e5c2326b3bfe098ca8820d13133703539cbaa790
2021-11-23 04:33:46 INFO     Creating local test cluster in /tmp/tmp1df06t5a/local-test-cluster
2021-11-23 04:33:46 INFO     Downloading bundle
2021-11-23 04:33:46 INFO     Copying /usr/share/opensearch/workspace/opensearch-build/dist/opensearch-dashboards-1.2.0-linux-x64.tar.gz into /tmp/tmp1df06t5a/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64.tar.gz ...
2021-11-23 04:33:46 INFO     Downloaded bundle to /tmp/tmp1df06t5a/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64.tar.gz
2021-11-23 04:33:46 INFO     Unpacking /tmp/tmp1df06t5a/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64.tar.gz
2021-11-23 04:33:58 INFO     self.install_dir is /tmp/tmp1df06t5a/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64
/tmp/tmp1df06t5a
bin  config  data  LICENSE.txt  manifest.yml  node  node_modules  NOTICE.txt  package.json  plugins  README.txt  src
2021-11-23 04:33:59 INFO     Unpacked /tmp/tmp1df06t5a/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64.tar.gz
opensearch-dashboards  opensearch-dashboards-keystore  opensearch-dashboards-plugin
2021-11-23 04:33:59 INFO     self.stdout /tmp/tmpowv4ocam
2021-11-23 04:33:59 INFO     self.stderr /tmp/tmpz57pioev
2021-11-23 04:33:59 INFO     command ./opensearch-dashboards and cwd is /tmp/tmp1df06t5a/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64/bin
2021-11-23 04:33:59 INFO     Started OpenSearch Dashboards with parent PID 3874342
2021-11-23 04:33:59 INFO     Waiting for service to become available
2021-11-23 04:33:59 INFO     Pinging service attempt 0
2021-11-23 04:33:59 INFO     Pinging http://localhost:5601/api/status
2021-11-23 04:33:59 INFO     Service not available yet
2021-11-23 04:33:59 INFO     - stdout:
2021-11-23 04:33:59 INFO     
2021-11-23 04:33:59 INFO     - stderr:
2021-11-23 04:33:59 INFO     
2021-11-23 04:34:09 INFO     Pinging service attempt 1
2021-11-23 04:34:09 INFO     Pinging http://localhost:5601/api/status
2021-11-23 04:34:09 INFO     200: {"name":"91b68901f49e","uuid":"3dd1bd17-6f7c-4355-ac63-b7a88bad1068","version":{"number":"1.2.0","build_hash":"caf668e73304bac890f41c37cd6c3a41257cd289","build_number":1,"build_snapshot":false},"status":{"overall":{"since":"2021-11-23T04:34:09.071Z","state":"green","title":"Green","nickname":"Looking good","icon":"success","uiColor":"secondary"},"statuses":[{"id":"core:opensearch@1.2.0","message":"OpenSearch is available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"core:savedObjects@1.2.0","message":"SavedObjects service has completed migrations and is available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:advancedSettings@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:bfetch@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:charts@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:devTools@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:discover@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:embeddable@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:expressions@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:indexPatternManagement@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:inspector@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:legacyExport@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:management@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:navigation@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchDashboardsOverview@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchDashboardsReact@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchDashboardsUsageCollection@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchDashboardsUtils@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchUiShared@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:savedObjects@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:savedObjectsManagement@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:share@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:uiActions@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:urlForwarding@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visDefaultEditor@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visualizations@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visualize@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:ganttChartDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:observabilityDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:queryWorkbenchDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:apmOss@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:console@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:dashboard@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:data@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:home@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:inputControlVis@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:mapsLegacy@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchDashboardsLegacy@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:regionMap@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:tileMap@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:timeline@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:usageCollection@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeMarkdown@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeMetric@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeTable@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeTagcloud@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeTimeline@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeTimeseries@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeVega@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeVislib@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:alertingDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:anomalyDetectionDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:indexManagementDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:reportsDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:securityDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:34:09.071Z","state":"green","icon":"success","uiColor":"secondary"}]},"metrics":{"last_updated":"2021-11-23T04:34:06.601Z","collection_interval_in_millis":5000,"os":{"platform":"linux","platformRelease":"linux-5.11.0-1020-aws","load":{"1m":0.48193359375,"5m":0.33056640625,"15m":0.3408203125},"memory":{"total_in_bytes":99010002944,"free_in_bytes":24924803072,"used_in_bytes":74085199872},"uptime_in_millis":2163305000,"distro":"CentOS","distroRelease":"CentOS-7.9.2009"},"process":{"memory":{"heap":{"total_in_bytes":152453120,"used_in_bytes":125050216,"size_limit":1526909922},"resident_set_size_in_bytes":187752448},"pid":3874342,"event_loop_delay":0.22176885604858398,"uptime_in_millis":7548},"response_times":{"avg_in_millis":0,"max_in_millis":0},"concurrent_connections":0,"requests":{"disconnects":0,"total":0,"statusCodes":{},"status_codes":{}}}}
2021-11-23 04:34:09 INFO     Service is available
2021-11-23 04:34:09 INFO     ===============================================
2021-11-23 04:34:09 INFO     Running integration tests for functionalTestDashboards
2021-11-23 04:34:09 INFO     ===============================================
2021-11-23 04:34:09 INFO     Executing "/tmp/tmp1df06t5a/functionalTestDashboards/integtest.sh -b localhost -p 9200 -s true -v 1.2.0" in /tmp/tmp1df06t5a/functionalTestDashboards

``` 

Without security
```
successfully ping 5601 without security

Running ./src/run_integ_test.py . ...
2021-11-23 04:15:21 INFO     Loading ./src/test_workflow/config/test_manifest.yml
2021-11-23 04:15:21 INFO     Loading /usr/share/opensearch/workspace/opensearch-build/dist/manifest.yml
2021-11-23 04:15:21 INFO     Loading /usr/share/opensearch/workspace/opensearch-build/builds/manifest.yml
2021-11-23 04:15:21 INFO     TestRecorder recording logs in /usr/share/opensearch/workspace/opensearch-build/test-results/b70374a0993040339f6a3f209a6eacc4/integ-test
2021-11-23 04:15:21 INFO     Executing "git init" in /tmp/tmp3kgepokj/functionalTestDashboards
2021-11-23 04:15:21 INFO     Executing "git remote add origin https://github.com/opensearch-project/opensearch-dashboards-functional-test.git" in /tmp/tmp3kgepokj/functionalTestDashboards
2021-11-23 04:15:21 INFO     Executing "git fetch --depth 1 origin e5c2326b3bfe098ca8820d13133703539cbaa790" in /tmp/tmp3kgepokj/functionalTestDashboards
2021-11-23 04:15:23 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmp3kgepokj/functionalTestDashboards
2021-11-23 04:15:24 INFO     Executing "git rev-parse HEAD" in /tmp/tmp3kgepokj/functionalTestDashboards
2021-11-23 04:15:24 INFO     Checked out https://github.com/opensearch-project/opensearch-dashboards-functional-test.git@e5c2326b3bfe098ca8820d13133703539cbaa790 into /tmp/tmp3kgepokj/functionalTestDashboards at e5c2326b3bfe098ca8820d13133703539cbaa790
2021-11-23 04:15:24 INFO     Creating local test cluster in /tmp/tmp3kgepokj/local-test-cluster
2021-11-23 04:15:24 INFO     Downloading bundle
2021-11-23 04:15:24 INFO     Copying /usr/share/opensearch/workspace/opensearch-build/dist/opensearch-dashboards-1.2.0-linux-x64.tar.gz into /tmp/tmp3kgepokj/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64.tar.gz ...
2021-11-23 04:15:24 INFO     Downloaded bundle to /tmp/tmp3kgepokj/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64.tar.gz
2021-11-23 04:15:24 INFO     Unpacking /tmp/tmp3kgepokj/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64.tar.gz
2021-11-23 04:15:37 INFO     self.install_dir is /tmp/tmp3kgepokj/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64
/tmp/tmp3kgepokj
bin  config  data  LICENSE.txt  manifest.yml  node  node_modules  NOTICE.txt  package.json  plugins  README.txt  src
2021-11-23 04:15:37 INFO     Unpacked /tmp/tmp3kgepokj/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64.tar.gz
Removing securityDashboards...
Plugin removal complete
opensearch-dashboards  opensearch-dashboards-keystore  opensearch-dashboards-plugin
2021-11-23 04:15:37 INFO     self.stdout /tmp/tmpa89_hm67
2021-11-23 04:15:37 INFO     self.stderr /tmp/tmpruyt1x23
2021-11-23 04:15:37 INFO     command ./opensearch-dashboards and cwd is /tmp/tmp3kgepokj/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64/bin
2021-11-23 04:15:37 INFO     Started OpenSearch Dashboards with parent PID 3862762
2021-11-23 04:15:37 INFO     Waiting for service to become available
2021-11-23 04:15:37 INFO     Pinging service attempt 0
2021-11-23 04:15:37 INFO     Pinging http://localhost:5601/api/status
2021-11-23 04:15:37 INFO     Service not available yet
2021-11-23 04:15:37 INFO     - stdout:
2021-11-23 04:15:37 INFO     
2021-11-23 04:15:37 INFO     - stderr:
2021-11-23 04:15:37 INFO     
2021-11-23 04:15:47 INFO     Pinging service attempt 1
2021-11-23 04:15:47 INFO     Pinging http://localhost:5601/api/status
2021-11-23 04:15:47 INFO     200: {"name":"91b68901f49e","uuid":"fa75ca02-62ea-4404-bbbd-b5dca066ae83","version":{"number":"1.2.0","build_hash":"caf668e73304bac890f41c37cd6c3a41257cd289","build_number":1,"build_snapshot":false},"status":{"overall":{"since":"2021-11-23T04:15:47.580Z","state":"green","title":"Green","nickname":"Looking good","icon":"success","uiColor":"secondary"},"statuses":[{"id":"core:opensearch@1.2.0","message":"OpenSearch is available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"core:savedObjects@1.2.0","message":"SavedObjects service has completed migrations and is available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:ganttChartDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:observabilityDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:queryWorkbenchDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:advancedSettings@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:bfetch@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:charts@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:devTools@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:discover@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:embeddable@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:expressions@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:indexPatternManagement@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:inspector@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:legacyExport@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:management@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:navigation@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchDashboardsOverview@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchDashboardsReact@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchDashboardsUsageCollection@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchDashboardsUtils@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchUiShared@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:savedObjects@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:savedObjectsManagement@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:share@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:uiActions@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:urlForwarding@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visDefaultEditor@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visualizations@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visualize@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:alertingDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:anomalyDetectionDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:indexManagementDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:reportsDashboards@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:apmOss@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:console@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:dashboard@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:data@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:home@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:inputControlVis@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:mapsLegacy@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:opensearchDashboardsLegacy@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:regionMap@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:tileMap@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:timeline@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:usageCollection@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeMarkdown@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeMetric@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeTable@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeTagcloud@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeTimeline@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeTimeseries@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeVega@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"},{"id":"plugin:visTypeVislib@1.2.0","message":"All dependencies are available","since":"2021-11-23T04:15:47.580Z","state":"green","icon":"success","uiColor":"secondary"}]},"metrics":{"last_updated":"2021-11-23T04:15:45.004Z","collection_interval_in_millis":5000,"os":{"platform":"linux","platformRelease":"linux-5.11.0-1020-aws","load":{"1m":0.7177734375,"5m":0.36767578125,"15m":0.2822265625},"memory":{"total_in_bytes":99010002944,"free_in_bytes":24997011456,"used_in_bytes":74012991488},"uptime_in_millis":2162204000,"distro":"CentOS","distroRelease":"CentOS-7.9.2009"},"process":{"memory":{"heap":{"total_in_bytes":145113088,"used_in_bytes":117416624,"size_limit":1526909922},"resident_set_size_in_bytes":180658176},"pid":3862762,"event_loop_delay":0.21001386642456055,"uptime_in_millis":7442},"response_times":{"avg_in_millis":0,"max_in_millis":0},"concurrent_connections":0,"requests":{"disconnects":0,"total":0,"statusCodes":{},"status_codes":{}}}}
2021-11-23 04:15:47 INFO     Service is available
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
