### PR TITLE
Improve output of stdout/stderr.

### DIFF
--- a/src/test_workflow/integ_test/service.py
+++ b/src/test_workflow/integ_test/service.py
@@ -89,13 +89,13 @@ class Service(abc.ABC):
                 if self.service_alive():
                     return
             except requests.exceptions.ConnectionError:
-                logging.info("Service not available yet")
-                logging.info("- stdout:")
-                logging.info(self.process_handler.stdout_data)
-
-                logging.info("- stderr:")
-                logging.info(self.process_handler.stderr_data)
-
+                logging.info("Service not available, yet")
+                stdout = self.process_handler.stdout_data
+                if stdout:
+                    logging.info("- stdout:\n{stdout}")
+                stderr = self.process_handler.stderr_data
+                if stderr:
+                    logging.info("- stderr:\n{stderr}")
             time.sleep(10)
         raise ClusterCreationException("Cluster is not available after 10 attempts")
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Compare,

#### Before

```
2021-12-11 19:14:07 INFO     Pinging service attempt 0
2021-12-11 19:14:07 INFO     Pinging https://localhost:9200/_cluster/health
2021-12-11 19:14:07 INFO     Service not available yet
2021-12-11 19:14:07 INFO     - stdout:
2021-12-11 19:14:07 INFO     
2021-12-11 19:14:07 INFO     - stderr:
2021-12-11 19:14:07 INFO     
2021-12-11 19:14:17 INFO     Pinging service attempt 1
2021-12-11 19:14:17 INFO     Pinging https://localhost:9200/_cluster/health
2021-12-11 19:14:17 INFO     Service not available yet
2021-12-11 19:14:17 INFO     - stdout:
2021-12-11 19:14:17 INFO     
2021-12-11 19:14:17 INFO     - stderr:
2021-12-11 19:14:17 INFO     
```

#### After

```
2021-12-11 19:09:55 INFO     Started OpenSearch with parent PID 82234
2021-12-11 19:09:55 INFO     Waiting for service to become available
2021-12-11 19:09:55 INFO     Pinging service attempt 0
2021-12-11 19:09:55 INFO     Pinging https://localhost:9200/_cluster/health
2021-12-11 19:09:55 INFO     Service not available, yet
2021-12-11 19:10:05 INFO     Pinging service attempt 1
2021-12-11 19:10:05 INFO     Pinging https://localhost:9200/_cluster/health
2021-12-11 19:10:05 INFO     Service not available, yet
2021-12-11 19:10:15 INFO     Pinging service attempt 2
2021-12-11 19:10:15 INFO     Pinging https://localhost:9200/_cluster/health
```

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
