### PR TITLE
Only update core for 1.2.1 aso plugin teams can depend on it for bulds

### DIFF
--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -7,8 +7,6 @@ ci:
 build:
   name: OpenSearch
   version: 1.2.1
-  patches: 
-    - 1.2.0
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
@@ -16,55 +14,3 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
-  - name: common-utils
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: job-scheduler
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: alerting
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: asynchronous-search
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: index-management
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: k-NN
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: security
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: performance-analyzer
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: anomaly-detection
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: cross-cluster-replication
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: sql
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: dashboards-reports
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: opensearch-observability
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Updating core so it will build and teams can take a dependency on it
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
