### PR TITLE
implement local test cluster for dashboards

### DIFF
--- a/src/test_workflow/integ_test/local_test_cluster.py
+++ b/src/test_workflow/integ_test/local_test_cluster.py
@@ -4,12 +4,10 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import os
 
 from test_workflow.integ_test.service_opensearch import ServiceOpenSearch
-from test_workflow.test_cluster import ClusterServiceNotInitializedException, TestCluster
+from test_workflow.test_cluster import TestCluster
 from test_workflow.test_recorder.test_recorder import TestRecorder
-from test_workflow.test_recorder.test_result_data import TestResultData
 
 
 class LocalTestCluster(TestCluster):
@@ -48,11 +46,13 @@ class LocalTestCluster(TestCluster):
             self.work_dir
         )
 
-    def services(self):
-        # Put the target service as the first element so that the test result will be correctly constructed in save_test_result_data().
+    def service(self):
         return [
-            self. service_opensearch,
+            self.service_opensearch,
         ]
+
+    def dependencies(self):
+        return []
 
     def port(self):
         return 9200

--- a/src/test_workflow/integ_test/local_test_cluster.py
+++ b/src/test_workflow/integ_test/local_test_cluster.py
@@ -28,44 +28,31 @@ class LocalTestCluster(TestCluster):
         component_test_config,
         test_recorder: TestRecorder,
     ):
-        self.manifest = bundle_manifest
-        self.work_dir = os.path.join(work_dir, "local-test-cluster")
-        os.makedirs(self.work_dir, exist_ok=True)
-        self.component_name = component_name
-        self.security_enabled = security_enabled
-        self.component_test_config = component_test_config
-        self.additional_cluster_config = additional_cluster_config
-        self.save_logs = test_recorder.local_cluster_logs
-        self.dependency_installer = dependency_installer
-        self.service_opensearch = None
+        super().__init__(
+            work_dir,
+            component_name,
+            component_test_config,
+            security_enabled,
+            additional_cluster_config,
+            test_recorder.local_cluster_logs
+        )
 
-    def create_cluster(self):
+        self.manifest = bundle_manifest
+        self.dependency_installer = dependency_installer
+
         self.service_opensearch = ServiceOpenSearch(
             self.manifest.build.version,
             self.additional_cluster_config,
             self.security_enabled,
             self.dependency_installer,
-            self.work_dir)
+            self.work_dir
+        )
 
-        self.service_opensearch.start()
-        self.service_opensearch.wait_for_service()
-
-    def endpoint(self):
-        return "localhost"
+    def services(self):
+        # Put the target service as the first element so that the test result will be correctly constructed in save_test_result_data().
+        return [
+            self. service_opensearch,
+        ]
 
     def port(self):
         return 9200
-
-    def destroy(self):
-        if not self.service_opensearch:
-            raise ClusterServiceNotInitializedException()
-
-        self.return_code, self.stdout_data, self.stderr_data, self.log_files = self.service_opensearch.terminate()
-
-        self.__save_test_result_data()
-
-    def __save_test_result_data(self):
-        test_result_data = TestResultData(
-            self.component_name, self.component_test_config, self.return_code, self.stdout_data, self.stderr_data, self.log_files
-        )
-        self.save_logs.save_test_result_data(test_result_data)

--- a/src/test_workflow/integ_test/local_test_cluster.py
+++ b/src/test_workflow/integ_test/local_test_cluster.py
@@ -5,8 +5,6 @@
 # compatible open source license.
 
 
-import logging
-
 from test_workflow.integ_test.service_opensearch import ServiceOpenSearch
 from test_workflow.test_cluster import TestCluster
 from test_workflow.test_recorder.test_recorder import TestRecorder
@@ -47,8 +45,6 @@ class LocalTestCluster(TestCluster):
             self.dependency_installer,
             self.work_dir
         )
-
-        logging.info(f"self.service_opensearch is {self.service_opensearch}")
 
     @property
     def service(self):

