### PR TITLE
Support separate paths for OpenSearch and OpenSearch Dashboards dur…

### DIFF
--- a/src/run_bwc_test.py
+++ b/src/run_bwc_test.py
@@ -18,7 +18,7 @@ def main():
     args = TestArgs()
     console.configure(level=args.logging_level)
     with TemporaryDirectory(keep=args.keep) as work_dir:
-        bundle_manifest = BundleManifest.from_urlpath(args.path)
+        bundle_manifest = BundleManifest.from_urlpath(args.opensearch_path)
         BwcTestSuite(bundle_manifest, work_dir.name, args.component, args.keep).execute()
 
 

--- a/src/test_workflow/README.md
+++ b/src/test_workflow/README.md
@@ -27,7 +27,7 @@ The following options are available.
 |----------------------|-------------------------------------------------------------------------|
 | test-type            | Run tests of a test suite. [integ-test, bwc-test, perf-test]            |
 | test-manifest-path   | Specify a test manifest path                                            |
-| path                 | Location of manifest(s).                                                |
+| --paths              | Location of manifest(s)                                                 |
 | --test-run-id        | Unique identifier for a test run                                        |
 | --component          | Test a specific component in a manifest                                 |
 | --keep               | Do not delete the temporary working directory on both success or error. |
@@ -56,7 +56,14 @@ For example, build locally and run integration tests.
 Or run integration tests against an existing build.
 
 ```bash
-./test.sh integ-test manifests/1.3.0/opensearch-1.3.0-test.yml https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/869/linux/x64 # looks for https://.../builds/opensearch/manifest.yml and https://.../dist/opensearch/manifest.yml
+./test.sh integ-test manifests/1.3.0/opensearch-1.3.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/869/linux/x64 # looks for https://.../builds/opensearch/manifest.yml and https://.../dist/opensearch/manifest.yml
+```
+
+To run OpenSearch Dashboards integ tests
+
+```bash
+./test.sh integ-test manifests/1.3.0/opensearch-1.3.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/869/linux/x64
+opensearch-dashboards=https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.2.0/869/linux/x64 
 ```
 
 ### Backwards Compatibility Tests

--- a/src/test_workflow/README.md
+++ b/src/test_workflow/README.md
@@ -62,7 +62,7 @@ Or run integration tests against an existing build.
 To run OpenSearch Dashboards integ tests
 
 ```bash
-./test.sh integ-test manifests/1.3.0/opensearch-1.3.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/869/linux/x64
+./test.sh integ-test manifests/1.3.0/opensearch-dashboards-1.3.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/869/linux/x64
 opensearch-dashboards=https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.2.0/869/linux/x64 
 ```
 

--- a/src/test_workflow/README.md
+++ b/src/test_workflow/README.md
@@ -26,10 +26,10 @@ The following options are available.
 | name                 | description                                                             |
 |----------------------|-------------------------------------------------------------------------|
 | test-type            | Run tests of a test suite. [integ-test, bwc-test, perf-test]            |
-| test-manifest-path   | Specify a test manifest path                                            |
-| --paths              | Location of manifest(s)                                                 |
-| --test-run-id        | Unique identifier for a test run                                        |
-| --component          | Test a specific component in a manifest                                 |
+| test-manifest-path   | Specify a test manifest path.                                           |
+| --paths              | Location of manifest(s).                                                |
+| --test-run-id        | Unique identifier for a test run.                                       |
+| --component          | Test a specific component in a manifest.                                |
 | --keep               | Do not delete the temporary working directory on both success or error. |
 | -v, --verbose        | Show more verbose output.                                               |
 
@@ -59,7 +59,7 @@ Or run integration tests against an existing build.
 ./test.sh integ-test manifests/1.3.0/opensearch-1.3.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/869/linux/x64 # looks for https://.../builds/opensearch/manifest.yml and https://.../dist/opensearch/manifest.yml
 ```
 
-To run OpenSearch Dashboards integ tests
+To run OpenSearch Dashboards integration tests.
 
 ```bash
 ./test.sh integ-test manifests/1.3.0/opensearch-dashboards-1.3.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/869/linux/x64

--- a/src/test_workflow/integ_test/integ_test_runner_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_runner_opensearch.py
@@ -9,13 +9,14 @@ import logging
 from test_workflow.integ_test.integ_test_runner import IntegTestRunner
 from test_workflow.integ_test.integ_test_start_properties_opensearch import IntegTestStartPropertiesOpenSearch
 from test_workflow.integ_test.integ_test_suite_opensearch import IntegTestSuiteOpenSearch
