### PR TITLE
set logging dest param for dashboards service

### DIFF
--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -83,8 +83,6 @@ class ServiceOpenSearchDashboards(Service):
         return requests.get(url, verify=False, auth=("kibanaserver", "kibanaserver") if self.security_enabled else None)
 
     def __add_plugin_specific_config(self, additional_config):
-        logging.info("inside __add_plugin_specific_config")
-        logging.info(f"{additional_config}")
         with open(self.opensearch_dashboards_yml_dir, "a") as yamlfile:
             yamlfile.write(yaml.dump(additional_config))
 

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -44,11 +44,18 @@ class ServiceOpenSearchDashboards(Service):
         if not self.security_enabled:
             self.__remove_security()
 
+        self.__set_logging_dest()
+
         if self.additional_config:
             self.__add_plugin_specific_config(self.additional_config)
 
         self.process_handler.start("./opensearch-dashboards", self.executable_dir)
         logging.info(f"Started OpenSearch Dashboards with parent PID {self.process_handler.pid}")
+
+    def __set_logging_dest(self):
+        self.log_dir = os.path.join(self.install_dir, "logs")
+        os.makedirs(self.log_dir, exist_ok=True)
+        self.additional_config["logging.dest"] = os.path.join(self.log_dir, "opensearch_dashboards.log")
 
     def __remove_security(self):
         subprocess.check_call("./opensearch-dashboards-plugin remove securityDashboards", cwd=self.executable_dir, shell=True)
@@ -76,6 +83,8 @@ class ServiceOpenSearchDashboards(Service):
         return requests.get(url, verify=False, auth=("kibanaserver", "kibanaserver") if self.security_enabled else None)
 
     def __add_plugin_specific_config(self, additional_config):
+        logging.info("inside __add_plugin_specific_config")
+        logging.info(f"{additional_config}")
         with open(self.opensearch_dashboards_yml_dir, "a") as yamlfile:
             yamlfile.write(yaml.dump(additional_config))
 

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -60,7 +60,7 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_dump.assert_called_once_with(
             {
                 "script.context.field.max_compilations_rate": "1000/1m",
-                "logging.dest": "test_work_dir/opensearch-dashboards-1.1.0-linux-x64/logs/opensearch_dashboards.log"
+                "logging.dest": os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "logs", "opensearch_dashboards.log")
             }
         )
         mock_file.return_value.write.assert_called_once_with(mock_dump_result)
@@ -117,7 +117,8 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
             shell=True
         )
 
-        mock_dump.assert_called_once_with({"logging.dest": "test_work_dir/opensearch-dashboards-1.1.0-linux-x64/logs/opensearch_dashboards.log"})
+        mock_dump.assert_called_once_with({"logging.dest": os.path.join(
+            self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "logs", "opensearch_dashboards.log")})
 
         mock_file_hanlder_for_security.close.assert_called_once()
         mock_file_hanlder_for_additional_config.write.assert_called_once_with(mock_dump_result)
@@ -137,8 +138,8 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         self.assertEqual(service.port(), 5601)
         self.assertEqual(service.url(), "http://localhost:5601")
 
-    @ patch("requests.get")
-    @ patch.object(ServiceOpenSearchDashboards, "url")
+    @patch("requests.get")
+    @patch.object(ServiceOpenSearchDashboards, "url")
     def test_get_service_response_with_security(self, mock_url, mock_requests_get):
         service = ServiceOpenSearchDashboards(
             self.version,
@@ -158,8 +159,8 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_url.assert_called_once_with("/api/status")
         mock_requests_get.assert_called_once_with(mock_url_result, verify=False, auth=("kibanaserver", "kibanaserver"))
 
-    @ patch("requests.get")
-    @ patch.object(ServiceOpenSearchDashboards, "url")
+    @patch("requests.get")
+    @patch.object(ServiceOpenSearchDashboards, "url")
     def test_get_service_response_without_security(self, mock_url, mock_requests_get):
         service = ServiceOpenSearchDashboards(
             self.version,

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -6,7 +6,7 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, PropertyMock, mock_open, patch
+from unittest.mock import MagicMock, PropertyMock, call, mock_open, patch
 
 from test_workflow.integ_test.service_opensearch_dashboards import ServiceOpenSearchDashboards
 
@@ -57,7 +57,12 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_bundle_tar.extractall.assert_called_once_with(self.work_dir)
 
         mock_file.assert_called_once_with(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "config", "opensearch_dashboards.yml"), "a")
-        mock_dump.assert_called_once_with(self.additional_config)
+        mock_dump.assert_called_once_with(
+            {
+                "script.context.field.max_compilations_rate": "1000/1m",
+                "logging.dest": "test_work_dir/opensearch-dashboards-1.1.0-linux-x64/logs/opensearch_dashboards.log"
+            }
+        )
         mock_file.return_value.write.assert_called_once_with(mock_dump_result)
 
         mock_process.assert_called_once_with("./opensearch-dashboards", os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "bin"))