--- a/src/test_workflow/integ_test/local_test_cluster.py
+++ b/src/test_workflow/integ_test/local_test_cluster.py
@@ -5,6 +5,8 @@
 # compatible open source license.
 
 
+import logging
+
 from test_workflow.integ_test.service_opensearch import ServiceOpenSearch
 from test_workflow.test_cluster import TestCluster
 from test_workflow.test_recorder.test_recorder import TestRecorder
@@ -46,13 +48,18 @@ class LocalTestCluster(TestCluster):
             self.work_dir
         )
 
-    def service(self):
-        return [
-            self.service_opensearch,
-        ]
+        logging.info(f"self.service_opensearch is {self.service_opensearch}")
 
+    @property
+    def service(self):
+        return self.service_opensearch
+
+    @property
     def dependencies(self):
         return []
+
+    def endpoint(self):
+        return "localhost"
 
     def port(self):
         return 9200

--- a/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
@@ -17,7 +17,8 @@ class LocalTestClusterOpenSearchDashboards(TestCluster):
 
     def __init__(
         self,
-        dependency_installer,
+        dependency_installer_opensearch,
+        dependency_installer_opensearch_dashboards,
         work_dir,
         component_name,
         additional_cluster_config,
@@ -39,13 +40,14 @@ class LocalTestClusterOpenSearchDashboards(TestCluster):
         self.manifest_opensearch = bundle_manifest_opensearch
         self.manifest_opensearch_dashboards = bundle_manifest_opensearch_dashboards
 
-        self.dependency_installer = dependency_installer
+        self.dependency_installer_opensearch = dependency_installer_opensearch
+        self.dependency_installer_opensearch_dashboards = dependency_installer_opensearch_dashboards
 
         self.service_opensearch = ServiceOpenSearch(
             self.manifest_opensearch.build.version,
             {},
             self.security_enabled,
-            self.dependency_installer,
+            self.dependency_installer_opensearch,
             self.work_dir)
 
         build = self.manifest_opensearch_dashboards.build
@@ -56,18 +58,21 @@ class LocalTestClusterOpenSearchDashboards(TestCluster):
             build.architecture,
             self.additional_cluster_config,
             self.security_enabled,
-            self.dependency_installer,
+            self.dependency_installer_opensearch_dashboards,
             self.work_dir)
+
+    def endpoint(self):
+        return "localhost"
 
     def port(self):
         return 5601
 
+    @property
     def service(self):
-        return [
-            self.service_opensearch_dashboards,
-        ]
+        return self.service_opensearch_dashboards
 
+    @property
     def dependencies(self):
         return [
-            self.service_opensearch,
+            self.service_opensearch
         ]

--- a/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
@@ -4,14 +4,10 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import logging
-import os
-
 from test_workflow.integ_test.service_opensearch import ServiceOpenSearch
 from test_workflow.integ_test.service_opensearch_dashboards import ServiceOpenSearchDashboards
-from test_workflow.test_cluster import ClusterServiceNotInitializedException, TestCluster
+from test_workflow.test_cluster import TestCluster
 from test_workflow.test_recorder.test_recorder import TestRecorder
-from test_workflow.test_recorder.test_result_data import TestResultData
 
 
 class LocalTestClusterOpenSearchDashboards(TestCluster):
@@ -43,7 +39,6 @@ class LocalTestClusterOpenSearchDashboards(TestCluster):
         self.manifest_opensearch = bundle_manifest_opensearch
         self.manifest_opensearch_dashboards = bundle_manifest_opensearch_dashboards
 
