### PR TITLE
Add try-catch block to catch error while triggering other jobs

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -57,11 +57,15 @@ pipeline {
                         if (sha.exists) {
                             echo "Skipping, ${sha.path} already exists."
                         } else {
-                            build job: "${TARGET_JOB_NAME}", parameters: [
+                            try {
+                                build job: "${TARGET_JOB_NAME}", parameters: [
                                 string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}")
-                            ], wait: true
-                            echo "Build succeeded, uploading build SHA for that job"
-                            buildUploadManifestSHA(jobName: "${TARGET_JOB_NAME}")
+                                ], wait: true
+                                echo "Build succeeded, uploading build SHA for that job"
+                                buildUploadManifestSHA(jobName: "${TARGET_JOB_NAME}")
+                            } catch (err) {
+                                echo "${TARGET_JOB_NAME} failed"
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Currently our `check-for-build` jenkins job will fail if its child job fails, which also sends out failure notification. Adding a `try-catch` block will continue the workflow and only fails if there is an issue in `check-for-build` itself. 
 
### Issues Resolved
#1285 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
