### PR TITLE
Enable builds of 1.1.1 in Jenkins now

### DIFF
--- a/.github/meta_issue_template/release-1.1.1-component-issues.md
+++ b/.github/meta_issue_template/release-1.1.1-component-issues.md
@@ -14,7 +14,7 @@ Steps have completion dates for coordinating efforts between the components of a
 
 You can find all the corresponding dates of each step in the release issue above.
 
-### What should I do if my plugin isn't making any changes?
+## What should I do if my plugin isn't making any changes?
 If including changes in this release, increment the version on 1.1 branch to `1.1.1` for Min/Core, and `1.1.1.0` for components. Otherwise, keep the version number unchanged for both.
 
 </p>

--- a/.github/meta_issue_template/release-1.3.0-component-issues.md
+++ b/.github/meta_issue_template/release-1.3.0-component-issues.md
@@ -14,7 +14,7 @@ Steps have completion dates for coordinating efforts between the components of a
 
 You can find all the corresponding dates of each step in the release issue above.
 
-### What should I do if my plugin isn't making any changes?
+## What should I do if my plugin isn't making any changes?
 If including changes in this release, increment the version on 1.1 branch to `1.1.1` for Min/Core, and `1.1.1.0` for components. Otherwise, keep the version number unchanged for both.
 
 </p>

--- a/jenkins/opensearch-dashboards/Jenkinsfile
+++ b/jenkins/opensearch-dashboards/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     agent none
     triggers {
         parameterizedCron '''
+            H */2 * * * %INPUT_MANIFEST=1.1.1/opensearch-dashboards-1.1.1.yml
             H */2 * * * %INPUT_MANIFEST=1.3.0/opensearch-dashboards-1.3.0.yml
             H 1 * * * %INPUT_MANIFEST=2.0.0/opensearch-dashboards-2.0.0.yml
         '''

--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
     agent none
     triggers {
         parameterizedCron '''
+            H */2 * * * %INPUT_MANIFEST=1.1.1/opensearch-1.1.1.yml
             H */2 * * * %INPUT_MANIFEST=1.3.0/opensearch-1.3.0.yml
             H 1 * * * %INPUT_MANIFEST=2.0.0/opensearch-2.0.0.yml
         '''


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Enable builds of 1.1.1 in Jenkins now
 
### Issues Resolved
Relate to #870
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
