### PR TITLE
Manually generate 1.2.1 release from 1.2.0

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
         parameterizedCron '''
             H/10 * * * * %INPUT_MANIFEST=1.1.1/opensearch-1.1.1.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.1.1/opensearch-dashboards-1.1.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
+            H/10 * * * * %INPUT_MANIFEST=1.2.1/opensearch-1.2.1.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.3.0/opensearch-1.3.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.3.0/opensearch-dashboards-1.3.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H 1 * * * %INPUT_MANIFEST=2.0.0/opensearch-2.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch

--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -1,0 +1,99 @@
+---
+schema-version: "1.0"
+ci:
+  image:
+     name: "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028"
+     args: "-e JAVA_HOME=/usr/lib/jvm/adoptopenjdk-14-hotspot"
+build:
+  name: OpenSearch
+  version: 1.2.1
+components:
+  - name: OpenSearch
+    repository: https://github.com/opensearch-project/OpenSearch.git
+    ref: tags/1.2.0
+    checks:
+      - gradle:publish
+      - gradle:properties:version
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: "1.2"
+    checks:
+      - gradle:publish
+      - gradle:properties:version
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting
+  - name: asynchronous-search
+    repository: https://github.com/opensearch-project/asynchronous-search.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: index-management
+    repository: https://github.com/opensearch-project/index-management.git
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: k-NN
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: tags/1.2.0.0
+    platforms:
+      - darwin
+      - linux
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: "1.2"
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+    platforms:
+      - darwin
+      - linux
+  - name: anomaly-detection
+    repository: https://github.com/opensearch-project/anomaly-detection.git
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: cross-cluster-replication
+    repository: https://github.com/opensearch-project/cross-cluster-replication.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: sql
+    repository: https://github.com/opensearch-project/sql.git
+    ref: "1.2.0.0"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: plugin
+  - name: dashboards-reports
+    repository: https://github.com/opensearch-project/dashboards-reports.git
+    ref: "1.2.0.0"
+    working_directory: "reports-scheduler"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: opensearch-observability
+    repository: https://github.com/opensearch-project/trace-analytics.git
+    ref: "1.2.0.0"
+    working_directory: "opensearch-observability"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version

--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -9,91 +9,58 @@ build:
   version: 1.2.1
 components:
   - name: OpenSearch
-    repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: tags/1.2.0
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:publish
-      - gradle:properties:version
+      - manifest:component
   - name: common-utils
-    repository: https://github.com/opensearch-project/common-utils.git
-    ref: "1.2"
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:publish
-      - gradle:properties:version
+      - manifest:component
   - name: job-scheduler
-    repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: "1.2"
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
+      - manifest:component
   - name: alerting
-    repository: https://github.com/opensearch-project/alerting.git
-    ref: "1.2"
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: alerting
+      - manifest:component
   - name: asynchronous-search
-    repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: "1.2"
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
+      - manifest:component
   - name: index-management
-    repository: https://github.com/opensearch-project/index-management.git
-    ref: tags/1.2.0.0
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
+      - manifest:component
   - name: k-NN
-    repository: https://github.com/opensearch-project/k-NN.git
-    ref: tags/1.2.0.0
-    platforms:
-      - darwin
-      - linux
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
+      - manifest:component
   - name: security
-    repository: https://github.com/opensearch-project/security.git
-    ref: "1.2"
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
+    checks:
+      - manifest:component
   - name: performance-analyzer
-    repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: tags/1.2.0.0
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
-    platforms:
-      - darwin
-      - linux
+      - manifest:component
   - name: anomaly-detection
-    repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: tags/1.2.0.0
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
+      - manifest:component
   - name: cross-cluster-replication
-    repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: "1.2"
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
+      - manifest:component
   - name: sql
-    repository: https://github.com/opensearch-project/sql.git
-    ref: "1.2.0.0"
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: plugin
+      - manifest:component
   - name: dashboards-reports
-    repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: "1.2.0.0"
-    working_directory: "reports-scheduler"
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
+      - manifest:component
   - name: opensearch-observability
-    repository: https://github.com/opensearch-project/trace-analytics.git
-    ref: "1.2.0.0"
-    working_directory: "opensearch-observability"
+    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
+      - manifest:component

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -48,12 +48,6 @@ class BuildArgs:
             action="store_true",
             help="Do not delete the working temporary directory.",
         )
-        parser.add_argument(
-            "--patch",
-            dest="patch",
-            action="store_true",
-            help="Create a patch manifest.",
-        )
         parser.add_argument("-p", "--platform", type=str, choices=self.SUPPORTED_PLATFORMS, help="Platform to build.")
         parser.add_argument("-a", "--architecture", type=str, choices=self.SUPPORTED_ARCHITECTURES, help="Architecture to build.")
         parser.add_argument(
@@ -73,7 +67,6 @@ class BuildArgs:
         self.snapshot = args.snapshot
         self.component = args.component
         self.keep = args.keep
-        self.patch = args.patch
         self.platform = args.platform
         self.architecture = args.architecture
         self.script_path = sys.argv[0].replace("/src/run_build.py", "/build.sh")

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -48,6 +48,12 @@ class BuildArgs:
             action="store_true",
             help="Do not delete the working temporary directory.",
         )
+        parser.add_argument(
+            "--patch",
+            dest="patch",
+            action="store_true",
+            help="Create a patch manifest.",
+        )
         parser.add_argument("-p", "--platform", type=str, choices=self.SUPPORTED_PLATFORMS, help="Platform to build.")
         parser.add_argument("-a", "--architecture", type=str, choices=self.SUPPORTED_ARCHITECTURES, help="Architecture to build.")
         parser.add_argument(
@@ -67,6 +73,7 @@ class BuildArgs:
         self.snapshot = args.snapshot
         self.component = args.component
         self.keep = args.keep
+        self.patch = args.patch
         self.platform = args.platform
         self.architecture = args.architecture
         self.script_path = sys.argv[0].replace("/src/run_build.py", "/build.sh")

--- a/src/build_workflow/builder_from_dist.py
+++ b/src/build_workflow/builder_from_dist.py
@@ -7,6 +7,7 @@
 import logging
 import os
 import urllib.request
+from typing import List
 
 from build_workflow.builder import Builder
 from manifests.build_manifest import BuildManifest
@@ -40,14 +41,28 @@ class BuilderFromDist(Builder):
             logging.info(f"Downloading into {artifact_path} ...")
             if artifact_type not in ["maven"]:  # avoid re-publishing maven artifacts, see https://github.com/opensearch-project/opensearch-build/issues/1279
                 for artifact in component_manifest.artifacts[artifact_type]:
-                    artifact_url = f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds/{self.target_name}/{artifact}"
-                    artifact_dest = os.path.realpath(os.path.join(self.output_path, artifact))
-                    os.makedirs(os.path.dirname(artifact_dest), exist_ok=True)
-                    logging.info(f"Downloading {artifact_url} into {artifact_dest}")
-                    urllib.request.urlretrieve(artifact_url, artifact_dest)
-                    build_recorder.record_artifact(self.component.name, artifact_type, artifact, artifact_dest)
+                    for url_pattern in self.__get_url_patterns():
+                        artifact_url = f"{url_pattern}/{artifact}"
+                        try:
+                            artifact_dest = os.path.realpath(os.path.join(self.output_path, artifact))
+                            os.makedirs(os.path.dirname(artifact_dest), exist_ok=True)
+                            logging.info(f"Downloading {artifact_url} into {artifact_dest}")
+                            urllib.request.urlretrieve(artifact_url, artifact_dest)
+                            build_recorder.record_artifact(self.component.name, artifact_type, artifact, artifact_dest)
+                        except:
+                            pass
 
     def __download_build_manifest(self):
-        url = f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds/{self.target_name}/manifest.yml"
-        logging.info(f"Downloading {url} ...")
-        self.build_manifest = BuildManifest.from_url(url)
+        for url_pattern in self.__get_url_patterns():
+            manifest_url = f"{url_pattern}/manifest.yml"
+            try:
+                logging.info(f"Downloading {manifest_url} ...")
+                self.build_manifest = BuildManifest.from_url(manifest_url)
+            except:
+                pass
+
+    def __get_url_patterns(self) -> List[str]:
+        return [
+            f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds/{self.target_name}",
+            f"{self.component.dist}/{self.target.platform}/{self.target.architecture}/builds"
+        ]

--- a/src/ci_workflow/ci_check_manifest_component.py
+++ b/src/ci_workflow/ci_check_manifest_component.py
@@ -8,6 +8,7 @@ import logging
 
 from build_workflow.build_args import BuildArgs
 from ci_workflow.ci_check import CiCheckDist
+from manifests import distribution
 from manifests.build_manifest import BuildManifest
 
 
@@ -20,9 +21,10 @@ class CiCheckManifestComponent(CiCheckDist):
         for architecture in BuildArgs.SUPPORTED_ARCHITECTURES:
             # Since we only have 'linux' builds now we hard code it to 'linux'
             # Once we have all platform builds on S3 we can then add a second loop for 'BuildArgs.SUPPORTED_PLATFORMS'
-            url = "/".join([self.component.dist, "linux", architecture, "builds", self.target.name, "manifest.yml"])
-            self.build_manifest = BuildManifest.from_url(url)
+            distribution_url = distribution.find_build_root(self.component.dist, "linux", architecture, self.target.name)
+            manifest_url = f"{distribution_url}/manifest.yml"
+            self.build_manifest = BuildManifest.from_url(manifest_url)
             if self.component.name in self.build_manifest.components:
-                logging.info(f"Found {self.component.name} in {url}.")
+                logging.info(f"Found {self.component.name} in {manifest_url}.")
             else:
-                raise CiCheckManifestComponent.MissingComponentError(self.component.name, url)
+                raise CiCheckManifestComponent.MissingComponentError(self.component.name, manifest_url)

--- a/src/manifests/distribution.py
+++ b/src/manifests/distribution.py
@@ -1,0 +1,26 @@
+import logging
+import urllib.request
+from typing import List
+
+
+class DistributionNotFound(Exception):
+    def __init__(self, urls: List[str]):
+        self.urls = urls
+        super().__init__(f"Unable to find a distribution under urls {self.urls}")
+
+
+def find_build_root(base_url: str, platform: str, architecture: str, product_name: str) -> str:
+    possible_urls = [
+        f"{base_url}/{platform}/{architecture}/builds/{product_name}",
+        f"{base_url}/{platform}/{architecture}/builds"
+    ]
+
+    for distribution_url in possible_urls:
+        manifest_url = f"{distribution_url}/manifest.yml"
+        try:
+            with urllib.request.urlopen(manifest_url):
+                # OK we could access the manifest, return the url
+                return distribution_url
+        except:
+            logging.info(f"No build manifest found at {manifest_url}")
+    raise DistributionNotFound(possible_urls)

--- a/tests/tests_build_workflow/test_builder_from_dist.py
+++ b/tests/tests_build_workflow/test_builder_from_dist.py
@@ -60,7 +60,9 @@ class TestBuilderFromDist(unittest.TestCase):
             exist_ok=True
         )
         mock_urllib.assert_has_calls([
-            call('dist_url/plugins/opensearch-notifications-1.1.0.0.zip', '/local/home/petern/git/opensearch-build/builds/plugins/opensearch-notifications-1.1.0.0.zip')
+            call(
+                'dist_url/plugins/opensearch-notifications-1.1.0.0.zip',
+                os.path.realpath(os.path.join("builds", "plugins", "opensearch-notifications-1.1.0.0.zip")))
         ])
 
     @patch("os.makedirs")

--- a/tests/tests_ci_workflow/test_ci_check_lists_dist.py
+++ b/tests/tests_ci_workflow/test_ci_check_lists_dist.py
@@ -6,7 +6,7 @@
 
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from ci_workflow.ci_check_list_dist import CiCheckListDist
 from ci_workflow.ci_target import CiTarget
@@ -18,9 +18,10 @@ class TestCiCheckListsDist(unittest.TestCase):
     DATA = os.path.join(os.path.dirname(__file__), "data")
     BUILD_MANIFEST = os.path.join(DATA, "opensearch-1.1.0-x64-build-manifest.yml")
 
+    @patch("manifests.distribution.find_build_root")
     @patch("manifests.build_manifest.BuildManifest.from_url")
-    def test_check(self, mock_manifest, *mocks):
-        mock_manifest.return_value = BuildManifest.from_path(self.BUILD_MANIFEST)
+    def test_check(self, mock_manifest_from_url: Mock, find_build_root: Mock):
+        mock_manifest_from_url.return_value = BuildManifest.from_path(self.BUILD_MANIFEST)
         component = InputComponentFromDist({
             "name": "common-utils",
             "dist": "url",
@@ -28,7 +29,8 @@ class TestCiCheckListsDist(unittest.TestCase):
         })
         list = CiCheckListDist(component, CiTarget(version="1.1.0", name="opensearch", snapshot=True))
         list.check()
-        mock_manifest.assert_called()
+        mock_manifest_from_url.assert_called()
+        find_build_root.assert_called()
 
     def test_invalid_check(self, *mocks):
         component = InputComponentFromDist({

--- a/tests/tests_ci_workflow/test_ci_check_manifest_component.py
+++ b/tests/tests_ci_workflow/test_ci_check_manifest_component.py
@@ -6,7 +6,7 @@
 
 import os
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import Mock, call, patch
 
 from ci_workflow.ci_check_manifest_component import CiCheckManifestComponent
 from ci_workflow.ci_target import CiTarget
@@ -18,8 +18,10 @@ class TestCiCheckManifestComponent(unittest.TestCase):
     DATA = os.path.join(os.path.dirname(__file__), "data")
     BUILD_MANIFEST = os.path.join(DATA, "opensearch-1.1.0-x64-build-manifest.yml")
 
+    @patch("manifests.distribution.find_build_root")
     @patch("ci_workflow.ci_check_manifest_component.BuildManifest")
-    def test_retrieves_manifests(self, mock_manifest):
+    def test_retrieves_manifests(self, mock_manifest: Mock, find_build_root: Mock):
+        find_build_root.return_value = 'url/linux/ARCH/builds/opensearch'
         check = CiCheckManifestComponent(InputComponentFromDist({
             "name": "common-utils",
             "dist": "url"
@@ -29,12 +31,18 @@ class TestCiCheckManifestComponent(unittest.TestCase):
 
         check.check()
         mock_manifest.from_url.assert_has_calls([
-            call("url/linux/x64/builds/opensearch/manifest.yml"),
-            call("url/linux/arm64/builds/opensearch/manifest.yml"),
+            call("url/linux/ARCH/builds/opensearch/manifest.yml"),
+            call("url/linux/ARCH/builds/opensearch/manifest.yml"),
+        ])
+        find_build_root.assert_has_calls([
+            call('url', 'linux', 'x64', 'opensearch'),
+            call('url', 'linux', 'arm64', 'opensearch'),
         ])
 
+    @patch("manifests.distribution.find_build_root")
     @patch("ci_workflow.ci_check_manifest_component.BuildManifest")
-    def test_missing_component(self, mock_manifest):
+    def test_missing_component(self, mock_manifest: Mock, find_build_root: Mock):
+        find_build_root.return_value = 'url/linux/x64/builds/opensearch'
         check = CiCheckManifestComponent(InputComponentFromDist({
             "name": "does-not-exist",
             "dist": "url"
@@ -46,3 +54,4 @@ class TestCiCheckManifestComponent(unittest.TestCase):
             check.check()
 
         self.assertEqual(str(ctx.exception), "Missing does-not-exist in url/linux/x64/builds/opensearch/manifest.yml.")
+        find_build_root.assert_called()


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Creating a new release manifest for OpenSearch 1.2.1 patch release 

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