-        self.additional_cluster_config = additional_cluster_config
         self.dependency_installer = dependency_installer
 
         self.service_opensearch = ServiceOpenSearch(
@@ -67,9 +62,12 @@ class LocalTestClusterOpenSearchDashboards(TestCluster):
     def port(self):
         return 5601
 
-    def services(self):
-        # Put the target service as the first element so that the test result will be correctly constructed in save_test_result_data().
+    def service(self):
         return [
             self.service_opensearch_dashboards,
-            self. service_opensearch,
+        ]
+
+    def dependencies(self):
+        return [
+            self.service_opensearch,
         ]

--- a/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+
+from test_workflow.integ_test.service_opensearch import ServiceOpenSearch
+from test_workflow.integ_test.service_opensearch_dashboards import ServiceOpenSearchDashboards
+from test_workflow.test_cluster import ClusterServiceNotInitializedException, TestCluster
+from test_workflow.test_recorder.test_recorder import TestRecorder
+
+
+class LocalTestClusterOpenSearchDashboards(TestCluster):
+    """
+    Represents an on-box test cluster. This class runs OpenSearchService first and then OpenSearchServiceDashboards service.
+    """
+
+    def __init__(
+        self,
+        dependency_installer,
+        work_dir,
+        component_name,
+        additional_cluster_config,
+        bundle_manifest_opensearch,
+        bundle_manifest_opensearch_dashboards,
+        security_enabled,
+        component_test_config,
+        test_recorder: TestRecorder,
+    ):
+        self.manifest_opensearch = bundle_manifest_opensearch
+        self.manifest_opensearch_dashboards = bundle_manifest_opensearch_dashboards
+
+        self.work_dir = os.path.join(work_dir, "local-test-cluster")
+        os.makedirs(self.work_dir, exist_ok=True)
+        self.component_name = component_name
+        self.security_enabled = security_enabled
+        self.component_test_config = component_test_config
+        self.additional_cluster_config = additional_cluster_config
+        self.save_logs = test_recorder.local_cluster_logs
+        self.dependency_installer = dependency_installer
+        self.service_opensearch = None
+        self.service_opensearch_dashboards = None
+
+    def create_cluster(self):
+
+        # Need to extra the test data part outside of Service. Here is a good example where we just run OpenSearch endpoint but do not run its test.
+        # Some follow up comments of this https://github.com/opensearch-project/opensearch-build/pull/1128/files
+        self.service_opensearch = ServiceOpenSearch(
+            self.manifest_opensearch,
+            {},
+            self.component_test_config,
+            {},
+            self.security_enabled,
+            self.dependency_installer,
+            self.save_logs,
+            self.work_dir)
+
+        self.service_opensearch.start()
+        self.service_opensearch.wait_for_service()
+
+        self.service_opensearch_dashboards = ServiceOpenSearchDashboards(
+            self.manifest_opensearch_dashboards,
+            self.component_name,
+            self.component_test_config,
+            self.additional_cluster_config,
+            self.security_enabled,
+            self.dependency_installer,
+            self.save_logs,
+            self.work_dir)
+
+        self.service_opensearch_dashboards.start()
+        self.service_opensearch_dashboards.wait_for_service()
+
+    def endpoint(self):
+        return "localhost"
+
+    def port(self):
+        return 5601
+
+    def destroy(self):
+        if not self.service_opensearch or not self.service_opensearch_dashboards:
+            raise ClusterServiceNotInitializedException()
+
+        self.service_opensearch.terminate()
+        self.service_opensearch_dashboards.terminate()

--- a/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
@@ -4,12 +4,14 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 
 from test_workflow.integ_test.service_opensearch import ServiceOpenSearch
 from test_workflow.integ_test.service_opensearch_dashboards import ServiceOpenSearchDashboards
 from test_workflow.test_cluster import ClusterServiceNotInitializedException, TestCluster
 from test_workflow.test_recorder.test_recorder import TestRecorder
+from test_workflow.test_recorder.test_result_data import TestResultData
 
 
 class LocalTestClusterOpenSearchDashboards(TestCluster):
@@ -29,59 +31,45 @@ class LocalTestClusterOpenSearchDashboards(TestCluster):
         component_test_config,
         test_recorder: TestRecorder,
     ):
+        super().__init__(
+            work_dir,
+            component_name,
+            component_test_config,
+            security_enabled,
+            additional_cluster_config,
+            test_recorder.local_cluster_logs
+        )
+
         self.manifest_opensearch = bundle_manifest_opensearch
         self.manifest_opensearch_dashboards = bundle_manifest_opensearch_dashboards
 
