### PR TITLE
fix the bug of log files failing to copy during integ test

### DIFF
--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -66,9 +66,30 @@ class TestRecorder:
                 test_result_data.stderr,
                 os.path.realpath(dest_directory),
             )
-            for log_file in log_files:
-                dest_file = os.path.join(dest_directory, os.path.basename(log_file[0]))
-                shutil.copyfile(log_file[0], dest_file)
+
+            # This is a sample log_files
+            # [
+            #     (
+            #         '/tmp/tmpux1u0r47/local-test-cluster/opensearch-1.2.0/logs',
+            #         [],
+            #         [
+            #             'opensearch_index_indexing_slowlog.log',
+            #             'opensearch_deprecation.json',
+            #             'opensearch.log',
+            #             'gc.log',
+            #             'opensearch_index_search_slowlog.json',
+            #             'gc.log.00',
+            #             'opensearch_index_search_slowlog.log',
+            #             'opensearch_deprecation.log',
+            #             'opensearch_index_indexing_slowlog.json',
+            #             'opensearch_server.json'
+            #         ]
+            #     )
+            # ]
+
+            for log_file in log_files[0][2]:
+                dest_file = os.path.join(dest_directory, os.path.basename(log_file))
+                shutil.copyfile(os.path.join(log_files[0][0], log_file), dest_file)
 
     class RemoteClusterLogs(LogRecorder):
         def __init__(self, parent_class):

--- a/tests/tests_test_workflow/test_recorder/__init__.py
+++ b/tests/tests_test_workflow/test_recorder/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))

--- a/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
+++ b/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
@@ -5,7 +5,6 @@
 # compatible open source license.
 
 
-import logging
 import os
 import unittest
 from unittest.mock import MagicMock, call, patch

--- a/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
+++ b/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+
+import logging
+import os
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from test_workflow.test_recorder.test_recorder import TestRecorder
+
+
+class LocalClusterLogsTests(unittest.TestCase):
+
+    @patch("shutil.copyfile")
+    def test(self, mock_copyfile):
+
+        logging.info(locals())
+
+        mock_parent_class = MagicMock()
+
+        mock_parent_class._create_base_folder_structure.return_value = "test_base"
+
+        logs = TestRecorder.LocalClusterLogs(mock_parent_class)
+
+        mock_test_result_data = MagicMock()
+
+        mock_test_result_data.log_files = [
+            (
+                "dir",
+                [],
+                [
+                    "opensearch_index_indexing_slowlog.log",
+                    "opensearch_deprecation.json"
+                ]
+            )
+        ]
+
+        dest_directory = os.path.join("test_base", "local-cluster-logs")
+
+        dest_file_1 = os.path.join(dest_directory, "opensearch_index_indexing_slowlog.log")
+        dest_file_2 = os.path.join(dest_directory, "opensearch_deprecation.json")
+
+        source_file_1 = os.path.join("dir", "opensearch_index_indexing_slowlog.log")
+        source_file_2 = os.path.join("dir", "opensearch_deprecation.json")
+
+        logs.save_test_result_data(mock_test_result_data)
+
+        mock_copyfile.assert_has_calls(
+            [call(source_file_1, dest_file_1)],
+            [call(source_file_2, dest_file_2)]
+        )

--- a/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
+++ b/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
@@ -18,8 +18,6 @@ class LocalClusterLogsTests(unittest.TestCase):
     @patch("shutil.copyfile")
     def test(self, mock_copyfile):
 
-        logging.info(locals())
-
         mock_parent_class = MagicMock()
 
         mock_parent_class._create_base_folder_structure.return_value = "test_base"


### PR DESCRIPTION
### Description

During running of integ test script, I noticed the following error. After logging the log_files passed to the recorder, the code is not properly reading the file structure.

```
2021-11-25 08:34:46 INFO     Recording local cluster logs for alerting with test configuration as with-security at /usr/share/opensearch/workspace/opensearch-build/test-results/29465f14e581428e91ef7eb32306db19/integ-test/alerting/with-security/local-cluster-logs
Traceback (most recent call last):
  File "./src/run_integ_test.py", line 65, in <module>
    sys.exit(main())
  File "./src/run_integ_test.py", line 51, in main
    test_results = test_suite.execute()
  File "/usr/share/opensearch/workspace/opensearch-build/src/test_workflow/integ_test/integ_test_suite.py", line 57, in execute
    status = self.__setup_cluster_and_execute_test_config(config)
  File "/usr/share/opensearch/workspace/opensearch-build/src/test_workflow/integ_test/integ_test_suite.py", line 100, in __setup_cluster_and_execute_test_config
    return self.__execute_integtest_sh(test_cluster_endpoint, test_cluster_port, security, config)
  File "/usr/local/lib/python3.7/contextlib.py", line 119, in __exit__
    next(self.gen)
  File "/usr/share/opensearch/workspace/opensearch-build/src/test_workflow/test_cluster.py", line 28, in create
    cluster.destroy()
  File "/usr/share/opensearch/workspace/opensearch-build/src/test_workflow/integ_test/local_test_cluster.py", line 65, in destroy
    self.service_opensearch.terminate()
  File "/usr/share/opensearch/workspace/opensearch-build/src/test_workflow/integ_test/service.py", line 38, in terminate
    self.__test_result_data()
  File "/usr/share/opensearch/workspace/opensearch-build/src/test_workflow/integ_test/service.py", line 45, in __test_result_data
    self.save_logs.save_test_result_data(test_result_data)
  File "/usr/share/opensearch/workspace/opensearch-build/src/test_workflow/test_recorder/test_recorder.py", line 71, in save_test_result_data
    shutil.copyfile(log_file[0], dest_file)
  File "/usr/local/lib/python3.7/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
IsADirectoryError: [Errno 21] Is a directory: '/tmp/tmp7ylgdaf9/local-test-cluster/opensearch-1.2.0/logs'
```
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1159
 
