### PR TITLE
Always create a maven directory, but do not download.

### DIFF
--- a/src/build_workflow/builder_from_dist.py
+++ b/src/build_workflow/builder_from_dist.py
@@ -36,9 +36,10 @@ class BuilderFromDist(Builder):
         logging.info(f"Distribution was built from {component_manifest.repository}#{component_manifest.ref}")
         build_recorder.record_component(self.component.name, BuilderFromDist.ManifestGitRepository(component_manifest))
         for artifact_type in component_manifest.artifacts:
+            artifact_path = os.path.realpath(os.path.join(self.output_path, artifact_type))
+            logging.info(f"Downloading into {artifact_path} ...")
+            os.makedirs(artifact_path, exist_ok=True)
             if artifact_type not in ["maven"]:  # avoid re-publishing maven artifacts, see https://github.com/opensearch-project/opensearch-build/issues/1279
-                artifact_path = os.path.join(self.output_path, artifact_type)
-                logging.info(f"Downloading into {artifact_path} ...")
                 for artifact in component_manifest.artifacts[artifact_type]:
                     artifact_url = f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds/{self.target_name}/{artifact}"
                     artifact_dest = os.path.realpath(os.path.join(self.output_path, artifact))

--- a/tests/tests_build_workflow/test_builder_from_dist.py
+++ b/tests/tests_build_workflow/test_builder_from_dist.py
@@ -69,5 +69,9 @@ class TestBuilderFromDist(unittest.TestCase):
         mock_builder.build_manifest = BuildManifest.from_path(manifest_path)
         mock_builder.export_artifacts(build_recorder)
         build_recorder.record_component.assert_called_with("common-utils", mock_manifest_git_repository.return_value)
-        mock_makedirs.assert_called_with("builds", exist_ok=True)
+        # creates a directory to allow publish-snapshot.sh to run, but does not download
+        mock_makedirs.assert_called_with(
+            os.path.realpath(os.path.join("builds", "maven")),
+            exist_ok=True
+        )
         mock_urllib.assert_not_called()


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

We invoke `publish-snapshot.sh` on a directory that may not exist. Always create it when building from dist, but don't download anything into it.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
