### PR TITLE
Fix ruby and rvm version not running correctly in non-interactive shell

### DIFF
--- a/docker/ci/dockerfiles/ci-runner.al2.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.al2.dockerfile
@@ -111,6 +111,12 @@ RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 && \
     yum install -y rpm-build && \
     gem install fpm -v 1.13.0
 
+ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.4.0/bin
+ENV RVM_HOME=/usr/local/rvm/bin
+ENV GEM_HOME=/usr/share/opensearch/.gem
+ENV GEM_PATH=$GEM_HOME
+ENV PATH=$RUBY_HOME:$RVM_HOME:$PATH
+
 # Change User
 USER 1000
 WORKDIR /usr/share/opensearch

--- a/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
@@ -117,6 +117,12 @@ RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 && \
     yum install -y rpm-build && \
     gem install fpm -v 1.13.0
 
+ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.4.0/bin
+ENV RVM_HOME=/usr/local/rvm/bin
+ENV GEM_HOME=/usr/share/opensearch/.gem
+ENV GEM_PATH=$GEM_HOME
+ENV PATH=$RUBY_HOME:$RVM_HOME:$PATH
+
 # Install Python37 binary
 RUN curl https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz | tar xzvf - && \
     cd Python-3.7.7 && \


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Fix ruby and rvm version not running correctly in non-interactive shell
 
### Issues Resolved
#872 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
