### PR TITLE
Update release_template with step to update next release's manifest.

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -67,6 +67,7 @@ __Replace with OpenSearch wide initiatives to improve quality and consistency.__
 
 - [ ] Create [release tags](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging) for each component.
 - [ ] Replace refs in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}) with tags.
+- [ ] Update the next release's manifest with a ref to build for your component to ensure it is included in nightly builds. For example, if 1.2.0 is being released, update the [manifests/1.3.0](/opensearch-project/opensearch-build/tree/main/manifests/1.3.0).
 - [ ] Update [this template](./release_template.md) with any new or missed steps.
 - [ ] Conduct a postmortem, and publish its results.
 


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Updates the release template with a step to update the next release's manifest.
 
### Issues Resolved
related - https://github.com/opensearch-project/OpenSearch/issues/1317
closes #1140 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
