### PR TITLE
fix OpenSearch Dashboards install dir

### DIFF
--- a/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
@@ -54,8 +54,6 @@ class LocalTestClusterOpenSearchDashboards(TestCluster):
 
         self.service_opensearch_dashboards = ServiceOpenSearchDashboards(
             build.version,
-            build.platform,
-            build.architecture,
             self.additional_cluster_config,
             self.security_enabled,
             self.dependency_installer_opensearch_dashboards,

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -31,8 +31,7 @@ class ServiceOpenSearchDashboards(Service):
         self.platform = platform
         self.architecture = architecture
 
-        self.install_dir = os.path.join(
-            self.work_dir, f"opensearch-dashboards-{self.version}-{self.platform}-{self.architecture}")
+        self.install_dir = os.path.join(self.work_dir, f"opensearch-dashboards-{self.version}")
 
     def start(self):
         logging.info(f"Starting OpenSearch Dashboards service from {self.work_dir}")

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -19,18 +19,12 @@ class ServiceOpenSearchDashboards(Service):
     def __init__(
         self,
         version,
-        platform,
-        architecture,
         additional_config,
         security_enabled,
         dependency_installer,
         work_dir
     ):
         super().__init__(work_dir, version, security_enabled, additional_config, dependency_installer)
-
-        self.platform = platform
-        self.architecture = architecture
-
         self.install_dir = os.path.join(self.work_dir, f"opensearch-dashboards-{self.version}")
 
     def start(self):

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_local_test_cluster_opensearch_dashboards.py
@@ -22,8 +22,6 @@ class LocalTestClusterOpenSearchDashboardsTests(unittest.TestCase):
 
         mock_bundle_manifest_opensearch_dashboards = MagicMock()
         mock_bundle_manifest_opensearch_dashboards.build.version = "1.1.0"
-        mock_bundle_manifest_opensearch_dashboards.build.platform = "linux"
-        mock_bundle_manifest_opensearch_dashboards.build.architecture = "x64"
         self.mock_bundle_manifest_opensearch_dashboards = mock_bundle_manifest_opensearch_dashboards
 
         dependency_installer_opensearch = MagicMock()
@@ -83,8 +81,6 @@ class LocalTestClusterOpenSearchDashboardsTests(unittest.TestCase):
 
         mock_service_opensearch_dashboards.assert_called_once_with(
             "1.1.0",
-            "linux",
-            "x64",
             self.additional_cluster_config,
             self.security_enabled,
             self.dependency_installer_opensearch_dashboards,

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -56,16 +56,16 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_tarfile_open.assert_called_once_with(bundle_full_name, "r")
         mock_bundle_tar.extractall.assert_called_once_with(self.work_dir)
 
-        mock_file.assert_called_once_with(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "config", "opensearch_dashboards.yml"), "a")
+        mock_file.assert_called_once_with(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "config", "opensearch_dashboards.yml"), "a")
         mock_dump.assert_called_once_with(
             {
                 "script.context.field.max_compilations_rate": "1000/1m",
-                "logging.dest": os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "logs", "opensearch_dashboards.log")
+                "logging.dest": os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log")
             }
         )
         mock_file.return_value.write.assert_called_once_with(mock_dump_result)
 
-        mock_process.assert_called_once_with("./opensearch-dashboards", os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "bin"))
+        mock_process.assert_called_once_with("./opensearch-dashboards", os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "bin"))
         self.assertEqual(mock_pid.call_count, 1)
 
     @patch("subprocess.check_call")
