### PR TITLE
adding perms to grant read and put to clients dir on s3

### DIFF
--- a/deployment/lib/identities.ts
+++ b/deployment/lib/identities.ts
@@ -42,6 +42,9 @@ export class Identities {
     props.buildBucket.grantRead(bundleRole, '*/builds/*');
     props.buildBucket.grantPut(bundleRole, '*/builds/*');
 
+    props.buildBucket.grantRead(bundleRole, '*/clients/*');
+    props.buildBucket.grantPut(bundleRole, '*/clients/*');
+
     props.buildBucket.grantRead(bundleRole, '*/shas/*');
     props.buildBucket.grantPut(bundleRole, '*/shas/*');
 


### PR DESCRIPTION
Signed-off-by: Abhinav Gupta <abhng@amazon.com>

### Description
Adding perms so bundle role can upload to the clients dir on s3 bucket
 
### Issues Resolved
#872 - Part of this issue
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
