### PR TITLE
Revert "Remove plugins that still need a log4j version bump. (#1387)"

### DIFF
--- a/manifests/1.2.3/opensearch-1.2.3.yml
+++ b/manifests/1.2.3/opensearch-1.2.3.yml
@@ -56,6 +56,15 @@ components:
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: "1.2"
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+    platforms:
+      - darwin
+      - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
     ref: "1.2"
@@ -68,6 +77,12 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: sql
+    repository: https://github.com/opensearch-project/sql.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
     ref: "1.2"


### PR DESCRIPTION
This reverts commit ad157de68ff4346b16b93a358bb6b8ba72c403d9.

Signed-off-by: dblock <dblock@dblock.org>

### Description

Re-add the sql and PA plugins.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