-        self.work_dir = os.path.join(work_dir, "local-test-cluster")
-        os.makedirs(self.work_dir, exist_ok=True)
-        self.component_name = component_name
-        self.security_enabled = security_enabled
-        self.component_test_config = component_test_config
         self.additional_cluster_config = additional_cluster_config
-        self.save_logs = test_recorder.local_cluster_logs
         self.dependency_installer = dependency_installer
-        self.service_opensearch = None
-        self.service_opensearch_dashboards = None
 
-    def create_cluster(self):
-
-        # Need to extra the test data part outside of Service. Here is a good example where we just run OpenSearch endpoint but do not run its test.
-        # Some follow up comments of this https://github.com/opensearch-project/opensearch-build/pull/1128/files
         self.service_opensearch = ServiceOpenSearch(
-            self.manifest_opensearch,
-            {},
-            self.component_test_config,
+            self.manifest_opensearch.build.version,
             {},
             self.security_enabled,
             self.dependency_installer,
-            self.save_logs,
             self.work_dir)
 
-        self.service_opensearch.start()
-        self.service_opensearch.wait_for_service()
+        build = self.manifest_opensearch_dashboards.build
 
         self.service_opensearch_dashboards = ServiceOpenSearchDashboards(
-            self.manifest_opensearch_dashboards,
-            self.component_name,
-            self.component_test_config,
+            build.version,
+            build.platform,
+            build.architecture,
             self.additional_cluster_config,
             self.security_enabled,
             self.dependency_installer,
-            self.save_logs,
             self.work_dir)
-
-        self.service_opensearch_dashboards.start()
-        self.service_opensearch_dashboards.wait_for_service()
-
-    def endpoint(self):
-        return "localhost"
 
     def port(self):
         return 5601
 
-    def destroy(self):
-        if not self.service_opensearch or not self.service_opensearch_dashboards:
-            raise ClusterServiceNotInitializedException()
-
-        self.service_opensearch.terminate()
-        self.service_opensearch_dashboards.terminate()
+    def services(self):
+        # Put the target service as the first element so that the test result will be correctly constructed in save_test_result_data().
+        return [
+            self.service_opensearch_dashboards,
+            self. service_opensearch,
+        ]

--- a/src/test_workflow/integ_test/service.py
+++ b/src/test_workflow/integ_test/service.py
@@ -29,6 +29,7 @@ class Service(abc.ABC):
         self.dependency_installer = dependency_installer
 
         self.process_handler = Process()
+        self.install_dir = ""
 
     @abc.abstractmethod
     def start(self):
@@ -46,7 +47,7 @@ class Service(abc.ABC):
 
         log_files = walk(os.path.join(self.install_dir, "logs"))
 
-        return self.return_code, self.process_handler.stdout_data, self.process_handler.stderr_data, log_files
+        return ServiceTerminationResult(self.return_code, self.process_handler.stdout_data, self.process_handler.stderr_data, log_files)
 
     def endpoint(self):
         return "localhost"
@@ -92,3 +93,11 @@ class Service(abc.ABC):
 
             time.sleep(10)
         raise ClusterCreationException("Cluster is not available after 10 attempts")
+
+
+class ServiceTerminationResult:
+    def __init__(self, return_code, stdout_data, stderr_data, log_files):
+        self.return_code = return_code
+        self.stdout_data = stdout_data
+        self.stderr_data = stderr_data
+        self.log_files = log_files

--- a/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/src/test_workflow/perf_test/perf_test_cluster.py
@@ -12,7 +12,6 @@ class PerfTestCluster(TestCluster):
     """
 
     def __init__(self, bundle_manifest, config, stack_name, security, current_workspace):
-
         self.manifest = bundle_manifest
         self.work_dir = os.path.join("opensearch-cluster", "cdk", "single-node")
         self.current_workspace = current_workspace

--- a/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/src/test_workflow/perf_test/perf_test_cluster.py
@@ -12,6 +12,7 @@ class PerfTestCluster(TestCluster):
     """
 
     def __init__(self, bundle_manifest, config, stack_name, security, current_workspace):
