### PR TITLE
Re-adding job-scheduler

### DIFF
--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -19,6 +19,12 @@ components:
   checks:
     - gradle:publish
     - gradle:properties:version
+- name: job-scheduler
+  repository: https://github.com/opensearch-project/job-scheduler.git
+  ref: 'main'
+  checks:
+    - gradle:properties:version
+    - gradle:dependencies:opensearch.version
 - name: alerting
   repository: https://github.com/opensearch-project/alerting.git
   ref: 'main'


### PR DESCRIPTION
### Description
Job-scheduler was removed when it looked like the promixal cause of build failures.  Now that that issue has been resolved, job-scheduler needs to be re-added index-management's dependency on it is failing.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
