### PR TITLE
Add new manifests to crontab.

### DIFF
--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -6,6 +6,7 @@
 
 import os
 import unittest
+from unittest.mock import call, mock_open, patch
 
 from manifests_workflow.input_manifests import InputManifests
 
@@ -25,6 +26,44 @@ class TestInputManifests(unittest.TestCase):
                 "build": {"name": "test", "version": "1.2.3"},
                 "ci": {"image": {"name": "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028"}},
             },
+        )
+
+    @patch("os.makedirs")
+    @patch("manifests_workflow.input_manifests.InputManifests.create_manifest")
+    def test_write_manifest(self, mock_create_manifest, mock_makedirs):
+        input_manifests = InputManifests("test")
+        input_manifests.write_manifest('0.1.2', [])
+        mock_create_manifest.assert_called_with('0.1.2', [])
+        mock_makedirs.assert_called_with(os.path.join(InputManifests.manifests_path(), '0.1.2'), exist_ok=True)
+        mock_create_manifest.return_value.to_file.assert_called_with(
+            os.path.join(InputManifests.manifests_path(), '0.1.2', 'test-0.1.2.yml')
+        )
+
+    def test_jenkins_path(self):
+        self.assertEqual(
+            InputManifests.jenkins_path(),
+            os.path.realpath(
+                os.path.join(
+                    os.path.dirname(__file__), "..", "..", "jenkins"
+                )
+            )
+        )
+
+    def test_cron_jenkinsfile(self):
+        self.assertEqual(
+            InputManifests.cron_jenkinsfile(),
+            os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "jenkins", "check-for-build.jenkinsfile"))
+        )
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_add_to_cron(self, mock_open):
+        mock_open().read.return_value = "parameterizedCron '''\n"
+        input_manifests = InputManifests("test")
+        input_manifests.add_to_cron('0.1.2')
+        mock_open.assert_has_calls([call(InputManifests.cron_jenkinsfile(), 'w')])
+        mock_open.assert_has_calls([call(InputManifests.cron_jenkinsfile(), 'r')])
+        mock_open().write.assert_called_once_with(
+            f"parameterizedCron '''\n{' ' * 12}H/10 * * * * %INPUT_MANIFEST=0.1.2/test-0.1.2.yml;TARGET_JOB_NAME=distribution-build-test\n"
         )
 
     def test_create_manifest_with_components(self):

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
@@ -30,11 +30,12 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
 
     @patch("os.makedirs")
     @patch("os.chdir")
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
     @patch("manifests_workflow.input_manifests.InputManifest.from_path")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearchMin")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearch")
     @patch("manifests_workflow.input_manifests.InputManifest")
-    def test_update(self, mock_input_manifest, mock_component_opensearch, mock_component_opensearch_min, mock_input_manifest_from_path, *mocks):
+    def test_update(self, mock_input_manifest, mock_component_opensearch, mock_component_opensearch_min, mock_input_manifest_from_path, mock_add_to_cron, *mocks):
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
         mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
@@ -63,13 +64,18 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
             ),
         ]
         mock_input_manifest().to_file.assert_has_calls(calls)
+        mock_add_to_cron.assert_has_calls([
+            call('0.10.0'),
+            call('0.9.0')
+        ])
 
     @patch("os.makedirs")
     @patch("os.chdir")
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearchMin")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearch")
     @patch("manifests_workflow.input_manifests_opensearch.InputManifestsOpenSearch.write_manifest")
-    def test_update_with_latest_manifest(self, mock_write_manifest, mock_component_opensearch, mock_component_opensearch_min, *mocks):
+    def test_update_with_latest_manifest(self, mock_write_manifest, mock_component_opensearch, mock_component_opensearch_min, mock_add_to_cron, *mocks):
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
         mock_component_opensearch_min.branches.return_value = ["main"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
@@ -79,3 +85,4 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
         manifests.update()
         mock_component_opensearch_min.branches.assert_called()
         mock_write_manifest.assert_called_with("0.9.0", [mock_component_opensearch_min.checkout.return_value])
+        mock_add_to_cron.assert_called_with("0.9.0")

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
@@ -29,10 +29,11 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
 
     @patch("os.makedirs")
     @patch("os.chdir")
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
     @patch("manifests_workflow.input_manifests.InputManifest.from_path")
     @patch("manifests_workflow.input_manifests_opensearch_dashboards.ComponentOpenSearchDashboardsMin")
     @patch("manifests_workflow.input_manifests.InputManifest")
-    def test_update(self, mock_input_manifest, mock_component_opensearch_min, mock_input_manifest_from_path, *mocks):
+    def test_update(self, mock_input_manifest, mock_component_opensearch_min, mock_input_manifest_from_path, mock_add_to_cron, *mocks):
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch-Dashboards")
         mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
@@ -50,3 +51,6 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
             )
         ]
         mock_input_manifest().to_file.assert_has_calls(calls)
+        mock_add_to_cron.assert_has_calls([
+            call('0.9.0')
+        ])


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

When a new manifest is added, such as in https://github.com/opensearch-project/opensearch-build/pull/1404, also add it to the cron build so it starts building right away.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
