### PR TITLE
Update opensearch core reference to 1.2 build

### DIFF
--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -9,9 +9,11 @@ build:
   version: 1.2.1
 components:
   - name: OpenSearch
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
+    repository: https://github.com/opensearch-project/OpenSearch.git
+    ref: "1.2"
     checks:
-      - manifest:component
+      - gradle:publish
+      - gradle:properties:version
   - name: common-utils
     dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
     checks:


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Update opensearch core reference to 1.2 build, needed for https://github.com/opensearch-project/opensearch-build/issues/1290
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
