### PR TITLE
Remove restriction from publish snapshot script that jars must end in -SNAPSHOT.jar.

### DIFF
--- a/publish/publish-snapshot.sh
+++ b/publish/publish-snapshot.sh
@@ -113,11 +113,12 @@ for pom in ${pomFiles}; do
   pom_dir="$(dirname "${pom}")"
   for FILE in "${pom_dir}"/*; do
     # The POM is deployed with the artifact in a single deploy-file command, we can skip over it
-    if [[ $FILE != $pom ]]; then
+    if [[ $FILE != $pom ]] &&
+       [[ $FILE != *"test-fixtures"* ]] && # This is a hack to ensure the OpenSearch build-tools test fixture jar is not uploaded instead of the actual build-tools jar.
+       [[ $FILE != *"javadoc"* ]] &&
+       [[ $FILE != *"sources"* ]]; then
       extension="${FILE##*.}"
       case $extension in jar | war | zip)
-        # Ensure we are only pushing the artifact that ends with -SNAPSHOT.<extension> and its pom.
-        if [[ $FILE == *SNAPSHOT.${extension} ]]; then
           echo "Uploading: ${FILE} with ${pom} to ${url}"
           mvn --settings="${mvn_settings}" deploy:deploy-file \
             -DgeneratePom=false \
@@ -125,9 +126,6 @@ for pom in ${pomFiles}; do
             -Durl="${SNAPSHOT_REPO_URL}" \
             -DpomFile="${pom}" \
             -Dfile="${FILE}" || echo "Failed to upload ${FILE}"
-        else
-          echo "Skipping upload of additional artifact: ${FILE}"
-        fi
         ;;
       *) echo "Skipping upload for ${FILE}" ;;
       esac


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
Remove restriction from publish snapshot script that jars must end in -SNAPSHOT.jar.

The reason this was introduced in the first place was because of #447, the build-tools publication includes an additional test-fixtures jar that would sometimes get picked up and deployed instead of the actual build-tools jar.  To account for this, this will look for a jar named test-fixtures and exclude it.  
```
Uploading: ./gradle/build-tools/2.0.0-SNAPSHOT/build-tools-2.0.0-SNAPSHOT.jar with ./gradle/build-tools/2.0.0-SNAPSHOT/build-tools-2.0.0-SNAPSHOT.pom to 
Skipping upload for ./gradle/build-tools/2.0.0-SNAPSHOT/build-tools-2.0.0-SNAPSHOT.module
Skipping upload for ./gradle/build-tools/2.0.0-SNAPSHOT/maven-metadata-local.xml
Finished uploading ./gradle/build-tools/2.0.0-SNAPSHOT

```

This is only necessary because we are deploying pre-built artifacts directly with the deploy-file plugin, it is not a problem if both of those files were to get deployed with a normal gradle publish - see #1182.
 
### Issues Resolved
closes #1180  
### Check List
- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