+
         self.manifest = bundle_manifest
         self.work_dir = os.path.join("opensearch-cluster", "cdk", "single-node")
         self.current_workspace = current_workspace
@@ -42,7 +43,7 @@ class PerfTestCluster(TestCluster):
         )
         self.params = "".join(params_list) + role_params
 
-    def create_cluster(self):
+    def start(self):
         os.chdir(self.work_dir)
         command = f"cdk deploy {self.params} --outputs-file {self.output_file}"
         logging.info(f'Executing "{command}" in {os.getcwd()}')
@@ -50,7 +51,7 @@ class PerfTestCluster(TestCluster):
         with open(self.output_file, "r") as read_file:
             load_output = json.load(read_file)
         self.ip_address = load_output[self.stack_name]["PrivateIp"]
-        logging.info("Private IP:", self.ip_address)
+        logging.info(f"Private IP: {self.ip_address}")
 
     def endpoint(self):
         self.cluster_endpoint = self.ip_address
@@ -60,8 +61,14 @@ class PerfTestCluster(TestCluster):
         self.cluster_port = 443 if self.security == "enable" else 9200
         return self.cluster_port
 
-    def destroy(self):
+    def terminate(self):
         os.chdir(os.path.join(self.current_workspace, self.work_dir))
         command = f"cdk destroy {self.params} --force"
         logging.info(f'Executing "{command}" in {os.getcwd()}')
         subprocess.check_call(command, cwd=os.getcwd(), shell=True)
+
+    def service(self):
+        return []
+
+    def dependencies(self):
+        return []

--- a/src/test_workflow/test_cluster.py
+++ b/src/test_workflow/test_cluster.py
@@ -5,7 +5,6 @@
 # compatible open source license.
 
 import abc
-import logging
 import os
 from contextlib import contextmanager
 
@@ -54,8 +53,6 @@ class TestCluster(abc.ABC):
         os.makedirs(self.work_dir, exist_ok=True)
 
         self.all_services = [self.service] + self.dependencies
-
-        logging.info(f"self.all_services is {self.all_services}")
 
         for service in self.all_services:
             service.start()

--- a/src/test_workflow/test_cluster.py
+++ b/src/test_workflow/test_cluster.py
@@ -32,6 +32,8 @@ class TestCluster(abc.ABC):
         self.additional_cluster_config = additional_cluster_config
         self.save_logs = save_logs
 
+        self.all_services = [self.service] + self.dependencies
+
     @classmethod
     @contextmanager
     def create(cls, *args):
@@ -46,19 +48,19 @@ class TestCluster(abc.ABC):
         finally:
             cluster.destroy()
 
-    def start():
+    def start(self):
         os.makedirs(self.work_dir, exist_ok=True)
 
-        for service in self.services:
+        for service in self.all_services:
             service.start()
 
-        for service in self.services:
+        for service in self.all_services:
             service.wait_for_service()
 
     def terminate(self):
         self.termination_results = []
 
-        for service in self.services:
+        for service in self.all_services:
             self.termination_results.append(service.terminate())
 
         self.__save_test_result_data()
@@ -83,9 +85,16 @@ class TestCluster(abc.ABC):
         pass
 
     @abc.abstractproperty
-    def services(self):
+    def service(self):
         """
-        The services running in this cluster.
+        The main service running in this cluster.
+        """
+        pass
+
+    @abc.abstractproperty
+    def dependencies(self):
+        """
+        The dependencies running in this cluster.
         """
         pass
 

--- a/src/test_workflow/test_cluster.py
+++ b/src/test_workflow/test_cluster.py
@@ -47,7 +47,7 @@ class TestCluster(abc.ABC):
             cluster.start()
             yield cluster.endpoint(), cluster.port()
         finally:
