### PR TITLE
Make arm64 running arm64 cypress binary

### DIFF
--- a/docker/ci/dockerfiles/ci-runner.al2.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.al2.dockerfile
@@ -139,7 +139,11 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 # install yarn
 RUN npm install -g yarn@^1.21.1
 # install cypress last known version that works for all existing opensearch-dashboards plugin integtests
-RUN npm install -g cypress@^6.9.1 && npm cache verify
+RUN npm install -g cypress@5.6.0 && npm cache verify
+# replace default binary with arm64 specific binary from ci.opensearch.org
+RUN if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
+    curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-5.6.0-arm64.tar.gz && tar -xzf Cypress-5.6.0-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
+    rm -vf Cypress-5.6.0-arm64.tar.gz; fi
 # We use the version test to check if packages installed correctly
 # And get added to the PATH
 # This will fail the docker build if any of the packages not exist

--- a/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
@@ -47,99 +47,99 @@ RUN yum install -y nss xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils
 # Add Yarn dependencies
 RUN yum groupinstall -y "Development Tools" && yum clean all && rm -rf /var/cache/yum/*
 
-## Downloads JDK-8, JDK-11 and JDK-17 distributions using Eclipse Adoptium project.
-## The distributions are extracted to /opt/java/ folder with environment variables JAVA8_HOME,
-## JAVA11_HOME and JAVA17_HOME exported and pointing at respective ones.
-#RUN set -eux; \
-#    ARCH="$(uname -m)"; \
-#    JDKS=""; \
-#    case "${ARCH}" in \
-#       aarch64|arm64) \
-#         # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
-#         JDKS+="f287cdc2a688c2df247ea0d8bfe2863645b73848e4e5c35b02a8a3d2d6b69551@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz "; \
-#         JDKS+="105bdc12fcd54c551e8e8ac96bc82412467244c32063689c41cee29ceb7452a2@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.12_7.tar.gz "; \
-#         JDKS+="e08e6d8c84da28a2c49ccd511f8835c329fbdd8e4faff662c58fa24cca74021d@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_aarch64_linux_hotspot_17_35.tar.gz "; \
-#         ;; \
-#       amd64|x86_64) \
-#         # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
-#         JDKS+="cc13f274becf9dd5517b6be583632819dfd4dd81e524b5c1b4f406bdaf0e063a@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz "; \
-#         JDKS+="8770f600fc3b89bf331213c7aa21f8eedd9ca5d96036d1cd48cb2748a3dbefd2@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz "; \
-#         JDKS+="6f1335d9a7855159f982dac557420397be9aa85f3f7bc84e111d25871c02c0c7@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz "; \
-#         ;; \
-#       *) \
-#         echo "Unsupported arch: ${ARCH}"; \
-#         exit 1; \
-#         ;; \
-#    esac; \
-#    for jdk in ${JDKS}; do \
-#        ESUM=$(echo ${jdk} | cut -d '@' -f1); \
-#        BINARY_URL=$(echo ${jdk} | cut -d '@' -f2); \
-#        regex="temurin([0-9]+)[-]"; \
-#        if [[ $jdk =~ $regex ]]; then \
-#            MAJOR=${BASH_REMATCH[1]}; \
-#            curl -LfsSo /tmp/openjdk-${MAJOR}.tar.gz ${BINARY_URL}; \
-#            echo "${ESUM} */tmp/openjdk-${MAJOR}.tar.gz" | sha256sum -c -; \
-#            mkdir -p /opt/java/openjdk-${MAJOR}; \
-#            cd /opt/java/openjdk-${MAJOR}; \
-#            tar -xf /tmp/openjdk-${MAJOR}.tar.gz --strip-components=1; \
-#            rm -rf /tmp/openjdk-${MAJOR}.tar.gz; \
-#            echo "export JAVA${MAJOR}_HOME=/opt/java/openjdk-${MAJOR}" >> /etc/profile.d/java_home.sh; \
-#        fi; \
-#    done;
-#
-## Install higher version of maven 3.8.x
-#RUN export MAVEN_URL=`curl -s https://maven.apache.org/download.cgi | grep -Eo '["\047].*.bin.tar.gz["\047]' | tr -d '"'`  && \
-#    mkdir -p $MAVEN_DIR && (curl -s $MAVEN_URL | tar xzf - --strip-components=1 -C $MAVEN_DIR) && \
-#    echo "export M2_HOME=$MAVEN_DIR" > /etc/profile.d/maven_path.sh && \
-#    echo "export M2=\$M2_HOME/bin" >> /etc/profile.d/maven_path.sh && \
-#    echo "export PATH=\$M2:\$PATH" >> /etc/profile.d/maven_path.sh && \
-#    ln -sfn $MAVEN_DIR/bin/mvn /usr/local/bin/mvn
-#
-## Setup Shared Memory
-#RUN chmod -R 777 /dev/shm
-#
-## Set JAVA_HOME and JAVA14_HOME
-## AdoptOpenJDK apparently does not add JAVA_HOME after installation
-#RUN echo "export JAVA_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh && \
-#    echo "export JAVA14_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh
-#
-## Install PKG builder dependencies with rvm
-#RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - && \
-#    curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import - && \
-#    curl -sSL https://get.rvm.io | bash -s stable
-#
-## Switch shell for rvm related commands
-#SHELL ["/bin/bash", "-lc"]
-#CMD ["/bin/bash", "-l"]
-#
-## Install ruby / rpm / fpm related dependencies
-#RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 && \
-#    yum install -y rpm-build && \
-#    gem install fpm -v 1.13.0
-#
-#ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.4.0/bin
-#ENV RVM_HOME=/usr/local/rvm/bin
-#ENV GEM_HOME=/usr/share/opensearch/.gem
-#ENV GEM_PATH=$GEM_HOME
-#ENV PATH=$RUBY_HOME:$RVM_HOME:$PATH
-#
-## Install Python37 binary
-#RUN curl https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz | tar xzvf - && \
-#    cd Python-3.7.7 && \
-#    ./configure --enable-optimizations && \
-#    make altinstall
-#
-## Setup Python37 links
-#RUN ln -sfn /usr/local/bin/python3.7 /usr/bin/python3 && \
-#    ln -sfn /usr/local/bin/pip3.7 /usr/bin/pip && \
-#    ln -sfn /usr/local/bin/pip3.7 /usr/local/bin/pip && \
-#    ln -sfn /usr/local/bin/pip3.7 /usr/bin/pip3 && \
-#    pip3 install pipenv && pipenv --version
-#
-## Add k-NN Library dependencies
-#RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack -y
-#RUN pip3 install pip==21.3.1
-#RUN pip3 install cmake==3.21.3
+# Downloads JDK-8, JDK-11 and JDK-17 distributions using Eclipse Adoptium project.
+# The distributions are extracted to /opt/java/ folder with environment variables JAVA8_HOME,
+# JAVA11_HOME and JAVA17_HOME exported and pointing at respective ones.
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    JDKS=""; \
+    case "${ARCH}" in \
+       aarch64|arm64) \
+         # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
+         JDKS+="f287cdc2a688c2df247ea0d8bfe2863645b73848e4e5c35b02a8a3d2d6b69551@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz "; \
+         JDKS+="105bdc12fcd54c551e8e8ac96bc82412467244c32063689c41cee29ceb7452a2@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.12_7.tar.gz "; \
+         JDKS+="e08e6d8c84da28a2c49ccd511f8835c329fbdd8e4faff662c58fa24cca74021d@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_aarch64_linux_hotspot_17_35.tar.gz "; \
+         ;; \
+       amd64|x86_64) \
+         # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
+         JDKS+="cc13f274becf9dd5517b6be583632819dfd4dd81e524b5c1b4f406bdaf0e063a@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz "; \
+         JDKS+="8770f600fc3b89bf331213c7aa21f8eedd9ca5d96036d1cd48cb2748a3dbefd2@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz "; \
+         JDKS+="6f1335d9a7855159f982dac557420397be9aa85f3f7bc84e111d25871c02c0c7@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz "; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+    for jdk in ${JDKS}; do \
+        ESUM=$(echo ${jdk} | cut -d '@' -f1); \
+        BINARY_URL=$(echo ${jdk} | cut -d '@' -f2); \
+        regex="temurin([0-9]+)[-]"; \
+        if [[ $jdk =~ $regex ]]; then \
+            MAJOR=${BASH_REMATCH[1]}; \
+            curl -LfsSo /tmp/openjdk-${MAJOR}.tar.gz ${BINARY_URL}; \
+            echo "${ESUM} */tmp/openjdk-${MAJOR}.tar.gz" | sha256sum -c -; \
+            mkdir -p /opt/java/openjdk-${MAJOR}; \
+            cd /opt/java/openjdk-${MAJOR}; \
+            tar -xf /tmp/openjdk-${MAJOR}.tar.gz --strip-components=1; \
+            rm -rf /tmp/openjdk-${MAJOR}.tar.gz; \
+            echo "export JAVA${MAJOR}_HOME=/opt/java/openjdk-${MAJOR}" >> /etc/profile.d/java_home.sh; \
+        fi; \
+    done;
+
+# Install higher version of maven 3.8.x
+RUN export MAVEN_URL=`curl -s https://maven.apache.org/download.cgi | grep -Eo '["\047].*.bin.tar.gz["\047]' | tr -d '"'`  && \
+    mkdir -p $MAVEN_DIR && (curl -s $MAVEN_URL | tar xzf - --strip-components=1 -C $MAVEN_DIR) && \
+    echo "export M2_HOME=$MAVEN_DIR" > /etc/profile.d/maven_path.sh && \
+    echo "export M2=\$M2_HOME/bin" >> /etc/profile.d/maven_path.sh && \
+    echo "export PATH=\$M2:\$PATH" >> /etc/profile.d/maven_path.sh && \
+    ln -sfn $MAVEN_DIR/bin/mvn /usr/local/bin/mvn
+
+# Setup Shared Memory
+RUN chmod -R 777 /dev/shm
+
+# Set JAVA_HOME and JAVA14_HOME
+# AdoptOpenJDK apparently does not add JAVA_HOME after installation
+RUN echo "export JAVA_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh && \
+    echo "export JAVA14_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh
+
+# Install PKG builder dependencies with rvm
+RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - && \
+    curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import - && \
+    curl -sSL https://get.rvm.io | bash -s stable
+
+# Switch shell for rvm related commands
+SHELL ["/bin/bash", "-lc"]
+CMD ["/bin/bash", "-l"]
+
+# Install ruby / rpm / fpm related dependencies
+RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 && \
+    yum install -y rpm-build && \
+    gem install fpm -v 1.13.0
+
+ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.4.0/bin
+ENV RVM_HOME=/usr/local/rvm/bin
+ENV GEM_HOME=/usr/share/opensearch/.gem
+ENV GEM_PATH=$GEM_HOME
+ENV PATH=$RUBY_HOME:$RVM_HOME:$PATH
+
+# Install Python37 binary
+RUN curl https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz | tar xzvf - && \
+    cd Python-3.7.7 && \
+    ./configure --enable-optimizations && \
+    make altinstall
+
+# Setup Python37 links
+RUN ln -sfn /usr/local/bin/python3.7 /usr/bin/python3 && \
+    ln -sfn /usr/local/bin/pip3.7 /usr/bin/pip && \
+    ln -sfn /usr/local/bin/pip3.7 /usr/local/bin/pip && \
+    ln -sfn /usr/local/bin/pip3.7 /usr/bin/pip3 && \
+    pip3 install pipenv && pipenv --version
+
+# Add k-NN Library dependencies
+RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack -y
+RUN pip3 install pip==21.3.1
+RUN pip3 install cmake==3.21.3
 
 # Change User
 USER 1000

