### PR TITLE
Add type checking for build_workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,7 @@ jobs:
           pipenv run flake8 .
       - name: Run Type Checker
         run: |
-          pipenv run mypy src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests
+          pipenv run mypy src/build_workflow tests/tests_build_workflow src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests
       - name: Run Tests with Coverage
         run: |
           pipenv run coverage run -m pytest --cov=./src --cov-report=xml

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,7 @@ jobs:
           pipenv run flake8 .
       - name: Run Type Checker
         run: |
-          pipenv run mypy src/build_workflow tests/tests_build_workflow src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests
+          pipenv run mypy src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests
       - name: Run Tests with Coverage
         run: |
           pipenv run coverage run -m pytest --cov=./src --cov-report=xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: mypy
     stages: [commit]
     name: mypy
-    entry: bash -c 'pipenv run mypy src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests'
+    entry: bash -c 'pipenv run mypy src/build_workflow tests/tests_build_workflow src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests'
     language: system
   - id: pytest
     stages: [commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: mypy
     stages: [commit]
     name: mypy
-    entry: bash -c 'pipenv run mypy src/build_workflow tests/tests_build_workflow src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests'
+    entry: bash -c 'pipenv run mypy src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests'
     language: system
   - id: pytest
     stages: [commit]

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -7,6 +7,7 @@
 import argparse
 import logging
 import sys
+from typing import IO
 
 
 class BuildArgs:
@@ -16,14 +17,14 @@ class BuildArgs:
         "arm64",
     ]
 
-    manifest: str
+    manifest: IO
     snapshot: bool
     component: str
     keep: bool
     platform: str
     architecture: str
 