-            cluster.destroy()
+            cluster.terminate()
 
     def start(self):
         os.makedirs(self.work_dir, exist_ok=True)

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster_opensearch_dashboards.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from test_workflow.integ_test.local_test_cluster_opensearch_dashboards import LocalTestClusterOpenSearchDashboards
+from test_workflow.integ_test.service import ServiceTerminationResult
+from test_workflow.test_cluster import ClusterServiceNotInitializedException
+
+
+class LocalTestClusterOpenSearchDashboardsTests(unittest.TestCase):
+
+    def setUp(self):
+        mock_bundle_manifest_opensearch = MagicMock()
+        mock_bundle_manifest_opensearch.build.version = "1.1.0"
+        self.mock_bundle_manifest_opensearch = mock_bundle_manifest_opensearch
+
+        mock_bundle_manifest_opensearch_dashboards = MagicMock()
+        mock_bundle_manifest_opensearch_dashboards.build.version = "1.1.0"
+        mock_bundle_manifest_opensearch_dashboards.build.platform = "linux"
+        mock_bundle_manifest_opensearch_dashboards.build.architecture = "x64"
+        self.mock_bundle_manifest_opensearch_dashboards = mock_bundle_manifest_opensearch_dashboards
+
+        dependency_installer_opensearch = MagicMock()
+        self.dependency_installer_opensearch = dependency_installer_opensearch
+
+        dependency_installer_opensearch_dashboards = MagicMock()
+        self.dependency_installer_opensearch_dashboards = dependency_installer_opensearch_dashboards
+
+        self.work_dir = "test_work_dir"
+
+        self.component_name = "sql"
+        self.security_enabled = True
+        self.component_test_config = "test_config"
+        self.additional_cluster_config = {"script.context.field.max_compilations_rate": "1000/1m"}
+        self.save_logs = ""
+        self.dependency_installer = ""
+        self.test_recorder = ""
+
+    @patch("test_workflow.integ_test.local_test_cluster_opensearch_dashboards.ServiceOpenSearch")
+    @patch("test_workflow.integ_test.local_test_cluster_opensearch_dashboards.ServiceOpenSearchDashboards")
+    def test_start(self, mock_service_opensearch_dashboards, mock_service_opensearch):
+        mock_test_recorder = MagicMock()
+        mock_local_cluster_logs = MagicMock()
+        mock_test_recorder.local_cluster_logs = mock_local_cluster_logs
+
+        mock_service_opensearch_object = MagicMock()
+        mock_service_opensearch.return_value = mock_service_opensearch_object
+
+        mock_service_opensearch_dashboards_object = MagicMock()
+        mock_service_opensearch_dashboards.return_value = mock_service_opensearch_dashboards_object
+
+        cluster = LocalTestClusterOpenSearchDashboards(
+            self.dependency_installer_opensearch,
+            self.dependency_installer_opensearch_dashboards,
+            self.work_dir,
+            self.component_name,
+            self.additional_cluster_config,
+            self.mock_bundle_manifest_opensearch,
+            self.mock_bundle_manifest_opensearch_dashboards,
+            self.security_enabled,
+            self.component_test_config,
+            mock_test_recorder
+        )
+
+        cluster.start()
+
+        mock_service_opensearch.assert_called_once_with(
+            "1.1.0",
+            {},
+            self.security_enabled,
+            self.dependency_installer_opensearch,
+            os.path.join(self.work_dir, "local-test-cluster")
+        )
+
+        mock_service_opensearch_object.start.assert_called_once()
+        mock_service_opensearch_object.wait_for_service.assert_called_once()
+
+        mock_service_opensearch_dashboards.assert_called_once_with(
+            "1.1.0",
+            "linux",
+            "x64",
+            self.additional_cluster_config,
+            self.security_enabled,
+            self.dependency_installer_opensearch_dashboards,
+            os.path.join(self.work_dir, "local-test-cluster")
+        )
+
+        mock_service_opensearch_dashboards_object.start.assert_called_once()
+        mock_service_opensearch_dashboards_object.wait_for_service.assert_called_once()
+
+    @patch("test_workflow.integ_test.local_test_cluster_opensearch_dashboards.ServiceOpenSearch")
+    @patch("test_workflow.integ_test.local_test_cluster_opensearch_dashboards.ServiceOpenSearchDashboards")
+    @patch("test_workflow.test_cluster.TestResultData")
+    def test_terminate(self, mock_test_result_data, mock_service_opensearch_dashboards, mock_service_opensearch):
+        mock_test_recorder = MagicMock()
+        mock_local_cluster_logs = MagicMock()
+        mock_test_recorder.local_cluster_logs = mock_local_cluster_logs
+
+        mock_service_opensearch_object = MagicMock()
+        mock_service_opensearch.return_value = mock_service_opensearch_object
+
+        mock_service_opensearch_dashboards_object = MagicMock()
+        mock_service_opensearch_dashboards.return_value = mock_service_opensearch_dashboards_object
+
+        cluster = LocalTestClusterOpenSearchDashboards(
+            self.dependency_installer_opensearch,
+            self.dependency_installer_opensearch_dashboards,
+            self.work_dir,
+            self.component_name,
+            self.additional_cluster_config,
+            self.mock_bundle_manifest_opensearch,
+            self.mock_bundle_manifest_opensearch_dashboards,
+            self.security_enabled,
+            self.component_test_config,
+            mock_test_recorder
+        )
+
+        mock_log_files = MagicMock()
+        mock_service_opensearch_dashboards_object.terminate.return_value = ServiceTerminationResult(123, "test stdout_data", "test stderr_data", mock_log_files)
+
+        mock_test_result_data_object = MagicMock()
+        mock_test_result_data.return_value = mock_test_result_data_object
+
+        cluster.terminate()
+
+        mock_service_opensearch_object.terminate.assert_called_once()
+        mock_service_opensearch_dashboards_object.terminate.assert_called_once()
+
+        mock_test_result_data.assert_called_once_with(
+            self.component_name,
+            self.component_test_config,
+            123,
+            "test stdout_data",
+            "test stderr_data",
+            mock_log_files
+        )
+
+        mock_local_cluster_logs.save_test_result_data.assert_called_once_with(mock_test_result_data_object)
+
+    @patch("test_workflow.integ_test.local_test_cluster_opensearch_dashboards.ServiceOpenSearch")
+    @patch("test_workflow.integ_test.local_test_cluster_opensearch_dashboards.ServiceOpenSearchDashboards")
+    def test_terminate_service_not_initialized(self, mock_service_opensearch_dashboards, mock_service_opensearch):
+        mock_test_recorder = MagicMock()
+        mock_local_cluster_logs = MagicMock()
+        mock_test_recorder.local_cluster_logs = mock_local_cluster_logs
+
+        mock_service_opensearch_object = MagicMock()
+        mock_service_opensearch.return_value = mock_service_opensearch_object
+
+        mock_service_opensearch_dashboards.return_value = None
+
+        cluster = LocalTestClusterOpenSearchDashboards(
+            self.dependency_installer_opensearch,
+            self.dependency_installer_opensearch_dashboards,
+            self.work_dir,
+            self.component_name,
+            self.additional_cluster_config,
+            self.mock_bundle_manifest_opensearch,
+            self.mock_bundle_manifest_opensearch_dashboards,
+            self.security_enabled,
+            self.component_test_config,
+            mock_test_recorder
+        )
+
+        with self.assertRaises(ClusterServiceNotInitializedException) as ctx:
+            cluster.terminate()
+
+        self.assertEqual(str(ctx.exception), "Service is not initialized")
+
+        mock_service_opensearch_object.terminate.assert_called_once()
+
+    @patch("test_workflow.integ_test.local_test_cluster_opensearch_dashboards.ServiceOpenSearch")
+    @patch("test_workflow.integ_test.local_test_cluster_opensearch_dashboards.ServiceOpenSearchDashboards")
+    def test_endpoint_port(self, mock_service_opensearch_dashboards, mock_service_opensearch):
+        mock_test_recorder = MagicMock()
+        mock_local_cluster_logs = MagicMock()
+        mock_test_recorder.local_cluster_logs = mock_local_cluster_logs
+
+        mock_service_opensearch_object = MagicMock()
+        mock_service_opensearch.return_value = mock_service_opensearch_object
+
+        mock_service_opensearch_dashboards_object = MagicMock()
+        mock_service_opensearch_dashboards.return_value = mock_service_opensearch_dashboards_object
+
+        cluster = LocalTestClusterOpenSearchDashboards(
+            self.dependency_installer_opensearch,
+            self.dependency_installer_opensearch_dashboards,
+            self.work_dir,
+            self.component_name,
+            self.additional_cluster_config,
+            self.mock_bundle_manifest_opensearch,
+            self.mock_bundle_manifest_opensearch_dashboards,
+            self.security_enabled,
+            self.component_test_config,
+            mock_test_recorder
+        )
+
+        self.assertEqual(cluster.endpoint(), "localhost")
+        self.assertEqual(cluster.port(), 5601)

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
@@ -134,15 +134,15 @@ class ServiceOpenSearchTests(unittest.TestCase):
         mock_log_files = MagicMock()
         mock_walk.return_value = mock_log_files
 
