### PR TITLE
Updates ISM to 1.2 tag in manifest

### DIFF
--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -40,7 +40,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: "1.2"
+    ref: tags/1.2.0.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: Robert Downs <downsrob@amazon.com>

### Description
Release for Index Management was created for 1.2 and tag was set to 1.2.0.0: https://github.com/opensearch-project/index-management/releases/tag/1.2.0.0
 
### Issues Resolved
https://github.com/opensearch-project/index-management/issues/154
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
