### PR TITLE
Revert "Fix epel-release install error for CI AL2 Dockerfile"

### DIFF
--- a/docker/ci/dockerfiles/ci-runner.al2.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.al2.dockerfile
@@ -35,7 +35,7 @@ RUN yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GC
 RUN yum install -y libnss3.so xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc fontconfig freetype && yum clean all
 
 # Add k-NN Library dependencies
-RUN amazon-linux-extras install epel -y && yum install openblas-static lapack -y
+RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack -y
 RUN pip3 install cmake==3.21.3
 
 # Add Yarn dependencies


### PR DESCRIPTION
Reverts opensearch-project/opensearch-build#821
Also reopening #1148 
Facing the below error:
```
#36 41.15 Error: Package: openblas-openmp-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.15 Error: Package: openblas-openmp-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3()(64bit)
#36 41.15 Error: Package: openblas-serial-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.15 Error: Package: openblas-serial64_-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3()(64bit)
#36 41.15 Error: Package: openblas-serial64_-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.15 Error: Package: openblas-openmp64_-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3()(64bit)
#36 41.15 Error: Package: openblas-threads64-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3()(64bit)
#36 41.15 Error: Package: openblas-serial64-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.15 Error: Package: openblas-threads64_-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.15 Error: Package: openblas-openmp64-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.15 Error: Package: openblas-openmp64-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3()(64bit)
#36 41.15 Error: Package: openblas-threads-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3()(64bit)
#36 41.15 Error: Package: openblas-serial64-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3()(64bit)
#36 41.15 Error: Package: openblas-threads-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.15 Error: Package: openblas-threads64-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.15 Error: Package: openblas-openmp64_-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.16 Error: Package: openblas-threads64_-0.3.3-2.el7.aarch64 (epel)
#36 41.16            Requires: libgfortran.so.3()(64bit)
#36 41.16 Error: Package: openblas-serial-0.3.3-2.el7.aarch64 (epel)
#36 41.16            Requires: libgfortran.so.3()(64bit)
#36 41.16  You could try using --skip-broken to work around the problem
#36 42.71  You could try running: rpm -Va --nofiles --nodigest
#36 ERROR: process "/bin/sh -c amazon-linux-extras install epel -y && yum install openblas-static lapack -y" did not complete successfully: exit code: 1

#20 [linux/amd64 15/24] RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 &&     yum install -y rpm-build &&     gem install fpm -v 1.13.0
#20 DONE 58.1s
------
 > [linux/arm64  7/24] RUN amazon-linux-extras install epel -y && yum install openblas-static lapack -y:
#36 41.15 Error: Package: openblas-threads64-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.15 Error: Package: openblas-openmp64_-0.3.3-2.el7.aarch64 (epel)
#36 41.15            Requires: libgfortran.so.3(GFORTRAN_1.0)(64bit)
#36 41.16 Error: Package: openblas-threads64_-0.3.3-2.el7.aarch64 (epel)
#36 41.16            Requires: libgfortran.so.3()(64bit)
#36 41.16 Error: Package: openblas-serial-0.3.3-2.el7.aarch64 (epel)
#36 41.16            Requires: libgfortran.so.3()(64bit)
#36 41.16  You could try using --skip-broken to work around the problem
#36 42.71  You could try running: rpm -Va --nofiles --nodigest
------
ci-runner.al2.dockerfile:38
--------------------
  36 |     
  37 |     # Add k-NN Library dependencies
  38 | >>> RUN amazon-linux-extras install epel -y && yum install openblas-static lapack -y
  39 |     RUN pip3 install cmake==3.21.3
  40 |     
--------------------
error: failed to solve: process "/bin/sh -c amazon-linux-extras install epel -y && yum install openblas-static lapack -y" did not complete successfully: exit code: 1
```