### PR TITLE
Rename trace-analytics to observability

### DIFF
--- a/meta/.gitignore
+++ b/meta/.gitignore
@@ -13,6 +13,7 @@
 /security/
 /sql/
 /trace-analytics/
+/observability/
 /alerting-dashboards-plugin/
 /notifications/
 /index-management-dashboards-plugin/

--- a/meta/.meta
+++ b/meta/.meta
@@ -14,7 +14,7 @@
     "security-dashboards-plugin": "git@github.com:opensearch-project/security-dashboards-plugin.git",
     "security": "git@github.com:opensearch-project/security.git",
     "sql": "git@github.com:opensearch-project/sql.git",
-    "trace-analytics": "git@github.com:opensearch-project/trace-analytics.git",
+    "observability": "git@github.com:opensearch-project/observability.git",
     "alerting-dashboards-plugin": "git@github.com:opensearch-project/alerting-dashboards-plugin.git",
     "notifications": "git@github.com:opensearch-project/notifications.git",
     "index-management-dashboards-plugin": "git@github.com:opensearch-project/index-management-dashboards-plugin.git",

--- a/scripts/components/observabilityDashboards/build.sh
+++ b/scripts/components/observabilityDashboards/build.sh
@@ -62,7 +62,7 @@ fi
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
 mkdir -p $OUTPUT/plugins
-# For hybrid plugin it actually resides in 'trace-analytics/dashboards-observability'
+# For hybrid plugin it actually resides in 'observability/dashboards-observability'
 PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # TODO: [CLEANUP] Needed OpenSearch Dashboards git repo to build the required modules for plugins

--- a/tools/vulnerability-scan/wss-scan.config
+++ b/tools/vulnerability-scan/wss-scan.config
@@ -1,3 +1,3 @@
 baseDirPath=$(pwd)
 gitBasePath=https://github.com/opensearch-project/
-gitRepos=OpenSearch-Dashboards,alerting,alerting-dashboards-plugin,anomaly-detection,anomaly-detection-dashboards-plugin,asynchronous-search,common-utils,cross-cluster-replication,dashboards-reports,dashboards-visualizations,data-prepper,index-management,index-management-dashboards-plugin,job-scheduler,k-NN,opensearch-java,opensearch-js,opensearch-py,opensearch-dsl-py,performance-analyzer,perftop,security,security-dashboards-plugin,sql,trace-analytics
+gitRepos=OpenSearch-Dashboards,alerting,alerting-dashboards-plugin,anomaly-detection,anomaly-detection-dashboards-plugin,asynchronous-search,common-utils,cross-cluster-replication,dashboards-reports,dashboards-visualizations,data-prepper,index-management,index-management-dashboards-plugin,job-scheduler,k-NN,opensearch-java,opensearch-js,opensearch-py,opensearch-dsl-py,performance-analyzer,perftop,security,security-dashboards-plugin,sql,observability


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Trace-analytics repo is renamed to Observability, rename it here as well
 
### Issues Resolved
https://github.com/opensearch-project/observability/issues/336
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
