### PR TITLE
Adding security dashboards plugin to 1.3.0 manifest

### DIFF
--- a/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
@@ -11,4 +11,7 @@ components:
 - name: functionalTestDashboards
   repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
   ref: "main"
+- name: securityDashboards
+  repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+  ref: "main"
 schema-version: '1.0'


### PR DESCRIPTION
Signed-off-by: Dave Lago <davelago@amazon.com>

### Description
Updated manifest to add security dashboards plugin to 1.3.0. Needs https://github.com/opensearch-project/security-dashboards-plugin/pull/884 to merge first... so if you're reading this and it hasn't already merged, please take a look and see if you can add a quick review ;)
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