+from test_workflow.test_args import TestArgs
 
 
 class IntegTestRunnerOpenSearch(IntegTestRunner):
 
-    def __init__(self, args, test_manifest):
+    def __init__(self, args: TestArgs, test_manifest):
         super().__init__(args, test_manifest)
-        self.properties = IntegTestStartPropertiesOpenSearch(args.path)
+        self.properties = IntegTestStartPropertiesOpenSearch(args.opensearch_path)
 
         self.properties.dependency_installer.install_maven_dependencies()
 

--- a/src/test_workflow/integ_test/integ_test_runner_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/integ_test_runner_opensearch_dashboards.py
@@ -10,15 +10,16 @@ from test_workflow.integ_test.integ_test_runner import IntegTestRunner
 from test_workflow.integ_test.integ_test_start_properties_opensearch import IntegTestStartPropertiesOpenSearch
 from test_workflow.integ_test.integ_test_start_properties_opensearch_dashboards import IntegTestStartPropertiesOpenSearchDashboards
 from test_workflow.integ_test.integ_test_suite_opensearch_dashboards import IntegTestSuiteOpenSearchDashboards
+from test_workflow.test_args import TestArgs
 
 
 class IntegTestRunnerOpenSearchDashboards(IntegTestRunner):
 
-    def __init__(self, args, test_manifest):
+    def __init__(self, args: TestArgs, test_manifest):
         super().__init__(args, test_manifest)
 
-        self.properties_dependency = IntegTestStartPropertiesOpenSearch(args.path)
-        self.properties = IntegTestStartPropertiesOpenSearchDashboards(args.path)
+        self.properties_dependency = IntegTestStartPropertiesOpenSearch(args.opensearch_path)
+        self.properties = IntegTestStartPropertiesOpenSearchDashboards(args.opensearch_dashboards_path)
 
         self.components = self.properties.build_manifest.components
 

--- a/src/test_workflow/test_args.py
+++ b/src/test_workflow/test_args.py
@@ -33,7 +33,6 @@ class TestArgs:
         parser.add_argument(
             "-v", "--verbose", help="Show more verbose output.", action="store_const", default=logging.INFO, const=logging.DEBUG, dest="logging_level"
         )
-
         args = parser.parse_args()
         self.test_run_id = args.test_run_id or uuid.uuid4().hex
         self.component = args.component
@@ -43,8 +42,6 @@ class TestArgs:
 
         self.opensearch_path = self._validate_paths(args.paths, "opensearch")
         self.opensearch_dashboards_path = self._validate_paths(args.paths, "opensearch-dashboards")
-
-        print(args)
 
     def _validate_paths(self, args_paths: dict, name: str) -> str:
         path = "."

--- a/src/test_workflow/test_args.py
+++ b/src/test_workflow/test_args.py
@@ -26,7 +26,7 @@ class TestArgs:
     def __init__(self):
         parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
         parser.add_argument("test_manifest_path", type=str, help="Specify a test manifest path.")
-        parser.add_argument('-p', '--paths', nargs='*', action=ParseKwargs, help="Specify paths for OpenSearch and OpenSearch Dashboards.")
+        parser.add_argument("-p", "--paths", nargs='*', action=ParseKwargs, help="Specify paths for OpenSearch and OpenSearch Dashboards.")
         parser.add_argument("--test-run-id", type=int, help="The unique execution id for the test")
         parser.add_argument("--component", type=str, help="Test a specific component instead of the entire distribution.")
         parser.add_argument("--keep", dest="keep", action="store_true", help="Do not delete the working temporary directory.")

--- a/src/test_workflow/test_args.py
+++ b/src/test_workflow/test_args.py
@@ -14,6 +14,8 @@ import uuid
 
 import validators  # type:ignore
 
+from test_workflow.test_kwargs import ParseKwargs
+
 
 class TestArgs:
     test_run_id: int
@@ -24,25 +26,35 @@ class TestArgs:
     def __init__(self):
         parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
         parser.add_argument("test_manifest_path", type=str, help="Specify a test manifest path.")
-        parser.add_argument("opensearch_path", type=str, help="Location of build and bundle manifests.", default=".")
-        parser.add_argument("opensearch_dashboards_path", type=str, help="Location of build and bundle manifests for OpenSearch Dashboards.", default=".")
+        parser.add_argument('-p', '--paths', nargs='*', action=ParseKwargs, help="Specify paths for OpenSearch and OpenSearch Dashboards.")
         parser.add_argument("--test-run-id", type=int, help="The unique execution id for the test")
         parser.add_argument("--component", type=str, help="Test a specific component instead of the entire distribution.")
         parser.add_argument("--keep", dest="keep", action="store_true", help="Do not delete the working temporary directory.")
         parser.add_argument(
             "-v", "--verbose", help="Show more verbose output.", action="store_const", default=logging.INFO, const=logging.DEBUG, dest="logging_level"
         )
