### PR TITLE
Added alerting to 1.2.4 manifest.

### DIFF
--- a/manifests/1.2.4/opensearch-1.2.4.yml
+++ b/manifests/1.2.4/opensearch-1.2.4.yml
@@ -24,3 +24,9 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: "1.2"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Coming from https://github.com/opensearch-project/opensearch-build/issues/1417, and after https://github.com/opensearch-project/alerting/pull/264, this will unblock index-management.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
