### PR TITLE
Added r/w for shas to the bundle role.

### DIFF
--- a/deployment/lib/identities.ts
+++ b/deployment/lib/identities.ts
@@ -41,6 +41,10 @@ export class Identities {
 
     props.buildBucket.grantRead(bundleRole, '*/builds/*');
     props.buildBucket.grantPut(bundleRole, '*/builds/*');
+
+    props.buildBucket.grantRead(bundleRole, '*/shas/*');
+    props.buildBucket.grantPut(bundleRole, '*/shas/*');
+
     props.buildBucket.grantPut(bundleRole, '*/dist/*');
 
     props.buildBucket.grantRead(testRole, '*/dist/*');


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Fixes permissions for reading and writing SHAs. 

What do I need to do to deploy this?

We should consolidate these build and bundle roles, it's confusing to have both build and bundle.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