+
         args = parser.parse_args()
         self.test_run_id = args.test_run_id or uuid.uuid4().hex
         self.component = args.component
         self.keep = args.keep
         self.logging_level = args.logging_level
-
-        self.opensearch_path = self._validate_path(args.opensearch_path)
-        self.opensearch_dashboards_path = self._validate_path(args.opensearch_dashboards_path)
         self.test_manifest_path = self._validate_path(args.test_manifest_path)
 
-    def _validate_path(self, path):
+        self.opensearch_path = self._validate_paths(args.paths, "opensearch")
+        self.opensearch_dashboards_path = self._validate_paths(args.paths, "opensearch-dashboards")
+
+        print(args)
+
+    def _validate_paths(self, args_paths: dict, name: str) -> str:
+        path = "."
+
+        if args_paths and (name in args_paths):
+            path = args_paths[name]
+
+        return self._validate_path(path)
+
+    def _validate_path(self, path: str) -> str:
         return path if validators.url(path) else os.path.realpath(path)
 
 

--- a/src/test_workflow/test_args.py
+++ b/src/test_workflow/test_args.py
@@ -24,7 +24,8 @@ class TestArgs:
     def __init__(self):
         parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
         parser.add_argument("test_manifest_path", type=str, help="Specify a test manifest path.")
-        parser.add_argument("path", type=str, help="Location of build and bundle manifests.", default=".")
+        parser.add_argument("opensearch_path", type=str, help="Location of build and bundle manifests.", default=".")
+        parser.add_argument("opensearch_dashboards_path", type=str, help="Location of build and bundle manifests for OpenSearch Dashboards.", default=".")
         parser.add_argument("--test-run-id", type=int, help="The unique execution id for the test")
         parser.add_argument("--component", type=str, help="Test a specific component instead of the entire distribution.")
         parser.add_argument("--keep", dest="keep", action="store_true", help="Do not delete the working temporary directory.")
@@ -36,9 +37,13 @@ class TestArgs:
         self.component = args.component
         self.keep = args.keep
         self.logging_level = args.logging_level
-        self.path = args.path if validators.url(args.path) else os.path.realpath(args.path)
 
-        self.test_manifest_path = args.test_manifest_path if validators.url(args.test_manifest_path) else os.path.realpath(args.test_manifest_path)
+        self.opensearch_path = self._validate_path(args.opensearch_path)
+        self.opensearch_dashboards_path = self._validate_path(args.opensearch_dashboards_path)
+        self.test_manifest_path = self._validate_path(args.test_manifest_path)
+
+    def _validate_path(self, path):
+        return path if validators.url(path) else os.path.realpath(path)
 
 
 TestArgs.__test__ = False  # type:ignore

--- a/src/test_workflow/test_args.py
+++ b/src/test_workflow/test_args.py
@@ -14,7 +14,7 @@ import uuid
 
 import validators  # type:ignore
 
-from test_workflow.test_kwargs import ParseKwargs
+from test_workflow.test_kwargs import TestKwargs
 
 
 class TestArgs:
@@ -26,7 +26,7 @@ class TestArgs:
     def __init__(self):
         parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
         parser.add_argument("test_manifest_path", type=str, help="Specify a test manifest path.")
-        parser.add_argument("-p", "--paths", nargs='*', action=ParseKwargs, help="Specify paths for OpenSearch and OpenSearch Dashboards.")
+        parser.add_argument("-p", "--paths", nargs='*', action=TestKwargs, help="Specify paths for OpenSearch and OpenSearch Dashboards.")
         parser.add_argument("--test-run-id", type=int, help="The unique execution id for the test")
         parser.add_argument("--component", type=str, help="Test a specific component instead of the entire distribution.")
         parser.add_argument("--keep", dest="keep", action="store_true", help="Do not delete the working temporary directory.")

--- a/src/test_workflow/test_kwargs.py
+++ b/src/test_workflow/test_kwargs.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+import argparse
+
+
+class ParseKwargs(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, dict())
+        for value in values:
+            key, value = value.split('=')
+            getattr(namespace, self.dest)[key] = value

--- a/src/test_workflow/test_kwargs.py
+++ b/src/test_workflow/test_kwargs.py
@@ -10,9 +10,12 @@
 import argparse
 
 
