### PR TITLE
Update docker builder image dockerfile to allow data prepper build

### DIFF
--- a/docker/ci/dockerfiles/ci-runner.docker-builder.ubuntu2004.x64.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.docker-builder.ubuntu2004.x64.dockerfile
@@ -17,7 +17,17 @@ FROM ubuntu:20.04
 RUN apt-get update -y && apt-get install -y software-properties-common && add-apt-repository ppa:jacob/virtualisation -y
 
 # Install necessary packages
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y binfmt-support qemu qemu-user qemu-user-static docker.io curl && apt clean -y
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y binfmt-support qemu qemu-user qemu-user-static docker.io curl python3-pip && apt clean -y && pip3 install awscli==1.22.12
+
+# Install JDK
+RUN curl -SL https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz -o /opt/jdk14.tar.gz && \
+    mkdir -p /opt/java/openjdk-14 && \
+    tar -xzf /opt/jdk14.tar.gz --strip-components 1 -C /opt/java/openjdk-14/ && \
+    rm /opt/jdk14.tar.gz
+
+# ENV JDK
+ENV JAVA_HOME=/opt/java/openjdk-14
+ENV PATH=$PATH:$JAVA_HOME/bin
 
 # Install docker buildx
 RUN mkdir -p ~/.docker/cli-plugins && \

--- a/jenkins/docker/Jenkinsfile
+++ b/jenkins/docker/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
             agent {
                 docker {
                     label 'Jenkins-Agent-Ubuntu2004-X64-m52xlarge-Docker-Builder'
-                    image 'opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0'
+                    image 'opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk14'
                     args '-u root -v /var/run/docker.sock:/var/run/docker.sock'
                     alwaysPull true
                 }


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Update docker builder image dockerfile to allow data prepper build.
Include awscli 1.22 as well as jdk14.
Thanks.

 
### Issues Resolved
#1106 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
