### PR TITLE
fix the path to plugins dir under builds/

### DIFF
--- a/src/test_workflow/dependency_installer.py
+++ b/src/test_workflow/dependency_installer.py
@@ -43,7 +43,7 @@ class DependencyInstaller:
         """
         os.makedirs(dest, exist_ok=True)
         for dependency, version in dependency_dict.items():
-            path = f"{self.root_url}/builds/plugins/{dependency}-{version}.zip"
+            path = f"{self.root_url}/builds/opensearch/plugins/{dependency}-{version}.zip"
             local_path = os.path.join(dest, f"{dependency}-{version}.zip")
             self.__download_or_copy(path, local_path)
 

--- a/tests/tests_test_workflow/test_dependency_installer.py
+++ b/tests/tests_test_workflow/test_dependency_installer.py
@@ -94,7 +94,7 @@ class DependencyInstallerTests(unittest.TestCase):
         mock_makedirs.assert_called_with(os.path.dirname(__file__), exist_ok=True)
         mock_request.assert_not_called()
         mock_copyfile.assert_called_once_with(
-            os.path.join(self.DATA, "builds", "plugins", "opensearch-job-scheduler-1.1.0.0.zip"),
+            os.path.join(self.DATA, "builds", "opensearch", "plugins", "opensearch-job-scheduler-1.1.0.0.zip"),
             os.path.realpath(os.path.join(os.path.dirname(__file__), "opensearch-job-scheduler-1.1.0.0.zip")),
         )
 
@@ -110,6 +110,6 @@ class DependencyInstallerTests(unittest.TestCase):
         mock_makedirs.assert_called_with(os.path.dirname(__file__), exist_ok=True)
         mock_copyfile.assert_not_called()
         mock_request.assert_called_once_with(
-            "https://ci.opensearch.org/x/y/builds/plugins/opensearch-job-scheduler-1.1.0.0.zip",
+            "https://ci.opensearch.org/x/y/builds/opensearch/plugins/opensearch-job-scheduler-1.1.0.0.zip",
             os.path.realpath(os.path.join(os.path.dirname(__file__), "opensearch-job-scheduler-1.1.0.0.zip")),
         )


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
Recently we added a `opensearch` sub dir under `builds`. However, this path was not modified. Previous manual test didn't catch this case because my dev env has both the new file hierarchy and the old hierarchy which covers this issue.
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1164

### Test
Before this change, the integ test will crash when it arrives at `index-management`  
```
FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/opensearch/workspace/opensearch-build/builds/plugins/opensearch-job-scheduler-1.2.0.0.zip'
```
After this change, the integ test can complete for all components. This is the sample output.

```
021-11-27 09:35:36 INFO     | alerting             | with-security        | PASS  |    0 |
2021-11-27 09:35:36 INFO     | alerting             | without-security     | PASS  |    0 |
2021-11-27 09:35:36 INFO     | anomaly-detection    | with-security        | PASS  |    0 |
2021-11-27 09:35:36 INFO     | anomaly-detection    | without-security     | PASS  |    0 |
2021-11-27 09:35:36 INFO     | asynchronous-search  | with-security        | PASS  |    0 |
2021-11-27 09:35:36 INFO     | asynchronous-search  | without-security     | PASS  |    0 |
2021-11-27 09:35:36 INFO     | dashboards-reports   | without-security     | PASS  |    0 |
2021-11-27 09:35:36 INFO     | index-management     | with-security        | PASS  |    0 |
2021-11-27 09:35:36 ERROR    | index-management     | without-security     | FAIL  |    1 |
2021-11-27 09:35:36 ERROR    | k-NN                 | with-security        | FAIL  |    1 |
2021-11-27 09:35:36 INFO     | k-NN                 | without-security     | PASS  |    0 |
2021-11-27 09:35:36 INFO     | sql                  | with-security        | PASS  |    0 |
2021-11-27 09:35:36 INFO     | sql                  | without-security     | PASS  |    0 |
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
