### PR TITLE
Added job-scheduler to the 1.2.3 manifest.

### DIFF
--- a/manifests/1.2.3/opensearch-1.2.3.yml
+++ b/manifests/1.2.3/opensearch-1.2.3.yml
@@ -20,3 +20,9 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description
Added job-scheduler to the 1.2.3 manifest.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