### Test

Now we can see that the integ test can properly move to next component instead of failing at the previous component.

```
2021-11-25 11:47:26 INFO     Running integration tests for alerting
2021-11-25 11:47:26 INFO     ===============================================
2021-11-25 11:47:26 INFO     Executing "/usr/share/opensearch/workspace/opensearch-build/scripts/components/alerting/integtest.sh -b localhost -p 9200 -s false -v 1.2.0" in /tmp/tmpkfs9tt4c/alerting
2021-11-25 11:48:51 INFO     Recording component test results for alerting at /usr/share/opensearch/workspace/opensearch-build/test-results/00af92a637c54e6aa23cad371e2f4837/integ-test/alerting/without-security/test-results
2021-11-25 11:48:51 INFO     Walking tree from /tmp/tmpkfs9tt4c/alerting/build/reports/tests/integTest
2021-11-25 11:48:51 INFO     Integration test run failed for component alerting
2021-11-25 11:48:51 INFO     WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jetbrains.kotlin.com.intellij.util.ReflectionUtil (file:/usr/share/opensearch/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-compiler-embeddable/1.4.31/6451ea797cef544e81f507b0d9959cd97ae09c0/kotlin-compiler-embeddable-1.4.31.jar) to method java.util.ResourceBundle.setParent(java.util.ResourceBundle)
WARNING: Please consider reporting this to the maintainers of org.jetbrains.kotlin.com.intellij.util.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

2021-11-25 11:48:51 INFO     Sending SIGKILL to PID 1483489
2021-11-25 11:48:51 INFO     Process killed with exit code None
2021-11-25 11:48:51 INFO     Recording local cluster logs for alerting with test configuration as without-security at /usr/share/opensearch/workspace/opensearch-build/test-results/00af92a637c54e6aa23cad371e2f4837/integ-test/alerting/without-security/local-cluster-logs
2021-11-25 11:48:51 INFO     Executing "git init" in /tmp/tmpkfs9tt4c/asynchronous-search
2021-11-25 11:48:51 INFO     Executing "git remote add origin https://github.com/opensearch-project/asynchronous-search.git" in /tmp/tmpkfs9tt4c/asynchronous-search
2021-11-25 11:48:51 INFO     Executing "git fetch --depth 1 origin cddcd91cf5421dda2cf51bcc61c57f3e9c3fb6b4" in /tmp/tmpkfs9tt4c/asynchronous-search
2021-11-25 11:48:52 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmpkfs9tt4c/asynchronous-search
2021-11-25 11:48:52 INFO     Executing "git rev-parse HEAD" in /tmp/tmpkfs9tt4c/asynchronous-search
2021-11-25 11:48:52 INFO     Checked out https://github.com/opensearch-project/asynchronous-search.git@cddcd91cf5421dda2cf51bcc61c57f3e9c3fb6b4 into /tmp/tmpkfs9tt4c/asynchronous-search at cddcd91cf5421dda2cf51bcc61c57f3e9c3fb6b4
2021-11-25 11:48:52 INFO     Creating local test cluster in /tmp/tmpkfs9tt4c/local-test-cluster
2021-11-25 11:48:52 INFO     Downloading bundle
2021-11-25 11:48:52 INFO     Copying /usr/share/opensearch/workspace/opensearch-build/dist/opensearch-1.2.0-linux-x64.tar.gz into /tmp/tmpkfs9tt4c/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz ...
2021-11-25 11:48:53 INFO     Downloaded bundle to /tmp/tmpkfs9tt4c/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-25 11:48:53 INFO     Unpacking /tmp/tmpkfs9tt4c/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-25 11:49:27 INFO     Unpacked /tmp/tmpkfs9tt4c/local-test-cluster/opensearch-1.2.0-linux-x64.tar.gz
2021-11-25 11:49:27 INFO     Started OpenSearch with parent PID 1487776
2021-11-25 11:49:27 INFO     Waiting for service to become available
2021-11-25 11:49:27 INFO     Pinging service attempt 0
2021-11-25 11:49:27 INFO     Pinging https://localhost:9200/_cluster/health
2021-11-25 11:49:27 INFO     Service not available yet
2021-11-25 11:49:27 INFO     - stdout:
2021-11-25 11:49:27 INFO     
2021-11-25 11:49:27 INFO     - stderr:
2021-11-25 11:49:27 INFO     
2021-11-25 11:49:37 INFO     Pinging service attempt 1
2021-11-25 11:49:37 INFO     Pinging https://localhost:9200/_cluster/health
/usr/share/opensearch/.local/share/virtualenvs/opensearch-build-B4-P-5sk/lib/python3.7/site-packages/urllib3/connectionpool.py:1020: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  InsecureRequestWarning,
2021-11-25 11:49:37 INFO     200: {"cluster_name":"opensearch","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"active_primary_shards":1,"active_shards":1,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0}
2021-11-25 11:49:37 INFO     Service is available
2021-11-25 11:49:37 INFO     ===============================================
2021-11-25 11:49:37 INFO     Running integration tests for asynchronous-search
2021-11-25 11:49:37 INFO     ===============================================
2021-11-25 11:49:37 INFO     Executing "/usr/share/opensearch/workspace/opensearch-build/scripts/default/integtest.sh -b localhost -p 9200 -s true -v 1.2.0" in /tmp/tmpkfs9tt4c/asynchronous-search
```


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
