### PR TITLE
Typechecking for checkout workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,7 @@ jobs:
           pipenv run flake8 .
       - name: Run Type Checker
         run: |
-          pipenv run mypy src/manifests tests/tests_manifests
+          pipenv run mypy src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests
       - name: Run Tests with Coverage
         run: |
           pipenv run coverage run -m pytest --cov=./src --cov-report=xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: mypy
     stages: [commit]
     name: mypy
-    entry: bash -c 'pipenv run mypy src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests'
+    entry: bash -c 'pipenv run mypy src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests'
     language: system
   - id: pytest
     stages: [commit]

--- a/src/checkout_workflow/checkout_args.py
+++ b/src/checkout_workflow/checkout_args.py
@@ -6,12 +6,13 @@
 
 import argparse
 import logging
+from typing import IO
 
 
 class CheckoutArgs:
-    manifest: str
+    manifest: IO
 
-    def __init__(self):
+    def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="Checkout an OpenSearch Bundle")
         parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
         parser.add_argument(

--- a/tests/tests_checkout_workflow/test_checkout_args.py
+++ b/tests/tests_checkout_workflow/test_checkout_args.py
@@ -28,9 +28,9 @@ class TestCheckoutArgs(unittest.TestCase):
     )
 
     @patch("argparse._sys.argv", [CHECKOUT_PY, OPENSEARCH_MANIFEST])
-    def test_manifest(self):
+    def test_manifest(self) -> None:
         self.assertEqual(CheckoutArgs().manifest.name, TestCheckoutArgs.OPENSEARCH_MANIFEST)
 
     @patch("argparse._sys.argv", [CHECKOUT_PY, OPENSEARCH_MANIFEST, "--verbose"])
-    def test_verbose_true(self):
+    def test_verbose_true(self) -> None:
         self.assertTrue(CheckoutArgs().logging_level, logging.DEBUG)


### PR DESCRIPTION
Signed-off-by: Yilin Zhang <yilizhan@amazon.com>

### Description
Adding typechecking onto all files under src/checkout_workflow
```
pipenv run mypy src/checkout_workflow tests/tests_checkout_workflow
Success: no issues found in 4 source files
```
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
