### PR TITLE
[Dashboards][1.2.0] update plugins to use tags

### DIFF
--- a/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
@@ -18,28 +18,28 @@ components:
   ref: "main"
 - name: securityDashboards
   repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-  ref: "1.2"
+  ref: tags/1.2.0.0
 - name: indexManagementDashboards
   repository: https://github.com/opensearch-project/index-management-dashboards-plugin
-  ref: "1.2"
+  ref: tags/1.2.0.0
 - name: queryWorkbenchDashboards
   repository: https://github.com/opensearch-project/sql.git
   working_directory: workbench
-  ref: "1.2.0.0"
+  ref: tags/1.2.0.0
 - name: reportsDashboards
   repository: https://github.com/opensearch-project/dashboards-reports.git
   working_directory: dashboards-reports
-  ref: "1.2.0.0"
+  ref: tags/1.2.0.0
   platforms:
     - linux
 - name: observabilityDashboards
   repository: https://github.com/opensearch-project/trace-analytics.git
   working_directory: dashboards-observability
-  ref: "1.2.0.0"
+  ref: tags/1.2.0.0
 - name: ganttChartDashboards
   repository: https://github.com/opensearch-project/dashboards-visualizations.git
   working_directory: gantt-chart
-  ref: "1.2.0.0"
+  ref: tags/1.2.0.0
 - name: anomalyDetectionDashboards
   repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
   ref: tags/1.2.0.0


### PR DESCRIPTION
### Description
Ensures the plugins for OpenSearch Dashboards utilizes the tag for 1.2.0.0

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
