### PR TITLE
Fix: check for maven directory in build.

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -44,8 +44,12 @@ pipeline {
                             buildManifest(
                                 snapshot: true
                             )
-                            withCredentials([usernamePassword(credentialsId: 'Sonatype', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD')]) {
-                                sh('test -d $WORKSPACE/builds/opensearch/maven && $WORKSPACE/publish/publish-snapshot.sh $WORKSPACE/builds/opensearch/maven')
+                            if (fileExists("$WORKSPACE/builds/opensearch/maven")) {
+                                withCredentials([usernamePassword(credentialsId: 'Sonatype', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD')]) {
+                                    sh('$WORKSPACE/publish/publish-snapshot.sh $WORKSPACE/builds/opensearch/maven')
+                                }
+                            } else {
+                                echo "Skipping publishing snapshots, builds/opensearch/maven does not exist."
                             }
                         }
                     }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Use a Jenkins pipeline script for checking whether the maven folder exists.
 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
