### PR TITLE
fix the status check of service in cluster

### DIFF
--- a/src/test_workflow/integ_test/service.py
+++ b/src/test_workflow/integ_test/service.py
@@ -68,7 +68,7 @@ class Service(abc.ABC):
     def service_alive(self):
         response = self.get_service_response()
         logging.info(f"{response.status_code}: {response.text}")
-        if response.status_code == 200 and ('"status":"green"' or '"status":"yellow"' in response.text):
+        if response.status_code == 200 and (('"status":"green"' in response.text) or ('"status":"yellow"' in response.text)):
             logging.info("Service is available")
             return True
         else:

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
@@ -336,7 +336,7 @@ class ServiceOpenSearchTests(unittest.TestCase):
         mock_response = MagicMock()
 
         mock_response.status_code = 200
-        mock_response.text = '"status": "green"'
+        mock_response.text = '"status":"green"'
 
         mock_get_service_response.return_value = mock_response
 
@@ -355,11 +355,30 @@ class ServiceOpenSearchTests(unittest.TestCase):
         mock_response = MagicMock()
 
         mock_response.status_code = 200
-        mock_response.text = '"status": "yellow"'
+        mock_response.text = '"status":"yellow"'
 
         mock_get_service_response.return_value = mock_response
 
         self.assertTrue(service.service_alive())
+
+    @patch.object(ServiceOpenSearch, "get_service_response")
+    def test_service_alive_red_unavailable(self, mock_get_service_response):
+        service = ServiceOpenSearch(
+            self.version,
+            self.additional_config,
+            True,
+            self.dependency_installer,
+            self.work_dir
+        )
+
+        mock_response = MagicMock()
+
+        mock_response.status_code = 200
+        mock_response.text = '"status":"red"'
+
+        mock_get_service_response.return_value = mock_response
+
+        self.assertFalse(service.service_alive())        
 
     @patch.object(ServiceOpenSearch, "get_service_response")
     def test_service_alive_unavailable(self, mock_get_service_response):

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
@@ -378,7 +378,7 @@ class ServiceOpenSearchTests(unittest.TestCase):
 
         mock_get_service_response.return_value = mock_response
 
-        self.assertFalse(service.service_alive())        
+        self.assertFalse(service.service_alive())
 
     @patch.object(ServiceOpenSearch, "get_service_response")
     def test_service_alive_unavailable(self, mock_get_service_response):


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
fix the status check of service in cluster
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1165
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
