### PR TITLE
mv instead of cp performance-analyzer-rca to OS home dir

### DIFF
--- a/scripts/components/performance-analyzer/install.sh
+++ b/scripts/components/performance-analyzer/install.sh
@@ -68,6 +68,6 @@ fi
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 ## Setup Performance Analyzer Agent
-cp -r $OUTPUT/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OUTPUT/
+mv $OUTPUT/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OUTPUT/
 mv $OUTPUT/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli $OUTPUT/bin
 rm -rf $OUTPUT/bin/opensearch-performance-analyzer

--- a/scripts/legacy/tar/linux/opensearch-tar-build.sh
+++ b/scripts/legacy/tar/linux/opensearch-tar-build.sh
@@ -137,7 +137,7 @@ echo "Plugins installed are:"
 ls -tlr $WORKING_DIR/plugins
 
 # Setup Performance Analyzer Agent
-cp -r $WORKING_DIR/plugins/opensearch-performance-analyzer/performance-analyzer-rca $WORKING_DIR/
+mv $WORKING_DIR/plugins/opensearch-performance-analyzer/performance-analyzer-rca $WORKING_DIR/
 chmod -R 755 $WORKING_DIR/performance-analyzer-rca
 mv $WORKING_DIR/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli $WORKING_DIR/bin
 rm -rf $WORKING_DIR/bin/opensearch-performance-analyzer


### PR DESCRIPTION
Signed-off-by: Karishma Joseph <karisjos@amazon.com>

### Description
mv instead of cp performance-analyzer-rca to OS home dir

`/plugins/opensearch-performance-analyzer/performance-analyzer-rca/` is not required and used only for copying `performance-analyzer-rca` to OS home dir. Hence, we can move `performance-analyzer-rca` to OS home dir instead of copying it to remove duplicate files.

`plugins/opensearch-performance-analyzer` before moving `performance-analyzer-rca`

```
du -hs plugins/opensearch-performance-analyzer
69M	plugins/opensearch-performance-analyzer
```

`plugins/opensearch-performance-analyzer` after moving `performance-analyzer-rca`

```
du -hs plugins/opensearch-performance-analyzer
34M	plugins/opensearch-performance-analyzer
```

 
### Issues Resolved
https://github.com/opensearch-project/performance-analyzer/issues/82
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
