### PR TITLE
Remove repository param as it is not used now

### DIFF
--- a/docker/ci/build-image-multi-arch.sh
+++ b/docker/ci/build-image-multi-arch.sh
@@ -70,12 +70,12 @@ while getopts ":hv:f:" arg; do
 done
 
 # Validate the required parameters to present
-if [ -z "$TAG_NAME" ] || [ -z "$DOCKERFILE" ] || [ -z "$REPOSITORY" ]; then
-  echo "You must specify '-v TAG_NAME', '-f DOCKERFILE', '-r REPOSITORY'"
+if [ -z "$TAG_NAME" ] || [ -z "$DOCKERFILE" ]; then
+  echo "You must specify '-v TAG_NAME', '-f DOCKERFILE'"
   usage
   exit 1
 else
-  echo $TAG_NAME $DOCKERFILE $REPOSITORY
+  echo $TAG_NAME $DOCKERFILE
 fi
 
 # Warning docker desktop


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove repository param as it is not used now
 
### Issues Resolved
#1142 follow up
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
