### PR TITLE
Add support for OpenSearch Dashboards patches

### DIFF
--- a/src/build_workflow/builder_from_dist.py
+++ b/src/build_workflow/builder_from_dist.py
@@ -25,6 +25,10 @@ class BuilderFromDist(Builder):
     def build(self, build_recorder):
         pass
 
+    @property
+    def target_name(self):
+        return self.target.name.lower().replace(' ', '-')
+
     def export_artifacts(self, build_recorder):
         os.makedirs(self.output_path, exist_ok=True)
         component_manifest = self.build_manifest.components[self.component.name]
@@ -35,7 +39,7 @@ class BuilderFromDist(Builder):
             artifact_path = os.path.join(self.output_path, artifact_type)
             logging.info(f"Downloading into {artifact_path} ...")
             for artifact in component_manifest.artifacts[artifact_type]:
-                artifact_url = f"{self.component.dist}/{self.target.architecture}/{artifact}"
+                artifact_url = f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds/{self.target_name}/{artifact}"
                 artifact_dest = os.path.realpath(os.path.join(self.output_path, artifact))
                 os.makedirs(os.path.dirname(artifact_dest), exist_ok=True)
                 logging.info(f"Downloading {artifact_url} into {artifact_dest}")
@@ -43,6 +47,6 @@ class BuilderFromDist(Builder):
                 build_recorder.record_artifact(self.component.name, artifact_type, artifact, artifact_dest)
 
     def __download_build_manifest(self):
-        url = f"{self.component.dist}/{self.target.architecture}/manifest.yml"
+        url = f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds/{self.target_name}/manifest.yml"
         logging.info(f"Downloading {url} ...")
         self.build_manifest = BuildManifest.from_url(url)

--- a/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
+++ b/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
@@ -17,21 +17,25 @@ class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
     def check(self, path):
         if os.path.splitext(path)[1] != ".zip":
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")
-        opensearch_dashboards_version = re.sub(r"-SNAPSHOT$", "", self.target.opensearch_version)
-        match = re.search(rf"^(\w+)-{opensearch_dashboards_version}.zip$", os.path.basename(path))
+
+        match = re.search(r"^(\w+)-[\d\.]*.*.zip$", os.path.basename(path))
         if not match:
-            raise BuildArtifactCheck.BuildArtifactInvalidError(
-                path,
-                f"Expected filename to be in the format of pluginName-{opensearch_dashboards_version}.zip.",
-            )
+            raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Expected filename to be in the format of pluginName-1.1.0.zip.")
+
         plugin_name = match.group(1)
+        valid_filenames = self.__valid_paths(plugin_name)
+        if not os.path.basename(path) in valid_filenames:
+            raise BuildArtifactCheck.BuildArtifactInvalidError(path, f"Expected filename to to be one of {valid_filenames}.")
+
         with ZipFile(path, "r") as zip:
             data = zip.read(f"opensearch-dashboards/{plugin_name}/opensearch_dashboards.json").decode("UTF-8")
             config = ConfigFile(data)
             try:
-                component_version = re.sub(r"-SNAPSHOT$", "", self.target.component_version)
-                config.check_value("version", component_version)
-                config.check_value("opensearchDashboardsVersion", opensearch_dashboards_version)
+                config.check_value_in("version", self.target.compatible_component_versions)
+                config.check_value_in("opensearchDashboardsVersion", self.target.compatible_versions)
             except ConfigFile.CheckError as e:
                 raise BuildArtifactCheck.BuildArtifactInvalidError(path, e.__str__())
             logging.info(f'Checked {path} ({config.get_value("version", "N/A")})')
+
+    def __valid_paths(self, pluginName):
+        return list(map(lambda version: f"{pluginName}-{version}.zip", self.target.compatible_versions))

--- a/tests/tests_build_workflow/opensearch/__init__.py
+++ b/tests/tests_build_workflow/opensearch/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))

--- a/tests/tests_build_workflow/opensearch_dashboards/__init__.py
+++ b/tests/tests_build_workflow/opensearch_dashboards/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))

--- a/tests/tests_build_workflow/test_builder_from_dist.py
+++ b/tests/tests_build_workflow/test_builder_from_dist.py
@@ -33,7 +33,7 @@ class TestBuilderFromDist(unittest.TestCase):
     @patch("build_workflow.builder_from_dist.BuildManifest")
     def test_checkout(self, mock_manifest):
         self.builder.checkout("dir")
-        mock_manifest.from_url.assert_called_with("url/x64/manifest.yml")
+        mock_manifest.from_url.assert_called_with("url/windows/x64/builds/opensearch/manifest.yml")
 
     def test_build(self):
         build_recorder = MagicMock()
@@ -53,6 +53,6 @@ class TestBuilderFromDist(unittest.TestCase):
             exist_ok=True
         )
         mock_urllib.assert_called_with(
-            "url/x64/maven/org/opensearch/common-utils/1.1.0.0/common-utils-1.1.0.0.jar",
+            "url/windows/x64/builds/opensearch/maven/org/opensearch/common-utils/1.1.0.0/common-utils-1.1.0.0.jar",
             os.path.realpath(os.path.join("builds", "maven", "org", "opensearch", "common-utils", "1.1.0.0", "common-utils-1.1.0.0.jar")),
         )


### PR DESCRIPTION
### Description

In https://github.com/opensearch-project/opensearch-build/pull/789 we introduced a mechanism to combine artifacts from previous releases in a new distribution. The version checks for OpenSearch were relaxed to support patches. This extends OpenSearch Dashboards version checks to do the same.

During 1.2.0 we have fixed https://github.com/opensearch-project/opensearch-build/issues/669 to avoid path collisions. This adjusts paths accordingly for downloading existing distributions.
 
### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/1225.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
