### PR TITLE
Fix remaining CVEs, remove jcenter and netbeans maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,12 @@ repositories {
 }
 
 dependencies {
+    compile group: 'junit', name: 'junit', version: '4.13.2'
     implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '3.0.9', ext: 'pom'
     implementation group: 'com.cloudbees', name: 'groovy-cps', version: '1.31'
     testImplementation group: 'org.yaml', name: 'snakeyaml', version: '1.29'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.4.1'
     testImplementation group: 'com.lesfurets', name:'jenkins-pipeline-unit', version: '1.13'
-    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -63,11 +63,11 @@ sourceSets {
 }
 
 sharedLibrary {
-    coreVersion = '2.326' //  https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-core
-    testHarnessVersion = '2.72' //  https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-test-harness
+    coreVersion = '2.326' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-core?repo=jenkins-releases
+    testHarnessVersion = '2.72' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-test-harness?repo=jenkins-releases
     pluginDependencies {
-        workflowCpsGlobalLibraryPluginVersion = '2.16'
-        dependency('org.jenkins-ci.plugins', 'pipeline-input-step', '2.8')
+        workflowCpsGlobalLibraryPluginVersion = '2.18' // https://mvnrepository.com/artifact/org.jenkins-ci.plugins.workflow/workflow-cps-global-lib?repo=jenkins-releases
+        dependency('org.jenkins-ci.plugins', 'pipeline-input-step', '2.12') // https://mvnrepository.com/artifact/org.jenkins-ci.plugins/pipeline-input-step?repo=jenkins-releases
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,11 @@ sharedLibrary {
     testHarnessVersion = '2.72' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-test-harness?repo=jenkins-releases
     pluginDependencies {
         workflowCpsGlobalLibraryPluginVersion = '2.18' // https://mvnrepository.com/artifact/org.jenkins-ci.plugins.workflow/workflow-cps-global-lib?repo=jenkins-releases
-        dependency('org.jenkins-ci.plugins', 'pipeline-input-step', '2.12') // https://mvnrepository.com/artifact/org.jenkins-ci.plugins/pipeline-input-step?repo=jenkins-releases
+        // see https://mvnrepository.com/artifact/org.jenkins-ci.plugins/<name>?repo=jenkins-releases for latest
+        dependency('org.jenkins-ci.plugins', 'pipeline-input-step', '2.12')
+        dependency('org.jenkins-ci.plugins', 'script-security', '1.78')
+        dependency('org.jenkins-ci.plugins', 'credentials', '2.6.2')
+        dependency('org.jenkins-ci.plugins', 'git-client', '3.10.1')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '3.0.9', ext: 'pom'
     implementation group: 'com.cloudbees', name: 'groovy-cps', version: '1.31'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
+    implementation group: 'commons-codec', name: 'commons-codec', version: '1.15'
+    implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.19.3'
     testImplementation group: 'org.yaml', name: 'snakeyaml', version: '1.29'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.4.1'
     testImplementation group: 'com.lesfurets', name:'jenkins-pipeline-unit', version: '1.13'

--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,17 @@ dependencies {
     compile group: 'junit', name: 'junit', version: '4.13.2'
     implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '3.0.9', ext: 'pom'
     implementation group: 'com.cloudbees', name: 'groovy-cps', version: '1.31'
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
-    implementation group: 'commons-codec', name: 'commons-codec', version: '1.15'
-    implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.19.3'
     testImplementation group: 'org.yaml', name: 'snakeyaml', version: '1.29'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.4.1'
     testImplementation group: 'com.lesfurets', name:'jenkins-pipeline-unit', version: '1.13'
+}
+
+configurations.all {
+    resolutionStrategy {
+        force group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
+        force group: 'commons-codec', name: 'commons-codec', version: '1.15'
+        force group: 'com.google.protobuf', name: 'protobuf-java', version: '3.19.3'
+    }
 }
 
 sourceSets {
@@ -77,8 +82,8 @@ sharedLibrary {
 }
 
 test {
-    if (project.hasProperty("pipeline.stack.write")) {
-        systemProperty "pipeline.stack.write", project.getProperty("pipeline.stack.write")
+    if (project.hasProperty('pipeline.stack.write')) {
+        systemProperty 'pipeline.stack.write', project.getProperty('pipeline.stack.write')
     }
 
     jacoco {
@@ -89,7 +94,7 @@ test {
 }
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = '0.8.7'
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,7 @@ plugins {
 }
 
 repositories {
-    maven { url 'http://bits.netbeans.org/maven2/' }
     maven { url 'https://repo.jenkins-ci.org/releases/' }
-    jcenter()
     maven { url 'https://mvnrepository.com/artifact/' }
     mavenLocal()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile group: 'junit', name: 'junit', version: '4.13.2'
     implementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '3.0.9', ext: 'pom'
     implementation group: 'com.cloudbees', name: 'groovy-cps', version: '1.31'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
     testImplementation group: 'org.yaml', name: 'snakeyaml', version: '1.29'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.4.1'
     testImplementation group: 'com.lesfurets', name:'jenkins-pipeline-unit', version: '1.13'


### PR DESCRIPTION
### Description

Fixing remaining Whitesource CVEs by either declaring Jenkins plugin versions or force-resolving dependencies.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
