### PR TITLE
Fix jenkins failures

### DIFF
--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
                                 snapshot: true
                             )
                             withCredentials([usernamePassword(credentialsId: 'Sonatype', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD')]) {
-                                sh('$WORKSPACE/publish/publish-snapshot.sh $WORKSPACE/builds/maven')
+                                sh('$WORKSPACE/publish/publish-snapshot.sh $WORKSPACE/builds/opensearch/maven')
                             }
                         }
                     }

--- a/tests/jenkins/jobs/Build_Jenkinsfile
+++ b/tests/jenkins/jobs/Build_Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
                                 snapshot: true
                             )
                             withCredentials([usernamePassword(credentialsId: 'Sonatype', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD')]) {
-                                echo "$WORKSPACE/publish/publish-snapshot.sh $WORKSPACE/builds/maven"
+                                echo "$WORKSPACE/publish/publish-snapshot.sh $WORKSPACE/builds/opensearch/maven"
                             }
                         }
                     }

--- a/vars/uploadArtifacts.groovy
+++ b/vars/uploadArtifacts.groovy
@@ -1,7 +1,7 @@
 void call(Map args = [:]) {
     def lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
 
-    def manifestFilename = args.dryRun ? 'tests/data/opensearch-build-1.1.0.yml' : 'builds/manifest.yml'
+    def manifestFilename = args.dryRun ? 'tests/data/opensearch-build-1.1.0.yml' : 'builds/opensearch/manifest.yml'
     def buildManifest = lib.jenkins.BuildManifest.new(readYaml(file: manifestFilename))
 
     def artifactPath = buildManifest.getArtifactRoot("${JOB_NAME}", "${BUILD_NUMBER}")


### PR DESCRIPTION
### Description
The latest Jenkins job is failing. There are two errors inside it.
<img width="1549" alt="Screen Shot 2021-11-27 at 10 21 47 AM" src="https://user-images.githubusercontent.com/60111637/143705443-4de769ca-337f-4446-8a3a-b35d2ffc8a22.png">


 
<img width="1529" alt="Screen Shot 2021-11-27 at 10 21 41 AM" src="https://user-images.githubusercontent.com/60111637/143705501-946e8f38-985d-4111-b27a-2817ba9f9372.png">

After searching in the code base, found these two places where the same string is from.

### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
