### PR TITLE
Adding patches to the 1.2.1 manifest

### DIFF
--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -7,6 +7,8 @@ ci:
 build:
   name: OpenSearch
   version: 1.2.1
+  patches: 
+    - 1.2.0
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Adds the patch property to the 1.2.1 manifest so 1.2.0 versions of components are usable in the build process.
 
### Issues Resolved
- Resolves https://github.com/opensearch-project/opensearch-build/issues/1295 

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