-class ParseKwargs(argparse.Action):
+class TestKwargs(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, dict())
         for value in values:
             key, value = value.split('=')
             getattr(namespace, self.dest)[key] = value
+
+
+TestKwargs.__test__ = False  # type:ignore

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_run_bwc_test.py
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/test_run_bwc_test.py
@@ -17,7 +17,8 @@ class TestRunBwcTest(unittest.TestCase):
         [
             "run_bwc_test.py",
             os.path.join(os.path.dirname(__file__), "..", "..", "data", "test_manifest.yml"),
-            os.path.join(os.path.dirname(__file__), "..", "..", "data", "remote", "dist", "opensearch", "manifest.yml")
+            "--paths",
+            "opensearch=" + os.path.join(os.path.dirname(__file__), "..", "..", "data", "remote", "dist", "opensearch", "manifest.yml")
         ])
     @ patch("run_bwc_test.BwcTestSuite")
     def test_run_bwc_test(self, mock_bwc_suite, *mock):

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_run_integ_test.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_run_integ_test.py
@@ -18,7 +18,8 @@ class TestRunIntegTest(unittest.TestCase):
         [
             "run_integ_test.py",
             os.path.join(os.path.dirname(__file__), "..", "..", "data", "test_manifest.yml"),
-            os.path.join(os.path.dirname(__file__), "..", "..", "data", "remote")
+            "--paths",
+            "opensearch=" + os.path.join(os.path.dirname(__file__), "..", "..", "data", "remote")
         ])
     def test_run_integ_test(self, *mock):
 

--- a/tests/tests_test_workflow/test_test_args.py
+++ b/tests/tests_test_workflow/test_test_args.py
@@ -22,30 +22,93 @@ class TestTestArgs(unittest.TestCase):
         os.path.dirname(__file__), "data", "test_manifest.yml"
     )
 
-    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, PATH])
-    def test_defaults(self):
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH])
+    def test_opensearch_default_opensearch_dashboards_default(self):
         test_args = TestArgs()
-        self.assertEqual(test_args.path, os.path.realpath(self.PATH))
+        self.assertEqual(test_args.opensearch_path, os.getcwd())
+        self.assertEqual(test_args.opensearch_dashboards_path, os.getcwd())
+
         self.assertIsNotNone(test_args.test_run_id)
         self.assertIsNone(test_args.component)
         self.assertFalse(test_args.keep)
         self.assertEqual(test_args.logging_level, logging.INFO)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
 
-    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, PATH, "--test-run-id", "6"])
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=" + PATH])
+    def test_opensearch_file_opensearch_dashboards_default(self):
+        test_args = TestArgs()
+        self.assertEqual(test_args.opensearch_path, os.path.realpath(self.PATH))
+        self.assertEqual(test_args.opensearch_dashboards_path, os.getcwd())
+
+        self.assertIsNotNone(test_args.test_run_id)
+        self.assertIsNone(test_args.component)
+        self.assertFalse(test_args.keep)
+        self.assertEqual(test_args.logging_level, logging.INFO)
+        self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
+
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch-dashboards=" + PATH])
+    def test_opensearch_default_opensearch_dashboards_file(self):
+        test_args = TestArgs()
+        self.assertEqual(test_args.opensearch_dashboards_path, os.path.realpath(self.PATH))
+        self.assertEqual(test_args.opensearch_path, os.getcwd())
+
+        self.assertIsNotNone(test_args.test_run_id)
+        self.assertIsNone(test_args.component)
+        self.assertFalse(test_args.keep)
+        self.assertEqual(test_args.logging_level, logging.INFO)
+        self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
+
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch-dashboards=" + PATH, "opensearch=" + PATH])
+    def test_opensearch_file_opensearch_dashboards_file(self):
+        test_args = TestArgs()
+        self.assertEqual(test_args.opensearch_dashboards_path, os.path.realpath(self.PATH))
+        self.assertEqual(test_args.opensearch_path, os.path.realpath(self.PATH))
+
+        self.assertIsNotNone(test_args.test_run_id)
+        self.assertIsNone(test_args.component)
+        self.assertFalse(test_args.keep)
+        self.assertEqual(test_args.logging_level, logging.INFO)
+        self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
+
+    @ patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=" + PATH, "--test-run-id", "6"])
     def test_run_id(self):
         test_args = TestArgs()
         self.assertEqual(test_args.test_run_id, 6)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
 