--- a/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
@@ -47,99 +47,99 @@ RUN yum install -y nss xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils
 # Add Yarn dependencies
 RUN yum groupinstall -y "Development Tools" && yum clean all && rm -rf /var/cache/yum/*
 
-# Downloads JDK-8, JDK-11 and JDK-17 distributions using Eclipse Adoptium project.
-# The distributions are extracted to /opt/java/ folder with environment variables JAVA8_HOME,
-# JAVA11_HOME and JAVA17_HOME exported and pointing at respective ones.
-RUN set -eux; \
-    ARCH="$(uname -m)"; \
-    JDKS=""; \
-    case "${ARCH}" in \
-       aarch64|arm64) \
-         # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
-         JDKS+="f287cdc2a688c2df247ea0d8bfe2863645b73848e4e5c35b02a8a3d2d6b69551@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz "; \
-         JDKS+="105bdc12fcd54c551e8e8ac96bc82412467244c32063689c41cee29ceb7452a2@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.12_7.tar.gz "; \
-         JDKS+="e08e6d8c84da28a2c49ccd511f8835c329fbdd8e4faff662c58fa24cca74021d@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_aarch64_linux_hotspot_17_35.tar.gz "; \
-         ;; \
-       amd64|x86_64) \
-         # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
-         JDKS+="cc13f274becf9dd5517b6be583632819dfd4dd81e524b5c1b4f406bdaf0e063a@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz "; \
-         JDKS+="8770f600fc3b89bf331213c7aa21f8eedd9ca5d96036d1cd48cb2748a3dbefd2@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz "; \
-         JDKS+="6f1335d9a7855159f982dac557420397be9aa85f3f7bc84e111d25871c02c0c7@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz "; \
-         ;; \
-       *) \
-         echo "Unsupported arch: ${ARCH}"; \
-         exit 1; \
-         ;; \
-    esac; \
-    for jdk in ${JDKS}; do \
-        ESUM=$(echo ${jdk} | cut -d '@' -f1); \
-        BINARY_URL=$(echo ${jdk} | cut -d '@' -f2); \
-        regex="temurin([0-9]+)[-]"; \
-        if [[ $jdk =~ $regex ]]; then \
-            MAJOR=${BASH_REMATCH[1]}; \
-            curl -LfsSo /tmp/openjdk-${MAJOR}.tar.gz ${BINARY_URL}; \
-            echo "${ESUM} */tmp/openjdk-${MAJOR}.tar.gz" | sha256sum -c -; \
-            mkdir -p /opt/java/openjdk-${MAJOR}; \
-            cd /opt/java/openjdk-${MAJOR}; \
-            tar -xf /tmp/openjdk-${MAJOR}.tar.gz --strip-components=1; \
-            rm -rf /tmp/openjdk-${MAJOR}.tar.gz; \
-            echo "export JAVA${MAJOR}_HOME=/opt/java/openjdk-${MAJOR}" >> /etc/profile.d/java_home.sh; \
-        fi; \
-    done;
-
-# Install higher version of maven 3.8.x
-RUN export MAVEN_URL=`curl -s https://maven.apache.org/download.cgi | grep -Eo '["\047].*.bin.tar.gz["\047]' | tr -d '"'`  && \
-    mkdir -p $MAVEN_DIR && (curl -s $MAVEN_URL | tar xzf - --strip-components=1 -C $MAVEN_DIR) && \
-    echo "export M2_HOME=$MAVEN_DIR" > /etc/profile.d/maven_path.sh && \
-    echo "export M2=\$M2_HOME/bin" >> /etc/profile.d/maven_path.sh && \
-    echo "export PATH=\$M2:\$PATH" >> /etc/profile.d/maven_path.sh && \
-    ln -sfn $MAVEN_DIR/bin/mvn /usr/local/bin/mvn
-
-# Setup Shared Memory
-RUN chmod -R 777 /dev/shm
-
-# Set JAVA_HOME and JAVA14_HOME
-# AdoptOpenJDK apparently does not add JAVA_HOME after installation
-RUN echo "export JAVA_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh && \
-    echo "export JAVA14_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh
-
-# Install PKG builder dependencies with rvm
-RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - && \
-    curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import - && \
-    curl -sSL https://get.rvm.io | bash -s stable
-
-# Switch shell for rvm related commands
-SHELL ["/bin/bash", "-lc"]
-CMD ["/bin/bash", "-l"]
-
-# Install ruby / rpm / fpm related dependencies
-RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 && \
-    yum install -y rpm-build && \
-    gem install fpm -v 1.13.0
-
-ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.4.0/bin
-ENV RVM_HOME=/usr/local/rvm/bin
-ENV GEM_HOME=/usr/share/opensearch/.gem
-ENV GEM_PATH=$GEM_HOME
-ENV PATH=$RUBY_HOME:$RVM_HOME:$PATH
-
-# Install Python37 binary
-RUN curl https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz | tar xzvf - && \
-    cd Python-3.7.7 && \
-    ./configure --enable-optimizations && \
-    make altinstall
-
-# Setup Python37 links
-RUN ln -sfn /usr/local/bin/python3.7 /usr/bin/python3 && \
-    ln -sfn /usr/local/bin/pip3.7 /usr/bin/pip && \
-    ln -sfn /usr/local/bin/pip3.7 /usr/local/bin/pip && \
-    ln -sfn /usr/local/bin/pip3.7 /usr/bin/pip3 && \
-    pip3 install pipenv && pipenv --version
-
-# Add k-NN Library dependencies
-RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack -y
-RUN pip3 install pip==21.3.1
-RUN pip3 install cmake==3.21.3
+## Downloads JDK-8, JDK-11 and JDK-17 distributions using Eclipse Adoptium project.
+## The distributions are extracted to /opt/java/ folder with environment variables JAVA8_HOME,
+## JAVA11_HOME and JAVA17_HOME exported and pointing at respective ones.
+#RUN set -eux; \
+#    ARCH="$(uname -m)"; \
+#    JDKS=""; \
+#    case "${ARCH}" in \
+#       aarch64|arm64) \
+#         # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
+#         JDKS+="f287cdc2a688c2df247ea0d8bfe2863645b73848e4e5c35b02a8a3d2d6b69551@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz "; \
+#         JDKS+="105bdc12fcd54c551e8e8ac96bc82412467244c32063689c41cee29ceb7452a2@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.12_7.tar.gz "; \
+#         JDKS+="e08e6d8c84da28a2c49ccd511f8835c329fbdd8e4faff662c58fa24cca74021d@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_aarch64_linux_hotspot_17_35.tar.gz "; \
+#         ;; \
+#       amd64|x86_64) \
+#         # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
+#         JDKS+="cc13f274becf9dd5517b6be583632819dfd4dd81e524b5c1b4f406bdaf0e063a@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz "; \
+#         JDKS+="8770f600fc3b89bf331213c7aa21f8eedd9ca5d96036d1cd48cb2748a3dbefd2@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz "; \
+#         JDKS+="6f1335d9a7855159f982dac557420397be9aa85f3f7bc84e111d25871c02c0c7@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz "; \
+#         ;; \
+#       *) \
+#         echo "Unsupported arch: ${ARCH}"; \
+#         exit 1; \
+#         ;; \
+#    esac; \
+#    for jdk in ${JDKS}; do \
+#        ESUM=$(echo ${jdk} | cut -d '@' -f1); \
+#        BINARY_URL=$(echo ${jdk} | cut -d '@' -f2); \
+#        regex="temurin([0-9]+)[-]"; \
+#        if [[ $jdk =~ $regex ]]; then \
+#            MAJOR=${BASH_REMATCH[1]}; \
+#            curl -LfsSo /tmp/openjdk-${MAJOR}.tar.gz ${BINARY_URL}; \
+#            echo "${ESUM} */tmp/openjdk-${MAJOR}.tar.gz" | sha256sum -c -; \
+#            mkdir -p /opt/java/openjdk-${MAJOR}; \
+#            cd /opt/java/openjdk-${MAJOR}; \
+#            tar -xf /tmp/openjdk-${MAJOR}.tar.gz --strip-components=1; \
+#            rm -rf /tmp/openjdk-${MAJOR}.tar.gz; \
+#            echo "export JAVA${MAJOR}_HOME=/opt/java/openjdk-${MAJOR}" >> /etc/profile.d/java_home.sh; \
+#        fi; \
+#    done;
+#
+## Install higher version of maven 3.8.x
+#RUN export MAVEN_URL=`curl -s https://maven.apache.org/download.cgi | grep -Eo '["\047].*.bin.tar.gz["\047]' | tr -d '"'`  && \
+#    mkdir -p $MAVEN_DIR && (curl -s $MAVEN_URL | tar xzf - --strip-components=1 -C $MAVEN_DIR) && \
+#    echo "export M2_HOME=$MAVEN_DIR" > /etc/profile.d/maven_path.sh && \
+#    echo "export M2=\$M2_HOME/bin" >> /etc/profile.d/maven_path.sh && \
+#    echo "export PATH=\$M2:\$PATH" >> /etc/profile.d/maven_path.sh && \
+#    ln -sfn $MAVEN_DIR/bin/mvn /usr/local/bin/mvn
+#
+## Setup Shared Memory
+#RUN chmod -R 777 /dev/shm
+#
+## Set JAVA_HOME and JAVA14_HOME
+## AdoptOpenJDK apparently does not add JAVA_HOME after installation
+#RUN echo "export JAVA_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh && \
+#    echo "export JAVA14_HOME=`dirname $(dirname $(readlink -f $(which javac)))`" >> /etc/profile.d/java_home.sh
+#
+## Install PKG builder dependencies with rvm
+#RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - && \
+#    curl -sSL https://rvm.io/pkuczynski.asc | gpg2 --import - && \
+#    curl -sSL https://get.rvm.io | bash -s stable
+#
+## Switch shell for rvm related commands
+#SHELL ["/bin/bash", "-lc"]
+#CMD ["/bin/bash", "-l"]
+#
+## Install ruby / rpm / fpm related dependencies
+#RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 && \
+#    yum install -y rpm-build && \
+#    gem install fpm -v 1.13.0
+#
+#ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.4.0/bin
+#ENV RVM_HOME=/usr/local/rvm/bin
+#ENV GEM_HOME=/usr/share/opensearch/.gem
+#ENV GEM_PATH=$GEM_HOME
+#ENV PATH=$RUBY_HOME:$RVM_HOME:$PATH
+#
+## Install Python37 binary
+#RUN curl https://www.python.org/ftp/python/3.7.7/Python-3.7.7.tgz | tar xzvf - && \
+#    cd Python-3.7.7 && \
+#    ./configure --enable-optimizations && \
+#    make altinstall
+#
+## Setup Python37 links
+#RUN ln -sfn /usr/local/bin/python3.7 /usr/bin/python3 && \
+#    ln -sfn /usr/local/bin/pip3.7 /usr/bin/pip && \
+#    ln -sfn /usr/local/bin/pip3.7 /usr/local/bin/pip && \
+#    ln -sfn /usr/local/bin/pip3.7 /usr/bin/pip3 && \
+#    pip3 install pipenv && pipenv --version
+#
+## Add k-NN Library dependencies
+#RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack -y
+#RUN pip3 install pip==21.3.1
+#RUN pip3 install cmake==3.21.3
 
 # Change User
 USER 1000
@@ -163,7 +163,11 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 # install yarn
 RUN npm install -g yarn@^1.21.1
 # install cypress last known version that works for all existing opensearch-dashboards plugin integtests
-RUN npm install -g cypress@^6.9.1 && npm cache verify
+RUN npm install -g cypress@5.6.0 && npm cache verify
+# replace default binary with arm64 specific binary from ci.opensearch.org
+RUN if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
+    curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-5.6.0-arm64.tar.gz && tar -xzf Cypress-5.6.0-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
+    rm -vf Cypress-5.6.0-arm64.tar.gz; fi
 # We use the version test to check if packages installed correctly
 # And get added to the PATH
 # This will fail the docker build if any of the packages not exist


### PR DESCRIPTION
### Description
Make arm64 running arm64 cypress binary.
X64 will use the default installation of 5.6.0.
ARM64 will replace the binary with our in-house compilation of cypress 5.6.0.

@Tengda-He has confirmed their own setup is running correctly for functional tests dashboards with this version of cypress.

Will sync up with @ohltyler to fix AD on arm64 specifically after this PR merged.

Thanks.

 
### Issues Resolved
#1206 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
