### PR TITLE
Fix: Relax compatible versions checks for snapshot dependencies.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E722
-max-line-length = 160
+ignore = E722,W503
+max-line-length = 200

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -28,7 +28,7 @@ class BuildTarget:
         name=None,
         snapshot=True,
         build_id=None,
-        output_dir="artifacts",
+        output_dir="artifacts"
     ):
         self.build_id = os.getenv("BUILD_NUMBER") or build_id or uuid.uuid4().hex
         self.name = name
@@ -45,7 +45,11 @@ class BuildTarget:
 
     @property
     def compatible_opensearch_versions(self):
-        return list(map(lambda version: version + "-SNAPSHOT" if self.snapshot else version, self.compatible_versions))
+        return (
+            [self.version + "-SNAPSHOT" if self.snapshot else self.version]
+            + self.patches
+            + list(map(lambda version: version + "-SNAPSHOT", self.patches))
+        )
 
     @property
     def component_version(self):
@@ -54,8 +58,11 @@ class BuildTarget:
 
     @property
     def compatible_component_versions(self):
-        # BUG: the 4th digit is dictated by the component, it's not .0, this will break for 1.1.0.1
-        return list(map(lambda version: version + ".0-SNAPSHOT" if self.snapshot else f"{version}.0", self.compatible_versions))
+        return (
+            [self.version + ".0-SNAPSHOT" if self.snapshot else f"{self.version}.0"]
+            + list(map(lambda version: version + ".0", self.patches))
+            + list(map(lambda version: version + ".0-SNAPSHOT", self.patches))
+        )
 
     @property
     def compatible_versions(self):

--- a/src/build_workflow/builder_from_dist.py
+++ b/src/build_workflow/builder_from_dist.py
@@ -36,15 +36,16 @@ class BuilderFromDist(Builder):
         logging.info(f"Distribution was built from {component_manifest.repository}#{component_manifest.ref}")
         build_recorder.record_component(self.component.name, BuilderFromDist.ManifestGitRepository(component_manifest))
         for artifact_type in component_manifest.artifacts:
-            artifact_path = os.path.join(self.output_path, artifact_type)
-            logging.info(f"Downloading into {artifact_path} ...")
-            for artifact in component_manifest.artifacts[artifact_type]:
-                artifact_url = f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds/{self.target_name}/{artifact}"
-                artifact_dest = os.path.realpath(os.path.join(self.output_path, artifact))
-                os.makedirs(os.path.dirname(artifact_dest), exist_ok=True)
-                logging.info(f"Downloading {artifact_url} into {artifact_dest}")
-                urllib.request.urlretrieve(artifact_url, artifact_dest)
-                build_recorder.record_artifact(self.component.name, artifact_type, artifact, artifact_dest)
+            if artifact_type not in ["maven"]:  # avoid re-publishing maven artifacts, see https://github.com/opensearch-project/opensearch-build/issues/1279
+                artifact_path = os.path.join(self.output_path, artifact_type)
+                logging.info(f"Downloading into {artifact_path} ...")
+                for artifact in component_manifest.artifacts[artifact_type]:
+                    artifact_url = f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds/{self.target_name}/{artifact}"
+                    artifact_dest = os.path.realpath(os.path.join(self.output_path, artifact))
+                    os.makedirs(os.path.dirname(artifact_dest), exist_ok=True)
+                    logging.info(f"Downloading {artifact_url} into {artifact_dest}")
+                    urllib.request.urlretrieve(artifact_url, artifact_dest)
+                    build_recorder.record_artifact(self.component.name, artifact_type, artifact, artifact_dest)
 
     def __download_build_manifest(self):
         url = f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds/{self.target_name}/manifest.yml"

--- a/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_maven.py
+++ b/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_maven.py
@@ -54,6 +54,6 @@ class TestBuildArtifactOpenSearchCheckMaven(unittest.TestCase):
                 mock.check("valid.jar")
 
         self.assertEqual(
-            "Artifact valid.jar is invalid. Expected to have Implementation-Version=any of [None, '1.1.0.0', '1.0.0.0', '1.1.0', '1.0.0'], but was '1.2.3.4'.",
+            "Artifact valid.jar is invalid. Expected to have Implementation-Version=any of [None, '1.1.0.0', '1.0.0.0', '1.0.0.0-SNAPSHOT', '1.1.0', '1.0.0', '1.0.0-SNAPSHOT'], but was '1.2.3.4'.",
             str(context.exception),
         )

--- a/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_plugin.py
+++ b/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_plugin.py
@@ -26,7 +26,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
                     version="1.1.0",
                     patches=["1.0.0"],
                     architecture="x64",
-                    snapshot=snapshot,
+                    snapshot=snapshot
                 )
             )
 