-    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, PATH, "--verbose"])
+    @ patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=" + PATH, "--verbose"])
     def test_verbose(self):
         test_args = TestArgs()
         self.assertEqual(test_args.logging_level, logging.DEBUG)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
 
-    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, 'https://ci.opensearch.org/x/y', "--verbose"])
-    def test_url(self):
+    @ patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=https://ci.opensearch.org/x/y", "--verbose"])
+    def test_opensearch_url_opensearch_dashboards_default(self):
         test_args = TestArgs()
-        self.assertEqual(TestArgs().path, 'https://ci.opensearch.org/x/y')
+        self.assertEqual(test_args.opensearch_path, "https://ci.opensearch.org/x/y")
+        self.assertEqual(test_args.opensearch_dashboards_path, os.getcwd())
+        self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
+
+    @ patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch-dashboards=https://ci.opensearch.org/x/y", "--verbose"])
+    def test_opensearch_default_opensearch_dashboards_url(self):
+        test_args = TestArgs()
+        self.assertEqual(test_args.opensearch_dashboards_path, "https://ci.opensearch.org/x/y")
+        self.assertEqual(test_args.opensearch_path, os.getcwd())
+        self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
+
+    @ patch(
+        "argparse._sys.argv",
+        [
+            ARGS_PY,
+            TEST_MANIFEST_PATH,
+            "--paths",
+            "opensearch=https://ci.opensearch.org/x/y",
+            "opensearch-dashboards=https://ci.opensearch.org/x/y/dashboards",
+            "--verbose"
+        ]
+    )
+    def test_opensearch_url_opensearch_dashboards_url(self):
+        test_args = TestArgs()
+        self.assertEqual(test_args.opensearch_path, "https://ci.opensearch.org/x/y")
+        self.assertEqual(test_args.opensearch_dashboards_path, "https://ci.opensearch.org/x/y/dashboards")
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)

--- a/tests/tests_test_workflow/test_test_args.py
+++ b/tests/tests_test_workflow/test_test_args.py
@@ -70,33 +70,33 @@ class TestTestArgs(unittest.TestCase):
         self.assertEqual(test_args.logging_level, logging.INFO)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
 
-    @ patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=" + PATH, "--test-run-id", "6"])
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=" + PATH, "--test-run-id", "6"])
     def test_run_id(self):
         test_args = TestArgs()
         self.assertEqual(test_args.test_run_id, 6)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
 
-    @ patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=" + PATH, "--verbose"])
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=" + PATH, "--verbose"])
     def test_verbose(self):
         test_args = TestArgs()
         self.assertEqual(test_args.logging_level, logging.DEBUG)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
 
-    @ patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=https://ci.opensearch.org/x/y", "--verbose"])
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=https://ci.opensearch.org/x/y", "--verbose"])
     def test_opensearch_url_opensearch_dashboards_default(self):
         test_args = TestArgs()
         self.assertEqual(test_args.opensearch_path, "https://ci.opensearch.org/x/y")
         self.assertEqual(test_args.opensearch_dashboards_path, os.getcwd())
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
 
-    @ patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch-dashboards=https://ci.opensearch.org/x/y", "--verbose"])
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch-dashboards=https://ci.opensearch.org/x/y", "--verbose"])
     def test_opensearch_default_opensearch_dashboards_url(self):
         test_args = TestArgs()
         self.assertEqual(test_args.opensearch_dashboards_path, "https://ci.opensearch.org/x/y")
         self.assertEqual(test_args.opensearch_path, os.getcwd())
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
 
-    @ patch(
+    @patch(
         "argparse._sys.argv",
         [
             ARGS_PY,

--- a/tests/tests_test_workflow/test_test_kwargs.py
+++ b/tests/tests_test_workflow/test_test_kwargs.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from test_workflow.test_kwargs import TestKwargs
+
+
+class TestTestKwargs(unittest.TestCase):
+    def test(self):
+        kwargs = TestKwargs(dest="test", option_strings=[])
+        mock_parser = MagicMock()
+        namespace = SimpleNamespace()
+        values = ["key1=value1", "key2=value2"]
+
+        kwargs.__call__(parser=mock_parser, namespace=namespace, values=values)
+
+        self.assertEqual(namespace.__getattribute__("test"), {'key1': 'value1', 'key2': 'value2'})


### PR DESCRIPTION
…ing integ test

Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
The CI public endpoint is different for OpenSearch and OpenSearch Dashboards. Thus add a new param for specifying such for OpenSearch Dashboards
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1259
 
### Test
1. unit test in progress.
2. manual test in progress.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
