### PR TITLE
Fixing issue with loading legacy manifests components

### DIFF
--- a/src/manifests/build/build_manifest_1_0.py
+++ b/src/manifests/build/build_manifest_1_0.py
@@ -77,6 +77,7 @@ class BuildManifest_1_0(ComponentManifest['BuildManifest_1_0', 'BuildComponents_
     def __init__(self, data: Any):
         super().__init__(data)
         self.build = self.Build(data["build"])
+        self.components = BuildComponents_1_0(data.get("components", []))  # type: ignore[assignment]
 
     def __to_dict__(self) -> dict:
         return {

--- a/src/manifests/build/build_manifest_1_1.py
+++ b/src/manifests/build/build_manifest_1_1.py
@@ -78,6 +78,7 @@ class BuildManifest_1_1(ComponentManifest['BuildManifest_1_1', 'BuildComponents_
     def __init__(self, data: Any):
         super().__init__(data)
         self.build = self.Build(data["build"])
+        self.components = BuildComponents_1_1(data.get("components", []))  # type: ignore[assignment]
 
     def __to_dict__(self) -> dict:
         return {

--- a/src/manifests/bundle/bundle_manifest_1_0.py
+++ b/src/manifests/bundle/bundle_manifest_1_0.py
@@ -62,6 +62,7 @@ class BundleManifest_1_0(ComponentManifest['BundleManifest_1_0', 'BundleComponen
     def __init__(self, data: Any):
         super().__init__(data)
         self.build = self.Build(data["build"])
+        self.components = BundleComponents_1_0(data.get("components", []))  # type: ignore[assignment]
 
     def __to_dict__(self) -> dict:
         return {

--- a/tests/tests_manifests/data/opensearch-dashboards-build-1.1.0.yml
+++ b/tests/tests_manifests/data/opensearch-dashboards-build-1.1.0.yml
@@ -1,0 +1,88 @@
+build:
+  architecture: x64
+  id: '524'
+  name: OpenSearch Dashboards
+#  platform: linux
+  version: 1.1.0
+components:
+- artifacts:
+    dist:
+    - dist/opensearch-dashboards-min-1.1.0-linux-x64.tar.gz
+  commit_id: 44d2cb5b4f9a7c641c1fef32ec569bc48ec46979
+  name: OpenSearch-Dashboards
+  ref: '1.1'
+  repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+  version: 1.1.0.0
+- artifacts:
+    plugins:
+    - plugins/alertingDashboards-1.1.0.zip
+  commit_id: ff9edaab1c7baf9c72192d9e8c6965886ce80b24
+  name: alertingDashboards
+  ref: '1.1'
+  repository: https://github.com/opensearch-project/alerting-dashboards-plugin
+  version: 1.1.0.0
+- artifacts:
+    plugins:
+    - plugins/securityDashboards-1.1.0.zip
+  commit_id: 67b540831b5b5b987090bfb887ab3402b9acbdda
+  name: securityDashboards
+  ref: '1.1'
+  repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+  version: 1.1.0.0
+- artifacts:
+    plugins:
+    - plugins/indexManagementDashboards-1.1.0.zip
+  commit_id: 7d50077be789d812626f1c3228c9052b8bbc7ba1
+  name: indexManagementDashboards
+  ref: '1.1'
+  repository: https://github.com/opensearch-project/index-management-dashboards-plugin
+  version: 1.1.0.0
+- artifacts:
+    plugins:
+    - plugins/queryWorkbenchDashboards-1.1.0.zip
+  commit_id: ceedf9a1da2c35f64e5aa95077098baa71df46f0
+  name: queryWorkbenchDashboards
+  ref: '1.1'
+  repository: https://github.com/opensearch-project/sql.git
+  version: 1.1.0.0
+- artifacts:
+    plugins:
+    - plugins/notebooksDashboards-1.1.0.zip
+  commit_id: 0d498b10f62f0cc3896b736651af5103132200e1
+  name: notebooksDashboards
+  ref: '1.1'
+  repository: https://github.com/opensearch-project/dashboards-notebooks.git
+  version: 1.1.0.0
+- artifacts:
+    plugins:
+    - plugins/reportsDashboards-1.1.0.zip
+  commit_id: 8df794287ae8c83acc5c96a90f4cd606e720e015
+  name: reportsDashboards
+  ref: '1.1'
+  repository: https://github.com/opensearch-project/dashboards-reports.git
+  version: 1.1.0.0
+- artifacts:
+    plugins:
+    - plugins/traceAnalyticsDashboards-1.1.0.zip
+  commit_id: 58237889693bc46abd0d19e27a13b363018d07f9
+  name: traceAnalyticsDashboards
+  ref: '1.1'
+  repository: https://github.com/opensearch-project/trace-analytics.git
+  version: 1.1.0.0
+- artifacts:
+    plugins:
+    - plugins/ganttChartDashboards-1.1.0.zip
+  commit_id: ba2911ec4f4273dd784272ce62842ccbdbb93da7
+  name: ganttChartDashboards
+  ref: '1.1'
+  repository: https://github.com/opensearch-project/dashboards-visualizations.git
+  version: 1.1.0.0
+- artifacts:
+    plugins:
+    - plugins/anomalyDetectionDashboards-1.1.0.zip
+  commit_id: 569cedeedab46167614fb0148db37b35cd648712
+  name: anomalyDetectionDashboards
+  ref: '1.1'
+  repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
+  version: 1.1.0.0
+schema-version: '1.1'

--- a/tests/tests_manifests/data/opensearch-dashboards-from-dist-1.1.1.yml
+++ b/tests/tests_manifests/data/opensearch-dashboards-from-dist-1.1.1.yml
@@ -1,0 +1,59 @@
+schema-version: "1.0"
+ci:
+  image:
+     name: "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028"
+build:
+  name: OpenSearch Dashboards
+  version: 1.1.1
+  patches:
+    - 1.1.0
+components:
+  - name: OpenSearch-Dashboards
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930
+    checks:
+        - manifest:component
+  - name: alertingDashboards
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930
+    checks:
+        - manifest:component
+  - name: securityDashboards
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930
+    checks:
+        - manifest:component
+  - name: indexManagementDashboards
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930
+    checks:
+        - manifest:component
+  - name: queryWorkbenchDashboards
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930
+    checks:
+        - manifest:component
+  - name: reportsDashboards
+    repository: https://github.com/opensearch-project/dashboards-reports
+    ref: "1.1"
+    working_directory: "dashboards-reports"
+    platforms:
+      - linux
+    checks:
+        - manifest:component
+  - name: notebooksDashboards
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930
+    checks:
+        - manifest:component
+  - name: ganttChartDashboards
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930
+    checks:
+        - manifest:component
+  - name: traceAnalyticsDashboards
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930
+    checks:
+        - manifest:component
+  - name: anomalyDetectionDashboards
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930
+    checks:
+        - manifest:component
+  - name: functionalTestDashboards
+    repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
+    ref: "main"
+    checks:
+        - manifest:component

--- a/tests/tests_manifests/test_build_manifest.py
+++ b/tests/tests_manifests/test_build_manifest.py
@@ -59,6 +59,7 @@ class TestBuildManifest(unittest.TestCase):
         self.assertEqual(component.name, 'OpenSearch-Dashboards')
         self.assertEqual(component.ref, "1.1")
         self.assertEqual(component.repository, 'https://github.com/opensearch-project/OpenSearch-Dashboards.git')
+        self.assertEqual(component.artifacts['dist'], ['dist/opensearch-dashboards-min-1.1.0-linux-x64.tar.gz'])
 
         urlopen.assert_called_once_with('http://fakeurl')
 

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -19,6 +19,27 @@ class TestInputManifest(unittest.TestCase):
         self.maxDiff = None
         self.manifests_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "manifests"))
 
+    def test_1_1_1_dist(self) -> None:
+        data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
+        path = os.path.join(data_path, "opensearch-dashboards-from-dist-1.1.1.yml")
+        manifest = InputManifest.from_path(path)
+        self.assertEqual(manifest.version, "1.0")
+        self.assertEqual(manifest.build.name, "OpenSearch Dashboards")
+        self.assertEqual(manifest.build.version, "1.1.1")
+        self.assertEqual(len(list(manifest.components.select(focus="alertingDashboards"))), 1)
+        opensearch_component: InputComponentFromDist = manifest.components["OpenSearch-Dashboards"]  # type: ignore[assignment]
+        self.assertIsInstance(opensearch_component, InputComponentFromDist)
+        self.assertEqual(opensearch_component.name, "OpenSearch-Dashboards")
+        self.assertEqual(
+            opensearch_component.dist,
+            "https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930",
+        )
+        for component in manifest.components.values():
+            if component.name in ['reportsDashboards', 'functionalTestDashboards']:
+                self.assertIsInstance(component, InputComponentFromSource)
+            else:
+                self.assertIsInstance(component, InputComponentFromDist)
+
     def test_1_0(self) -> None:
         path = os.path.join(self.manifests_path, "1.0.0", "opensearch-1.0.0.yml")
         manifest = InputManifest.from_path(path)


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Legacy build and bundle manifests were missed when recent changes to Manifest were made, @peterzhuamazon  caught this while doing 1.1.1 testing.  Added new test cases to make sure this scenario is covered.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