@@ -35,8 +35,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
             with self.__mock() as mock:
                 mock.check("invalid.zip")
         self.assertEqual(
-            "Artifact invalid.zip is invalid. Expected filename to include one of ['1.1.0.0-SNAPSHOT', '1.0.0.0-SNAPSHOT'].",
-            str(context.exception),
+            "Artifact invalid.zip is invalid. Expected filename to include one of ['1.1.0.0-SNAPSHOT', '1.0.0.0', '1.0.0.0-SNAPSHOT'].", str(context.exception)
         )
 
     def test_check_plugin_zip_version(self):
@@ -44,8 +43,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
             with self.__mock(snapshot=False) as mock:
                 mock.check("invalid.zip")
         self.assertEqual(
-            "Artifact invalid.zip is invalid. Expected filename to include one of ['1.1.0.0', '1.0.0.0'].",
-            str(context.exception),
+            "Artifact invalid.zip is invalid. Expected filename to include one of ['1.1.0.0', '1.0.0.0', '1.0.0.0-SNAPSHOT'].", str(context.exception)
         )
 
     def test_check_plugin_version_properties_missing(self, *mocks):
@@ -53,7 +51,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
             with self.__mock("") as mock:
                 mock.check("valid-1.1.0.0-SNAPSHOT.zip")
         self.assertEqual(
-            "Artifact valid-1.1.0.0-SNAPSHOT.zip is invalid. Expected to have version=any of ['1.1.0.0-SNAPSHOT', '1.0.0.0-SNAPSHOT'], but none was found.",
+            "Artifact valid-1.1.0.0-SNAPSHOT.zip is invalid. Expected to have version=any of ['1.1.0.0-SNAPSHOT', '1.0.0.0', '1.0.0.0-SNAPSHOT'], but none was found.",
             str(context.exception),
         )
 
@@ -62,7 +60,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
             with self.__mock("version=1.2.3.4") as mock:
                 mock.check("valid-1.1.0.0-SNAPSHOT.zip")
             self.assertEqual(
-                "Artifact valid-1.1.0.0-SNAPSHOT.zip is invalid. Expected to have version=any of ['1.1.0.0-SNAPSHOT', '1.0.0.0-SNAPSHOT'], but was '1.2.3.4'.",
+                "Artifact valid-1.1.0.0-SNAPSHOT.zip is invalid. Expected to have version=any of ['1.1.0-SNAPSHOT', '1.0.0.0', '1.0.0.0-SNAPSHOT'], but was '1.2.3.4'.",
                 str(context.exception),
             )
 

--- a/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
+++ b/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
@@ -71,7 +71,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             with self.__mock(snapshot=False) as mock:
                 mock.check("pluginName-1.1.0.zip")
         self.assertEqual(
-            "Artifact pluginName-1.1.0.zip is invalid. Expected to have version=any of ['1.1.0.0', '1.0.0.0'], but none was found.",
+            "Artifact pluginName-1.1.0.zip is invalid. Expected to have version=any of ['1.1.0.0', '1.0.0.0', '1.0.0.0-SNAPSHOT'], but none was found.",
             str(context.exception),
         )
 

