### PR TITLE
Use 1.2.0.0 tag in 1.2 manifest for observability plugins

### DIFF
--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -79,20 +79,20 @@ components:
       - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: "1.2"
+    ref: "1.2.0.0"
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: "1.2"
+    ref: "1.2.0.0"
     working_directory: "reports-scheduler"
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/trace-analytics.git
-    ref: "1.2"
+    ref: "1.2.0.0"
     working_directory: "opensearch-observability"
     checks:
       - gradle:properties:version

--- a/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
@@ -25,21 +25,21 @@ components:
 - name: queryWorkbenchDashboards
   repository: https://github.com/opensearch-project/sql.git
   working_directory: workbench
-  ref: "1.2"
+  ref: "1.2.0.0"
 - name: reportsDashboards
   repository: https://github.com/opensearch-project/dashboards-reports.git
   working_directory: dashboards-reports
-  ref: "1.2"
+  ref: "1.2.0.0"
   platforms:
     - linux
 - name: observabilityDashboards
   repository: https://github.com/opensearch-project/trace-analytics.git
   working_directory: dashboards-observability
-  ref: "1.2"
+  ref: "1.2.0.0"
 - name: ganttChartDashboards
   repository: https://github.com/opensearch-project/dashboards-visualizations.git
   working_directory: gantt-chart
-  ref: "1.2"
+  ref: "1.2.0.0"
 - name: anomalyDetectionDashboards
   repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
   ref: "1.2"


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Use 1.2.0.0 tag in manifest for sql, observability, reporting, gantt chart
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
