### PR TITLE
Fix: build.getFilename()

### DIFF
--- a/vars/buildAssembleUpload.groovy
+++ b/vars/buildAssembleUpload.groovy
@@ -36,14 +36,14 @@ void call(Map args = [:]) {
 
         assembleManifest(
             args + [
-                manifest: args.dryRun ? 'tests/data/opensearch-build-1.1.0.yml' : "builds/${inputManifest.getFilename()}/manifest.yml"
+                manifest: args.dryRun ? 'tests/data/opensearch-build-1.1.0.yml' : "builds/${inputManifest.build.getFilename()}/manifest.yml"
             ]
         )
 
         uploadArtifacts(args)
 
         withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
-            if (! args.dryRun) {
+            if (!args.dryRun) {
                 s3Upload(bucket: "${ARTIFACT_BUCKET_NAME}", file: manifestLock, path: manifestShaPath)
             } else {
                 echo "s3Upload(bucket: ${ARTIFACT_BUCKET_NAME}, file: ${manifestLock}, path: ${manifestShaPath})"

--- a/vars/uploadArtifacts.groovy
+++ b/vars/uploadArtifacts.groovy
@@ -8,7 +8,7 @@ void call(Map args = [:]) {
     echo "Uploading to s3://${ARTIFACT_BUCKET_NAME}/${artifactPath}"
 
     withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
-        if (! args.dryRun) {
+        if (!args.dryRun) {
             s3Upload(file: 'builds', bucket: "${ARTIFACT_BUCKET_NAME}", path: "${artifactPath}/builds")
             s3Upload(file: 'dist', bucket: "${ARTIFACT_BUCKET_NAME}", path: "${artifactPath}/dist")
         } else {

--- a/vars/uploadTestResults.groovy
+++ b/vars/uploadTestResults.groovy
@@ -8,7 +8,7 @@ void call(Map args = [:]) {
     echo "Uploading to s3://${ARTIFACT_BUCKET_NAME}/${artifactPath}"
 
     withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
-        if (! args.dryRun) {
+        if (!args.dryRun) {
             s3Upload(file: 'test-results', bucket: "${ARTIFACT_BUCKET_NAME}", path: "${artifactPath}/test-results")
         } else {
             echo "s3Upload(file: 'test-results', bucket: ${ARTIFACT_BUCKET_NAME}, path: ${artifactPath}/test-results)"


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

The unit tests use `dryRun` so this is never exercised and wasn't caught in tests. The method is implemented on `manifest.build`. Don't think it's worth doing something more elaborate test-wise here.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
