### PR TITLE
fix failed docker build due to missing plugins

### DIFF
--- a/docker/release/dockerfiles/opensearch.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2.dockerfile
@@ -30,13 +30,17 @@ RUN groupadd -g $GID opensearch && \
     mkdir /tmp/opensearch
 
 # Prepare working directory
+
+ARG SECURITY_PLUGIN_DIR=$OPENSEARCH_HOME/plugins/opensearch-security
+ARG PERFORMANCE_ANALYZER_PLUGIN_DIR=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer
+
 COPY opensearch-*.tgz /tmp/opensearch/
 RUN tar -xzpf /tmp/opensearch/opensearch-`uname -p`.tgz -C $OPENSEARCH_HOME --strip-components=1 && rm -rf /tmp/opensearch && \
-    chmod 750 $OPENSEARCH_HOME/plugins/opensearch-security/tools/* && \
     mkdir -p $OPENSEARCH_HOME/data && chown -R $UID:$GID $OPENSEARCH_HOME/data
+RUN if [[ -d $SECURITY_PLUGIN_DIR ]] ; then chmod 750 $SECURITY_PLUGIN_DIR/tools/* ; fi
 COPY opensearch-docker-entrypoint.sh opensearch-onetime-setup.sh $OPENSEARCH_HOME/
 COPY log4j2.properties opensearch.yml $OPENSEARCH_HOME/config/
-COPY performance-analyzer.properties $OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/pa_config/
+RUN if [[ -d $PERFORMANCE_ANALYZER_PLUGIN_DIR ]] ; then cp performance-analyzer.properties $PERFORMANCE_ANALYZER_PLUGIN_DIR/pa_config/; fi
 
 
 ########################### Stage 1 ########################
@@ -89,14 +93,14 @@ ARG NOTES
 
 # Label
 LABEL org.label-schema.schema-version="1.0" \
-  org.label-schema.name="opensearch" \
-  org.label-schema.version="$VERSION" \
-  org.label-schema.url="https://opensearch.org" \
-  org.label-schema.vcs-url="https://github.com/OpenSearch" \
-  org.label-schema.license="Apache-2.0" \
-  org.label-schema.vendor="OpenSearch" \
-  org.label-schema.description="$NOTES" \
-  org.label-schema.build-date="$BUILD_DATE"
+    org.label-schema.name="opensearch" \
+    org.label-schema.version="$VERSION" \
+    org.label-schema.url="https://opensearch.org" \
+    org.label-schema.vcs-url="https://github.com/OpenSearch" \
+    org.label-schema.license="Apache-2.0" \
+    org.label-schema.vendor="OpenSearch" \
+    org.label-schema.description="$NOTES" \
+    org.label-schema.build-date="$BUILD_DATE"
 
 # CMD to run
 CMD ["./opensearch-docker-entrypoint.sh"]

--- a/docker/release/dockerfiles/opensearch.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2.dockerfile
@@ -93,14 +93,14 @@ ARG NOTES
 
 # Label
 LABEL org.label-schema.schema-version="1.0" \
-    org.label-schema.name="opensearch" \
-    org.label-schema.version="$VERSION" \
-    org.label-schema.url="https://opensearch.org" \
-    org.label-schema.vcs-url="https://github.com/OpenSearch" \
-    org.label-schema.license="Apache-2.0" \
-    org.label-schema.vendor="OpenSearch" \
-    org.label-schema.description="$NOTES" \
-    org.label-schema.build-date="$BUILD_DATE"
+  org.label-schema.name="opensearch" \
+  org.label-schema.version="$VERSION" \
+  org.label-schema.url="https://opensearch.org" \
+  org.label-schema.vcs-url="https://github.com/OpenSearch" \
+  org.label-schema.license="Apache-2.0" \
+  org.label-schema.vendor="OpenSearch" \
+  org.label-schema.description="$NOTES" \
+  org.label-schema.build-date="$BUILD_DATE"
 
 # CMD to run
 CMD ["./opensearch-docker-entrypoint.sh"]

--- a/scripts/opensearch-onetime-setup.sh
+++ b/scripts/opensearch-onetime-setup.sh
@@ -33,8 +33,11 @@ fi
 
 ##Perf Plugin
 PA_PLUGIN="opensearch-performance-analyzer"
-chmod 755 $OPENSEARCH_HOME/plugins/$PA_PLUGIN/pa_bin/performance-analyzer-agent
-chmod 755 $OPENSEARCH_HOME/bin/performance-analyzer-agent-cli
+
+if [ -d $OPENSEARCH_HOME/plugins/$PA_PLUGIN ]; then
+    chmod 755 $OPENSEARCH_HOME/plugins/$PA_PLUGIN/pa_bin/performance-analyzer-agent
+    chmod 755 $OPENSEARCH_HOME/bin/performance-analyzer-agent-cli
+fi
 
 if ! grep -q '## OpenDistro Performance Analyzer' $OPENSEARCH_HOME/config/jvm.options; then
    CLK_TCK=`/usr/bin/getconf CLK_TCK`


### PR DESCRIPTION
### Description
Add conditional check when plugins are not ready.
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1154

### Test
Downloaded a bundle 1.2.0 and removed the security and PA plugins. Re-compress it to simulate a tar without such plugins.  Verify that the same file not found error happened when running main branch code against this local tar.

With this fix, we are able to run the docker build.
`./build-image-single-arch.sh -v 1.2.0-fix-docker-build -f ./dockerfiles/opensearch.al2.dockerfile -p opensearch -a x64 -t ~/archive-without-plugins.tar.gz
`

This is the cmd output

```
Successfully built 7b583e175be1
Successfully tagged opensearchproject/opensearch:1.2.0-fix-docker-build
Attempt to rm /tmp/tmp.OC07sdoCJD
Removing /tmp/tmp.OC07sdoCJD
```

This is the docker ls

```
docker image ls

EPOSITORY                     TAG                                                            IMAGE ID       CREATED              SIZE
opensearchproject/opensearch   1.2.0-fix-docker-build                                         7b583e175be1   About a minute ago   738MB
```
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
