### PR TITLE
Added default CI image.

### DIFF
--- a/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
@@ -1,8 +1,11 @@
 build:
   name: OpenSearch Dashboards
   version: 1.3.0
+ci:
+  image:
+    name: "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211019"
 components:
-- name: OpenSearch-Dashboards
-  ref: 1.x
-  repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-schema-version: '1.0'
+  - name: OpenSearch-Dashboards
+    ref: 1.x
+    repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+schema-version: "1.0"

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -91,8 +91,7 @@ class InputManifests(Manifests):
             for release_version in sorted(main_versions.keys() - known_versions):
                 self.write_manifest(release_version, main_versions[release_version])
 
-    def write_manifest(self, version, components=[]):
-        logging.info(f"Creating new version: {version}")
+    def create_manifest(self, version, components=[]):
         data = {
             "schema-version": "1.0",
             "build": {
@@ -106,11 +105,16 @@ class InputManifests(Manifests):
             },
             "components": [],
         }
+
         for component in components:
             logging.info(f" Adding {component.name}")
             data["components"].append(component.to_dict())
 
-        manifest = InputManifest(data)
+        return InputManifest(data)
+
+    def write_manifest(self, version, components=[]):
+        logging.info(f"Creating new version: {version}")
+        manifest = self.create_manifest(version, components)
         manifest_dir = os.path.join(self.manifests_path(), version)
         os.makedirs(manifest_dir, exist_ok=True)
         manifest_path = os.path.join(manifest_dir, f"{self.prefix}-{version}.yml")

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -95,7 +95,15 @@ class InputManifests(Manifests):
         logging.info(f"Creating new version: {version}")
         data = {
             "schema-version": "1.0",
-            "build": {"name": self.name, "version": version},
+            "build": {
+                "name": self.name,
+                "version": version
+            },
+            "ci": {
+                "image": {
+                    "name": "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211019"
+                }
+            },
             "components": [],
         }
         for component in components:

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -121,3 +121,6 @@ class TestRecorder:
                     dest_file = os.path.join(dest_directory, os.path.basename(result[0]))
                     shutil.copyfile(result[0], dest_file)
             self.parent_class._generate_yml(test_result_data, dest_directory)
+
+
+TestRecorder.__test__ = False  # type:ignore

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -14,3 +14,18 @@ class TestInputManifests(unittest.TestCase):
     def test_manifests_path(self):
         path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "manifests"))
         self.assertEqual(path, InputManifests.manifests_path())
+
+    def test_create_manifest(self):
+        input_manifests = InputManifests("test")
+        input_manifest = input_manifests.create_manifest("1.2.3", [])
+        self.assertEqual(
+            input_manifest.to_dict(),
+            {
+                "schema-version": "1.0",
+                "build": {"name": "test", "version": "1.2.3"},
+                "ci": {"image": {"name": "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211019"}},
+            },
+        )
+
+    def test_create_manifest_with_components(self):
+        pass

--- a/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
+++ b/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, call, patch
 from test_workflow.test_recorder.test_recorder import TestRecorder
 
 
-class LocalClusterLogsTests(unittest.TestCase):
+class TestLocalClusterLogs(unittest.TestCase):
 
     @patch("shutil.copyfile")
     def test(self, mock_copyfile):


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

The auto-generated manifests need to include CI image.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