-    def __init__(self):
+    def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="Build an OpenSearch Bundle")
         parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
         parser.add_argument(
@@ -71,7 +72,7 @@ class BuildArgs:
         self.architecture = args.architecture
         self.script_path = sys.argv[0].replace("/src/run_build.py", "/build.sh")
 
-    def component_command(self, name):
+    def component_command(self, name: str) -> str:
         return " ".join(
             filter(
                 None,

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -7,7 +7,6 @@
 import argparse
 import logging
 import sys
-from typing import IO
 
 
 class BuildArgs:
@@ -17,14 +16,14 @@ class BuildArgs:
         "arm64",
     ]
 
-    manifest: IO
+    manifest: str
     snapshot: bool
     component: str
     keep: bool
     platform: str
     architecture: str
 
-    def __init__(self) -> None:
+    def __init__(self):
         parser = argparse.ArgumentParser(description="Build an OpenSearch Bundle")
         parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
         parser.add_argument(
@@ -72,7 +71,7 @@ class BuildArgs:
         self.architecture = args.architecture
         self.script_path = sys.argv[0].replace("/src/run_build.py", "/build.sh")
 
-    def component_command(self, name: str) -> str:
+    def component_command(self, name):
         return " ".join(
             filter(
                 None,

--- a/src/build_workflow/build_artifact_check.py
+++ b/src/build_workflow/build_artifact_check.py
@@ -7,16 +7,18 @@
 import os
 from abc import ABC, abstractmethod
 
+from build_workflow.build_target import BuildTarget
+
 
 class BuildArtifactCheck(ABC):
     class BuildArtifactInvalidError(Exception):
-        def __init__(self, path, message):
+        def __init__(self, path: str, message: str) -> None:
             self.path = path
             super().__init__(f"Artifact {os.path.basename(path)} is invalid. {message}")
 
-    def __init__(self, target):
+    def __init__(self, target: BuildTarget) -> None:
         self.target = target
 
     @abstractmethod
-    def check(self, path):
+    def check(self, path: str) -> None:
         pass

--- a/src/build_workflow/build_artifact_check.py
+++ b/src/build_workflow/build_artifact_check.py
@@ -7,18 +7,16 @@
 import os
 from abc import ABC, abstractmethod
 
-from build_workflow.build_target import BuildTarget
-
 
 class BuildArtifactCheck(ABC):
     class BuildArtifactInvalidError(Exception):
-        def __init__(self, path: str, message: str) -> None:
+        def __init__(self, path, message):
             self.path = path
             super().__init__(f"Artifact {os.path.basename(path)} is invalid. {message}")
 
-    def __init__(self, target: BuildTarget) -> None:
+    def __init__(self, target):
         self.target = target
 
     @abstractmethod
-    def check(self, path: str) -> None:
+    def check(self, path):
         pass

--- a/src/build_workflow/build_artifact_checks.py
+++ b/src/build_workflow/build_artifact_checks.py
@@ -4,13 +4,16 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+from typing import Any, Dict
+
+from build_workflow.build_target import BuildTarget
 from build_workflow.opensearch.build_artifact_check_maven import BuildArtifactOpenSearchCheckMaven
 from build_workflow.opensearch.build_artifact_check_plugin import BuildArtifactOpenSearchCheckPlugin
 from build_workflow.opensearch_dashboards.build_artifact_check_plugin import BuildArtifactOpenSearchDashboardsCheckPlugin
 
 
 class BuildArtifactChecks:
-    TYPES = {
+    TYPES: Dict[str, Dict[str, Any]] = {
         "OpenSearch": {
             "plugins": BuildArtifactOpenSearchCheckPlugin,
             "maven": BuildArtifactOpenSearchCheckMaven,
@@ -19,21 +22,21 @@ class BuildArtifactChecks:
     }
 
     @classmethod
-    def from_name_and_type(cls, name, type):
+    def from_name_and_type(cls, name: str, type: str) -> Any:
         checks = cls.TYPES.get(name, None)
         if not checks:
             raise ValueError(f"Unsupported bundle: {name}")
         return checks.get(type, None)
 
     @classmethod
-    def create(cls, target, artifact_type):
+    def create(cls, target: BuildTarget, artifact_type: str) -> Any:
         klass = cls.from_name_and_type(target.name, artifact_type)
         if not klass:
             return None
         return klass(target)
 
     @classmethod
-    def check(cls, target, artifact_type, path):
+    def check(cls, target: BuildTarget, artifact_type: str, path: str) -> None:
         instance = cls.create(target, artifact_type)
         if instance:
             instance.check(path)

--- a/src/build_workflow/build_artifact_checks.py
+++ b/src/build_workflow/build_artifact_checks.py
@@ -4,16 +4,13 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from typing import Any, Dict
-
-from build_workflow.build_target import BuildTarget
 from build_workflow.opensearch.build_artifact_check_maven import BuildArtifactOpenSearchCheckMaven
 from build_workflow.opensearch.build_artifact_check_plugin import BuildArtifactOpenSearchCheckPlugin
 from build_workflow.opensearch_dashboards.build_artifact_check_plugin import BuildArtifactOpenSearchDashboardsCheckPlugin
 
 
 class BuildArtifactChecks:
-    TYPES: Dict[str, Dict[str, Any]] = {
+    TYPES = {
         "OpenSearch": {
             "plugins": BuildArtifactOpenSearchCheckPlugin,
             "maven": BuildArtifactOpenSearchCheckMaven,
@@ -22,21 +19,21 @@ class BuildArtifactChecks:
     }
 
     @classmethod
-    def from_name_and_type(cls, name: str, type: str) -> Any:
+    def from_name_and_type(cls, name, type):
         checks = cls.TYPES.get(name, None)
         if not checks:
             raise ValueError(f"Unsupported bundle: {name}")
         return checks.get(type, None)
 
     @classmethod
-    def create(cls, target: BuildTarget, artifact_type: str) -> Any:
+    def create(cls, target, artifact_type):
         klass = cls.from_name_and_type(target.name, artifact_type)
         if not klass:
             return None
         return klass(target)
 
     @classmethod
-    def check(cls, target: BuildTarget, artifact_type: str, path: str) -> None:
+    def check(cls, target, artifact_type, path):
         instance = cls.create(target, artifact_type)
         if instance:
             instance.check(path)

--- a/src/build_workflow/build_recorder.py
+++ b/src/build_workflow/build_recorder.py
@@ -7,21 +7,18 @@
 import logging
 import os
 import shutil
-from typing import Any, Dict
 
 from build_workflow.build_artifact_checks import BuildArtifactChecks
-from build_workflow.build_target import BuildTarget
-from git.git_repository import GitRepository
 from manifests.build_manifest import BuildManifest
 
 
 class BuildRecorder:
-    def __init__(self, target: BuildTarget):
+    def __init__(self, target):
         self.build_manifest = self.BuildManifestBuilder(target)
         self.target = target
         self.name = target.name
 
-    def record_component(self, component_name: str, git_repo: GitRepository) -> None:
+    def record_component(self, component_name, git_repo):
         self.build_manifest.append_component(
             component_name,
             self.target.component_version,
@@ -30,7 +27,7 @@ class BuildRecorder:
             git_repo.sha,
         )
 
-    def record_artifact(self, component_name: str, artifact_type: str, artifact_path: str, artifact_file: str) -> None:
+    def record_artifact(self, component_name, artifact_type, artifact_path, artifact_file):
         logging.info(f"Recording {artifact_type} artifact for {component_name}: {artifact_path} (from {artifact_file})")
         # Ensure the target directory exists
         dest_file = os.path.join(self.target.output_dir, artifact_path)
@@ -43,17 +40,17 @@ class BuildRecorder:
         # Notify the recorder
         self.build_manifest.append_artifact(component_name, artifact_type, artifact_path)
 
-    def get_manifest(self) -> BuildManifest:
+    def get_manifest(self):
         return self.build_manifest.to_manifest()
 
-    def write_manifest(self) -> None:
+    def write_manifest(self):
         manifest_path = os.path.join(self.target.output_dir, "manifest.yml")
         self.get_manifest().to_file(manifest_path)
         logging.info(f"Created build manifest {manifest_path}")
 
     class BuildManifestBuilder:
-        def __init__(self, target: BuildTarget):
-            self.data: Dict[str, Any] = {}
+        def __init__(self, target):
+            self.data = {}
             self.data["build"] = {}
             self.data["build"]["id"] = target.build_id
             self.data["build"]["name"] = target.name
@@ -61,9 +58,9 @@ class BuildRecorder:
             self.data["build"]["platform"] = target.platform
             self.data["build"]["architecture"] = target.architecture
             self.data["schema-version"] = "1.2"
-            self.components_hash: Dict[str, Dict[str, Any]] = {}
+            self.components_hash = {}
 
-        def append_component(self, name: str, version: str, repository_url: str, ref: str, commit_id: str) -> None:
+        def append_component(self, name, version, repository_url, ref, commit_id):
             component = {
                 "name": name,
                 "repository": repository_url,
@@ -74,14 +71,14 @@ class BuildRecorder:
             }
             self.components_hash[name] = component
 
-        def append_artifact(self, component: str, type: str, path: str) -> None:
+        def append_artifact(self, component, type, path):
             artifacts = self.components_hash[component]["artifacts"]
             list = artifacts.get(type, [])
             if len(list) == 0:
                 artifacts[type] = list
             list.append(path)
 
-        def to_manifest(self) -> 'BuildManifest':
+        def to_manifest(self):
             # The build manifest expects `components` to be a list, not a hash, so we need to munge things a bit
             components = self.components_hash.values()
             if len(components):

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -6,6 +6,7 @@
 
 import os
 import uuid
+from typing import List
 
 from system.os import current_architecture, current_platform
 
@@ -21,14 +22,14 @@ class BuildTarget:
 
     def __init__(
         self,
-        version,
-        patches=[],
-        platform=None,
-        architecture=None,
-        name=None,
-        snapshot=True,
-        build_id=None,
-        output_dir="artifacts"
+        version: str,
+        patches: List[str] = [],
+        platform: str = None,
+        architecture: str = None,
+        name: str = None,
+        snapshot: bool = True,
+        build_id: str = None,
+        output_dir: str = "artifacts",
     ):
         self.build_id = os.getenv("BUILD_NUMBER") or build_id or uuid.uuid4().hex
         self.name = name
@@ -40,11 +41,11 @@ class BuildTarget:
         self.output_dir = output_dir
 
     @property
-    def opensearch_version(self):
+    def opensearch_version(self) -> str:
         return self.version + "-SNAPSHOT" if self.snapshot else self.version
 
     @property
-    def compatible_opensearch_versions(self):
+    def compatible_opensearch_versions(self) -> List[str]:
         return (
             [self.version + "-SNAPSHOT" if self.snapshot else self.version]
             + self.patches
@@ -52,12 +53,12 @@ class BuildTarget:
         )
 
     @property
-    def component_version(self):
+    def component_version(self) -> str:
         # BUG: the 4th digit is dictated by the component, it's not .0, this will break for 1.1.0.1
         return self.version + ".0-SNAPSHOT" if self.snapshot else f"{self.version}.0"
 
     @property
-    def compatible_component_versions(self):
+    def compatible_component_versions(self) -> List[str]:
         return (
             [self.version + ".0-SNAPSHOT" if self.snapshot else f"{self.version}.0"]
             + list(map(lambda version: version + ".0", self.patches))
@@ -65,7 +66,7 @@ class BuildTarget:
         )
 
     @property
-    def compatible_versions(self):
+    def compatible_versions(self) -> List[str]:
         versions = [self.version]
         versions.extend(self.patches)
         return versions

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -6,7 +6,6 @@
 
 import os
 import uuid
-from typing import List
 
 from system.os import current_architecture, current_platform
 
@@ -22,14 +21,14 @@ class BuildTarget:
 
     def __init__(
         self,
-        version: str,
-        patches: List[str] = [],
-        platform: str = None,
-        architecture: str = None,
-        name: str = None,
-        snapshot: bool = True,
-        build_id: str = None,
-        output_dir: str = "artifacts",
+        version,
+        patches=[],
+        platform=None,
+        architecture=None,
+        name=None,
+        snapshot=True,
+        build_id=None,
+        output_dir="artifacts"
     ):
         self.build_id = os.getenv("BUILD_NUMBER") or build_id or uuid.uuid4().hex
         self.name = name
@@ -41,11 +40,11 @@ class BuildTarget:
         self.output_dir = output_dir
 
     @property
-    def opensearch_version(self) -> str:
+    def opensearch_version(self):
         return self.version + "-SNAPSHOT" if self.snapshot else self.version
 
     @property
-    def compatible_opensearch_versions(self) -> List[str]:
+    def compatible_opensearch_versions(self):
         return (
             [self.version + "-SNAPSHOT" if self.snapshot else self.version]
             + self.patches
@@ -53,12 +52,12 @@ class BuildTarget:
         )
 
     @property
-    def component_version(self) -> str:
+    def component_version(self):
         # BUG: the 4th digit is dictated by the component, it's not .0, this will break for 1.1.0.1
         return self.version + ".0-SNAPSHOT" if self.snapshot else f"{self.version}.0"
 
     @property
-    def compatible_component_versions(self) -> List[str]:
+    def compatible_component_versions(self):
         return (
             [self.version + ".0-SNAPSHOT" if self.snapshot else f"{self.version}.0"]
             + list(map(lambda version: version + ".0", self.patches))
@@ -66,7 +65,7 @@ class BuildTarget:
         )
 
     @property
-    def compatible_versions(self) -> List[str]:
+    def compatible_versions(self):
         versions = [self.version]
         versions.extend(self.patches)
         return versions

--- a/src/build_workflow/builder.py
+++ b/src/build_workflow/builder.py
@@ -5,22 +5,26 @@
 # compatible open source license.
 
 from abc import ABC, abstractmethod
+from typing import Any
+
+from build_workflow.build_recorder import BuildRecorder
+from build_workflow.build_target import BuildTarget
 
 
 class Builder(ABC):
-    def __init__(self, component, target):
+    def __init__(self, component: Any, target: BuildTarget) -> None:
         self.output_path = "builds"
         self.component = component
         self.target = target
 
     @abstractmethod
-    def checkout(self):
+    def checkout(self, work_dir: str) -> None:
         pass
 
     @abstractmethod
-    def build(self, build_recorder):
+    def build(self, build_recorder: BuildRecorder) -> None:
         pass
 
     @abstractmethod
-    def export_artifacts(self, build_recorder):
+    def export_artifacts(self, build_recorder: BuildRecorder) -> None:
         pass

--- a/src/build_workflow/builder.py
+++ b/src/build_workflow/builder.py
@@ -5,26 +5,22 @@
 # compatible open source license.
 
 from abc import ABC, abstractmethod
-from typing import Any
-
-from build_workflow.build_recorder import BuildRecorder
-from build_workflow.build_target import BuildTarget
 
 
 class Builder(ABC):
-    def __init__(self, component: Any, target: BuildTarget) -> None:
+    def __init__(self, component, target):
         self.output_path = "builds"
         self.component = component
         self.target = target
 
     @abstractmethod
-    def checkout(self, work_dir: str) -> None:
+    def checkout(self):
         pass
 
     @abstractmethod
-    def build(self, build_recorder: BuildRecorder) -> None:
+    def build(self, build_recorder):
         pass
 
     @abstractmethod
-    def export_artifacts(self, build_recorder: BuildRecorder) -> None:
+    def export_artifacts(self, build_recorder):
         pass

--- a/src/build_workflow/builder_from_dist.py
+++ b/src/build_workflow/builder_from_dist.py
@@ -7,30 +7,33 @@
 import logging
 import os
 import urllib.request
+from typing import Any
 
 import manifests.distribution
+from build_workflow.build_recorder import BuildRecorder
 from build_workflow.builder import Builder
+from git.git_repository import GitRepository
 from manifests.build_manifest import BuildManifest
 
 
 class BuilderFromDist(Builder):
-    class ManifestGitRepository:
-        def __init__(self, manifest):
+    class ManifestGitRepository(GitRepository):
+        def __init__(self, manifest: Any) -> None:
             self.url = manifest.repository
             self.ref = manifest.ref
             self.sha = manifest.commit_id
 
-    def checkout(self, work_dir):
+    def checkout(self, work_dir: str) -> None:
         self.__download_build_manifest()
 
-    def build(self, build_recorder):
+    def build(self, build_recorder: 'BuildRecorder') -> None:
         pass
 
     @property
-    def target_name(self):
+    def target_name(self) -> str:
         return self.target.name.lower().replace(' ', '-')
 
-    def export_artifacts(self, build_recorder):
+    def export_artifacts(self, build_recorder: 'BuildRecorder') -> None:
         os.makedirs(self.output_path, exist_ok=True)
         component_manifest = self.build_manifest.components[self.component.name]
         logging.info(f"Downloading {component_manifest.name} {component_manifest.version} ({component_manifest.commit_id}) ...")
@@ -48,7 +51,7 @@ class BuilderFromDist(Builder):
                     urllib.request.urlretrieve(artifact_url, artifact_dest)
                     build_recorder.record_artifact(self.component.name, artifact_type, artifact, artifact_dest)
 
-    def __download_build_manifest(self):
+    def __download_build_manifest(self) -> None:
         self.distribution_url = manifests.distribution.find_build_root(self.component.dist, self.target.platform, self.target.architecture, self.target_name)
         manifest_url = f"{self.distribution_url}/manifest.yml"
         logging.info(f"Downloading {manifest_url} ...")

--- a/src/build_workflow/builder_from_dist.py
+++ b/src/build_workflow/builder_from_dist.py
@@ -7,33 +7,30 @@
 import logging
 import os
 import urllib.request
-from typing import Any
 
 import manifests.distribution
-from build_workflow.build_recorder import BuildRecorder
 from build_workflow.builder import Builder
-from git.git_repository import GitRepository
 from manifests.build_manifest import BuildManifest
 
 
 class BuilderFromDist(Builder):
-    class ManifestGitRepository(GitRepository):
-        def __init__(self, manifest: Any) -> None:
+    class ManifestGitRepository:
+        def __init__(self, manifest):
             self.url = manifest.repository
             self.ref = manifest.ref
             self.sha = manifest.commit_id
 
-    def checkout(self, work_dir: str) -> None:
+    def checkout(self, work_dir):
         self.__download_build_manifest()
 
-    def build(self, build_recorder: 'BuildRecorder') -> None:
+    def build(self, build_recorder):
         pass
 
     @property
-    def target_name(self) -> str:
+    def target_name(self):
         return self.target.name.lower().replace(' ', '-')
 
-    def export_artifacts(self, build_recorder: 'BuildRecorder') -> None:
+    def export_artifacts(self, build_recorder):
         os.makedirs(self.output_path, exist_ok=True)
         component_manifest = self.build_manifest.components[self.component.name]
         logging.info(f"Downloading {component_manifest.name} {component_manifest.version} ({component_manifest.commit_id}) ...")
@@ -51,7 +48,7 @@ class BuilderFromDist(Builder):
                     urllib.request.urlretrieve(artifact_url, artifact_dest)
                     build_recorder.record_artifact(self.component.name, artifact_type, artifact, artifact_dest)
 
-    def __download_build_manifest(self) -> None:
+    def __download_build_manifest(self):
         self.distribution_url = manifests.distribution.find_build_root(self.component.dist, self.target.platform, self.target.architecture, self.target_name)
         manifest_url = f"{self.distribution_url}/manifest.yml"
         logging.info(f"Downloading {manifest_url} ...")

--- a/src/build_workflow/builder_from_source.py
+++ b/src/build_workflow/builder_from_source.py
@@ -6,6 +6,7 @@
 
 import os
 
+from build_workflow.build_recorder import BuildRecorder
 from build_workflow.builder import Builder
 from git.git_repository import GitRepository
 from paths.script_finder import ScriptFinder
@@ -18,7 +19,7 @@ Artifacts found in "<build root>/artifacts/<maven|plugins|libs|dist|core-plugins
 
 
 class BuilderFromSource(Builder):
-    def checkout(self, work_dir):
+    def checkout(self, work_dir: str) -> None:
         self.git_repo = GitRepository(
             self.component.repository,
             self.component.ref,
@@ -26,7 +27,7 @@ class BuilderFromSource(Builder):
             self.component.working_directory,
         )
 
-    def build(self, build_recorder):
+    def build(self, build_recorder: BuildRecorder) -> None:
         build_script = ScriptFinder.find_build_script(self.target.name, self.component.name, self.git_repo.working_directory)
 
         build_command = " ".join(
@@ -49,7 +50,7 @@ class BuilderFromSource(Builder):
         self.git_repo.execute(build_command)
         build_recorder.record_component(self.component.name, self.git_repo)
 
-    def export_artifacts(self, build_recorder):
+    def export_artifacts(self, build_recorder: BuildRecorder) -> None:
         artifacts_path = os.path.join(self.git_repo.working_directory, self.output_path)
         for artifact_type in ["maven", "dist", "plugins", "libs", "core-plugins"]:
             for dir, _, files in os.walk(os.path.join(artifacts_path, artifact_type)):

--- a/src/build_workflow/builder_from_source.py
+++ b/src/build_workflow/builder_from_source.py
@@ -6,7 +6,6 @@
 
 import os
 
-from build_workflow.build_recorder import BuildRecorder
 from build_workflow.builder import Builder
 from git.git_repository import GitRepository
 from paths.script_finder import ScriptFinder
@@ -19,7 +18,7 @@ Artifacts found in "<build root>/artifacts/<maven|plugins|libs|dist|core-plugins
 
 
 class BuilderFromSource(Builder):
-    def checkout(self, work_dir: str) -> None:
+    def checkout(self, work_dir):
         self.git_repo = GitRepository(
             self.component.repository,
             self.component.ref,
@@ -27,7 +26,7 @@ class BuilderFromSource(Builder):
             self.component.working_directory,
         )
 
-    def build(self, build_recorder: BuildRecorder) -> None:
+    def build(self, build_recorder):
         build_script = ScriptFinder.find_build_script(self.target.name, self.component.name, self.git_repo.working_directory)
 
         build_command = " ".join(
@@ -50,7 +49,7 @@ class BuilderFromSource(Builder):
         self.git_repo.execute(build_command)
         build_recorder.record_component(self.component.name, self.git_repo)
 
-    def export_artifacts(self, build_recorder: BuildRecorder) -> None:
+    def export_artifacts(self, build_recorder):
         artifacts_path = os.path.join(self.git_repo.working_directory, self.output_path)
         for artifact_type in ["maven", "dist", "plugins", "libs", "core-plugins"]:
             for dir, _, files in os.walk(os.path.join(artifacts_path, artifact_type)):

--- a/src/build_workflow/builders.py
+++ b/src/build_workflow/builders.py
@@ -6,14 +6,16 @@
 
 from abc import ABC
 
+from build_workflow.build_target import BuildTarget
+from build_workflow.builder import Builder
 from build_workflow.builder_from_dist import BuilderFromDist
 from build_workflow.builder_from_source import BuilderFromSource
-from manifests.input_manifest import InputComponentFromDist, InputComponentFromSource
+from manifests.input_manifest import InputComponent, InputComponentFromDist, InputComponentFromSource
 
 
 class Builders(ABC):
     @classmethod
-    def builder_from(self, component, target):
+    def builder_from(self, component: InputComponent, target: BuildTarget) -> Builder:
         if type(component) is InputComponentFromDist:
             return BuilderFromDist(component, target)
         elif type(component) is InputComponentFromSource:

--- a/src/build_workflow/builders.py
+++ b/src/build_workflow/builders.py
@@ -6,16 +6,14 @@
 
 from abc import ABC
 
-from build_workflow.build_target import BuildTarget
-from build_workflow.builder import Builder
 from build_workflow.builder_from_dist import BuilderFromDist
 from build_workflow.builder_from_source import BuilderFromSource
-from manifests.input_manifest import InputComponent, InputComponentFromDist, InputComponentFromSource
+from manifests.input_manifest import InputComponentFromDist, InputComponentFromSource
 
 
 class Builders(ABC):
     @classmethod
-    def builder_from(self, component: InputComponent, target: BuildTarget) -> Builder:
+    def builder_from(self, component, target):
         if type(component) is InputComponentFromDist:
             return BuilderFromDist(component, target)
         elif type(component) is InputComponentFromSource:

--- a/src/build_workflow/opensearch/build_artifact_check_maven.py
+++ b/src/build_workflow/opensearch/build_artifact_check_maven.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+from typing import Any, List
 from zipfile import ZipFile
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
@@ -13,7 +14,7 @@ from system.properties_file import PropertiesFile
 
 
 class BuildArtifactOpenSearchCheckMaven(BuildArtifactCheck):
-    def check(self, path):
+    def check(self, path: str) -> None:
         ext = os.path.splitext(path)[1]
         if ext not in [
             ".asc",
@@ -34,7 +35,7 @@ class BuildArtifactOpenSearchCheckMaven(BuildArtifactCheck):
                 data = zip.read("META-INF/MANIFEST.MF").decode("UTF-8")
                 properties = PropertiesFile(data)
                 try:
-                    versions = [None]
+                    versions: List[Any] = [None]
                     versions.extend(self.target.compatible_component_versions)
                     versions.extend(self.target.compatible_opensearch_versions)
                     properties.check_value_in("Implementation-Version", versions)

--- a/src/build_workflow/opensearch/build_artifact_check_maven.py
+++ b/src/build_workflow/opensearch/build_artifact_check_maven.py
@@ -6,7 +6,6 @@
 
 import logging
 import os
-from typing import Any, List
 from zipfile import ZipFile
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
@@ -14,7 +13,7 @@ from system.properties_file import PropertiesFile
 
 
 class BuildArtifactOpenSearchCheckMaven(BuildArtifactCheck):
-    def check(self, path: str) -> None:
+    def check(self, path):
         ext = os.path.splitext(path)[1]
         if ext not in [
             ".asc",
@@ -35,7 +34,7 @@ class BuildArtifactOpenSearchCheckMaven(BuildArtifactCheck):
                 data = zip.read("META-INF/MANIFEST.MF").decode("UTF-8")
                 properties = PropertiesFile(data)
                 try:
-                    versions: List[Any] = [None]
+                    versions = [None]
                     versions.extend(self.target.compatible_component_versions)
                     versions.extend(self.target.compatible_opensearch_versions)
                     properties.check_value_in("Implementation-Version", versions)

--- a/src/build_workflow/opensearch/build_artifact_check_plugin.py
+++ b/src/build_workflow/opensearch/build_artifact_check_plugin.py
@@ -13,7 +13,7 @@ from system.properties_file import PropertiesFile
 
 
 class BuildArtifactOpenSearchCheckPlugin(BuildArtifactCheck):
-    def check(self, path):
+    def check(self, path: str) -> None:
         if os.path.splitext(path)[1] != ".zip":
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")
         if not self.valid_path(path):
@@ -28,5 +28,5 @@ class BuildArtifactOpenSearchCheckPlugin(BuildArtifactCheck):
                 raise BuildArtifactCheck.BuildArtifactInvalidError(path, e.__str__())
             logging.info(f'Checked {path} ({properties.get_value("version", "N/A")})')
 
-    def valid_path(self, path):
+    def valid_path(self, path: str) -> bool:
         return any(map(lambda version: path.endswith(f"-{version}.zip"), self.target.compatible_component_versions))

--- a/src/build_workflow/opensearch/build_artifact_check_plugin.py
+++ b/src/build_workflow/opensearch/build_artifact_check_plugin.py
@@ -13,7 +13,7 @@ from system.properties_file import PropertiesFile
 
 
 class BuildArtifactOpenSearchCheckPlugin(BuildArtifactCheck):
-    def check(self, path: str) -> None:
+    def check(self, path):
         if os.path.splitext(path)[1] != ".zip":
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")
         if not self.valid_path(path):
@@ -28,5 +28,5 @@ class BuildArtifactOpenSearchCheckPlugin(BuildArtifactCheck):
                 raise BuildArtifactCheck.BuildArtifactInvalidError(path, e.__str__())
             logging.info(f'Checked {path} ({properties.get_value("version", "N/A")})')
 
-    def valid_path(self, path: str) -> bool:
+    def valid_path(self, path):
         return any(map(lambda version: path.endswith(f"-{version}.zip"), self.target.compatible_component_versions))

--- a/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
+++ b/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
@@ -7,6 +7,7 @@
 import logging
 import os
 import re
+from typing import List
 from zipfile import ZipFile
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
@@ -14,7 +15,7 @@ from system.config_file import ConfigFile
 
 
 class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
-    def check(self, path):
+    def check(self, path: str) -> None:
         if os.path.splitext(path)[1] != ".zip":
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")
 
@@ -37,5 +38,5 @@ class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
                 raise BuildArtifactCheck.BuildArtifactInvalidError(path, e.__str__())
             logging.info(f'Checked {path} ({config.get_value("version", "N/A")})')
 
-    def __valid_paths(self, pluginName):
+    def __valid_paths(self, pluginName: str) -> List[str]:
         return list(map(lambda version: f"{pluginName}-{version}.zip", self.target.compatible_versions))

--- a/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
+++ b/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
@@ -7,7 +7,6 @@
 import logging
 import os
 import re
-from typing import List
 from zipfile import ZipFile
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
@@ -15,7 +14,7 @@ from system.config_file import ConfigFile
 
 
 class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
-    def check(self, path: str) -> None:
+    def check(self, path):
         if os.path.splitext(path)[1] != ".zip":
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")
 
@@ -38,5 +37,5 @@ class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
                 raise BuildArtifactCheck.BuildArtifactInvalidError(path, e.__str__())
             logging.info(f'Checked {path} ({config.get_value("version", "N/A")})')
 
-    def __valid_paths(self, pluginName: str) -> List[str]:
+    def __valid_paths(self, pluginName):
         return list(map(lambda version: f"{pluginName}-{version}.zip", self.target.compatible_versions))

--- a/src/system/config_file.py
+++ b/src/system/config_file.py
@@ -5,6 +5,7 @@
 # compatible open source license.
 
 import json
+from typing import Any, List
 
 
 class ConfigFile:
@@ -12,13 +13,13 @@ class ConfigFile:
         pass
 
     class UnexpectedKeyValueError(CheckError):
-        def __init__(self, key, expected, current=None):
+        def __init__(self, key: str, expected: str, current: str = None) -> None:
             super().__init__(
                 f"Expected to have {key}='{expected}', but was '{current}'." if current else f"Expected to have {key}='{expected}', but none was found."
             )
 
     class UnexpectedKeyValuesError(CheckError):
-        def __init__(self, key, expected, current=None):
+        def __init__(self, key: str, expected: List[str], current: str = None) -> None:
             super().__init__(
                 f"Expected to have {key}=any of {expected}, but was '{current}'."
                 if current
@@ -26,15 +27,15 @@ class ConfigFile:
             )
 
     @property
-    def data(self):
+    def data(self) -> Any:
         return self.__data
 
     @classmethod
-    def from_file(cls, path):
+    def from_file(cls, path: str) -> 'ConfigFile':
         with open(path, "r") as f:
             return cls(json.load(f))
 
-    def __init__(self, data=None):
+    def __init__(self, data: Any = None) -> None:
         if type(data) is str:
             self.__data = json.loads(data)
         elif type(data) is dict:
@@ -44,13 +45,13 @@ class ConfigFile:
         else:
             self.__data = {}
 
-    def get_value(self, key, default_value=None):
+    def get_value(self, key: str, default_value: str = None) -> Any:
         try:
             return self.__data[key]
         except KeyError:
             return default_value
 
-    def check_value(self, key, expected):
+    def check_value(self, key: str, expected: str) -> None:
         try:
             value = self.__data[key]
             if value != expected:
@@ -58,7 +59,7 @@ class ConfigFile:
         except KeyError:
             raise ConfigFile.UnexpectedKeyValueError(key, expected)
 
-    def check_value_in(self, key, expected):
+    def check_value_in(self, key: str, expected: List[str]) -> None:
         try:
             value = self.__data[key]
             if value not in expected:

--- a/src/system/config_file.py
+++ b/src/system/config_file.py
@@ -5,7 +5,6 @@
 # compatible open source license.
 
 import json
-from typing import Any, List
 
 
 class ConfigFile:
@@ -13,13 +12,13 @@ class ConfigFile:
         pass
 
     class UnexpectedKeyValueError(CheckError):
-        def __init__(self, key: str, expected: str, current: str = None) -> None:
+        def __init__(self, key, expected, current=None):
             super().__init__(
                 f"Expected to have {key}='{expected}', but was '{current}'." if current else f"Expected to have {key}='{expected}', but none was found."
             )
 
     class UnexpectedKeyValuesError(CheckError):
-        def __init__(self, key: str, expected: List[str], current: str = None) -> None:
+        def __init__(self, key, expected, current=None):
             super().__init__(
                 f"Expected to have {key}=any of {expected}, but was '{current}'."
                 if current
@@ -27,15 +26,15 @@ class ConfigFile:
             )
 
     @property
-    def data(self) -> Any:
+    def data(self):
         return self.__data
 
     @classmethod
-    def from_file(cls, path: str) -> 'ConfigFile':
+    def from_file(cls, path):
         with open(path, "r") as f:
             return cls(json.load(f))
 
-    def __init__(self, data: Any = None) -> None:
+    def __init__(self, data=None):
         if type(data) is str:
             self.__data = json.loads(data)
         elif type(data) is dict:
@@ -45,13 +44,13 @@ class ConfigFile:
         else:
             self.__data = {}
 
-    def get_value(self, key: str, default_value: str = None) -> Any:
+    def get_value(self, key, default_value=None):
         try:
             return self.__data[key]
         except KeyError:
             return default_value
 
-    def check_value(self, key: str, expected: str) -> None:
+    def check_value(self, key, expected):
         try:
             value = self.__data[key]
             if value != expected:
@@ -59,7 +58,7 @@ class ConfigFile:
         except KeyError:
             raise ConfigFile.UnexpectedKeyValueError(key, expected)
 
-    def check_value_in(self, key: str, expected: List[str]) -> None:
+    def check_value_in(self, key, expected):
         try:
             value = self.__data[key]
             if value not in expected:

--- a/src/system/properties_file.py
+++ b/src/system/properties_file.py
@@ -4,6 +4,8 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+from typing import Any, List
+
 from jproperties import Properties
 
 
@@ -12,20 +14,20 @@ class PropertiesFile(Properties):
         pass
 
     class UnexpectedKeyValueError(CheckError):
-        def __init__(self, key, expected, current=None):
+        def __init__(self, key: str, expected: str, current: str = None) -> None:
             super().__init__(
                 f"Expected to have {key}='{expected}', but was '{current}'." if current else f"Expected to have {key}='{expected}', but none was found."
             )
 
     class UnexpectedKeyValuesError(CheckError):
-        def __init__(self, key, expected, current=None):
+        def __init__(self, key: str, expected: List[str], current: str = None) -> None:
             super().__init__(
                 f"Expected to have {key}=any of {expected}, but was '{current}'."
                 if current
                 else f"Expected to have {key}=any of {expected}, but none was found."
             )
 
-    def __init__(self, data=None):
+    def __init__(self, data: Any = None) -> None:
         super().__init__(self)
         if type(data) is str:
             self.load(data)
@@ -34,13 +36,13 @@ class PropertiesFile(Properties):
         elif data is not None:
             raise TypeError()
 
-    def get_value(self, key, default_value=None):
+    def get_value(self, key: str, default_value: str = None) -> Any:
         try:
             return self[key].data
         except KeyError:
             return default_value
 
-    def check_value(self, key, expected):
+    def check_value(self, key: str, expected: str) -> None:
         try:
             value = self[key].data
             if value != expected:
@@ -48,7 +50,7 @@ class PropertiesFile(Properties):
         except KeyError:
             raise PropertiesFile.UnexpectedKeyValueError(key, expected)
 
-    def check_value_in(self, key, expected):
+    def check_value_in(self, key: str, expected: List[str]) -> None:
         try:
             value = self[key].data
             if value not in expected:

--- a/src/system/properties_file.py
+++ b/src/system/properties_file.py
@@ -4,8 +4,6 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-from typing import Any, List
-
 from jproperties import Properties
 
 
@@ -14,20 +12,20 @@ class PropertiesFile(Properties):
         pass
 
     class UnexpectedKeyValueError(CheckError):
-        def __init__(self, key: str, expected: str, current: str = None) -> None:
+        def __init__(self, key, expected, current=None):
             super().__init__(
                 f"Expected to have {key}='{expected}', but was '{current}'." if current else f"Expected to have {key}='{expected}', but none was found."
             )
 
     class UnexpectedKeyValuesError(CheckError):
-        def __init__(self, key: str, expected: List[str], current: str = None) -> None:
+        def __init__(self, key, expected, current=None):
             super().__init__(
                 f"Expected to have {key}=any of {expected}, but was '{current}'."
                 if current
                 else f"Expected to have {key}=any of {expected}, but none was found."
             )
 
-    def __init__(self, data: Any = None) -> None:
+    def __init__(self, data=None):
         super().__init__(self)
         if type(data) is str:
             self.load(data)
@@ -36,13 +34,13 @@ class PropertiesFile(Properties):
         elif data is not None:
             raise TypeError()
 
-    def get_value(self, key: str, default_value: str = None) -> Any:
+    def get_value(self, key, default_value=None):
         try:
             return self[key].data
         except KeyError:
             return default_value
 
-    def check_value(self, key: str, expected: str) -> None:
+    def check_value(self, key, expected):
         try:
             value = self[key].data
             if value != expected:
@@ -50,7 +48,7 @@ class PropertiesFile(Properties):
         except KeyError:
             raise PropertiesFile.UnexpectedKeyValueError(key, expected)
 
-    def check_value_in(self, key: str, expected: List[str]) -> None:
+    def check_value_in(self, key, expected):
         try:
             value = self[key].data
             if value not in expected:

--- a/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_maven.py
+++ b/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_maven.py
@@ -6,6 +6,7 @@
 
 import unittest
 from contextlib import contextmanager
+from typing import Generator
 from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
@@ -15,7 +16,7 @@ from build_workflow.opensearch.build_artifact_check_maven import BuildArtifactOp
 
 class TestBuildArtifactOpenSearchCheckMaven(unittest.TestCase):
     @contextmanager
-    def __mock(self, props="", snapshot=True):
+    def __mock(self, props: str = "", snapshot: bool = True) -> Generator[BuildArtifactOpenSearchCheckMaven, None, None]:
         with patch("build_workflow.opensearch.build_artifact_check_maven.ZipFile") as mock_zipfile:
             mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = props
             yield BuildArtifactOpenSearchCheckMaven(
@@ -30,25 +31,25 @@ class TestBuildArtifactOpenSearchCheckMaven(unittest.TestCase):
                 )
             )
 
-    def test_build_artifact_check_maven_version_properties_none(self):
+    def test_build_artifact_check_maven_version_properties_none(self) -> None:
         with self.__mock("") as mock:
             mock.check("valid.jar")
 
-    def test_record_maven_artifact_after_checking_maven_version_properties(self):
+    def test_record_maven_artifact_after_checking_maven_version_properties(self) -> None:
         with self.__mock("Implementation-Version: 1.1.0.0", snapshot=False) as mock:
             mock.check("valid.jar")
 
     def test_record_maven_artifact_after_checking_maven_version_properties_snapshot(
         self,
-    ):
+    ) -> None:
         with self.__mock("Implementation-Version: 1.1.0.0-SNAPSHOT") as mock:
             mock.check("valid.jar")
 
-    def test_record_maven_artifact_after_checking_maven_version_properties_patch(self):
+    def test_record_maven_artifact_after_checking_maven_version_properties_patch(self) -> None:
         with self.__mock("Implementation-Version: 1.0.0.0", snapshot=False) as mock:
             mock.check("valid.jar")
 
-    def test_build_artifact_check_maven_version_properties_mismatch(self):
+    def test_build_artifact_check_maven_version_properties_mismatch(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock("Implementation-Version: 1.2.3.4", snapshot=False) as mock:
                 mock.check("valid.jar")

--- a/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_maven.py
+++ b/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_maven.py
@@ -6,7 +6,6 @@
 
 import unittest
 from contextlib import contextmanager
-from typing import Generator
 from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
@@ -16,7 +15,7 @@ from build_workflow.opensearch.build_artifact_check_maven import BuildArtifactOp
 
 class TestBuildArtifactOpenSearchCheckMaven(unittest.TestCase):
     @contextmanager
-    def __mock(self, props: str = "", snapshot: bool = True) -> Generator[BuildArtifactOpenSearchCheckMaven, None, None]:
+    def __mock(self, props="", snapshot=True):
         with patch("build_workflow.opensearch.build_artifact_check_maven.ZipFile") as mock_zipfile:
             mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = props
             yield BuildArtifactOpenSearchCheckMaven(
@@ -31,25 +30,25 @@ class TestBuildArtifactOpenSearchCheckMaven(unittest.TestCase):
                 )
             )
 
-    def test_build_artifact_check_maven_version_properties_none(self) -> None:
+    def test_build_artifact_check_maven_version_properties_none(self):
         with self.__mock("") as mock:
             mock.check("valid.jar")
 
-    def test_record_maven_artifact_after_checking_maven_version_properties(self) -> None:
+    def test_record_maven_artifact_after_checking_maven_version_properties(self):
         with self.__mock("Implementation-Version: 1.1.0.0", snapshot=False) as mock:
             mock.check("valid.jar")
 
     def test_record_maven_artifact_after_checking_maven_version_properties_snapshot(
         self,
-    ) -> None:
+    ):
         with self.__mock("Implementation-Version: 1.1.0.0-SNAPSHOT") as mock:
             mock.check("valid.jar")
 
-    def test_record_maven_artifact_after_checking_maven_version_properties_patch(self) -> None:
+    def test_record_maven_artifact_after_checking_maven_version_properties_patch(self):
         with self.__mock("Implementation-Version: 1.0.0.0", snapshot=False) as mock:
             mock.check("valid.jar")
 
-    def test_build_artifact_check_maven_version_properties_mismatch(self) -> None:
+    def test_build_artifact_check_maven_version_properties_mismatch(self):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock("Implementation-Version: 1.2.3.4", snapshot=False) as mock:
                 mock.check("valid.jar")

--- a/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_plugin.py
+++ b/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_plugin.py
@@ -6,6 +6,7 @@
 
 import unittest
 from contextlib import contextmanager
+from typing import Generator
 from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
@@ -15,7 +16,7 @@ from build_workflow.opensearch.build_artifact_check_plugin import BuildArtifactO
 
 class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
     @contextmanager
-    def __mock(self, props="", snapshot=True):
+    def __mock(self, props: str = "", snapshot: bool = True) -> Generator[BuildArtifactOpenSearchCheckPlugin, None, None]:
         with patch("build_workflow.opensearch.build_artifact_check_plugin.ZipFile") as mock_zipfile:
             mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = props
             yield BuildArtifactOpenSearchCheckPlugin(
@@ -30,7 +31,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
                 )
             )
 
-    def test_check_plugin_zip_version_snapshot(self):
+    def test_check_plugin_zip_version_snapshot(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock() as mock:
                 mock.check("invalid.zip")
@@ -38,7 +39,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
             "Artifact invalid.zip is invalid. Expected filename to include one of ['1.1.0.0-SNAPSHOT', '1.0.0.0', '1.0.0.0-SNAPSHOT'].", str(context.exception)
         )
 
-    def test_check_plugin_zip_version(self):
+    def test_check_plugin_zip_version(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock(snapshot=False) as mock:
                 mock.check("invalid.zip")
@@ -46,7 +47,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
             "Artifact invalid.zip is invalid. Expected filename to include one of ['1.1.0.0', '1.0.0.0', '1.0.0.0-SNAPSHOT'].", str(context.exception)
         )
 
-    def test_check_plugin_version_properties_missing(self, *mocks):
+    def test_check_plugin_version_properties_missing(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock("") as mock:
                 mock.check("valid-1.1.0.0-SNAPSHOT.zip")
@@ -55,7 +56,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_version_properties_mismatch(self, *mocks):
+    def test_check_plugin_version_properties_mismatch(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock("version=1.2.3.4") as mock:
                 mock.check("valid-1.1.0.0-SNAPSHOT.zip")
@@ -64,10 +65,10 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
                 str(context.exception),
             )
 
-    def test_check_plugin_version_properties(self, *mocks):
+    def test_check_plugin_version_properties(self) -> None:
         with self.__mock("opensearch.version=1.1.0\nversion=1.1.0.0-SNAPSHOT") as mock:
             mock.check("valid-1.1.0.0-SNAPSHOT.zip")
 
-    def test_check_plugin_version_properties_patch(self, *mocks):
+    def test_check_plugin_version_properties_patch(self) -> None:
         with self.__mock("opensearch.version=1.1.0\nversion=1.0.0.0-SNAPSHOT") as mock:
             mock.check("valid-1.0.0.0-SNAPSHOT.zip")

--- a/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_plugin.py
+++ b/tests/tests_build_workflow/opensearch/test_build_artifact_opensearch_check_plugin.py
@@ -6,7 +6,6 @@
 
 import unittest
 from contextlib import contextmanager
-from typing import Generator
 from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
@@ -16,7 +15,7 @@ from build_workflow.opensearch.build_artifact_check_plugin import BuildArtifactO
 
 class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
     @contextmanager
-    def __mock(self, props: str = "", snapshot: bool = True) -> Generator[BuildArtifactOpenSearchCheckPlugin, None, None]:
+    def __mock(self, props="", snapshot=True):
         with patch("build_workflow.opensearch.build_artifact_check_plugin.ZipFile") as mock_zipfile:
             mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = props
             yield BuildArtifactOpenSearchCheckPlugin(
@@ -31,7 +30,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
                 )
             )
 
-    def test_check_plugin_zip_version_snapshot(self) -> None:
+    def test_check_plugin_zip_version_snapshot(self):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock() as mock:
                 mock.check("invalid.zip")
@@ -39,7 +38,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
             "Artifact invalid.zip is invalid. Expected filename to include one of ['1.1.0.0-SNAPSHOT', '1.0.0.0', '1.0.0.0-SNAPSHOT'].", str(context.exception)
         )
 
-    def test_check_plugin_zip_version(self) -> None:
+    def test_check_plugin_zip_version(self):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock(snapshot=False) as mock:
                 mock.check("invalid.zip")
@@ -47,7 +46,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
             "Artifact invalid.zip is invalid. Expected filename to include one of ['1.1.0.0', '1.0.0.0', '1.0.0.0-SNAPSHOT'].", str(context.exception)
         )
 
-    def test_check_plugin_version_properties_missing(self) -> None:
+    def test_check_plugin_version_properties_missing(self, *mocks):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock("") as mock:
                 mock.check("valid-1.1.0.0-SNAPSHOT.zip")
@@ -56,7 +55,7 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_version_properties_mismatch(self) -> None:
+    def test_check_plugin_version_properties_mismatch(self, *mocks):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock("version=1.2.3.4") as mock:
                 mock.check("valid-1.1.0.0-SNAPSHOT.zip")
@@ -65,10 +64,10 @@ class TestBuildArtifactOpenSearchCheckPlugin(unittest.TestCase):
                 str(context.exception),
             )
 
-    def test_check_plugin_version_properties(self) -> None:
+    def test_check_plugin_version_properties(self, *mocks):
         with self.__mock("opensearch.version=1.1.0\nversion=1.1.0.0-SNAPSHOT") as mock:
             mock.check("valid-1.1.0.0-SNAPSHOT.zip")
 
-    def test_check_plugin_version_properties_patch(self) -> None:
+    def test_check_plugin_version_properties_patch(self, *mocks):
         with self.__mock("opensearch.version=1.1.0\nversion=1.0.0.0-SNAPSHOT") as mock:
             mock.check("valid-1.0.0.0-SNAPSHOT.zip")

--- a/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
+++ b/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
@@ -6,6 +6,7 @@
 
 import unittest
 from contextlib import contextmanager
+from typing import Generator
 from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
@@ -15,7 +16,7 @@ from build_workflow.opensearch_dashboards.build_artifact_check_plugin import Bui
 
 class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
     @contextmanager
-    def __mock(self, props={}, snapshot=True):
+    def __mock(self, props: dict = {}, snapshot: bool = True) -> Generator[BuildArtifactOpenSearchDashboardsCheckPlugin, None, None]:
         with patch("build_workflow.opensearch_dashboards.build_artifact_check_plugin.ZipFile") as mock_zipfile:
             mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = props
             yield BuildArtifactOpenSearchDashboardsCheckPlugin(
@@ -30,7 +31,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
                 )
             )
 
-    def test_check_plugin_invalid_zip_version_snapshot(self):
+    def test_check_plugin_invalid_zip_version_snapshot(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock() as mock:
                 mock.check("invalid.zip")
@@ -39,7 +40,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_invalid_zip_version(self):
+    def test_check_plugin_invalid_zip_version(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock(snapshot=False) as mock:
                 mock.check("invalid.zip")
@@ -48,7 +49,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_missing_name(self):
+    def test_check_plugin_missing_name(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock() as mock:
                 mock.check("-1.1.0.zip")
@@ -57,7 +58,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_invalid_version_in_filename(self):
+    def test_check_plugin_invalid_version_in_filename(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock(snapshot=False) as mock:
                 mock.check("pluginName-1.2.3.zip")
@@ -66,7 +67,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_version_properties_missing(self, *mocks):
+    def test_check_plugin_version_properties_missing(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock(snapshot=False) as mock:
                 mock.check("pluginName-1.1.0.zip")
@@ -75,7 +76,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_version_properties_mismatch(self, *mocks):
+    def test_check_plugin_version_properties_mismatch(self) -> None:
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock({"version": "1.2.3.4"}) as mock:
                 mock.check("pluginName-1.1.0.zip")
@@ -84,10 +85,10 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
                 str(context.exception),
             )
 
-    def test_check_plugin_version_properties(self, *mocks):
+    def test_check_plugin_version_properties(self) -> None:
         with self.__mock({"opensearchDashboardsVersion": "1.1.0", "version": "1.1.0.0"}, snapshot=False) as mock:
             mock.check("pluginName-1.1.0.zip")
 
-    def test_check_plugin_version_properties_patches(self, *mocks):
+    def test_check_plugin_version_properties_patches(self) -> None:
         with self.__mock({"opensearchDashboardsVersion": "1.0.0", "version": "1.0.0.0"}, snapshot=False) as mock:
             mock.check("pluginName-1.0.0.zip")

--- a/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
+++ b/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
@@ -6,7 +6,6 @@
 
 import unittest
 from contextlib import contextmanager
-from typing import Generator
 from unittest.mock import patch
 
 from build_workflow.build_artifact_check import BuildArtifactCheck
@@ -16,7 +15,7 @@ from build_workflow.opensearch_dashboards.build_artifact_check_plugin import Bui
 
 class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
     @contextmanager
-    def __mock(self, props: dict = {}, snapshot: bool = True) -> Generator[BuildArtifactOpenSearchDashboardsCheckPlugin, None, None]:
+    def __mock(self, props={}, snapshot=True):
         with patch("build_workflow.opensearch_dashboards.build_artifact_check_plugin.ZipFile") as mock_zipfile:
             mock_zipfile.return_value.__enter__.return_value.read.return_value.decode.return_value = props
             yield BuildArtifactOpenSearchDashboardsCheckPlugin(
@@ -31,7 +30,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
                 )
             )
 
-    def test_check_plugin_invalid_zip_version_snapshot(self) -> None:
+    def test_check_plugin_invalid_zip_version_snapshot(self):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock() as mock:
                 mock.check("invalid.zip")
@@ -40,7 +39,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_invalid_zip_version(self) -> None:
+    def test_check_plugin_invalid_zip_version(self):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock(snapshot=False) as mock:
                 mock.check("invalid.zip")
@@ -49,7 +48,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_missing_name(self) -> None:
+    def test_check_plugin_missing_name(self):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock() as mock:
                 mock.check("-1.1.0.zip")
@@ -58,7 +57,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_invalid_version_in_filename(self) -> None:
+    def test_check_plugin_invalid_version_in_filename(self):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock(snapshot=False) as mock:
                 mock.check("pluginName-1.2.3.zip")
@@ -67,7 +66,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_version_properties_missing(self) -> None:
+    def test_check_plugin_version_properties_missing(self, *mocks):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock(snapshot=False) as mock:
                 mock.check("pluginName-1.1.0.zip")
@@ -76,7 +75,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             str(context.exception),
         )
 
-    def test_check_plugin_version_properties_mismatch(self) -> None:
+    def test_check_plugin_version_properties_mismatch(self, *mocks):
         with self.assertRaises(BuildArtifactCheck.BuildArtifactInvalidError) as context:
             with self.__mock({"version": "1.2.3.4"}) as mock:
                 mock.check("pluginName-1.1.0.zip")
@@ -85,10 +84,10 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
                 str(context.exception),
             )
 
-    def test_check_plugin_version_properties(self) -> None:
+    def test_check_plugin_version_properties(self, *mocks):
         with self.__mock({"opensearchDashboardsVersion": "1.1.0", "version": "1.1.0.0"}, snapshot=False) as mock:
             mock.check("pluginName-1.1.0.zip")
 
-    def test_check_plugin_version_properties_patches(self) -> None:
+    def test_check_plugin_version_properties_patches(self, *mocks):
         with self.__mock({"opensearchDashboardsVersion": "1.0.0", "version": "1.0.0.0"}, snapshot=False) as mock:
             mock.check("pluginName-1.0.0.zip")

--- a/tests/tests_build_workflow/test_build_args.py
+++ b/tests/tests_build_workflow/test_build_args.py
@@ -30,79 +30,79 @@ class TestBuildArgs(unittest.TestCase):
     )
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_manifest(self):
+    def test_manifest(self) -> None:
         self.assertEqual(BuildArgs().manifest.name, TestBuildArgs.OPENSEARCH_MANIFEST)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_keep_default(self):
+    def test_keep_default(self) -> None:
         self.assertFalse(BuildArgs().keep)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--keep"])
-    def test_keep_true(self):
+    def test_keep_true(self) -> None:
         self.assertTrue(BuildArgs().keep)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_snapshot_default(self):
+    def test_snapshot_default(self) -> None:
         self.assertFalse(BuildArgs().snapshot)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--snapshot"])
-    def test_snapshot_true(self):
+    def test_snapshot_true(self) -> None:
         self.assertTrue(BuildArgs().snapshot)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_verbose_default(self):
+    def test_verbose_default(self) -> None:
         self.assertEqual(BuildArgs().logging_level, logging.INFO)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--verbose"])
-    def test_verbose_true(self):
+    def test_verbose_true(self) -> None:
         self.assertTrue(BuildArgs().logging_level, logging.DEBUG)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_component_default(self):
+    def test_component_default(self) -> None:
         self.assertIsNone(BuildArgs().component)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
-    def test_component(self):
+    def test_component(self) -> None:
         self.assertEqual(BuildArgs().component, "xyz")
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_platform_default(self):
+    def test_platform_default(self) -> None:
         self.assertIsNone(BuildArgs().platform)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--platform", "linux"])
-    def test_platform(self):
+    def test_platform(self) -> None:
         self.assertEqual(BuildArgs().platform, "linux")
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_architecture_default(self):
+    def test_architecture_default(self) -> None:
         self.assertIsNone(BuildArgs().architecture)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--architecture", "arm64"])
-    def test_architecture(self):
+    def test_architecture(self) -> None:
         self.assertEqual(BuildArgs().architecture, "arm64")
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
-    def test_script_path(self):
+    def test_script_path(self) -> None:
         self.assertEqual(BuildArgs().script_path, self.BUILD_SH)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_component_command(self):
+    def test_component_command(self) -> None:
         self.assertEqual(
             BuildArgs().component_command("component"),
             f"{self.BUILD_SH} {self.OPENSEARCH_MANIFEST} --component component",
         )
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--snapshot"])
-    def test_component_command_with_snapshot(self):
+    def test_component_command_with_snapshot(self) -> None:
         self.assertEqual(
             BuildArgs().component_command("component"),
             f"{self.BUILD_SH} {self.OPENSEARCH_MANIFEST} --component component --snapshot",
         )
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--lock"])
-    def test_manifest_lock(self):
+    def test_manifest_lock(self) -> None:
         self.assertEqual(BuildArgs().ref_manifest, TestBuildArgs.OPENSEARCH_MANIFEST + ".lock")
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_manifest_no_lock(self):
+    def test_manifest_no_lock(self) -> None:
         self.assertIsNone(BuildArgs().ref_manifest)

--- a/tests/tests_build_workflow/test_build_args.py
+++ b/tests/tests_build_workflow/test_build_args.py
@@ -30,79 +30,79 @@ class TestBuildArgs(unittest.TestCase):
     )
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_manifest(self) -> None:
+    def test_manifest(self):
         self.assertEqual(BuildArgs().manifest.name, TestBuildArgs.OPENSEARCH_MANIFEST)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_keep_default(self) -> None:
+    def test_keep_default(self):
         self.assertFalse(BuildArgs().keep)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--keep"])
-    def test_keep_true(self) -> None:
+    def test_keep_true(self):
         self.assertTrue(BuildArgs().keep)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_snapshot_default(self) -> None:
+    def test_snapshot_default(self):
         self.assertFalse(BuildArgs().snapshot)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--snapshot"])
-    def test_snapshot_true(self) -> None:
+    def test_snapshot_true(self):
         self.assertTrue(BuildArgs().snapshot)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_verbose_default(self) -> None:
+    def test_verbose_default(self):
         self.assertEqual(BuildArgs().logging_level, logging.INFO)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--verbose"])
-    def test_verbose_true(self) -> None:
+    def test_verbose_true(self):
         self.assertTrue(BuildArgs().logging_level, logging.DEBUG)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_component_default(self) -> None:
+    def test_component_default(self):
         self.assertIsNone(BuildArgs().component)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
-    def test_component(self) -> None:
+    def test_component(self):
         self.assertEqual(BuildArgs().component, "xyz")
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_platform_default(self) -> None:
+    def test_platform_default(self):
         self.assertIsNone(BuildArgs().platform)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--platform", "linux"])
-    def test_platform(self) -> None:
+    def test_platform(self):
         self.assertEqual(BuildArgs().platform, "linux")
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_architecture_default(self) -> None:
+    def test_architecture_default(self):
         self.assertIsNone(BuildArgs().architecture)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--architecture", "arm64"])
-    def test_architecture(self) -> None:
+    def test_architecture(self):
         self.assertEqual(BuildArgs().architecture, "arm64")
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
-    def test_script_path(self) -> None:
+    def test_script_path(self):
         self.assertEqual(BuildArgs().script_path, self.BUILD_SH)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_component_command(self) -> None:
+    def test_component_command(self):
         self.assertEqual(
             BuildArgs().component_command("component"),
             f"{self.BUILD_SH} {self.OPENSEARCH_MANIFEST} --component component",
         )
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--snapshot"])
-    def test_component_command_with_snapshot(self) -> None:
+    def test_component_command_with_snapshot(self):
         self.assertEqual(
             BuildArgs().component_command("component"),
             f"{self.BUILD_SH} {self.OPENSEARCH_MANIFEST} --component component --snapshot",
         )
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--lock"])
-    def test_manifest_lock(self) -> None:
+    def test_manifest_lock(self):
         self.assertEqual(BuildArgs().ref_manifest, TestBuildArgs.OPENSEARCH_MANIFEST + ".lock")
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
-    def test_manifest_no_lock(self) -> None:
+    def test_manifest_no_lock(self):
         self.assertIsNone(BuildArgs().ref_manifest)

--- a/tests/tests_build_workflow/test_build_artifact_checks.py
+++ b/tests/tests_build_workflow/test_build_artifact_checks.py
@@ -5,7 +5,7 @@
 # compatible open source license.
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from build_workflow.build_artifact_checks import BuildArtifactChecks
 from build_workflow.build_target import BuildTarget
@@ -15,7 +15,7 @@ from build_workflow.opensearch_dashboards.build_artifact_check_plugin import Bui
 
 
 class TestBuildArtifactChecks(unittest.TestCase):
-    def __mock_target(self, name="OpenSearch"):
+    def __mock_target(self, name: str = "OpenSearch") -> BuildTarget:
         return BuildTarget(
             build_id="1",
             output_dir="output_dir",
@@ -25,33 +25,33 @@ class TestBuildArtifactChecks(unittest.TestCase):
             snapshot=True,
         )
 
-    def test_opensearch_build_artifact_check_plugin(self):
+    def test_opensearch_build_artifact_check_plugin(self) -> None:
         target = self.__mock_target(name="OpenSearch")
         check = BuildArtifactChecks.create(target, "plugins")
         self.assertIs(type(check), BuildArtifactOpenSearchCheckPlugin)
 
-    def test_opensearch_build_artifact_check_maven(self):
+    def test_opensearch_build_artifact_check_maven(self) -> None:
         target = self.__mock_target(name="OpenSearch")
         check = BuildArtifactChecks.create(target, "maven")
         self.assertIs(type(check), BuildArtifactOpenSearchCheckMaven)
 
-    def test_opensearch_build_artifact_check_other(self):
+    def test_opensearch_build_artifact_check_other(self) -> None:
         target = self.__mock_target(name="OpenSearch")
         self.assertIsNone(BuildArtifactChecks.create(target, "other"))
 
-    def test_opensearch_dashboards_build_artifact_check_plugin(self):
+    def test_opensearch_dashboards_build_artifact_check_plugin(self) -> None:
         target = self.__mock_target(name="OpenSearch Dashboards")
         check = BuildArtifactChecks.create(target, "plugins")
         self.assertIs(type(check), BuildArtifactOpenSearchDashboardsCheckPlugin)
 
-    def test_build_artifact_check_invalid(self):
+    def test_build_artifact_check_invalid(self) -> None:
         target = self.__mock_target(name="invalid")
         with self.assertRaises(ValueError) as ctx:
             BuildArtifactChecks.create(target, "plugins")
         self.assertEqual(str(ctx.exception), "Unsupported bundle: invalid")
 
     @patch.object(BuildArtifactOpenSearchCheckPlugin, "check")
-    def test_check(self, mock_check):
+    def test_check(self, mock_check: Mock) -> None:
         target = self.__mock_target(name="OpenSearch")
         BuildArtifactChecks.check(target, "plugins", "artifact.zip")
         mock_check.assert_called_with("artifact.zip")

--- a/tests/tests_build_workflow/test_build_artifact_checks.py
+++ b/tests/tests_build_workflow/test_build_artifact_checks.py
@@ -5,7 +5,7 @@
 # compatible open source license.
 
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from build_workflow.build_artifact_checks import BuildArtifactChecks
 from build_workflow.build_target import BuildTarget
@@ -15,7 +15,7 @@ from build_workflow.opensearch_dashboards.build_artifact_check_plugin import Bui
 
 
 class TestBuildArtifactChecks(unittest.TestCase):
-    def __mock_target(self, name: str = "OpenSearch") -> BuildTarget:
+    def __mock_target(self, name="OpenSearch"):
         return BuildTarget(
             build_id="1",
             output_dir="output_dir",
@@ -25,33 +25,33 @@ class TestBuildArtifactChecks(unittest.TestCase):
             snapshot=True,
         )
 
-    def test_opensearch_build_artifact_check_plugin(self) -> None:
+    def test_opensearch_build_artifact_check_plugin(self):
         target = self.__mock_target(name="OpenSearch")
         check = BuildArtifactChecks.create(target, "plugins")
         self.assertIs(type(check), BuildArtifactOpenSearchCheckPlugin)
 
-    def test_opensearch_build_artifact_check_maven(self) -> None:
+    def test_opensearch_build_artifact_check_maven(self):
         target = self.__mock_target(name="OpenSearch")
         check = BuildArtifactChecks.create(target, "maven")
         self.assertIs(type(check), BuildArtifactOpenSearchCheckMaven)
 
-    def test_opensearch_build_artifact_check_other(self) -> None:
+    def test_opensearch_build_artifact_check_other(self):
         target = self.__mock_target(name="OpenSearch")
         self.assertIsNone(BuildArtifactChecks.create(target, "other"))
 
-    def test_opensearch_dashboards_build_artifact_check_plugin(self) -> None:
+    def test_opensearch_dashboards_build_artifact_check_plugin(self):
         target = self.__mock_target(name="OpenSearch Dashboards")
         check = BuildArtifactChecks.create(target, "plugins")
         self.assertIs(type(check), BuildArtifactOpenSearchDashboardsCheckPlugin)
 
-    def test_build_artifact_check_invalid(self) -> None:
+    def test_build_artifact_check_invalid(self):
         target = self.__mock_target(name="invalid")
         with self.assertRaises(ValueError) as ctx:
             BuildArtifactChecks.create(target, "plugins")
         self.assertEqual(str(ctx.exception), "Unsupported bundle: invalid")
 
     @patch.object(BuildArtifactOpenSearchCheckPlugin, "check")
-    def test_check(self, mock_check: Mock) -> None:
+    def test_check(self, mock_check):
         target = self.__mock_target(name="OpenSearch")
         BuildArtifactChecks.check(target, "plugins", "artifact.zip")
         mock_check.assert_called_with("artifact.zip")

--- a/tests/tests_build_workflow/test_build_recorder.py
+++ b/tests/tests_build_workflow/test_build_recorder.py
@@ -6,7 +6,7 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import yaml
 
@@ -19,7 +19,7 @@ from system.temporary_directory import TemporaryDirectory
 
 
 class TestBuildRecorder(unittest.TestCase):
-    def __mock(self, snapshot=True):
+    def __mock(self, snapshot: bool = True) -> BuildRecorder:
         return BuildRecorder(
             BuildTarget(
                 build_id="1",
@@ -34,7 +34,7 @@ class TestBuildRecorder(unittest.TestCase):
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
-    def test_record_component_and_artifact(self, mock_makedirs, mock_copyfile):
+    def test_record_component_and_artifact(self, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
         recorder = self.__mock(snapshot=False)
 
         recorder.record_component(
@@ -79,7 +79,7 @@ class TestBuildRecorder(unittest.TestCase):
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
-    def test_record_artifact(self, mock_makedirs, mock_copyfile):
+    def test_record_artifact(self, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
         recorder = self.__mock(snapshot=False)
 
         recorder.record_component(
@@ -99,7 +99,7 @@ class TestBuildRecorder(unittest.TestCase):
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
-    def test_record_artifact_check_plugin(self, *mocks):
+    def test_record_artifact_check_plugin(self, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
         recorder = self.__mock(snapshot=False)
 
         recorder.record_component("security", MagicMock())
@@ -108,10 +108,12 @@ class TestBuildRecorder(unittest.TestCase):
             recorder.record_artifact("security", "plugins", "../file1.zip", "invalid.file")
 
         mock_check.assert_called_with("invalid.file")
+        mock_copyfile.assert_called()
+        mock_makedirs.assert_called()
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
-    def test_record_artifact_check_maven(self, *mocks):
+    def test_record_artifact_check_maven(self, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
         recorder = self.__mock(snapshot=False)
 
         recorder.record_component("security", MagicMock())
@@ -120,8 +122,10 @@ class TestBuildRecorder(unittest.TestCase):
             recorder.record_artifact("security", "maven", "../file1.zip", "valid.jar")
 
         mock_check.assert_called_with("valid.jar")
+        mock_copyfile.assert_called()
+        mock_makedirs.assert_called()
 
-    def test_get_manifest(self):
+    def test_get_manifest(self) -> None:
         manifest = self.__mock(snapshot=False).get_manifest()
         self.assertIs(type(manifest), BuildManifest)
         self.assertEqual(
@@ -138,7 +142,7 @@ class TestBuildRecorder(unittest.TestCase):
             },
         )
 
-    def test_write_manifest(self):
+    def test_write_manifest(self) -> None:
         with TemporaryDirectory() as dest_dir:
             mock = self.__mock(snapshot=False)
             mock.target.output_dir = dest_dir.name
@@ -152,7 +156,7 @@ class TestBuildRecorder(unittest.TestCase):
     @patch("shutil.copyfile")
     @patch("os.makedirs")
     @patch.object(BuildArtifactOpenSearchCheckPlugin, "check")
-    def test_record_artifact_check_plugin_version_properties(self, *mocks):
+    def test_record_artifact_check_plugin_version_properties(self, mock_plugin_check: Mock, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
         mock = self.__mock(snapshot=False)
         mock.record_component(
             "security",
@@ -166,11 +170,14 @@ class TestBuildRecorder(unittest.TestCase):
         manifest_dict = mock.get_manifest().to_dict()
         self.assertEqual(manifest_dict["build"]["version"], "1.1.0")
         self.assertEqual(manifest_dict["components"][0]["version"], "1.1.0.0")
+        mock_plugin_check.assert_called()
+        mock_copyfile.assert_called()
+        mock_makedirs.assert_called()
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
     @patch.object(BuildArtifactOpenSearchCheckPlugin, "check")
-    def test_record_artifact_check_plugin_version_properties_snapshot(self, *mocks):
+    def test_record_artifact_check_plugin_version_properties_snapshot(self, mock_plugin_check: Mock, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
         mock = self.__mock(snapshot=True)
         mock.record_component(
             "security",
@@ -184,3 +191,6 @@ class TestBuildRecorder(unittest.TestCase):
         manifest_dict = mock.get_manifest().to_dict()
         self.assertEqual(manifest_dict["build"]["version"], "1.1.0-SNAPSHOT")
         self.assertEqual(manifest_dict["components"][0]["version"], "1.1.0.0-SNAPSHOT")
+        mock_plugin_check.assert_called()
+        mock_copyfile.assert_called()
+        mock_makedirs.assert_called()

--- a/tests/tests_build_workflow/test_build_recorder.py
+++ b/tests/tests_build_workflow/test_build_recorder.py
@@ -6,7 +6,7 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import yaml
 
@@ -19,7 +19,7 @@ from system.temporary_directory import TemporaryDirectory
 
 
 class TestBuildRecorder(unittest.TestCase):
-    def __mock(self, snapshot: bool = True) -> BuildRecorder:
+    def __mock(self, snapshot=True):
         return BuildRecorder(
             BuildTarget(
                 build_id="1",
@@ -34,7 +34,7 @@ class TestBuildRecorder(unittest.TestCase):
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
-    def test_record_component_and_artifact(self, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
+    def test_record_component_and_artifact(self, mock_makedirs, mock_copyfile):
         recorder = self.__mock(snapshot=False)
 
         recorder.record_component(
@@ -79,7 +79,7 @@ class TestBuildRecorder(unittest.TestCase):
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
-    def test_record_artifact(self, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
+    def test_record_artifact(self, mock_makedirs, mock_copyfile):
         recorder = self.__mock(snapshot=False)
 
         recorder.record_component(
@@ -99,7 +99,7 @@ class TestBuildRecorder(unittest.TestCase):
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
-    def test_record_artifact_check_plugin(self, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
+    def test_record_artifact_check_plugin(self, *mocks):
         recorder = self.__mock(snapshot=False)
 
         recorder.record_component("security", MagicMock())
@@ -108,12 +108,10 @@ class TestBuildRecorder(unittest.TestCase):
             recorder.record_artifact("security", "plugins", "../file1.zip", "invalid.file")
 
         mock_check.assert_called_with("invalid.file")
-        mock_copyfile.assert_called()
-        mock_makedirs.assert_called()
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
-    def test_record_artifact_check_maven(self, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
+    def test_record_artifact_check_maven(self, *mocks):
         recorder = self.__mock(snapshot=False)
 
         recorder.record_component("security", MagicMock())
@@ -122,10 +120,8 @@ class TestBuildRecorder(unittest.TestCase):
             recorder.record_artifact("security", "maven", "../file1.zip", "valid.jar")
 
         mock_check.assert_called_with("valid.jar")
-        mock_copyfile.assert_called()
-        mock_makedirs.assert_called()
 
-    def test_get_manifest(self) -> None:
+    def test_get_manifest(self):
         manifest = self.__mock(snapshot=False).get_manifest()
         self.assertIs(type(manifest), BuildManifest)
         self.assertEqual(
@@ -142,7 +138,7 @@ class TestBuildRecorder(unittest.TestCase):
             },
         )
 
-    def test_write_manifest(self) -> None:
+    def test_write_manifest(self):
         with TemporaryDirectory() as dest_dir:
             mock = self.__mock(snapshot=False)
             mock.target.output_dir = dest_dir.name
@@ -156,7 +152,7 @@ class TestBuildRecorder(unittest.TestCase):
     @patch("shutil.copyfile")
     @patch("os.makedirs")
     @patch.object(BuildArtifactOpenSearchCheckPlugin, "check")
-    def test_record_artifact_check_plugin_version_properties(self, mock_plugin_check: Mock, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
+    def test_record_artifact_check_plugin_version_properties(self, *mocks):
         mock = self.__mock(snapshot=False)
         mock.record_component(
             "security",
@@ -170,14 +166,11 @@ class TestBuildRecorder(unittest.TestCase):
         manifest_dict = mock.get_manifest().to_dict()
         self.assertEqual(manifest_dict["build"]["version"], "1.1.0")
         self.assertEqual(manifest_dict["components"][0]["version"], "1.1.0.0")
-        mock_plugin_check.assert_called()
-        mock_copyfile.assert_called()
-        mock_makedirs.assert_called()
 
     @patch("shutil.copyfile")
     @patch("os.makedirs")
     @patch.object(BuildArtifactOpenSearchCheckPlugin, "check")
-    def test_record_artifact_check_plugin_version_properties_snapshot(self, mock_plugin_check: Mock, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
+    def test_record_artifact_check_plugin_version_properties_snapshot(self, *mocks):
         mock = self.__mock(snapshot=True)
         mock.record_component(
             "security",
@@ -191,6 +184,3 @@ class TestBuildRecorder(unittest.TestCase):
         manifest_dict = mock.get_manifest().to_dict()
         self.assertEqual(manifest_dict["build"]["version"], "1.1.0-SNAPSHOT")
         self.assertEqual(manifest_dict["components"][0]["version"], "1.1.0.0-SNAPSHOT")
-        mock_plugin_check.assert_called()
-        mock_copyfile.assert_called()
-        mock_makedirs.assert_called()

--- a/tests/tests_build_workflow/test_build_target.py
+++ b/tests/tests_build_workflow/test_build_target.py
@@ -6,83 +6,85 @@
 
 import os
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from build_workflow.build_target import BuildTarget
 
 
 class TestBuildTarget(unittest.TestCase):
-    def test_output_dir(self):
+    def test_output_dir(self) -> None:
         self.assertEqual(BuildTarget(version="1.1.0", architecture="x86").output_dir, "artifacts")
 
-    def test_build_id_hex(self):
+    def test_build_id_hex(self) -> None:
         self.assertEqual(len(BuildTarget(version="1.1.0", architecture="x86").build_id), 32)
 
     @patch.dict(os.environ, {"BUILD_NUMBER": "id"})
-    def test_build_id_from_env(self):
+    def test_build_id_from_env(self) -> None:
         self.assertEqual(BuildTarget(version="1.1.0", architecture="x86").build_id, "id")
 
-    def test_build_id_from_arg(self):
+    def test_build_id_from_arg(self) -> None:
         self.assertEqual(BuildTarget(version="1.1.0", architecture="x86", build_id="id").build_id, "id")
 
-    def test_opensearch_version(self):
+    def test_opensearch_version(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.0", architecture="x86", snapshot=False).opensearch_version,
             "1.1.0",
         )
 
-    def test_compatible_opensearch_versions(self):
+    def test_compatible_opensearch_versions(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_opensearch_versions,
             ['1.1.2', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
-    def test_compatible_opensearch_versions_snapshot(self):
+    def test_compatible_opensearch_versions_snapshot(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_opensearch_versions,
             ['1.1.2-SNAPSHOT', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
-    def test_opensearch_version_snapshot(self):
+    def test_opensearch_version_snapshot(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.0", architecture="x86", snapshot=True).opensearch_version,
             "1.1.0-SNAPSHOT",
         )
 
-    def test_component_version(self):
+    def test_component_version(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.0", architecture="x86", snapshot=False).component_version,
             "1.1.0.0",
         )
 
-    def test_compatible_component_versions(self):
+    def test_compatible_component_versions(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_component_versions,
             ['1.1.2.0', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
         )
 
-    def test_compatible_component_versions_snapshot(self):
+    def test_compatible_component_versions_snapshot(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_component_versions,
             ['1.1.2.0-SNAPSHOT', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
         )
 
-    def test_component_version_snapshot(self):
+    def test_component_version_snapshot(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.0", architecture="x86", snapshot=True).component_version,
             "1.1.0.0-SNAPSHOT",
         )
 
     @patch("build_workflow.build_target.current_platform", return_value="value")
-    def test_platform(self, *mock):
+    def test_platform(self, value_platform: Mock) -> None:
         self.assertEqual(BuildTarget(version="1.1.0", snapshot=False).platform, "value")
+        value_platform.assert_called_once()
 
-    def test_platform_value(self):
+    def test_platform_value(self) -> None:
         self.assertEqual(BuildTarget(version="1.1.0", platform="value", snapshot=False).platform, "value")
 
     @patch("build_workflow.build_target.current_architecture", return_value="value")
-    def test_arch(self, *mock):
+    def test_arch(self, value_architecture: Mock) -> None:
         self.assertEqual(BuildTarget(version="1.1.0", snapshot=False).architecture, "value")
+        value_architecture.assert_called_once()
 
-    def test_arch_value(self):
+    def test_arch_value(self) -> None:
         self.assertEqual(BuildTarget(version="1.1.0", architecture="value", snapshot=False).architecture, "value")

--- a/tests/tests_build_workflow/test_build_target.py
+++ b/tests/tests_build_workflow/test_build_target.py
@@ -6,85 +6,83 @@
 
 import os
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from build_workflow.build_target import BuildTarget
 
 
 class TestBuildTarget(unittest.TestCase):
-    def test_output_dir(self) -> None:
+    def test_output_dir(self):
         self.assertEqual(BuildTarget(version="1.1.0", architecture="x86").output_dir, "artifacts")
 
-    def test_build_id_hex(self) -> None:
+    def test_build_id_hex(self):
         self.assertEqual(len(BuildTarget(version="1.1.0", architecture="x86").build_id), 32)
 
     @patch.dict(os.environ, {"BUILD_NUMBER": "id"})
-    def test_build_id_from_env(self) -> None:
+    def test_build_id_from_env(self):
         self.assertEqual(BuildTarget(version="1.1.0", architecture="x86").build_id, "id")
 
-    def test_build_id_from_arg(self) -> None:
+    def test_build_id_from_arg(self):
         self.assertEqual(BuildTarget(version="1.1.0", architecture="x86", build_id="id").build_id, "id")
 
-    def test_opensearch_version(self) -> None:
+    def test_opensearch_version(self):
         self.assertEqual(
             BuildTarget(version="1.1.0", architecture="x86", snapshot=False).opensearch_version,
             "1.1.0",
         )
 
-    def test_compatible_opensearch_versions(self) -> None:
+    def test_compatible_opensearch_versions(self):
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_opensearch_versions,
             ['1.1.2', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
-    def test_compatible_opensearch_versions_snapshot(self) -> None:
+    def test_compatible_opensearch_versions_snapshot(self):
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_opensearch_versions,
             ['1.1.2-SNAPSHOT', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
-    def test_opensearch_version_snapshot(self) -> None:
+    def test_opensearch_version_snapshot(self):
         self.assertEqual(
             BuildTarget(version="1.1.0", architecture="x86", snapshot=True).opensearch_version,
             "1.1.0-SNAPSHOT",
         )
 
-    def test_component_version(self) -> None:
+    def test_component_version(self):
         self.assertEqual(
             BuildTarget(version="1.1.0", architecture="x86", snapshot=False).component_version,
             "1.1.0.0",
         )
 
-    def test_compatible_component_versions(self) -> None:
+    def test_compatible_component_versions(self):
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_component_versions,
             ['1.1.2.0', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
         )
 
-    def test_compatible_component_versions_snapshot(self) -> None:
+    def test_compatible_component_versions_snapshot(self):
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_component_versions,
             ['1.1.2.0-SNAPSHOT', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
         )
 
-    def test_component_version_snapshot(self) -> None:
+    def test_component_version_snapshot(self):
         self.assertEqual(
             BuildTarget(version="1.1.0", architecture="x86", snapshot=True).component_version,
             "1.1.0.0-SNAPSHOT",
         )
 
     @patch("build_workflow.build_target.current_platform", return_value="value")
-    def test_platform(self, value_platform: Mock) -> None:
+    def test_platform(self, *mock):
         self.assertEqual(BuildTarget(version="1.1.0", snapshot=False).platform, "value")
-        value_platform.assert_called_once()
 
-    def test_platform_value(self) -> None:
+    def test_platform_value(self):
         self.assertEqual(BuildTarget(version="1.1.0", platform="value", snapshot=False).platform, "value")
 
     @patch("build_workflow.build_target.current_architecture", return_value="value")
-    def test_arch(self, value_architecture: Mock) -> None:
+    def test_arch(self, *mock):
         self.assertEqual(BuildTarget(version="1.1.0", snapshot=False).architecture, "value")
-        value_architecture.assert_called_once()
 
-    def test_arch_value(self) -> None:
+    def test_arch_value(self):
         self.assertEqual(BuildTarget(version="1.1.0", architecture="value", snapshot=False).architecture, "value")

--- a/tests/tests_build_workflow/test_builder_from_dist.py
+++ b/tests/tests_build_workflow/test_builder_from_dist.py
@@ -15,7 +15,7 @@ from manifests.input_manifest import InputComponentFromDist
 
 
 class TestBuilderFromDist(unittest.TestCase):
-    def __mock_builder(self, component_name):
+    def __mock_builder(self, component_name: str) -> BuilderFromDist:
         return BuilderFromDist(
             InputComponentFromDist({"name": component_name, "dist": "url"}),
             BuildTarget(
@@ -27,26 +27,26 @@ class TestBuilderFromDist(unittest.TestCase):
             ),
         )
 
-    def test_builder(self):
+    def test_builder(self) -> None:
         self.assertEqual(self.__mock_builder("common-utils").component.name, "common-utils")
 
     @patch("manifests.distribution.find_build_root")
     @patch("build_workflow.builder_from_dist.BuildManifest")
-    def test_checkout(self, mock_manifest: Mock, find_build_root: Mock):
+    def test_checkout(self, mock_manifest: Mock, find_build_root: Mock) -> None:
         builder = self.__mock_builder("common-utils")
         builder.checkout("dir")
         mock_manifest.from_url.assert_called_once()
         find_build_root.assert_called_once()
         self.assertIsNotNone(builder.distribution_url)
 
-    def test_build(self):
+    def test_build(self) -> None:
         build_recorder = MagicMock()
         self.__mock_builder("common-utils").build(build_recorder)
 
     @patch("os.makedirs")
     @patch("urllib.request.urlretrieve")
     @patch("build_workflow.builder_from_dist.BuilderFromDist.ManifestGitRepository")
-    def test_export_artifacts(self, mock_manifest_git_repository, mock_urllib: Mock, mock_makedirs, *mocks):
+    def test_export_artifacts(self, mock_manifest_git_repository: Mock, mock_urllib: Mock, mock_makedirs: Mock) -> None:
         build_recorder = MagicMock()
         manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-windows-1.1.0.yml")
         mock_builder = self.__mock_builder("notifications")
@@ -68,7 +68,7 @@ class TestBuilderFromDist(unittest.TestCase):
     @patch("os.makedirs")
     @patch("urllib.request.urlretrieve")
     @patch("build_workflow.builder_from_dist.BuilderFromDist.ManifestGitRepository")
-    def test_export_artifacts_skips_maven_artifacts(self, mock_manifest_git_repository, mock_urllib, mock_makedirs, *mocks):
+    def test_export_artifacts_skips_maven_artifacts(self, mock_manifest_git_repository: Mock, mock_urllib: Mock, mock_makedirs: Mock) -> None:
         build_recorder = MagicMock()
         manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-windows-1.1.0.yml")
         mock_builder = self.__mock_builder("common-utils")

--- a/tests/tests_build_workflow/test_builder_from_dist.py
+++ b/tests/tests_build_workflow/test_builder_from_dist.py
@@ -15,7 +15,7 @@ from manifests.input_manifest import InputComponentFromDist
 
 
 class TestBuilderFromDist(unittest.TestCase):
-    def __mock_builder(self, component_name: str) -> BuilderFromDist:
+    def __mock_builder(self, component_name):
         return BuilderFromDist(
             InputComponentFromDist({"name": component_name, "dist": "url"}),
             BuildTarget(
@@ -27,26 +27,26 @@ class TestBuilderFromDist(unittest.TestCase):
             ),
         )
 
-    def test_builder(self) -> None:
+    def test_builder(self):
         self.assertEqual(self.__mock_builder("common-utils").component.name, "common-utils")
 
     @patch("manifests.distribution.find_build_root")
     @patch("build_workflow.builder_from_dist.BuildManifest")
-    def test_checkout(self, mock_manifest: Mock, find_build_root: Mock) -> None:
+    def test_checkout(self, mock_manifest: Mock, find_build_root: Mock):
         builder = self.__mock_builder("common-utils")
         builder.checkout("dir")
         mock_manifest.from_url.assert_called_once()
         find_build_root.assert_called_once()
         self.assertIsNotNone(builder.distribution_url)
 
-    def test_build(self) -> None:
+    def test_build(self):
         build_recorder = MagicMock()
         self.__mock_builder("common-utils").build(build_recorder)
 
     @patch("os.makedirs")
     @patch("urllib.request.urlretrieve")
     @patch("build_workflow.builder_from_dist.BuilderFromDist.ManifestGitRepository")
-    def test_export_artifacts(self, mock_manifest_git_repository: Mock, mock_urllib: Mock, mock_makedirs: Mock) -> None:
+    def test_export_artifacts(self, mock_manifest_git_repository, mock_urllib: Mock, mock_makedirs, *mocks):
         build_recorder = MagicMock()
         manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-windows-1.1.0.yml")
         mock_builder = self.__mock_builder("notifications")
@@ -68,7 +68,7 @@ class TestBuilderFromDist(unittest.TestCase):
     @patch("os.makedirs")
     @patch("urllib.request.urlretrieve")
     @patch("build_workflow.builder_from_dist.BuilderFromDist.ManifestGitRepository")
-    def test_export_artifacts_skips_maven_artifacts(self, mock_manifest_git_repository: Mock, mock_urllib: Mock, mock_makedirs: Mock) -> None:
+    def test_export_artifacts_skips_maven_artifacts(self, mock_manifest_git_repository, mock_urllib, mock_makedirs, *mocks):
         build_recorder = MagicMock()
         manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-windows-1.1.0.yml")
         mock_builder = self.__mock_builder("common-utils")

--- a/tests/tests_build_workflow/test_builder_from_source.py
+++ b/tests/tests_build_workflow/test_builder_from_source.py
@@ -6,7 +6,8 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, call, patch
+from typing import Any, List
+from unittest.mock import MagicMock, Mock, call, patch
 
 from build_workflow.build_target import BuildTarget
 from build_workflow.builder_from_source import BuilderFromSource
@@ -15,7 +16,7 @@ from paths.script_finder import ScriptFinder
 
 
 class TestBuilderFromSource(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.builder = BuilderFromSource(
             InputComponentFromSource({"name": "common-utils", "repository": "url", "ref": "ref"}),
             BuildTarget(
@@ -27,11 +28,11 @@ class TestBuilderFromSource(unittest.TestCase):
             ),
         )
 
-    def test_builder(self):
+    def test_builder(self) -> None:
         self.assertEqual(self.builder.component.name, "common-utils")
 
     @patch("build_workflow.builder_from_source.GitRepository")
-    def test_build(self, mock_git_repo):
+    def test_build(self, mock_git_repo: Mock) -> None:
         mock_git_repo.return_value = MagicMock(working_directory="dir")
         build_recorder = MagicMock()
         self.builder.checkout("dir")
@@ -52,7 +53,7 @@ class TestBuilderFromSource(unittest.TestCase):
         build_recorder.record_component.assert_called_with("common-utils", mock_git_repo.return_value)
 
     @patch("build_workflow.builder_from_source.GitRepository")
-    def test_build_snapshot(self, mock_git_repo):
+    def test_build_snapshot(self, mock_git_repo: Mock) -> None:
         self.builder.target.snapshot = True
         mock_git_repo.return_value = MagicMock(working_directory="dir")
         build_recorder = MagicMock()
@@ -73,7 +74,7 @@ class TestBuilderFromSource(unittest.TestCase):
         )
         build_recorder.record_component.assert_called_with("common-utils", self.builder.git_repo)
 
-    def mock_os_walk(self, artifact_path):
+    def mock_os_walk(self, artifact_path: str) -> List[Any]:
         if artifact_path.endswith(os.path.join("dir", "builds", "core-plugins")):
             return [["core-plugins", [], ["plugin1.zip"]]]
         if artifact_path.endswith(os.path.join("dir", "builds", "maven")):
@@ -83,7 +84,7 @@ class TestBuilderFromSource(unittest.TestCase):
 
     @patch("os.walk")
     @patch("build_workflow.builder_from_source.GitRepository")
-    def test_export_artifacts(self, mock_git_repo, mock_walk):
+    def test_export_artifacts(self, mock_git_repo: Mock, mock_walk: Mock) -> None:
         build_recorder = MagicMock()
         mock_git_repo.return_value = MagicMock(working_directory="dir")
         mock_walk.side_effect = self.mock_os_walk

--- a/tests/tests_build_workflow/test_builder_from_source.py
+++ b/tests/tests_build_workflow/test_builder_from_source.py
@@ -6,8 +6,7 @@
 
 import os
 import unittest
-from typing import Any, List
-from unittest.mock import MagicMock, Mock, call, patch
+from unittest.mock import MagicMock, call, patch
 
 from build_workflow.build_target import BuildTarget
 from build_workflow.builder_from_source import BuilderFromSource
@@ -16,7 +15,7 @@ from paths.script_finder import ScriptFinder
 
 
 class TestBuilderFromSource(unittest.TestCase):
-    def setUp(self) -> None:
+    def setUp(self):
         self.builder = BuilderFromSource(
             InputComponentFromSource({"name": "common-utils", "repository": "url", "ref": "ref"}),
             BuildTarget(
@@ -28,11 +27,11 @@ class TestBuilderFromSource(unittest.TestCase):
             ),
         )
 
-    def test_builder(self) -> None:
+    def test_builder(self):
         self.assertEqual(self.builder.component.name, "common-utils")
 
     @patch("build_workflow.builder_from_source.GitRepository")
-    def test_build(self, mock_git_repo: Mock) -> None:
+    def test_build(self, mock_git_repo):
         mock_git_repo.return_value = MagicMock(working_directory="dir")
         build_recorder = MagicMock()
         self.builder.checkout("dir")
@@ -53,7 +52,7 @@ class TestBuilderFromSource(unittest.TestCase):
         build_recorder.record_component.assert_called_with("common-utils", mock_git_repo.return_value)
 
     @patch("build_workflow.builder_from_source.GitRepository")
-    def test_build_snapshot(self, mock_git_repo: Mock) -> None:
+    def test_build_snapshot(self, mock_git_repo):
         self.builder.target.snapshot = True
         mock_git_repo.return_value = MagicMock(working_directory="dir")
         build_recorder = MagicMock()
@@ -74,7 +73,7 @@ class TestBuilderFromSource(unittest.TestCase):
         )
         build_recorder.record_component.assert_called_with("common-utils", self.builder.git_repo)
 
-    def mock_os_walk(self, artifact_path: str) -> List[Any]:
+    def mock_os_walk(self, artifact_path):
         if artifact_path.endswith(os.path.join("dir", "builds", "core-plugins")):
             return [["core-plugins", [], ["plugin1.zip"]]]
         if artifact_path.endswith(os.path.join("dir", "builds", "maven")):
@@ -84,7 +83,7 @@ class TestBuilderFromSource(unittest.TestCase):
 
     @patch("os.walk")
     @patch("build_workflow.builder_from_source.GitRepository")
-    def test_export_artifacts(self, mock_git_repo: Mock, mock_walk: Mock) -> None:
+    def test_export_artifacts(self, mock_git_repo, mock_walk):
         build_recorder = MagicMock()
         mock_git_repo.return_value = MagicMock(working_directory="dir")
         mock_walk.side_effect = self.mock_os_walk


### PR DESCRIPTION
Signed-off-by: Yilin Zhang <yilizhan@amazon.com>

### Description
Adding type checking on all files under `src/build_workflow`.
Here is the result for mypy on those files:
```
pipenv run mypy src/build_workflow tests/tests_build_workflow
Success: no issues found in 28 source files
```
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