@@ -67,8 +72,9 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
     @patch("test_workflow.integ_test.service.Process.start")
     @patch('test_workflow.integ_test.service.Process.pid', new_callable=PropertyMock, return_value=12345)
     @patch("builtins.open", new_callable=mock_open)
+    @patch("yaml.dump")
     @patch("tarfile.open")
-    def test_start_without_security(self, mock_tarfile_open, mock_file, mock_pid, mock_process, mock_check_call):
+    def test_start_without_security(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_check_call):
 
         mock_dependency_installer = MagicMock()
 
@@ -88,8 +94,22 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_bundle_tar = MagicMock()
         mock_tarfile_open.return_value.__enter__.return_value = mock_bundle_tar
 
+        mock_file_hanlder_for_security = mock_open().return_value
+        mock_file_hanlder_for_additional_config = mock_open().return_value
+
+        # open() will be called twice, one for disabling security, second for additional_config
+        mock_file.side_effect = [mock_file_hanlder_for_security, mock_file_hanlder_for_additional_config]
+
+        mock_dump_result = MagicMock()
+        mock_dump.return_value = mock_dump_result
+
         # call the target test function
         service.start()
+
+        mock_file.assert_has_calls(
+            [call(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "config", "opensearch_dashboards.yml"), "w")],
+            [call(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "config", "opensearch_dashboards.yml"), "a")],
+        )
 
         mock_check_call.assert_called_once_with(
             "./opensearch-dashboards-plugin remove securityDashboards",
@@ -97,8 +117,10 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
             shell=True
         )
 
-        mock_file.assert_called_once_with(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "config", "opensearch_dashboards.yml"), "w")
-        mock_file.return_value.close.assert_called_once()
+        mock_dump.assert_called_once_with({"logging.dest": "test_work_dir/opensearch-dashboards-1.1.0-linux-x64/logs/opensearch_dashboards.log"})
+
+        mock_file_hanlder_for_security.close.assert_called_once()
+        mock_file_hanlder_for_additional_config.write.assert_called_once_with(mock_dump_result)
 
     def test_endpoint_port_url(self):
         service = ServiceOpenSearchDashboards(
@@ -115,8 +137,8 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         self.assertEqual(service.port(), 5601)
         self.assertEqual(service.url(), "http://localhost:5601")
 
-    @patch("requests.get")
-    @patch.object(ServiceOpenSearchDashboards, "url")
+    @ patch("requests.get")
+    @ patch.object(ServiceOpenSearchDashboards, "url")
     def test_get_service_response_with_security(self, mock_url, mock_requests_get):
         service = ServiceOpenSearchDashboards(
             self.version,
@@ -136,8 +158,8 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_url.assert_called_once_with("/api/status")
         mock_requests_get.assert_called_once_with(mock_url_result, verify=False, auth=("kibanaserver", "kibanaserver"))
 
-    @patch("requests.get")
-    @patch.object(ServiceOpenSearchDashboards, "url")
+    @ patch("requests.get")
+    @ patch.object(ServiceOpenSearchDashboards, "url")
     def test_get_service_response_without_security(self, mock_url, mock_requests_get):
         service = ServiceOpenSearchDashboards(
             self.version,


### PR DESCRIPTION
### Description
OpenSearch Dashboards generates logs to stdout by default. In order to persist logs during test cluster termination, we set up this yml param so that the logs is under the `logs` folder.
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1170
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
