### PR TITLE
Adding security to 1.2.2 manifest

### DIFF
--- a/manifests/1.2.2/opensearch-1.2.2.yml
+++ b/manifests/1.2.2/opensearch-1.2.2.yml
@@ -32,3 +32,6 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: "1.2"


### PR DESCRIPTION
Signed-off-by: Dave Lago <davelago@amazon.com>

### Description
Adding security plugin to 1.2.2 manifest.
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
