### PR TITLE
Fix OpenSearch Dashboards build manifest.

### DIFF
--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -1,4 +1,4 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
 
 pipeline {
     agent none
@@ -50,7 +50,9 @@ pipeline {
                                 platform: "linux",
                                 architecture: "x64"
                             )
-                            assembleManifest()
+                            assembleManifest(
+                                manifest: 'builds/opensearch-dashboards/manifest.yml'
+                            )
                             uploadArtifacts()
                         }
                     }
@@ -78,8 +80,15 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64'
                                     )
-                                    zip zipFile: 'buildArtifacts.zip', archive: false, dir: 'builds'
-                                    archiveArtifacts artifacts: 'buildArtifacts.zip', fingerprint: true
+                                    zip(
+                                        zipFile: 'buildArtifacts.zip',
+                                        archive: false,
+                                        dir: 'builds'
+                                    )
+                                    archiveArtifacts(
+                                        artifacts: 'buildArtifacts.zip',
+                                        fingerprint: true
+                                    )
                                 }
                             }
                             post {
@@ -99,10 +108,22 @@ pipeline {
                             }
                             steps {
                                 script {
-                                    copyArtifacts filter: 'buildArtifacts.zip', fingerprintArtifacts: true, projectName: env.JOB_NAME, selector: specific(env.BUILD_NUMBER)
-                                    unzip zipFile: 'buildArtifacts.zip', dir: './builds'
-                                    assembleManifest()
-                                    uploadArtifacts(upload: true)
+                                    copyArtifacts(
+                                        filter: 'buildArtifacts.zip',
+                                        fingerprintArtifacts: true,
+                                        projectName: env.JOB_NAME,
+                                        selector: specific(env.BUILD_NUMBER)
+                                    )
+                                    unzip(
+                                        zipFile: 'buildArtifacts.zip',
+                                        dir: './builds'
+                                    )
+                                    assembleManifest(
+                                        manifest: 'builds/opensearch-dashboards/manifest.yml'
+                                    )
+                                    uploadArtifacts(
+                                        upload: true
+                                    )
                                 }
                             }
                             post {
@@ -141,7 +162,7 @@ pipeline {
                     )
 
                     cleanWs(
-                        disableDeferredWipeout: true, 
+                        disableDeferredWipeout: true,
                         deleteDirs: true
                     )
                 }

--- a/vars/assembleManifest.groovy
+++ b/vars/assembleManifest.groovy
@@ -1,11 +1,10 @@
 void call(Map args = [:]) {
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
-    String manifestFilename = args.manifest ?: 'builds/opensearch/manifest.yml'
-    def buildManifest = lib.jenkins.BuildManifest.new(readYaml(file: manifestFilename))
+    def buildManifest = lib.jenkins.BuildManifest.new(readYaml(file: args.manifest))
     def baseUrl = buildManifest.getArtifactRootUrl("${PUBLIC_ARTIFACT_URL}", "${JOB_NAME}", "${BUILD_NUMBER}")
     sh ([
         args.dryRun ? 'echo ./assemble.sh' : './assemble.sh',
-        "\"${manifestFilename}\"",
+        "\"${args.manifest}\"",
         "--base-url ${baseUrl}"
     ].join(' '))
 }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Since we changed default output paths the location of the manifest needs to be dynamic. It already is in `buildAndAssemble`, but OpenSearch Dashboards doesn't use that.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
