### PR TITLE
Add read access for dist prefix in dev s3 bucket

### DIFF
--- a/deployment/lib/identities.ts
+++ b/deployment/lib/identities.ts
@@ -45,6 +45,7 @@ export class Identities {
     props.buildBucket.grantRead(bundleRole, '*/shas/*');
     props.buildBucket.grantPut(bundleRole, '*/shas/*');
 
+    props.buildBucket.grantRead(bundleRole, '*/dist/*');
     props.buildBucket.grantPut(bundleRole, '*/dist/*');
 
     props.buildBucket.grantRead(testRole, '*/dist/*');


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add read access for dist prefix in dev s3 bucket
 
### Issues Resolved
Part of #1332
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