-        actual_return_code, actual_stdout_data, actual_stderr_data, actual_log_files = service.terminate()
+        termination_result = service.terminate()
 
         mock_process_terminate.assert_called_once()
         mock_walk.assert_called_once()
 
-        self.assertEqual(actual_return_code, 123)
-        self.assertEqual(actual_stdout_data, "test stdout_data")
-        self.assertEqual(actual_stderr_data, "test stderr_data")
-        self.assertEqual(actual_log_files, mock_log_files)
+        self.assertEqual(termination_result.return_code, 123)
+        self.assertEqual(termination_result.stdout_data, "test stdout_data")
+        self.assertEqual(termination_result.stderr_data, "test stderr_data")
+        self.assertEqual(termination_result.log_files, mock_log_files)
 
     @patch("test_workflow.integ_test.service.Process.terminate")
     @patch('test_workflow.integ_test.service.Process.started', new_callable=PropertyMock, return_value=False)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -31,7 +31,7 @@ class TestPerfTestCluster(unittest.TestCase):
             with patch("subprocess.check_call") as mock_check_call:
                 with patch("builtins.open", MagicMock()):
                     with patch("json.load", mock_file):
-                        self.perf_test_cluster.create_cluster()
+                        self.perf_test_cluster.start()
                         mock_chdir.assert_called_once_with(os.path.join("opensearch-cluster", "cdk", "single-node"))
                         self.assertEqual(mock_check_call.call_count, 1)
 
@@ -41,9 +41,9 @@ class TestPerfTestCluster(unittest.TestCase):
     def test_port(self):
         self.assertEqual(self.perf_test_cluster.port(), 443)
 
-    def test_destroy(self):
+    def test_terminate(self):
         with patch("test_workflow.perf_test.perf_test_cluster.os.chdir") as mock_chdir:
             with patch("subprocess.check_call") as mock_check_call:
-                self.perf_test_cluster.destroy()
+                self.perf_test_cluster.terminate()
                 mock_chdir.assert_called_once_with(os.path.join("current_workspace", "opensearch-cluster", "cdk", "single-node"))
                 self.assertEqual(mock_check_call.call_count, 1)


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
Implement local test cluster for dashboards. We will need to address @dblock 's remaining comments on this PR https://github.com/opensearch-project/opensearch-build/pull/1128/files since the responsibility of test cluster and service shall be clear.

### Test
Manual testing is blocked by https://github.com/opensearch-project/opensearch-build/issues/1134
Unit test to be done
 
### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-build/issues/1081
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
