### PR TITLE
Add performance-analyzer and sql back to the 1.2.3 manifest

### DIFF
--- a/manifests/1.2.3/opensearch-1.2.3.yml
+++ b/manifests/1.2.3/opensearch-1.2.3.yml
@@ -77,6 +77,12 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: sql
+      repository: https://github.com/opensearch-project/sql.git
+      ref: "1.2"
+      checks:
+        - gradle:properties:version
+        - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
     ref: "1.2"

--- a/manifests/1.2.3/opensearch-1.2.3.yml
+++ b/manifests/1.2.3/opensearch-1.2.3.yml
@@ -56,6 +56,15 @@ components:
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: "1.2"
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+    platforms:
+      - darwin
+      - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
     ref: "1.2"

--- a/manifests/1.2.3/opensearch-1.2.3.yml
+++ b/manifests/1.2.3/opensearch-1.2.3.yml
@@ -78,11 +78,11 @@ components:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: sql
-      repository: https://github.com/opensearch-project/sql.git
-      ref: "1.2"
-      checks:
-        - gradle:properties:version
-        - gradle:dependencies:opensearch.version: plugin
+    repository: https://github.com/opensearch-project/sql.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
     ref: "1.2"


### PR DESCRIPTION
The performance-analyzer plugin was removed from the 1.2.3 manifset in

Signed-off-by: Joshua Tokle <joshtok@amazon.com>

### Description
Restore the performance-analyzer plugin to the 1.2.3 manifest following upgrade to Log4j 2.17.
 
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
