### PR TITLE
Remove SQL until it bumps log4j 2.17.1.

### DIFF
--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -40,12 +40,6 @@ components:
 - name: security
   repository: https://github.com/opensearch-project/security.git
   ref: 'main'
-- name: sql
-  repository: https://github.com/opensearch-project/sql.git
-  ref: 'main'
-  checks:
-    - gradle:properties:version
-    - gradle:dependencies:opensearch.version: plugin
 - name: dashboards-reports
   repository: https://github.com/opensearch-project/dashboards-reports.git
   ref: 'main'


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

https://github.com/opensearch-project/sql/pull/354 is failing because there's no snapshot build, and there's no snapshot build because sql is included in it; remove it for now
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
