### PR TITLE
Add alerting component to 1.2.2 manifest

### DIFF
--- a/manifests/1.2.2/opensearch-1.2.2.yml
+++ b/manifests/1.2.2/opensearch-1.2.2.yml
@@ -26,3 +26,9 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: tags/1.2.1.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting

--- a/manifests/1.2.2/opensearch-1.2.2.yml
+++ b/manifests/1.2.2/opensearch-1.2.2.yml
@@ -28,7 +28,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: tags/1.2.1.0
+    ref: "1.2"
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Add alerting component to 1.2.2 manifest
Need to first merge: https://github.com/opensearch-project/alerting/pull/257
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
