### PR TITLE
Fix issue with docker volume-mounted config file

### DIFF
--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
@@ -177,8 +177,8 @@ if [ -d "$OPENSEARCH_DASHBOARDS_HOME/plugins/$SECURITY_DASHBOARDS_PLUGIN" ]; the
     if [ "$DISABLE_SECURITY_DASHBOARDS_PLUGIN" = "true" ]; then
         echo "Disabling OpenSearch Security Dashboards Plugin"
         ./bin/opensearch-dashboards-plugin remove securityDashboards
-        sed -i /^opensearch_security/d $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
-        sed -i 's/https/http/' $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
+        sed "/^opensearch_security/d" $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
+        sed "s/https/http/" $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
     fi
 fi
 

--- a/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
@@ -66,11 +66,10 @@ if [ -d "$OPENSEARCH_HOME/plugins/$SECURITY_PLUGIN" ]; then
 
     if [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
         echo "Disabling OpenSearch Security Plugin"
-        sed -i '/plugins.security.disabled/d' $OPENSEARCH_HOME/config/opensearch.yml
-        echo "plugins.security.disabled: true" >> $OPENSEARCH_HOME/config/opensearch.yml
+        sed "s/plugins.security.disabled.*$/plugins.security.disabled: true" $OPENSEARCH_HOME/config/opensearch.yml | tee $OPENSEARCH_HOME/config/opensearch.yml
     else
         echo "Enabling OpenSearch Security Plugin"
-        sed -i '/plugins.security.disabled/d' $OPENSEARCH_HOME/config/opensearch.yml
+        sed "/plugins.security.disabled/d" $OPENSEARCH_HOME/config/opensearch.yml | tee $OPENSEARCH_HOME/config/opensearch.yml
     fi
 fi
 


### PR DESCRIPTION
### Description
Using `sed -i` was causing an issue when a custom opensearch.yml file was mounted as a volume.

```
sed: cannot rename /usr/share/opensearch/config/sedqdMb0d: Device or resource busy
```

The reason for the issue was found by @unhipzippo https://github.com/opensearch-project/OpenSearch/issues/768#issuecomment-968140380 :heart:

> The "sed -i" is an attempt to modify the opensearch.yml file "in place" -- But according to the GNU sed documentation (https://www.gnu.org/software/sed/manual/sed.html#Command_002dLine-Options), "in-place" actually "does this by creating a temporary file and sending output to this file rather than to the standard output. ... the temporary file is renamed to the output file’s original name".
>
> I believe this rename would require changing the inode of the original file -- something that Docker volume mounts don't permit.
 
### Issues Resolved
Potentially https://github.com/opensearch-project/OpenSearch/issues/768 and https://github.com/opensearch-project/OpenSearch/issues/1579
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
