### PR TITLE
Add common-utils and job-scheduler to 1.3 manifest

### DIFF
--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -13,3 +13,15 @@ components:
   checks:
     - gradle:publish
     - gradle:properties:version
+- name: common-utils
+  repository: https://github.com/opensearch-project/common-utils.git
+  ref: 'main'
+  checks:
+    - gradle:publish
+    - gradle:properties:version
+- name: job-scheduler
+  repository: https://github.com/opensearch-project/job-scheduler.git
+  ref: 'main'
+  checks:
+    - gradle:properties:version
+    - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

### Description
Add common-utils and job-scheduler to 1.3 manifest
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