@@ -107,18 +107,18 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         service.start()
 
         mock_file.assert_has_calls(
-            [call(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "config", "opensearch_dashboards.yml"), "w")],
-            [call(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "config", "opensearch_dashboards.yml"), "a")],
+            [call(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "config", "opensearch_dashboards.yml"), "w")],
+            [call(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "config", "opensearch_dashboards.yml"), "a")],
         )
 
         mock_check_call.assert_called_once_with(
             "./opensearch-dashboards-plugin remove securityDashboards",
-            cwd=os.path.join("test_work_dir", "opensearch-dashboards-1.1.0-linux-x64", "bin"),
+            cwd=os.path.join("test_work_dir", "opensearch-dashboards-1.1.0", "bin"),
             shell=True
         )
 
         mock_dump.assert_called_once_with({"logging.dest": os.path.join(
-            self.work_dir, "opensearch-dashboards-1.1.0-linux-x64", "logs", "opensearch_dashboards.log")})
+            self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log")})
 
         mock_file_hanlder_for_security.close.assert_called_once()
         mock_file_hanlder_for_additional_config.write.assert_called_once_with(mock_dump_result)

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -15,8 +15,6 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
 
     def setUp(self):
         self.version = "1.1.0"
-        self.platform = "linux"
-        self.architecture = "x64"
         self.work_dir = "test_work_dir"
         self.additional_config = {"script.context.field.max_compilations_rate": "1000/1m"}
         self.dependency_installer = ""
@@ -32,8 +30,6 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
 
         service = ServiceOpenSearchDashboards(
             self.version,
-            self.platform,
-            self.architecture,
             self.additional_config,
             True,
             mock_dependency_installer,
@@ -80,8 +76,6 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
 
         service = ServiceOpenSearchDashboards(
             self.version,
-            self.platform,
-            self.architecture,
             {},
             False,
             mock_dependency_installer,
@@ -126,8 +120,6 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
     def test_endpoint_port_url(self):
         service = ServiceOpenSearchDashboards(
             self.version,
-            self.platform,
-            self.architecture,
             self.additional_config,
             True,
             self.dependency_installer,
@@ -143,8 +135,6 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
     def test_get_service_response_with_security(self, mock_url, mock_requests_get):
         service = ServiceOpenSearchDashboards(
             self.version,
-            self.platform,
-            self.architecture,
             self.additional_config,
             True,
             self.dependency_installer,
@@ -164,8 +154,6 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
     def test_get_service_response_without_security(self, mock_url, mock_requests_get):
         service = ServiceOpenSearchDashboards(
             self.version,
-            self.platform,
-            self.architecture,
             self.additional_config,
             False,
             self.dependency_installer,
@@ -184,8 +172,6 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
     def test_service_alive_green_available(self, mock_get_service_response):
         service = ServiceOpenSearchDashboards(
             self.version,
-            self.platform,
-            self.architecture,
             self.additional_config,
             True,
             self.dependency_installer,
@@ -205,8 +191,6 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
     def test_service_alive_yellow_available(self, mock_get_service_response):
         service = ServiceOpenSearchDashboards(
             self.version,
-            self.platform,
-            self.architecture,
             self.additional_config,
             True,
             self.dependency_installer,
@@ -226,8 +210,6 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
     def test_service_alive_red_unavailable(self, mock_get_service_response):
         service = ServiceOpenSearchDashboards(
             self.version,
-            self.platform,
-            self.architecture,
             self.additional_config,
             True,
             self.dependency_installer,


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
The install dir has been changed to remove architecture and platform. 
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1310

### Test
Before
```
File "/usr/share/opensearch/workspace/opensearch-build/src/test_workflow/integ_test/service_opensearch_dashboards.py", line 50, in start
    self.__add_plugin_specific_config(self.additional_config)
  File "/usr/share/opensearch/workspace/opensearch-build/src/test_workflow/integ_test/service_opensearch_dashboards.py", line 86, in __add_plugin_specific_config
    with open(self.opensearch_dashboards_yml_dir, "a") as yamlfile:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpgp4hhhgu/local-test-cluster/opensearch-dashboards-1.2.0-linux-x64/config/opensearch_dashboards.yml'
```

Now, the integ test can run successfully.

```
2021-12-11 19:14:17 INFO     Keeping /tmp/tmp24ydsfzp
2021-12-11 19:14:17 INFO     | functionalTestDashboards | with-security        | PASS  |    0 |
2021-12-11 19:14:17 INFO     | functionalTestDashboards | without-security     | PASS  |    0 |
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
