### PR TITLE
update the status check for OpenSearch Dashboards

### DIFF
--- a/src/test_workflow/integ_test/service.py
+++ b/src/test_workflow/integ_test/service.py
@@ -69,7 +69,7 @@ class Service(abc.ABC):
     @abc.abstractmethod
     def check_service_response_text(self):
         """
-        Get response from the service endpoint.
+        Check response text from the service endpoint.
         """
         pass
 

--- a/src/test_workflow/integ_test/service.py
+++ b/src/test_workflow/integ_test/service.py
@@ -66,10 +66,19 @@ class Service(abc.ABC):
         """
         pass
 
+    @abc.abstractmethod
+    def check_service_response_text(self):
+        """
+        Get response from the service endpoint.
+        """
+        pass
+
     def service_alive(self):
         response = self.get_service_response()
         logging.info(f"{response.status_code}: {response.text}")
-        if response.status_code == 200 and (('"status":"green"' in response.text) or ('"status":"yellow"' in response.text)):
+
+        # TODO: https://github.com/opensearch-project/opensearch-build/issues/1217
+        if response.status_code == 200 and self.check_service_response_text(response.text):
             logging.info("Service is available")
             return True
         else:

--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -69,3 +69,6 @@ class ServiceOpenSearch(Service):
 
     def port(self):
         return 9200
+
+    def check_service_response_text(self, response_text):
+        return ('"status":"green"' in response_text) or ('"status":"yellow"' in response_text)

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -88,3 +88,6 @@ class ServiceOpenSearchDashboards(Service):
 
     def port(self):
         return 5601
+
+    def check_service_response_text(self, response_text):
+        return ('"state":"green"' in response_text) or ('"state":"yellow"' in response_text)

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -179,3 +179,66 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
 
         mock_url.assert_called_once_with("/api/status")
         mock_requests_get.assert_called_once_with(mock_url_result, auth=None, verify=False)
+
+    @patch.object(ServiceOpenSearchDashboards, "get_service_response")
+    def test_service_alive_green_available(self, mock_get_service_response):
+        service = ServiceOpenSearchDashboards(
+            self.version,
+            self.platform,
+            self.architecture,
+            self.additional_config,
+            True,
+            self.dependency_installer,
+            self.work_dir
+        )
+
+        mock_response = MagicMock()
+
+        mock_response.status_code = 200
+        mock_response.text = '"state":"green"'
+
+        mock_get_service_response.return_value = mock_response
+
+        self.assertTrue(service.service_alive())
+
+    @patch.object(ServiceOpenSearchDashboards, "get_service_response")
+    def test_service_alive_yellow_available(self, mock_get_service_response):
+        service = ServiceOpenSearchDashboards(
+            self.version,
+            self.platform,
+            self.architecture,
+            self.additional_config,
+            True,
+            self.dependency_installer,
+            self.work_dir
+        )
+
+        mock_response = MagicMock()
+
+        mock_response.status_code = 200
+        mock_response.text = '"state":"yellow"'
+
+        mock_get_service_response.return_value = mock_response
+
+        self.assertTrue(service.service_alive())
+
+    @patch.object(ServiceOpenSearchDashboards, "get_service_response")
+    def test_service_alive_red_unavailable(self, mock_get_service_response):
+        service = ServiceOpenSearchDashboards(
+            self.version,
+            self.platform,
+            self.architecture,
+            self.additional_config,
+            True,
+            self.dependency_installer,
+            self.work_dir
+        )
+
+        mock_response = MagicMock()
+
+        mock_response.status_code = 200
+        mock_response.text = '"state":"red"'
+
+        mock_get_service_response.return_value = mock_response
+
+        self.assertFalse(service.service_alive())


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
OpenSearch Dashboards has "state":"green" instead of "status":"green" which is different from OpenSearch.
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1218
 
### Test
unit test

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
