### PR TITLE
Fix Post Release component release template link

### DIFF
--- a/meta/templates/releases/release_template.md
+++ b/meta/templates/releases/release_template.md
@@ -34,5 +34,5 @@ Coming from [opensearch-build__REPLACE_ISSUE_NUMBER__](https://github.com/opense
 ### Post Release
 
 - [ ] Create [a release tag](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging).
-- [ ] [Suggest improvements](https://github.com/opensearch-project/opensearch-build/issues/new) to [this template](https://github.com/opensearch-project/opensearch-build/meta/templates/releases/release_template.md).
+- [ ] [Suggest improvements](https://github.com/opensearch-project/opensearch-build/issues/new) to [this template](https://github.com/opensearch-project/opensearch-build/blob/main/meta/templates/releases/release_template.md).
 - [ ] Conduct a postmortem, and publish its results.


### PR DESCRIPTION
### Description
Fixes the link added for the component release template in the Post Release section.
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
