### PR TITLE
update ruby version to 2.4.0 for centos dockerfile

### DIFF
--- a/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
@@ -113,7 +113,7 @@ SHELL ["/bin/bash", "-lc"]
 CMD ["/bin/bash", "-l"]
 
 # Install ruby / rpm / fpm related dependencies
-RUN . /etc/profile.d/rvm.sh && rvm install 2.3.3 && rvm --default use 2.3.3 && \
+RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 && \
     yum install -y rpm-build && \
     gem install fpm -v 1.13.0
 


### PR DESCRIPTION
Signed-off-by: Abhinav Gupta <abhng@amazon.com>

### Description
Update the ruby version to v2.4.0 for centos 
 
### Issues Resolved
The version of the ruby is not updated for centos dockerfile

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
