### PR TITLE
Update AD references to 1.2 tag

### DIFF
--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -67,7 +67,7 @@ components:
       - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: "1.2"
+    ref: tags/1.2.0.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
@@ -42,5 +42,5 @@ components:
   ref: "1.2"
 - name: anomalyDetectionDashboards
   repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-  ref: "1.2"
+  ref: tags/1.2.0.0
 schema-version: '1.0'


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Updates AD and AD Dashboards refs to 1.2.0.0 tags.
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