--- a/tests/tests_build_workflow/test_build_target.py
+++ b/tests/tests_build_workflow/test_build_target.py
@@ -34,13 +34,13 @@ class TestBuildTarget(unittest.TestCase):
     def test_compatible_opensearch_versions(self):
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_opensearch_versions,
-            ["1.1.2", "1.1.0", "1.1.1"],
+            ['1.1.2', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
     def test_compatible_opensearch_versions_snapshot(self):
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_opensearch_versions,
-            ["1.1.2-SNAPSHOT", "1.1.0-SNAPSHOT", "1.1.1-SNAPSHOT"],
+            ['1.1.2-SNAPSHOT', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
     def test_opensearch_version_snapshot(self):
@@ -58,13 +58,13 @@ class TestBuildTarget(unittest.TestCase):
     def test_compatible_component_versions(self):
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_component_versions,
-            ["1.1.2.0", "1.1.0.0", "1.1.1.0"],
+            ['1.1.2.0', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
         )
 
     def test_compatible_component_versions_snapshot(self):
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_component_versions,
-            ["1.1.2.0-SNAPSHOT", "1.1.0.0-SNAPSHOT", "1.1.1.0-SNAPSHOT"],
+            ['1.1.2.0-SNAPSHOT', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
         )
 
     def test_component_version_snapshot(self):

--- a/tests/tests_build_workflow/test_builder_from_dist.py
+++ b/tests/tests_build_workflow/test_builder_from_dist.py
@@ -15,9 +15,9 @@ from manifests.input_manifest import InputComponentFromDist
 
 
 class TestBuilderFromDist(unittest.TestCase):
-    def setUp(self):
-        self.builder = BuilderFromDist(
-            InputComponentFromDist({"name": "common-utils", "dist": "url"}),
+    def __mock_builder(self, component_name):
+        return BuilderFromDist(
+            InputComponentFromDist({"name": component_name, "dist": "url"}),
             BuildTarget(
                 name="OpenSearch",
                 version="1.1.0",
@@ -28,16 +28,16 @@ class TestBuilderFromDist(unittest.TestCase):
         )
 
     def test_builder(self):
-        self.assertEqual(self.builder.component.name, "common-utils")
+        self.assertEqual(self.__mock_builder("common-utils").component.name, "common-utils")
 
     @patch("build_workflow.builder_from_dist.BuildManifest")
     def test_checkout(self, mock_manifest):
-        self.builder.checkout("dir")
+        self.__mock_builder("common-utils").checkout("dir")
         mock_manifest.from_url.assert_called_with("url/windows/x64/builds/opensearch/manifest.yml")
 
     def test_build(self):
         build_recorder = MagicMock()
-        self.builder.build(build_recorder)
+        self.__mock_builder("common-utils").build(build_recorder)
 
     @patch("os.makedirs")
     @patch("urllib.request.urlretrieve")
@@ -45,14 +45,29 @@ class TestBuilderFromDist(unittest.TestCase):
     def test_export_artifacts(self, mock_manifest_git_repository, mock_urllib, mock_makedirs, *mocks):
         build_recorder = MagicMock()
         manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-windows-1.1.0.yml")
-        self.builder.build_manifest = BuildManifest.from_path(manifest_path)
-        self.builder.export_artifacts(build_recorder)
-        build_recorder.record_component.assert_called_with("common-utils", mock_manifest_git_repository.return_value)
+        mock_builder = self.__mock_builder("notifications")
+        mock_builder.build_manifest = BuildManifest.from_path(manifest_path)
+        mock_builder.export_artifacts(build_recorder)
+        build_recorder.record_component.assert_called_with(
+            "notifications", mock_manifest_git_repository.return_value)
         mock_makedirs.assert_called_with(
-            os.path.realpath(os.path.join("builds", "maven", "org", "opensearch", "common-utils", "1.1.0.0")),
+            os.path.realpath(os.path.join("builds", "plugins")),
             exist_ok=True
         )
         mock_urllib.assert_called_with(
-            "url/windows/x64/builds/opensearch/maven/org/opensearch/common-utils/1.1.0.0/common-utils-1.1.0.0.jar",
-            os.path.realpath(os.path.join("builds", "maven", "org", "opensearch", "common-utils", "1.1.0.0", "common-utils-1.1.0.0.jar")),
+            "url/windows/x64/builds/opensearch/plugins/opensearch-notifications-1.1.0.0.zip",
+            os.path.realpath(os.path.join("builds", "plugins", "opensearch-notifications-1.1.0.0.zip")),
         )
+
+    @patch("os.makedirs")
+    @patch("urllib.request.urlretrieve")
+    @patch("build_workflow.builder_from_dist.BuilderFromDist.ManifestGitRepository")
+    def test_export_artifacts_skips_maven_artifacts(self, mock_manifest_git_repository, mock_urllib, mock_makedirs, *mocks):
+        build_recorder = MagicMock()
+        manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-windows-1.1.0.yml")
+        mock_builder = self.__mock_builder("common-utils")
+        mock_builder.build_manifest = BuildManifest.from_path(manifest_path)
+        mock_builder.export_artifacts(build_recorder)
+        build_recorder.record_component.assert_called_with("common-utils", mock_manifest_git_repository.return_value)
+        mock_makedirs.assert_called_with("builds", exist_ok=True)
+        mock_urllib.assert_not_called()


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

When building a snapshot patch build we reference released components that aren't -SNAPSHOT causing the version checks to trip. 

```
expected version to be one of [None, '1.1.1.0-SNAPSHOT', '1.1.0.0-SNAPSHOT', '1.1.1-SNAPSHOT', '1.1.0-SNAPSHOT'], but was '1.1.0.0'.
```

This is saying that the downloaded artifact was `1.1.0.0`, but we're building `1.1.0.1-SNAPSHOT` and we expected `1.1.0.0-SNAPSHOT` at the very least. 

The first option was to disable snapshot build for the patch releases. But patch releases may very well contain snapshots for things like common-utils or job-scheduler-spi that need to be uploaded to AWS OSS repo, thus that is not a good plan.

The next obvious solution would be to download and use artifacts from a -SNAPSHOT build when building a snapshot version, but we never publish complete -SNAPSHOT build artifacts, since the only purpose of snapshot artifacts is to publish snapshot JARs to maven. On the other hand, if we were able to download 1.1.0.0-SNAPSHOT artifacts, we would probably not want to re-publish them either (they have already been published and we may potentially publish an older version on top of a newer one accidentally).

This PR fixes the build by relaxing the version compatibility checks to allow -SNAPSHOT builds to use both snapshot and non-snapshot older dependencies in the distribution. Since an older version has already been released, this is actually semantically correct.

<strike>But once this build succeeds, I believe our maven snapshot publication script will attempt to publish everything in maven/*, including non-snapshot artifacts, to the AWS OSS snapshot repo. Is this a problem?</strike>

Once this build succeeds,  our maven snapshot publication script attempts to publish everything in `maven/*`. This PR excludes downloading those non-snapshot maven artifacts to avoid pushing them to the AWS OSS snapshot repo.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/1279

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
