### PR TITLE
Add constrait to prevent pulling in older version of log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,15 @@ dependencies {
     compile group: 'com.lesfurets', name:'jenkins-pipeline-unit', version: '1.13'
     compile group: 'com.cloudbees', name: 'groovy-cps', version: '1.31'
     compile group: 'org.yaml', name: 'snakeyaml', version: '1.29'
+    constraints {
+        implementation("org.apache.logging.log4j:log4j-core") {
+            version {
+                strictly("[2.16, 3[")
+                prefer("2.16.0")
+            }
+            because("CVE-2021-44228: Log4j vulnerable to remote code execution")
+        }
+    }
 }
 
 sourceSets {


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Add constraint to prevent pulling in older version of log4j
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
