### PR TITLE
Add link to git-release-notes in release template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -62,7 +62,7 @@ __REPLACE with OpenSearch wide initiatives to improve quality and consistency.__
 - [ ] Verify all issued labeled `v{{ env.VERSION }}` in all projects have been resolved.
 - [ ] Complete [documentation](https://github.com/opensearch-project/documentation-website) for this release.
 - [ ] Author [blog post](https://github.com/opensearch-project/project-website) for this release.
-- [ ] Gather, review and publish release notes.
+- [ ] Gather, review and publish release notes. [git-release-notes](https://github.com/ariatemplates/git-release-notes) may be used to generate release notes from your commit history.
 - [ ] __REPLACE_RELEASE-minus-1-day - Publish this release on [opensearch.org](https://opensearch.org/downloads.html).
 - [ ] __REPLACE_RELEASE-day - Publish [blog post](https://github.com/opensearch-project/project-website) - release is launched!
 


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

### Description
This is a suggestion for the release template.  Many repos are generating release notes using [git-release-notes ](https://github.com/ariatemplates/git-release-notes).  This adds a link to it in the release template.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
