### PR TITLE
update cluster logs and test artifacts during test recording

### DIFF
--- a/src/test_workflow/integ_test/integ_test_suite.py
+++ b/src/test_workflow/integ_test/integ_test_suite.py
@@ -10,7 +10,6 @@ import os
 
 from git.git_repository import GitRepository
 from paths.script_finder import ScriptFinder
-from paths.tree_walker import walk
 from system.execute import execute
 from test_workflow.test_recorder.test_result_data import TestResultData
 
@@ -60,14 +59,14 @@ class IntegTestSuite(abc.ABC):
             cmd = f"{script} -b {endpoint} -p {port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
             work_dir = os.path.join(self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
             (status, stdout, stderr) = execute(cmd, work_dir, True, False)
-            results_dir = os.path.join(work_dir, "build", "reports", "tests", "integTest")
+
             test_result_data = TestResultData(
                 self.component.name,
                 test_config,
                 status,
                 stdout,
                 stderr,
-                walk(results_dir)
+                self.get_test_artifact_files(work_dir)
             )
             self.save_logs.save_test_result_data(test_result_data)
             if stderr:
@@ -87,6 +86,10 @@ class IntegTestSuite(abc.ABC):
         logging.info("===============================================")
         logging.info(message)
         logging.info("===============================================")
+
+    @abc.abstractmethod
+    def get_test_artifact_files(self, work_dir):
+        pass
 
 
 class InvalidTestConfigError(Exception):

--- a/src/test_workflow/integ_test/integ_test_suite.py
+++ b/src/test_workflow/integ_test/integ_test_suite.py
@@ -57,8 +57,9 @@ class IntegTestSuite(abc.ABC):
         script = ScriptFinder.find_integ_test_script(self.component.name, self.repo.working_directory)
         if os.path.exists(script):
             cmd = f"{script} -b {endpoint} -p {port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
-            work_dir = os.path.join(self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
-            (status, stdout, stderr) = execute(cmd, work_dir, True, False)
+            self.repo_work_dir = os.path.join(
+                self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
+            (status, stdout, stderr) = execute(cmd, self.repo_work_dir, True, False)
 
             test_result_data = TestResultData(
                 self.component.name,
@@ -66,7 +67,7 @@ class IntegTestSuite(abc.ABC):
                 status,
                 stdout,
                 stderr,
-                self.get_test_artifact_files(work_dir)
+                self.test_artifact_files
             )
             self.save_logs.save_test_result_data(test_result_data)
             if stderr:
@@ -87,8 +88,9 @@ class IntegTestSuite(abc.ABC):
         logging.info(message)
         logging.info("===============================================")
 
+    @property
     @abc.abstractmethod
-    def get_test_artifact_files(self, work_dir):
+    def test_artifact_files(self):
         pass
 
 

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -36,8 +36,6 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
             build_manifest_opensearch
         )
 
-        self.test_results_dir = os.path.join("build", "reports", "tests", "integTest")
-
     def execute_tests(self):
         test_results = TestComponentResults()
         self.__install_build_dependencies()

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -78,7 +78,8 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
             os.chdir(self.work_dir)
             return self.execute_integtest_sh(test_cluster_endpoint, test_cluster_port, security, config)
 
-    def get_test_artifact_files(self, work_dir):
+    @property
+    def test_artifact_files(self):
         return {
-            "opensearch-integ-test": os.path.join(work_dir, "build", "reports", "tests", "integTest")
+            "opensearch-integ-test": os.path.join(self.repo_work_dir, "build", "reports", "tests", "integTest")
         }

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -36,6 +36,8 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
             build_manifest_opensearch
         )
 
+        self.test_results_dir = os.path.join("build", "reports", "tests", "integTest")
+
     def execute_tests(self):
         test_results = TestComponentResults()
         self.__install_build_dependencies()
@@ -77,3 +79,8 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
             self.pretty_print_message("Running integration tests for " + self.component.name)
             os.chdir(self.work_dir)
             return self.execute_integtest_sh(test_cluster_endpoint, test_cluster_port, security, config)
+
+    def get_test_artifact_files(self, work_dir):
+        return {
+            "opensearch-integ-test": os.path.join(work_dir, "build", "reports", "tests", "integTest")
+        }

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
@@ -69,3 +69,10 @@ class IntegTestSuiteOpenSearchDashboards(IntegTestSuite):
             self.pretty_print_message("Running integration tests for " + self.component.name)
             os.chdir(self.work_dir)
             return self.execute_integtest_sh(test_cluster_endpoint, test_cluster_port, security, config)
+
+    def get_test_artifact_files(self, work_dir):
+        return {
+            "cypress-videos": os.path.join(work_dir, "cypress", "videos"),
+            "cypress-screenshots": os.path.join(work_dir, "cypress", "screenshots"),
+            "cypress-report": os.path.join(work_dir, "cypress", "results"),
+        }

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
@@ -70,9 +70,10 @@ class IntegTestSuiteOpenSearchDashboards(IntegTestSuite):
             os.chdir(self.work_dir)
             return self.execute_integtest_sh(test_cluster_endpoint, test_cluster_port, security, config)
 
-    def get_test_artifact_files(self, work_dir):
+    @property
+    def test_artifact_files(self):
         return {
-            "cypress-videos": os.path.join(work_dir, "cypress", "videos"),
-            "cypress-screenshots": os.path.join(work_dir, "cypress", "screenshots"),
-            "cypress-report": os.path.join(work_dir, "cypress", "results"),
+            "cypress-videos": os.path.join(self.repo_work_dir, "cypress", "videos"),
+            "cypress-screenshots": os.path.join(self.repo_work_dir, "cypress", "screenshots"),
+            "cypress-report": os.path.join(self.repo_work_dir, "cypress", "results"),
         }

--- a/src/test_workflow/integ_test/service.py
+++ b/src/test_workflow/integ_test/service.py
@@ -6,9 +6,7 @@
 
 import abc
 import logging
-import os
 import time
-from os import walk
 
 import requests
 
@@ -45,7 +43,7 @@ class Service(abc.ABC):
 
         self.return_code = self.process_handler.terminate()
 
-        log_files = walk(os.path.join(self.install_dir, "logs"))
+        log_files = self.get_log_files()
 
         return ServiceTerminationResult(self.return_code, self.process_handler.stdout_data, self.process_handler.stderr_data, log_files)
 
@@ -102,6 +100,10 @@ class Service(abc.ABC):
 
             time.sleep(10)
         raise ClusterCreationException("Cluster is not available after 10 attempts")
+
+    @abc.abstractmethod
+    def get_log_files(self):
+        pass
 
 
 class ServiceTerminationResult:

--- a/src/test_workflow/integ_test/service.py
+++ b/src/test_workflow/integ_test/service.py
@@ -43,7 +43,7 @@ class Service(abc.ABC):
 
         self.return_code = self.process_handler.terminate()
 
-        return ServiceTerminationResult(self.return_code, self.process_handler.stdout_data, self.process_handler.stderr_data, self.get_log_files())
+        return ServiceTerminationResult(self.return_code, self.process_handler.stdout_data, self.process_handler.stderr_data, self.log_files)
 
     def endpoint(self):
         return "localhost"
@@ -99,8 +99,9 @@ class Service(abc.ABC):
             time.sleep(10)
         raise ClusterCreationException("Cluster is not available after 10 attempts")
 
+    @property
     @abc.abstractmethod
-    def get_log_files(self):
+    def log_files(self):
         pass
 
 

--- a/src/test_workflow/integ_test/service.py
+++ b/src/test_workflow/integ_test/service.py
@@ -43,9 +43,7 @@ class Service(abc.ABC):
 
         self.return_code = self.process_handler.terminate()
 
-        log_files = self.get_log_files()
-
-        return ServiceTerminationResult(self.return_code, self.process_handler.stdout_data, self.process_handler.stderr_data, log_files)
+        return ServiceTerminationResult(self.return_code, self.process_handler.stdout_data, self.process_handler.stderr_data, self.get_log_files())
 
     def endpoint(self):
         return "localhost"

--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -72,3 +72,6 @@ class ServiceOpenSearch(Service):
 
     def check_service_response_text(self, response_text):
         return ('"status":"green"' in response_text) or ('"status":"yellow"' in response_text)
+
+    def get_log_files(self):
+        return {"opensearch-service-logs": os.path.join(self.install_dir, "logs")}

--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -73,5 +73,6 @@ class ServiceOpenSearch(Service):
     def check_service_response_text(self, response_text):
         return ('"status":"green"' in response_text) or ('"status":"yellow"' in response_text)
 
-    def get_log_files(self):
+    @property
+    def log_files(self):
         return {"opensearch-service-logs": os.path.join(self.install_dir, "logs")}

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -91,3 +91,6 @@ class ServiceOpenSearchDashboards(Service):
 
     def check_service_response_text(self, response_text):
         return ('"state":"green"' in response_text) or ('"state":"yellow"' in response_text)
+
+    def get_log_files(self):
+        return {"opensearch-dashboards-service-logs": os.path.join(self.install_dir, "logs")}

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -92,5 +92,6 @@ class ServiceOpenSearchDashboards(Service):
     def check_service_response_text(self, response_text):
         return ('"state":"green"' in response_text) or ('"state":"yellow"' in response_text)
 
-    def get_log_files(self):
+    @property
+    def log_files(self):
         return {"opensearch-dashboards-service-logs": os.path.join(self.install_dir, "logs")}

--- a/src/test_workflow/test_cluster.py
+++ b/src/test_workflow/test_cluster.py
@@ -51,7 +51,6 @@ class TestCluster(abc.ABC):
 
     def start(self):
         os.makedirs(self.work_dir, exist_ok=True)
-
         self.all_services = [self.service] + self.dependencies
 
         for service in self.all_services:
@@ -65,22 +64,23 @@ class TestCluster(abc.ABC):
             self.termination_result = self.service.terminate()
 
         for service in self.dependencies:
-            service.terminate()
+            termination_result = service.terminate()
+            self.__save_test_result_data(termination_result)
 
         if not self.termination_result:
             raise ClusterServiceNotInitializedException()
 
-        self.__save_test_result_data()
+        self.__save_test_result_data(self.termination_result)
 
-    def __save_test_result_data(self):
+    def __save_test_result_data(self, termination_result):
 
         test_result_data = TestResultData(
             self.component_name,
             self.component_test_config,
-            self.termination_result.return_code,
-            self.termination_result.stdout_data,
-            self.termination_result.stderr_data,
-            self.termination_result.log_files
+            termination_result.return_code,
+            termination_result.stdout_data,
+            termination_result.stderr_data,
+            termination_result.log_files
         )
 
         self.save_logs.save_test_result_data(test_result_data)

--- a/src/test_workflow/test_cluster.py
+++ b/src/test_workflow/test_cluster.py
@@ -51,6 +51,7 @@ class TestCluster(abc.ABC):
 
     def start(self):
         os.makedirs(self.work_dir, exist_ok=True)
+
         self.all_services = [self.service] + self.dependencies
 
         for service in self.all_services:

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -52,8 +52,8 @@ class TestRecorder:
         if log_files is not None:
             for log_dest_dir_name, source_log_dir in log_files.items():
                 if os.path.exists(source_log_dir):
-                    dest_file = os.path.join(dest_directory, log_dest_dir_name)
-                    shutil.copytree(source_log_dir, dest_file)
+                    dest_dir = os.path.join(dest_directory, log_dest_dir_name)
+                    shutil.copytree(source_log_dir, dest_dir)
 
     class LocalClusterLogs(LogRecorder):
         def __init__(self, parent_class):

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -48,6 +48,13 @@ class TestRecorder:
             yaml.dump(outcome, file)
         return os.path.realpath("%s.yml" % test_result_data.component_name)
 
+    def _copy_log_files(self, log_files, dest_directory):
+        if log_files is not None:
+            for log_dest_dir_name, source_log_dir in log_files.items():
+                if os.path.exists(source_log_dir):
+                    dest_file = os.path.join(dest_directory, log_dest_dir_name)
+                    shutil.copytree(source_log_dir, dest_file)
+
     class LocalClusterLogs(LogRecorder):
         def __init__(self, parent_class):
             self.parent_class = parent_class
@@ -56,7 +63,6 @@ class TestRecorder:
             base = self.parent_class._create_base_folder_structure(test_result_data.component_name, test_result_data.component_test_config)
             dest_directory = os.path.join(base, "local-cluster-logs")
             os.makedirs(dest_directory, exist_ok=True)
-            log_files = list(test_result_data.log_files)
             logging.info(
                 f"Recording local cluster logs for {test_result_data.component_name} with test configuration as "
                 f"{test_result_data.component_test_config} at {os.path.realpath(dest_directory)}"
@@ -67,29 +73,7 @@ class TestRecorder:
                 os.path.realpath(dest_directory),
             )
 
-            # This is a sample log_files
-            # [
-            #     (
-            #         '/tmp/tmpux1u0r47/local-test-cluster/opensearch-1.2.0/logs',
-            #         [],
-            #         [
-            #             'opensearch_index_indexing_slowlog.log',
-            #             'opensearch_deprecation.json',
-            #             'opensearch.log',
-            #             'gc.log',
-            #             'opensearch_index_search_slowlog.json',
-            #             'gc.log.00',
-            #             'opensearch_index_search_slowlog.log',
-            #             'opensearch_deprecation.log',
-            #             'opensearch_index_indexing_slowlog.json',
-            #             'opensearch_server.json'
-            #         ]
-            #     )
-            # ]
-
-            for log_file in log_files[0][2]:
-                dest_file = os.path.join(dest_directory, os.path.basename(log_file))
-                shutil.copyfile(os.path.join(log_files[0][0], log_file), dest_file)
+            self.parent_class._copy_log_files(test_result_data.log_files, dest_directory)
 
     class RemoteClusterLogs(LogRecorder):
         def __init__(self, parent_class):
@@ -115,11 +99,7 @@ class TestRecorder:
             os.makedirs(dest_directory, exist_ok=False)
             logging.info(f"Recording component test results for {test_result_data.component_name} at " f"{os.path.realpath(dest_directory)}")
             self.parent_class._generate_std_files(test_result_data.stdout, test_result_data.stderr, dest_directory)
-            if test_result_data.log_files is not None:
-                results_dir = list(test_result_data.log_files)
-                for result in results_dir:
-                    dest_file = os.path.join(dest_directory, os.path.basename(result[0]))
-                    shutil.copyfile(result[0], dest_file)
+            self.parent_class._copy_log_files(test_result_data.log_files, dest_directory)
             self.parent_class._generate_yml(test_result_data, dest_directory)
 
 

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -49,7 +49,7 @@ class TestRecorder:
         return os.path.realpath("%s.yml" % test_result_data.component_name)
 
     def _copy_log_files(self, log_files, dest_directory):
-        if log_files is not None:
+        if log_files:
             for log_dest_dir_name, source_log_dir in log_files.items():
                 if os.path.exists(source_log_dir):
                     dest_dir = os.path.join(dest_directory, log_dest_dir_name)

--- a/src/test_workflow/test_recorder/test_result_data.py
+++ b/src/test_workflow/test_recorder/test_result_data.py
@@ -5,7 +5,6 @@
 # compatible open source license.
 
 from dataclasses import dataclass
-from typing import Iterator
 
 
 @dataclass

--- a/src/test_workflow/test_recorder/test_result_data.py
+++ b/src/test_workflow/test_recorder/test_result_data.py
@@ -26,4 +26,4 @@ class TestResultData:
     exit_code: int
     stdout: str
     stderr: str
-    log_files: Iterator[str]
+    log_files: dict

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch_dashboards.py
@@ -38,10 +38,9 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
     @patch("os.chdir")
     @patch("os.path.exists")
     @patch("test_workflow.integ_test.integ_test_suite.TestResultData")
-    @patch("test_workflow.integ_test.integ_test_suite.walk")
     @patch("test_workflow.integ_test.integ_test_suite.GitRepository")
     @patch("test_workflow.integ_test.integ_test_suite.execute", return_value=True)
-    def test_execute_tests(self, mock_execute, mock_git, mock_walk, mock_test_result_data, mock_path_exists, mock_chdir):
+    def test_execute_tests(self, mock_execute, mock_git, mock_test_result_data, mock_path_exists, mock_chdir):
 
         mock_find = MagicMock()
         mock_find.return_value = "./integtest.sh"
@@ -53,9 +52,6 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
         mock_git.return_value = mock_git_object
 
         mock_execute.return_value = ("test_status", "test_stdout", "")
-
-        mock_walk_results = MagicMock()
-        mock_walk.return_value = mock_walk_results
 
         mock_test_result_data_object = MagicMock()
         mock_test_result_data.return_value = mock_test_result_data_object
@@ -94,10 +90,9 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
 
     @patch("os.path.exists")
     @patch("test_workflow.integ_test.integ_test_suite.TestResultData")
-    @patch("test_workflow.integ_test.integ_test_suite.walk")
     @patch("test_workflow.integ_test.integ_test_suite.GitRepository")
     @patch("test_workflow.integ_test.integ_test_suite.execute", return_value=True)
-    def test_execute_integtest_sh(self, mock_execute, mock_git, mock_walk, mock_test_result_data, mock_path_exists):
+    def test_execute_integtest_sh(self, mock_execute, mock_git, mock_test_result_data, mock_path_exists):
         logging.info(locals())
 
         mock_find = MagicMock()
@@ -110,9 +105,6 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
         mock_git.return_value = mock_git_object
 
         mock_execute.return_value = ("test_status", "test_stdout", "")
-
-        mock_walk_results = MagicMock()
-        mock_walk.return_value = mock_walk_results
 
         mock_test_result_data_object = MagicMock()
         mock_test_result_data.return_value = mock_test_result_data_object
@@ -138,15 +130,26 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
         self.assertEqual(status, "test_status")
         mock_execute.assert_called_once_with('./integtest.sh -b test_endpoint -p 1234 -s true -v 1.2.0',
                                              os.path.join("dir", "test_working_directory"), True, False)
-        mock_test_result_data.assert_called_once_with('sql', ['with-security', 'without-security'], 'test_status', 'test_stdout', '', mock_walk_results)
+
+        mock_test_result_data.assert_called_once_with(
+            "sql",
+            ["with-security", "without-security"],
+            "test_status",
+            "test_stdout",
+            "",
+            {
+                "cypress-videos": os.path.join("dir", "test_working_directory", "cypress", "videos"),
+                "cypress-screenshots": os.path.join("dir", "test_working_directory", "cypress", "screenshots"),
+                "cypress-report": os.path.join("dir", "test_working_directory", "cypress", "results")
+            }
+        )
         self.save_logs.save_test_result_data.assert_called_once_with(mock_test_result_data_object)
 
     @patch("os.path.exists")
     @patch("test_workflow.integ_test.integ_test_suite.TestResultData")
-    @patch("test_workflow.integ_test.integ_test_suite.walk")
     @patch("test_workflow.integ_test.integ_test_suite.GitRepository")
     @patch("test_workflow.integ_test.integ_test_suite.execute", return_value=True)
-    def test_execute_integtest_sh_script_do_not_exist(self, mock_execute, mock_git, mock_walk, mock_test_result_data, mock_path_exists):
+    def test_execute_integtest_sh_script_do_not_exist(self, mock_execute, mock_git, mock_test_result_data, mock_path_exists):
         mock_find = MagicMock()
         mock_find.return_value = "./integtest.sh"
 
@@ -182,10 +185,9 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
 
     @patch("os.path.exists")
     @patch("test_workflow.integ_test.integ_test_suite.TestResultData")
-    @patch("test_workflow.integ_test.integ_test_suite.walk")
     @patch("test_workflow.integ_test.integ_test_suite.GitRepository")
     @patch("test_workflow.integ_test.integ_test_suite.execute", return_value=True)
-    def test_is_security_enabled(self, mock_execute, mock_git, mock_walk, mock_test_result_data, mock_path_exists):
+    def test_is_security_enabled(self, mock_execute, mock_git, mock_test_result_data, mock_path_exists):
         mock_find = MagicMock()
         mock_find.return_value = "./integtest.sh"
 
@@ -221,10 +223,9 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
     @patch("test_workflow.integ_test.integ_test_suite.logging")
     @patch("os.path.exists")
     @patch("test_workflow.integ_test.integ_test_suite.TestResultData")
-    @patch("test_workflow.integ_test.integ_test_suite.walk")
     @patch("test_workflow.integ_test.integ_test_suite.GitRepository")
     @patch("test_workflow.integ_test.integ_test_suite.execute", return_value=True)
-    def test_pretty_print_message(self, mock_execute, mock_git, mock_walk, mock_test_result_data, mock_path_exists, mock_logging):
+    def test_pretty_print_message(self, mock_execute, mock_git, mock_test_result_data, mock_path_exists, mock_logging):
 
         mock_find = MagicMock()
         mock_find.return_value = "./integtest.sh"

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
@@ -114,10 +114,8 @@ class ServiceOpenSearchTests(unittest.TestCase):
     @patch('test_workflow.integ_test.service.Process.started', new_callable=PropertyMock, return_value=True)
     @patch('test_workflow.integ_test.service.Process.stdout_data', new_callable=PropertyMock, return_value="test stdout_data")
     @patch('test_workflow.integ_test.service.Process.stderr_data', new_callable=PropertyMock, return_value="test stderr_data")
-    @patch("test_workflow.integ_test.service.walk")
     def test_terminate(
         self,
-        mock_walk,
         mock_process_stderr_data,
         mock_process_stdout_data,
         mock_process_started,
@@ -131,18 +129,14 @@ class ServiceOpenSearchTests(unittest.TestCase):
             self.work_dir
         )
 
-        mock_log_files = MagicMock()
-        mock_walk.return_value = mock_log_files
-
         termination_result = service.terminate()
 
         mock_process_terminate.assert_called_once()
-        mock_walk.assert_called_once()
 
         self.assertEqual(termination_result.return_code, 123)
         self.assertEqual(termination_result.stdout_data, "test stdout_data")
         self.assertEqual(termination_result.stderr_data, "test stderr_data")
-        self.assertEqual(termination_result.log_files, mock_log_files)
+        self.assertEqual(termination_result.log_files, {"opensearch-service-logs": os.path.join("test_work_dir", "opensearch-1.1.0", "logs")})
 
     @patch("test_workflow.integ_test.service.Process.terminate")
     @patch('test_workflow.integ_test.service.Process.started', new_callable=PropertyMock, return_value=False)

--- a/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
+++ b/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
@@ -14,39 +14,29 @@ from test_workflow.test_recorder.test_recorder import TestRecorder
 
 class TestLocalClusterLogs(unittest.TestCase):
 
-    @patch("shutil.copyfile")
-    def test(self, mock_copyfile):
-
+    def test(self):
         mock_parent_class = MagicMock()
 
         mock_parent_class._create_base_folder_structure.return_value = "test_base"
+
+        mock_parent_class._copy_log_files = MagicMock()
 
         logs = TestRecorder.LocalClusterLogs(mock_parent_class)
 
         mock_test_result_data = MagicMock()
 
-        mock_test_result_data.log_files = [
-            (
-                "dir",
-                [],
-                [
-                    "opensearch_index_indexing_slowlog.log",
-                    "opensearch_deprecation.json"
-                ]
-            )
-        ]
-
         dest_directory = os.path.join("test_base", "local-cluster-logs")
-
-        dest_file_1 = os.path.join(dest_directory, "opensearch_index_indexing_slowlog.log")
-        dest_file_2 = os.path.join(dest_directory, "opensearch_deprecation.json")
 
         source_file_1 = os.path.join("dir", "opensearch_index_indexing_slowlog.log")
         source_file_2 = os.path.join("dir", "opensearch_deprecation.json")
 
+        mock_test_result_data.log_files = {
+            "slowlog": source_file_1,
+            "deprecation-log": source_file_2,
+        }
+        mock_test_result_data.component_name = "sql"
+        mock_test_result_data.component_test_config = "with-security"
+
         logs.save_test_result_data(mock_test_result_data)
 
-        mock_copyfile.assert_has_calls(
-            [call(source_file_1, dest_file_1)],
-            [call(source_file_2, dest_file_2)]
-        )
+        mock_parent_class._copy_log_files.assert_called_once_with(mock_test_result_data.log_files, dest_directory)

--- a/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
+++ b/tests/tests_test_workflow/test_recorder/test_local_cluster_logs.py
@@ -7,7 +7,7 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
 from test_workflow.test_recorder.test_recorder import TestRecorder
 


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
This PR will copy Dashboards Cypress test artifacts into the persistent dir and also save OpenSearch logs when running Dashboards tests (for ease of debugging)

Used `shutil.copytree` instead of `shutil.copyfile` for
1) simplicity
2) Cypress test folders have hierarchies
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1190
Resolves https://github.com/opensearch-project/opensearch-build/issues/1191

### Test
1 unit test in progress
2 manual test
Verified that the logs are saved.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
