### PR TITLE
Added job-scheduler and common-utils to 1.2.4 manifest.

### DIFF
--- a/manifests/1.2.4/opensearch-1.2.4.yml
+++ b/manifests/1.2.4/opensearch-1.2.4.yml
@@ -1,3 +1,4 @@
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.2.4
@@ -5,10 +6,21 @@ ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028
 components:
-- checks:
-  - gradle:publish
-  - gradle:properties:version
-  name: OpenSearch
-  ref: '1.2'
-  repository: https://github.com/opensearch-project/OpenSearch.git
-schema-version: '1.0'
+  - name: OpenSearch
+    checks:
+      - gradle:publish
+      - gradle:properties:version
+    ref: "1.2"
+    repository: https://github.com/opensearch-project/OpenSearch.git
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: "1.2"
+    checks:
+      - gradle:publish
+      - gradle:properties:version
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Added job-scheduler and common-utils to 1.2.4 manifest.

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/1417
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
