### PR TITLE
Remove plugins that still need a log4j version bump.

### DIFF
--- a/manifests/1.2.3/opensearch-1.2.3.yml
+++ b/manifests/1.2.3/opensearch-1.2.3.yml
@@ -56,15 +56,6 @@ components:
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: "1.2"
-  - name: performance-analyzer
-    repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: "1.2"
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
-    platforms:
-      - darwin
-      - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
     ref: "1.2"
@@ -77,12 +68,6 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
-  - name: sql
-    repository: https://github.com/opensearch-project/sql.git
-    ref: "1.2"
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
     ref: "1.2"


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Coming from https://github.com/opensearch-project/sql/pull/345, remove the plugins that haven't had the version bump for log4j to get a 1.2.3-SNAPSHOT with https://github.com/opensearch-project/OpenSearch/pull/1774.

Running `./build.sh manifests/1.2.3/opensearch-1.2.3.yml  --snapshot` passes with this change.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
