### PR TITLE
Updated manifest for 1.2.1 with tags

### DIFF
--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -10,7 +10,7 @@ build:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.1
     checks:
       - gradle:publish
       - gradle:properties:version

--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -10,43 +10,43 @@ build:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     platforms:
       - darwin
       - linux
@@ -58,7 +58,7 @@ components:
     ref: tags/1.2.1.0
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -67,32 +67,32 @@ components:
       - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     working_directory: "reports-scheduler"
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/trace-analytics.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
     working_directory: "opensearch-observability"
     checks:
       - gradle:properties:version

--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -55,7 +55,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: "1.2"
+    ref: tags/1.2.1.0
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: "1.2"


### PR DESCRIPTION
Signed-off-by: Dave Lago <davelago@amazon.com>

### Description
Updated plugin references in the `1.2.1` manifest to point to the `1.2.1.0` tags instead of the `1.2` branches

- [x] OpenSearch 
- [x] common-utils
- [x] job-scheduler
- [x] alerting
- [x] asynchronous-search
- [x] index-management
- [x] k-NN
- [x] security
- [x] performance-analyzer
- [x] anomaly-detection
- [x] cross-cluster-replication
- [x] sql
- [x] dashboards-reports
- [x] opensearch-observability

### Issues Resolved
- Finishes the post release task 'Replace refs in manifests/1.2.1 with tags.' from https://github.com/opensearch-project/opensearch-build/issues/1290
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
