### PR TITLE
Create a component release template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -12,15 +12,18 @@ I noticed that a manifest was automatically created in [manifests/{{ env.VERSION
 <p>
 
 ## This Release Issue
-This issue captures the state of the OpenSearch release, its assignee is responsible for driving the release.  Please contact them or @mention them on this issue for help.  There are linked issues on components of the release where individual components can be tracked.
+
+This issue captures the state of the OpenSearch release, its assignee is responsible for driving the release. Please contact them or @mention them on this issue for help. There are linked issues on components of the release where individual components can be tracked.
 
 ## Release Steps
+
 There are several steps to the release process, these steps are completed as the whole release and components that are behind present risk to the release.  The release owner completes the tasks in this ticket, whereas component owners resolve tasks on their ticket in their repositories.
 
 Steps have completion dates for coordinating efforts between the components of a release; components can start as soon as they are ready far in advance of a future release.
 
 ### Component List
-To aid in understanding the state of the release there is a table with status indicating each component state.  This is updated based on the status of the component issues.
+
+To aid in understanding the state of the release there is a table with status indicating each component state. This is updated based on the status of the component issues.
 
 </p>
 </details>
@@ -28,17 +31,17 @@ To aid in understanding the state of the release there is a table with status in
 ### Preparation
 
 - [ ] Assign this issue to a release owner.
-- [ ] Declare a pencils down date for new features to be merged. _RELEASE-minus-14-days is pencils down_
+- [ ] Declare a pencils down date for new features to be merged. ___REPLACE_RELEASE-minus-14-days__ is pencils down.
 - [ ] Update the Campaigns section to include monitoring campaigns during this release. 
-- [ ] Update this issue so all `RELEASE-` placeholders have actual dates.
+- [ ] Update this issue so all `__REPLACE_RELEASE-__` placeholders have actual dates.
 - [ ] Document any new quality requirements or changes.
 - [ ] Declare a pencils down date for new features to be merged.
 - [ ] Finalize scope and feature set and update [the Public Roadmap](https://github.com/orgs/opensearch-project/projects/1).
-- [ ] [Create a version label](https://github.com/opensearch-project/opensearch-plugins/blob/main/META.md#create-or-update-labels-in-all-plugin-repos) in each component repo.
+- [ ] [Create a version label](https://github.com/opensearch-project/opensearch-plugins/blob/main/META.md#create-or-update-labels-in-all-plugin-repos) in each component repo for this, and the next minor release.
 - [ ] [Create a release issue in every component repo](https://github.com/opensearch-project/opensearch-build/blob/main/meta/README.md#create-a-release-issue) that links back to this issue, update Components section with these links.
 - [ ] Ensure that all release issues created above are assigned to an owner in the component team.
 
-### CI/CD - _Ends RELEASE-minus-14-days_
+### CI/CD - _Ends __REPLACE_RELEASE-minus-14-days___
 
 - [ ] Create Jenkins workflows that run daily snapshot builds for OpenSearch and OpenSearch Dashboards. 
 - [ ] Increment each component version to {{ env.VERSION }} and ensure working CI in component repositories.
@@ -46,22 +49,22 @@ To aid in understanding the state of the release there is a table with status in
 
 ### Campaigns
 
-__Replace with OpenSearch wide initiatives to improve quality and consistency.__
+__REPLACE with OpenSearch wide initiatives to improve quality and consistency.__
 
-### Release testing - _Ends RELEASE-minus-6-days_
+### Release testing - _Ends __REPLACE_RELEASE-minus-6-days___
 
-- [ ] Code Complete (RELEASE-minus-14-days - RELEASE-minus-11-days): Teams test their component within the distribution, ensuring integration, backwards compatibility, and perf tests pass.
-- [ ] Sanity Testing (RELEASE-minus-8-days - RELEASE-minus-6-days): Sanity testing *and* fixing of critical issues found by teams.
+- [ ] Code Complete (__REPLACE_RELEASE-minus-14-days__ - __REPLACE_RELEASE-minus-11-days__): Teams test their component within the distribution, ensuring integration, backwards compatibility, and perf tests pass.
+- [ ] Sanity Testing (__REPLACE_RELEASE-minus-8-days__ - __REPLACE_RELEASE-minus-6-days__): Sanity testing and fixing of critical issues found by teams.
 
-### Release - _Ends {RELEASE-day}_
+### Release - _Ends {__REPLACE_RELEASE-day}_
 
 - [ ] Declare a release candidate build, and publish all test results.
 - [ ] Verify all issued labeled `v{{ env.VERSION }}` in all projects have been resolved.
 - [ ] Complete [documentation](https://github.com/opensearch-project/documentation-website) for this release.
 - [ ] Author [blog post](https://github.com/opensearch-project/project-website) for this release.
 - [ ] Gather, review and publish release notes.
-- [ ] RELEASE-minus-1-day - Publish this release on [opensearch.org](https://opensearch.org/downloads.html).
-- [ ] RELEASE-day - Publish [blog post](https://github.com/opensearch-project/project-website) - release is launched!
+- [ ] __REPLACE_RELEASE-minus-1-day - Publish this release on [opensearch.org](https://opensearch.org/downloads.html).
+- [ ] __REPLACE_RELEASE-day - Publish [blog post](https://github.com/opensearch-project/project-website) - release is launched!
 
 ### Post Release
 

--- a/meta/README.md
+++ b/meta/README.md
@@ -51,12 +51,14 @@ Install [ghi](https://github.com/stephencelis/ghi), e.g. `brew install ghi`.
 meta exec "ghi label 'v1.2.0' -c '#b94c47'"
 ```
 
+When creating a version label for the ongoing release, always create the next version's label as well.
+
 ### Create a Release Issue
 
 We create release issues in all component repos that link back to a parent release issue in this repository. 
 
-1. Locate the parent issue, e.g. [opensearch-build#567](https://github.com/opensearch-project/opensearch-build/issues/567) for version 1.2.
-2. Clone the last template in [templates/releases/](templates/releases), and update version numbers and links, e.g. [release-1.2.0.md](templates/releases/release-1.2.0.md).
+1. Locate the parent release issue, e.g. [opensearch-build#567](https://github.com/opensearch-project/opensearch-build/issues/567) for version 1.2.
+2. Clone the [release template](templates/releases/release_template.md) into a new `release-X.Y.Z.md`, e.g. [release-1.2.0.md](templates/releases/release-1.2.0.md). Update all `REPLACE` tags with actual versions and dates and commit and PR the file.
 3. From [components](components), run `meta exec "gh issue create --label v1.2.0 --title 'Release version 1.2' --body-file ../../templates/releases/release-1.2.0.md"`.
 
 ### Check for Release Tags

--- a/meta/templates/releases/release_template.md
+++ b/meta/templates/releases/release_template.md
@@ -1,0 +1,38 @@
+Coming from [opensearch-build__REPLACE_ISSUE_NUMBER__](https://github.com/opensearch-project/opensearch-build/issues/__REPLACE_ISSUE_NUMBER__), release version __REPLACE_MAJOR_MINOR__. Please follow the following checklist.
+
+### Preparation
+
+- [ ] Assign this issue to a release owner.
+- [ ] Finalize scope and feature set and update [the Public Roadmap](https://github.com/orgs/opensearch-project/projects/1).
+- [ ] Create, update, triage and label all features and issues targeted for this release with `v__REPLACE_MAJOR_MINOR_PATCH__`.
+
+### CI/CD - __REPLACE_DATE___
+
+- [ ] Increment version on main to `__REPLACE_MAJOR_MINOR_PATCH_BUILD__`.
+- [ ] Ensure working and passing CI.
+- [ ] Re(add) this repo to the [manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/__REPLACE_MAJOR_MINOR_PATCH__).
+
+### Pre-Release
+
+- [ ] Branch and build from a `__REPLACE_MAJOR_MINOR__` branch.
+- [ ] Update your branch in the [manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/__REPLACE_MAJOR_MINOR_PATCH__).
+- [ ] Increment the version on the parent branch.
+- [ ] Feature complete, pencils down.
+- [ ] Fix bugs that target this release.
+
+### Release Testing
+
+- [ ] Code Complete (__REPLACE_REPLACE_RELEASE-minus-14-days__ - __REPLACE_RELEASE-minus-11-days__): Test within the distribution, ensuring integration, backwards compatibility, and performance tests pass.
+- [ ] Sanity Testing (__REPLACE_REPLACE_RELEASE-minus-8-days__ - __REPLACE_RELEASE-minus-6-days__): Sanity testing *and* fixing of critical issues found.
+
+### Release
+
+- [ ] Complete [documentation](https://github.com/opensearch-project/documentation-website).
+- [ ] Gather, review and publish release notes.
+- [ ] Verify all issued labeled for this release are closed or labelled for the next release.
+
+### Post Release
+
+- [ ] Create [a release tag](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging).
+- [ ] [Suggest improvements](https://github.com/opensearch-project/opensearch-build/issues/new) to [this template](https://github.com/opensearch-project/opensearch-build/meta/templates/releases/release_template.md).
+- [ ] Conduct a postmortem, and publish its results.


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

- Added `release_template.md` for each individual component's release template to make it a permalink.
- We already have a `_` template, so I called this one the same.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
