### PR TITLE
Add new attribute filename to build manifest class property

### DIFF
--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -32,7 +32,7 @@ class BundleRecorder:
 
     def __get_package_name(self, build: BuildManifest.Build) -> str:
         parts = [
-            build.name.lower().replace(" ", "-"),
+            build.filename,
             build.version,
             build.platform,
             build.architecture,

--- a/src/manifests/build/build_manifest_1_0.py
+++ b/src/manifests/build/build_manifest_1_0.py
@@ -5,7 +5,8 @@
 # compatible open source license.
 
 from typing import Any
-from manifests.component_manifest import ComponentManifest, Components, Component
+
+from manifests.component_manifest import Component, ComponentManifest, Components
 
 """
 A BuildManifest is an immutable view of the outputs from a build step
@@ -100,6 +101,10 @@ class BuildManifest_1_0(ComponentManifest['BuildManifest_1_0', 'BuildComponents_
                 "architecture": self.architecture,
                 "id": self.id
             }
+
+        @property
+        def filename(self) -> str:
+            return self.name.lower().replace(" ", "-")
 
 
 class BuildComponents_1_0(Components['BuildComponent_1_0']):

--- a/src/manifests/build/build_manifest_1_0.py
+++ b/src/manifests/build/build_manifest_1_0.py
@@ -89,7 +89,7 @@ class BuildManifest_1_0(ComponentManifest['BuildManifest_1_0', 'BuildComponents_
 
     class Build:
         def __init__(self, data: Any):
-            self.name = data["name"]
+            self.name: str = data["name"]
             self.version = data["version"]
             self.architecture = data["architecture"]
             self.id = data["id"]

--- a/src/manifests/build/build_manifest_1_1.py
+++ b/src/manifests/build/build_manifest_1_1.py
@@ -5,7 +5,8 @@
 # compatible open source license.
 
 from typing import Any
-from manifests.component_manifest import ComponentManifest, Components, Component
+
+from manifests.component_manifest import Component, ComponentManifest, Components
 
 """
 A BuildManifest is an immutable view of the outputs from a build step
@@ -101,6 +102,10 @@ class BuildManifest_1_1(ComponentManifest['BuildManifest_1_1', 'BuildComponents_
                 "architecture": self.architecture,
                 "id": self.id
             }
+
+        @property
+        def filename(self) -> str:
+            return self.name.lower().replace(" ", "-")
 
 
 class BuildComponents_1_1(Components['BuildComponent_1_1']):

--- a/src/manifests/build/build_manifest_1_1.py
+++ b/src/manifests/build/build_manifest_1_1.py
@@ -90,7 +90,7 @@ class BuildManifest_1_1(ComponentManifest['BuildManifest_1_1', 'BuildComponents_
 
     class Build:
         def __init__(self, data: Any):
-            self.name = data["name"]
+            self.name: str = data["name"]
             self.version = data["version"]
             self.architecture = data["architecture"]
             self.id = data["id"]

--- a/src/manifests/build_manifest.py
+++ b/src/manifests/build_manifest.py
@@ -115,6 +115,10 @@ class BuildManifest(ComponentManifest['BuildManifest', 'BuildComponents']):
                 "id": self.id
             }
 
+        @property
+        def filename(self) -> str:
+            return self.name.lower().replace(" ", "-")
+
 
 class BuildComponents(Components['BuildComponent']):
     @classmethod

--- a/src/manifests/input_manifest.py
+++ b/src/manifests/input_manifest.py
@@ -146,7 +146,7 @@ class InputManifest(ComponentManifest['InputManifest', 'InputComponents']):
 
     class Build:
         def __init__(self, data: Any):
-            self.name = data["name"]
+            self.name: str = data["name"]
             self.version = data["version"]
             self.platform = data.get("platform", None)
             self.architecture = data.get("architecture", None)
@@ -167,6 +167,10 @@ class InputManifest(ComponentManifest['InputManifest', 'InputComponents']):
                 "architecture": self.architecture,
                 "snapshot": self.snapshot,
             }
+
+        @property
+        def filename(self) -> str:
+            return self.name.lower().replace(" ", "-")
 
 
 class InputComponents(Components['InputComponent']):

--- a/src/paths/assemble_output_dir.py
+++ b/src/paths/assemble_output_dir.py
@@ -8,5 +8,5 @@ from paths.output_dir import OutputDir
 
 
 class AssembleOutputDir(OutputDir):
-    def __init__(cls, name: str, cwd: str = None, makedirs: bool = True) -> None:
-        super().__init__("dist", name, cwd, makedirs)
+    def __init__(cls, filename: str, cwd: str = None, makedirs: bool = True) -> None:
+        super().__init__("dist", filename, cwd, makedirs)

--- a/src/paths/build_output_dir.py
+++ b/src/paths/build_output_dir.py
@@ -8,5 +8,5 @@ from paths.output_dir import OutputDir
 
 
 class BuildOutputDir(OutputDir):
-    def __init__(cls, name, cwd=None, makedirs=True):
-        super().__init__("builds", name.lower().replace(" ", "-"), cwd, makedirs)
+    def __init__(cls, filename, cwd=None, makedirs=True):
+        super().__init__("builds", filename, cwd, makedirs)

--- a/src/paths/build_output_dir.py
+++ b/src/paths/build_output_dir.py
@@ -9,4 +9,4 @@ from paths.output_dir import OutputDir
 
 class BuildOutputDir(OutputDir):
     def __init__(cls, name, cwd=None, makedirs=True):
-        super().__init__("builds", name, cwd, makedirs)
+        super().__init__("builds", name.lower().replace(" ", "-"), cwd, makedirs)

--- a/src/paths/output_dir.py
+++ b/src/paths/output_dir.py
@@ -9,11 +9,11 @@ import os
 
 
 class OutputDir(abc.ABC):
-    def __init__(cls, parent_dir: str, name: str, cwd: str = None, makedirs: bool = True) -> None:
+    def __init__(cls, parent_dir: str, filename: str, cwd: str = None, makedirs: bool = True) -> None:
         cls.dir = os.path.join(
             cwd or os.getcwd(),
             parent_dir,
-            name.lower().replace(' ', '-')
+            filename
         )
 
         if makedirs:

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -27,7 +27,7 @@ def main() -> int:
     build = build_manifest.build
     artifacts_dir = os.path.dirname(os.path.realpath(args.manifest.name))
 
-    output_dir = AssembleOutputDir(build.name).dir
+    output_dir = AssembleOutputDir(build.filename).dir
 
     logging.info(f"Bundling {build.name} ({build.architecture}) on {build.platform} into {output_dir} ...")
 

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -43,7 +43,7 @@ def main():
             manifest.to_file(args.ref_manifest)
         exit(0)
 
-    output_dir = BuildOutputDir(manifest.build.name).dir
+    output_dir = BuildOutputDir(manifest.build.filename).dir
 
     with TemporaryDirectory(keep=args.keep, chdir=True) as work_dir:
         logging.info(f"Building in {work_dir.name}")

--- a/tests/tests_manifests/test_build_manifest.py
+++ b/tests/tests_manifests/test_build_manifest.py
@@ -22,6 +22,7 @@ class TestBuildManifest(unittest.TestCase):
     def test_build(self) -> None:
         self.assertEqual(self.manifest.version, "1.2")
         self.assertEqual(self.manifest.build.name, "OpenSearch")
+        self.assertEqual(self.manifest.build.filename, "opensearch")
         self.assertEqual(self.manifest.build.version, "1.1.0")
         self.assertEqual(len(self.manifest.components), 15)
 
@@ -51,6 +52,7 @@ class TestBuildManifest(unittest.TestCase):
         self.manifest = BuildManifest.from_url('http://fakeurl')
         self.assertEqual(self.manifest.version, "1.1")
         self.assertEqual(self.manifest.build.name, "OpenSearch Dashboards")
+        self.assertEqual(self.manifest.build.filename, "opensearch-dashboards")
         self.assertEqual(self.manifest.build.version, "1.1.0")
         self.assertEqual(len(self.manifest.components), 10)
 

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -25,6 +25,7 @@ class TestInputManifest(unittest.TestCase):
         manifest = InputManifest.from_path(path)
         self.assertEqual(manifest.version, "1.0")
         self.assertEqual(manifest.build.name, "OpenSearch Dashboards")
+        self.assertEqual(manifest.build.filename, "openSearch-dashboards")
         self.assertEqual(manifest.build.version, "1.1.1")
         self.assertEqual(len(list(manifest.components.select(focus="alertingDashboards"))), 1)
         opensearch_component: InputComponentFromDist = manifest.components["OpenSearch-Dashboards"]  # type: ignore[assignment]
@@ -45,6 +46,7 @@ class TestInputManifest(unittest.TestCase):
         manifest = InputManifest.from_path(path)
         self.assertEqual(manifest.version, "1.0")
         self.assertEqual(manifest.build.name, "OpenSearch")
+        self.assertEqual(manifest.build.filename, "opensearch")
         self.assertEqual(manifest.build.version, "1.0.0")
         self.assertEqual(len(list(manifest.components.select(focus="common-utils"))), 1)
         opensearch_component: InputComponentFromSource = manifest.components["OpenSearch"]  # type: ignore[assignment]
@@ -63,6 +65,7 @@ class TestInputManifest(unittest.TestCase):
         manifest = InputManifest.from_path(path)
         self.assertEqual(manifest.version, "1.0")
         self.assertEqual(manifest.build.name, "OpenSearch")
+        self.assertEqual(manifest.build.filename, "opensearch")
         self.assertEqual(manifest.build.version, "1.1.0")
         self.assertEqual(len(list(manifest.components.select(focus="common-utils"))), 1)
         # opensearch component
@@ -90,6 +93,7 @@ class TestInputManifest(unittest.TestCase):
         manifest = InputManifest.from_path(path)
         self.assertEqual(manifest.version, "1.0")
         self.assertEqual(manifest.build.name, "OpenSearch")
+        self.assertEqual(manifest.build.filename, "opensearch")
         self.assertEqual(manifest.build.version, "1.2.0")
         self.assertEqual(manifest.ci.image.name, "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028")
         self.assertEqual(manifest.ci.image.args, "-e JAVA_HOME=/usr/lib/jvm/adoptopenjdk-14-hotspot")
@@ -174,6 +178,8 @@ class TestInputManifest(unittest.TestCase):
         mock_output.return_value.decode.return_value = "updated\tHEAD"
         path = os.path.join(self.manifests_path, "1.1.0", "opensearch-1.1.0.yml")
         manifest = InputManifest.from_path(path).stable(platform="windows", architecture="arm64", snapshot=True)
+        self.assertEqual(manifest.build.name, "OpenSearch")
+        self.assertEqual(manifest.build.filename, "opensearch")
         self.assertEqual(manifest.build.platform, "windows")
         self.assertEqual(manifest.build.architecture, "arm64")
         self.assertTrue(manifest.build.snapshot)

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -25,7 +25,7 @@ class TestInputManifest(unittest.TestCase):
         manifest = InputManifest.from_path(path)
         self.assertEqual(manifest.version, "1.0")
         self.assertEqual(manifest.build.name, "OpenSearch Dashboards")
-        self.assertEqual(manifest.build.filename, "openSearch-dashboards")
+        self.assertEqual(manifest.build.filename, "opensearch-dashboards")
         self.assertEqual(manifest.build.version, "1.1.1")
         self.assertEqual(len(list(manifest.components.select(focus="alertingDashboards"))), 1)
         opensearch_component: InputComponentFromDist = manifest.components["OpenSearch-Dashboards"]  # type: ignore[assignment]

--- a/tests/tests_manifests/test_input_manifests.py
+++ b/tests/tests_manifests/test_input_manifests.py
@@ -21,8 +21,12 @@ class TestInputManifests(unittest.TestCase):
         self.assertIsNotNone(manifest)
         self.assertEqual(manifest.version, "1.0")
         self.assertEqual(manifest.build.version, "1.1.0")
+        self.assertEqual(manifest.build.name, "OpenSearch")
+        self.assertEqual(manifest.build.filename, "opensearch")
 
     def test_latest(self) -> None:
         manifest = self.manifests.latest
         self.assertIsNotNone(manifest)
         self.assertEqual(manifest.build.version, max(self.manifests.keys()))
+        self.assertEqual(manifest.build.name, "OpenSearch")
+        self.assertEqual(manifest.build.filename, "opensearch")

--- a/tests/tests_paths/test_assemble_output_dir.py
+++ b/tests/tests_paths/test_assemble_output_dir.py
@@ -21,15 +21,15 @@ class AssembleOutputDirTests(unittest.TestCase):
         mock_dir = MagicMock()
         mock_os.path.join.return_value = mock_dir
 
-        AssembleOutputDir("OpenSearch", makedirs=True)
+        AssembleOutputDir("opensearch", makedirs=True)
 
-        mock_os.path.join.called_once_with(
+        mock_os.path.join.assert_called_once_with(
             mock_cwd,
             "dist",
             "opensearch"
         )
 
-        mock_os.makedirs.called_once_with(mock_dir, exist_ok=True)
+        mock_os.makedirs.assert_called_once_with(mock_dir, exist_ok=True)
 
     @patch("paths.output_dir.os")
     def test_opensearch_dashboards(self, mock_os):
@@ -40,24 +40,24 @@ class AssembleOutputDirTests(unittest.TestCase):
         mock_dir = MagicMock()
         mock_os.path.join.return_value = mock_dir
 
-        AssembleOutputDir("OpenSearch Dashboards", makedirs=True)
+        AssembleOutputDir("opensearch-dashboards", makedirs=True)
 
-        mock_os.path.join.called_once_with(
+        mock_os.path.join.assert_called_once_with(
             mock_cwd,
             "dist",
             "opensearch-dashboards"
         )
 
-        mock_os.makedirs.called_once_with(mock_dir, exist_ok=True)
+        mock_os.makedirs.assert_called_once_with(mock_dir, exist_ok=True)
 
     @patch("paths.output_dir.os")
     def test_with_cwd(self, mock_os):
         mock_dir = MagicMock()
         mock_os.path.join.return_value = mock_dir
 
-        AssembleOutputDir("OpenSearch", cwd="test_cwd", makedirs=False)
+        AssembleOutputDir("opensearch", cwd="test_cwd", makedirs=False)
 
-        mock_os.path.join.called_once_with(
+        mock_os.path.join.assert_called_once_with(
             "test_cwd",
             "dist",
             "opensearch"

--- a/tests/tests_paths/test_build_output_dir.py
+++ b/tests/tests_paths/test_build_output_dir.py
@@ -21,7 +21,7 @@ class BuildOutputDirTests(unittest.TestCase):
         mock_dir = MagicMock()
         mock_os.path.join.return_value = mock_dir
 
-        BuildOutputDir("OpenSearch", makedirs=True)
+        BuildOutputDir("opensearch", makedirs=True)
 
         mock_os.path.join.assert_called_once_with(
             mock_cwd,
@@ -40,7 +40,7 @@ class BuildOutputDirTests(unittest.TestCase):
         mock_dir = MagicMock()
         mock_os.path.join.return_value = mock_dir
 
-        BuildOutputDir("OpenSearch Dashboards", makedirs=True)
+        BuildOutputDir("opensearch-dashboards", makedirs=True)
 
         mock_os.path.join.assert_called_once_with(
             mock_cwd,
@@ -55,7 +55,7 @@ class BuildOutputDirTests(unittest.TestCase):
         mock_dir = MagicMock()
         mock_os.path.join.return_value = mock_dir
 
-        BuildOutputDir("OpenSearch", cwd="test_cwd", makedirs=False)
+        BuildOutputDir("opensearch", cwd="test_cwd", makedirs=False)
 
         mock_os.path.join.assert_called_once_with(
             "test_cwd",

--- a/tests/tests_paths/test_build_output_dir.py
+++ b/tests/tests_paths/test_build_output_dir.py
@@ -23,13 +23,13 @@ class BuildOutputDirTests(unittest.TestCase):
 
         BuildOutputDir("OpenSearch", makedirs=True)
 
-        mock_os.path.join.called_once_with(
+        mock_os.path.join.assert_called_once_with(
             mock_cwd,
             "builds",
             "opensearch"
         )
 
-        mock_os.makedirs.called_once_with(mock_dir, exist_ok=True)
+        mock_os.makedirs.assert_called_once_with(mock_dir, exist_ok=True)
 
     @patch("paths.output_dir.os")
     def test_opensearch_dashboards(self, mock_os):
@@ -42,13 +42,13 @@ class BuildOutputDirTests(unittest.TestCase):
 
         BuildOutputDir("OpenSearch Dashboards", makedirs=True)
 
-        mock_os.path.join.called_once_with(
+        mock_os.path.join.assert_called_once_with(
             mock_cwd,
             "builds",
             "opensearch-dashboards"
         )
 
-        mock_os.makedirs.called_once_with(mock_dir, exist_ok=True)
+        mock_os.makedirs.assert_called_once_with(mock_dir, exist_ok=True)
 
     @patch("paths.output_dir.os")
     def test_with_cwd(self, mock_os):
@@ -57,7 +57,7 @@ class BuildOutputDirTests(unittest.TestCase):
 
         BuildOutputDir("OpenSearch", cwd="test_cwd", makedirs=False)
 
-        mock_os.path.join.called_once_with(
+        mock_os.path.join.assert_called_once_with(
             "test_cwd",
             "builds",
             "opensearch"


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
During PR review of https://github.com/opensearch-project/opensearch-build/pull/1265, @dblock has the suggestion to introduce a new attribute `filename` into build manifest.
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1269
 
### Test
Snippet of the new OpenSearch build manifest
```
build:
  architecture: x64
  filename: opensearch
  id: 19bfc8c9ca4a45a6af22fcffc69c4ac5
  name: OpenSearch
  platform: linux
  version: 1.2.0

```
Snippet of the new OpenSearch Dashboards build manifest
```
build:
  architecture: x64
  filename: opensearch-dashboards
  id: 25ea85b70189487abff3eaaf8c463333
  name: OpenSearch Dashboards
  platform: linux
  version: 1.2.0
```

Verify that bundle manifest has the correct location for local assemble.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
