### PR TITLE
Update 1.2 manifest to use 1.2 tag of OpenSearch.

### DIFF
--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -10,7 +10,7 @@ build:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: "1.2"
+    ref: tags/1.2.0
     checks:
       - gradle:publish
       - gradle:properties:version

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -80,7 +80,7 @@ class TestInputManifest(unittest.TestCase):
             opensearch_component.repository,
             "https://github.com/opensearch-project/OpenSearch.git",
         )
-        self.assertEqual(opensearch_component.ref, "1.2")
+        self.assertEqual(opensearch_component.ref, "tags/1.2.0")
         # components
         for component in manifest.components.values():
             self.assertIsInstance(component.ref, str)


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Update 1.2 manifest to use 1.2 tag of OpenSearch.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/1317
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
