### PR TITLE
1.2.1 build all plugins

### DIFF
--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -7,8 +7,6 @@ ci:
 build:
   name: OpenSearch
   version: 1.2.1
-  patches: 
-    - 1.2.0
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
@@ -16,55 +14,3 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
-  - name: common-utils
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: job-scheduler
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: alerting
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: asynchronous-search
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: index-management
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: k-NN
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: security
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: performance-analyzer
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: anomaly-detection
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: cross-cluster-replication
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: sql
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: dashboards-reports
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component
-  - name: opensearch-observability
-    dist: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/1127
-    checks:
-      - manifest:component

--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -14,3 +14,86 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: "1.2"
+    checks:
+      - gradle:publish
+      - gradle:properties:version
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting
+  - name: asynchronous-search
+    repository: https://github.com/opensearch-project/asynchronous-search.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: index-management
+    repository: https://github.com/opensearch-project/index-management.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: k-NN
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: "1.2"
+    platforms:
+      - darwin
+      - linux
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: "1.2"
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+    platforms:
+      - darwin
+      - linux
+  - name: anomaly-detection
+    repository: https://github.com/opensearch-project/anomaly-detection.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: cross-cluster-replication
+    repository: https://github.com/opensearch-project/cross-cluster-replication.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: sql
+    repository: https://github.com/opensearch-project/sql.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: plugin
+  - name: dashboards-reports
+    repository: https://github.com/opensearch-project/dashboards-reports.git
+    ref: "1.2"
+    working_directory: "reports-scheduler"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: opensearch-observability
+    repository: https://github.com/opensearch-project/trace-analytics.git
+    ref: "1.2"
+    working_directory: "opensearch-observability"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
### Description
Adding in all plugins to the manifest so they are rebuilt for ver 1.2.1, needs to wait on plugins updating there version numbers.

Will use this to confirm that all plugins are in with latest version number:
- [x] common-utils https://github.com/opensearch-project/common-utils/pull/103 
- [x] job-scheduler
- [x] alerting https://github.com/opensearch-project/alerting/pull/255
- [ ] asynchronous-search https://github.com/opensearch-project/asynchronous-search/pull/77
- [ ] index-management https://github.com/opensearch-project/index-management/pull/222
- [ ] k-NNhttps://github.com/opensearch-project/k-NN/pull/241
- [ ] security
- [ ] performance-analyzer https://github.com/opensearch-project/performance-analyzer/pull/87
- [ ] anomaly-detection https://github.com/opensearch-project/anomaly-detection/pull/327
- [ ] cross-cluster-replication https://github.com/opensearch-project/cross-cluster-replication/pull/266
- [ ] sql https://github.com/opensearch-project/sql/pull/325
- [ ] dashboards-reports https://github.com/opensearch-project/dashboards-reports/pull/253
- [ ] opensearch-observability https://github.com/opensearch-project/trace-analytics/pull/317
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
