### PR TITLE
Adding common-util on its own

### DIFF
--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -13,6 +13,12 @@ components:
   checks:
     - gradle:publish
     - gradle:properties:version
+- name: common-utils
+  repository: https://github.com/opensearch-project/common-utils.git
+  ref: 'main'
+  checks:
+    - gradle:publish
+    - gradle:properties:version
 - name: alerting
   repository: https://github.com/opensearch-project/alerting.git
   ref: 'main'


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Seperating out common util from the job-scheduler changes that broke the build.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
