### PR TITLE
Fix snapshot build.

### DIFF
--- a/jenkins/opensearch/Jenkinsfile
+++ b/jenkins/opensearch/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
                                 snapshot: true
                             )
                             withCredentials([usernamePassword(credentialsId: 'Sonatype', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD')]) {
-                                sh('$WORKSPACE/publish/publish-snapshot.sh $WORKSPACE/builds/opensearch/maven')
+                                sh('test -d $WORKSPACE/builds/opensearch/maven && $WORKSPACE/publish/publish-snapshot.sh $WORKSPACE/builds/opensearch/maven')
                             }
                         }
                     }

--- a/src/build_workflow/builder_from_dist.py
+++ b/src/build_workflow/builder_from_dist.py
@@ -36,9 +36,8 @@ class BuilderFromDist(Builder):
         logging.info(f"Distribution was built from {component_manifest.repository}#{component_manifest.ref}")
         build_recorder.record_component(self.component.name, BuilderFromDist.ManifestGitRepository(component_manifest))
         for artifact_type in component_manifest.artifacts:
-            artifact_path = os.path.realpath(os.path.join(self.output_path, artifact_type))
+            artifact_path = os.path.join(self.output_path, artifact_type)
             logging.info(f"Downloading into {artifact_path} ...")
-            os.makedirs(artifact_path, exist_ok=True)
             if artifact_type not in ["maven"]:  # avoid re-publishing maven artifacts, see https://github.com/opensearch-project/opensearch-build/issues/1279
                 for artifact in component_manifest.artifacts[artifact_type]:
                     artifact_url = f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds/{self.target_name}/{artifact}"

--- a/tests/tests_build_workflow/test_builder_from_dist.py
+++ b/tests/tests_build_workflow/test_builder_from_dist.py
@@ -69,9 +69,5 @@ class TestBuilderFromDist(unittest.TestCase):
         mock_builder.build_manifest = BuildManifest.from_path(manifest_path)
         mock_builder.export_artifacts(build_recorder)
         build_recorder.record_component.assert_called_with("common-utils", mock_manifest_git_repository.return_value)
-        # creates a directory to allow publish-snapshot.sh to run, but does not download
-        mock_makedirs.assert_called_with(
-            os.path.realpath(os.path.join("builds", "maven")),
-            exist_ok=True
-        )
+        mock_makedirs.assert_called_with("builds", exist_ok=True)
         mock_urllib.assert_not_called()


### PR DESCRIPTION
Reverts opensearch-project/opensearch-build#1281 and checks whether the maven folder exists.

