### PR TITLE
Fix reference to distribution module

### DIFF
--- a/src/build_workflow/builder_from_dist.py
+++ b/src/build_workflow/builder_from_dist.py
@@ -8,7 +8,7 @@ import logging
 import os
 import urllib.request
 
-import manifests
+import manifests.distribution
 from build_workflow.builder import Builder
 from manifests.build_manifest import BuildManifest
 


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
This code path was broken in #1288, but was missed because type checking was not enabled on this codepath, https://github.com/opensearch-project/opensearch-build/issues/1237 is complete will prevent this scenario.
 

Bug as seen in the CI system:
```
2021-12-10 20:16:57 ERROR    Error building OpenSearch, retry with: ./build.sh manifests/1.2.1/opensearch-1.2.1.yml --component OpenSearch --snapshot
Traceback (most recent call last):
 ​File "./src/run_build.py", line 78, in <module>
   ​sys.exit(main())
 ​File "./src/run_build.py", line 65, in main
   ​builder.checkout(work_dir.name)
 ​File "/var/jenkins/workspace/distribution-build-opensearch/src/build_workflow/builder_from_dist.py", line 24, in checkout
   ​self.__download_build_manifest()
 ​File "/var/jenkins/workspace/distribution-build-opensearch/src/build_workflow/builder_from_dist.py", line 52, in __download_build_manifest
   ​self.distribution_url = manifests.distribution.find_build_root(self.component.dist, self.target.platform, self.target.architecture, self.target_name)
AttributeError: module 'manifests' has no attribute 'distribution'
```


### Testing
Re-ran the `./build.sh manifests/1.2.1/opensearch-1.2.1.yml --component OpenSearch --snapshot` and saw that it started building
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
