### PR TITLE
Adding alerting 1.2.1 to manifest

### DIFF
--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -26,3 +26,9 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting


### PR DESCRIPTION
Signed-off-by: Dave Lago <davelago@amazon.com>

### Description
Adding alerting 1.2.1 to manifest
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
