### PR TITLE
Only perform ref checks on components with stable refs.

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -69,7 +69,7 @@ __REPLACE with OpenSearch wide initiatives to improve quality and consistency.__
 ### Post Release
 
 - [ ] Create [release tags](https://github.com/opensearch-project/opensearch-build/issues/378#issuecomment-999700848) for each component.
-- [ ] Replace refs in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}) with tags.
+- [ ] Replace refs in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}) with tags and remove checks.
 - [ ] Prepare [for next patch release](https://github.com/opensearch-project/opensearch-plugins/blob/main/META.md#increment-a-version-in-every-plugin) by incrementing patch versions for each component.
 - [ ] Lower the [frequency of builds](https://github.com/opensearch-project/opensearch-build/pull/1475) for this version of OpenSearch and/or OpenSearch Dashboards.
 - [ ] Update [this template](https://github.com/opensearch-project/opensearch-build/blob/main/.github/ISSUE_TEMPLATE/release_template.md) with any new or missed steps.

--- a/manifests/1.0.0/opensearch-1.0.0.yml
+++ b/manifests/1.0.0/opensearch-1.0.0.yml
@@ -6,45 +6,45 @@ build:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: "1.0"
+    ref: tags/1.0.0
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: "1.0"
+    ref: tags/1.0.0.0
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: 1.0.0.0
+    ref: tags/1.0.0.0
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: 1.0.0.0
+    ref: tags/1.0.0.0
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: 1.0.0.0
+    ref: tags/1.0.0.0
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: 1.0.0.0
+    ref: tags/1.0.0.0
 #  - name: performance-analyzer-rca
 #    repository: https://github.com/opensearch-project/performance-analyzer-rca.git
-#    ref: 1.0.0.0
+#    ref: tags/1.0.0.0
 #  - name: performance-analyzer
 #    repository: https://github.com/opensearch-project/performance-analyzer.git
-#    ref: 1.0.0.0
+#    ref: tags/1.0.0.0
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: 1.0.0.0
+    ref: tags/1.0.0.0
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: 1.0.0.0
+    ref: tags/1.0.0.0
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: "1.0"
+    ref: tags/1.0.0.0
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: "main"
+    ref: tags/1.0.0.0
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: 1.0.0.0
+    ref: tags/1.0.0.0
     working_directory: "reports-scheduler"
   - name: dashboards-notebooks
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-    ref: 1.0.0.0
+    ref: tags/1.0.0.0
     working_directory: "opensearch-notebooks"

--- a/manifests/1.0.1/opensearch-1.0.1.yml
+++ b/manifests/1.0.1/opensearch-1.0.1.yml
@@ -21,16 +21,16 @@ components:
     ref: tags/1.0.0.0
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: "1.0"
+    ref: tags/v1.0.1.0-OS
   - name: performance-analyzer-rca
     repository: https://github.com/opensearch-project/performance-analyzer-rca.git
-    ref: 1.0.1
+    ref: tags/1.0.1.0
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: 1.0.1
+    ref: tags/1.0.1.0
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: "1.0"
+    ref: tags/1.0.1.0
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
     ref: tags/1.0.0.0

--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -11,89 +11,50 @@ components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
     ref: tags/1.2.0
-    checks:
-      - gradle:publish
-      - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
     ref: tags/1.2.0.0
-    checks:
-      - gradle:publish
-      - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
     ref: tags/1.2.0.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
     ref: tags/1.2.0.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: alerting
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
     ref: tags/1.2.0.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
     ref: tags/1.2.0.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
     ref: tags/1.2.0.0
     platforms:
       - darwin
       - linux
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: tags/1.2.0.0
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: tags/1.2.0.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     platforms:
       - darwin
       - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
     ref: tags/1.2.0.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
     ref: tags/1.2.0.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
     ref: tags/1.2.0.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
     ref: tags/1.2.0.0
     working_directory: "reports-scheduler"
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/trace-analytics.git
     ref: tags/1.2.0.0
     working_directory: "opensearch-observability"
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version

--- a/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
@@ -10,54 +10,36 @@ components:
   - name: OpenSearch-Dashboards
     ref: tags/1.2.0
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    checks:
-      - npm:package:version
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin
     ref: tags/1.2.0.0
-    checks:
-      - npm:package:version
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
     ref: "main"
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
     ref: tags/1.2.0.0
-    checks:
-      - npm:package:version
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
     ref: tags/1.2.0.0
-    checks:
-      - npm:package:version
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/sql.git
     working_directory: workbench
     ref: tags/1.2.0.0
-    checks:
-      - npm:package:version
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reports.git
     working_directory: dashboards-reports
     ref: tags/1.2.0.0
-    checks:
-      - npm:package:version
     platforms:
       - linux
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/trace-analytics.git
     working_directory: dashboards-observability
     ref: tags/1.2.0.0
-    checks:
-      - npm:package:version
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
     working_directory: gantt-chart
     ref: tags/1.2.0.0
-    checks:
-      - npm:package:version
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     ref: tags/1.2.0.0
-    checks:
-      - npm:package:version

--- a/manifests/1.2.2/opensearch-1.2.2.yml
+++ b/manifests/1.2.2/opensearch-1.2.2.yml
@@ -11,89 +11,50 @@ components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
     ref: tags/1.2.2
-    checks:
-      - gradle:publish
-      - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
     ref: tags/1.2.2.0
-    checks:
-      - gradle:publish
-      - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
     ref: tags/1.2.2.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
     ref: tags/1.2.2.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: alerting
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
     ref: tags/1.2.2.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
     ref: tags/1.2.2.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
     ref: tags/1.2.2.0
     platforms:
       - darwin
       - linux
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: tags/1.2.2.0
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: tags/1.2.2.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     platforms:
       - darwin
       - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
     ref: tags/1.2.2.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
     ref: tags/1.2.2.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
     ref: tags/1.2.2.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
     ref: tags/1.2.2.0
     working_directory: reports-scheduler
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability
     ref: tags/1.2.2.0
     working_directory: opensearch-observability
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version

--- a/manifests/1.2.3/opensearch-1.2.3.yml
+++ b/manifests/1.2.3/opensearch-1.2.3.yml
@@ -11,89 +11,50 @@ components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
     ref: tags/1.2.3
-    checks:
-      - gradle:publish
-      - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
     ref: tags/1.2.3.0
-    checks:
-      - gradle:publish
-      - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
     ref: tags/1.2.3.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
     ref: tags/1.2.3.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: alerting
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
     ref: tags/1.2.3.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
     ref: tags/1.2.3.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
     ref: tags/1.2.3.0
     platforms:
       - darwin
       - linux
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: tags/1.2.3.0
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: tags/1.2.3.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     platforms:
       - darwin
       - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
     ref: tags/1.2.3.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
     ref: tags/1.2.3.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
     ref: tags/1.2.3.0
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
     ref: tags/1.2.3.0
     working_directory: reports-scheduler
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability
     ref: tags/1.2.3.0
     working_directory: opensearch-observability
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version

--- a/src/ci_workflow/ci_check_list_source_ref.py
+++ b/src/ci_workflow/ci_check_list_source_ref.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import logging
+import subprocess
+
+from ci_workflow.ci_check_list import CiCheckList
+
+
+class CiCheckListSourceRef(CiCheckList):
+    class MissingRefError(Exception):
+        def __init__(self, url: str, ref: str) -> None:
+            super().__init__(f"Missing {url}@{ref}.")
+
+    def checkout(self, work_dir):
+        return super().checkout(work_dir)
+
+    def check(self):
+        logging.info(f"Checking {self.component.repository} at {self.component.ref}.")
+        results = subprocess.check_output(f"git ls-remote {self.component.repository} {self.component.ref}", shell=True).decode().strip().split("\t")
+        if len(results) != 2:
+            raise CiCheckListSourceRef.MissingRefError(self.component.repository, self.component.ref)
+        else:
+            logging.info(f"Found {self.component.repository} at {self.component.ref} ({results[0]}).")

--- a/src/ci_workflow/ci_check_lists.py
+++ b/src/ci_workflow/ci_check_lists.py
@@ -8,6 +8,7 @@ from abc import ABC
 
 from ci_workflow.ci_check_list_dist import CiCheckListDist
 from ci_workflow.ci_check_list_source import CiCheckListSource
+from ci_workflow.ci_check_list_source_ref import CiCheckListSourceRef
 from manifests.input_manifest import InputComponentFromDist, InputComponentFromSource
 
 
@@ -17,6 +18,9 @@ class CiCheckLists(ABC):
         if type(component) is InputComponentFromDist:
             return CiCheckListDist(component, target)
         elif type(component) is InputComponentFromSource:
-            return CiCheckListSource(component, target)
+            if len(component.checks) > 0:
+                return CiCheckListSource(component, target)
+            else:
+                return CiCheckListSourceRef(component, target)
         else:
             raise ValueError(f"Invalid component type: {type(component)}")

--- a/tests/tests_ci_workflow/test_ci_check_lists.py
+++ b/tests/tests_ci_workflow/test_ci_check_lists.py
@@ -8,6 +8,7 @@ import unittest
 
 from ci_workflow.ci_check_list_dist import CiCheckListDist
 from ci_workflow.ci_check_list_source import CiCheckListSource
+from ci_workflow.ci_check_list_source_ref import CiCheckListSourceRef
 from ci_workflow.ci_check_lists import CiCheckLists
 from manifests.input_manifest import InputComponentFromDist, InputComponentFromSource
 
@@ -19,6 +20,19 @@ class TestCiCheckLists(unittest.TestCase):
             "repository": "url",
             "ref": "ref"
         }), None)
+        self.assertIs(type(check_list), CiCheckListSourceRef)
+
+    def test_from_component_source_with_checks(self):
+        check_list = CiCheckLists.from_component(
+            InputComponentFromSource({
+                "name": "common-utils",
+                "repository": "url",
+                "ref": "ref",
+                "checks": [
+                    "check1"
+                ]
+            }), None
+        )
         self.assertIs(type(check_list), CiCheckListSource)
 
     def test_from_component_dist(self):

--- a/tests/tests_ci_workflow/test_ci_check_lists_source_ref.py
+++ b/tests/tests_ci_workflow/test_ci_check_lists_source_ref.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ci_workflow.ci_check_list_source_ref import CiCheckListSourceRef
+from manifests.input_manifest import InputComponentFromSource
+
+
+class TestCiCheckListsSourceRef(unittest.TestCase):
+    @patch("subprocess.check_output", return_value="invalid".encode())
+    def test_ref_does_not_exist(self, mock_check_output):
+        component = InputComponentFromSource({"name": "common-utils", "repository": "url", "ref": "ref"})
+        with self.assertRaises(CiCheckListSourceRef.MissingRefError) as ctx:
+            list = CiCheckListSourceRef(component, MagicMock())
+            list.check()
+        self.assertEqual("Missing url@ref.", str(ctx.exception))
+        mock_check_output.assert_called_with("git ls-remote url ref", shell=True)
+
+    @patch("subprocess.check_output", return_value="valid\tref".encode())
+    def test_ref_exists(self, mock_check_output):
+        component = InputComponentFromSource({"name": "common-utils", "repository": "url", "ref": "ref"})
+        list = CiCheckListSourceRef(component, MagicMock())
+        list.check()
+        mock_check_output.assert_called_with("git ls-remote url ref", shell=True)

--- a/tests/tests_manifests/data/opensearch-1.2.0.yml
+++ b/tests/tests_manifests/data/opensearch-1.2.0.yml
@@ -6,55 +6,94 @@ ci:
      args: "-e JAVA_HOME=/usr/lib/jvm/adoptopenjdk-14-hotspot"
 build:
   name: OpenSearch
-  version: 1.2.1
+  version: 1.2.0
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: tags/1.2.1
+    ref: tags/1.2.0
+    checks:
+      - gradle:publish
+      - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:publish
+      - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
     platforms:
       - darwin
       - linux
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
     platforms:
       - darwin
       - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
     working_directory: "reports-scheduler"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/trace-analytics.git
-    ref: tags/1.2.1.0
+    ref: tags/1.2.0.0
     working_directory: "opensearch-observability"
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -36,7 +36,7 @@ class TestInputManifest(unittest.TestCase):
             "https://ci.opensearch.org/ci/dbc/bundle-build-dashboards/1.1.0/20210930",
         )
         for component in manifest.components.values():
-            if component.name in ['reportsDashboards', 'functionalTestDashboards']:
+            if component.name in ["reportsDashboards", "functionalTestDashboards"]:
                 self.assertIsInstance(component, InputComponentFromSource)
             else:
                 self.assertIsInstance(component, InputComponentFromDist)
@@ -56,7 +56,7 @@ class TestInputManifest(unittest.TestCase):
             opensearch_component.repository,
             "https://github.com/opensearch-project/OpenSearch.git",
         )
-        self.assertEqual(opensearch_component.ref, "1.0")
+        self.assertEqual(opensearch_component.ref, "tags/1.0.0")
         for component in manifest.components.values():
             self.assertIsInstance(component, InputComponentFromSource)
 
@@ -89,7 +89,8 @@ class TestInputManifest(unittest.TestCase):
         self.assertEqual(alerting_component.checks[1].args, "alerting")
 
     def test_1_2(self) -> None:
-        path = os.path.join(self.manifests_path, "1.2.0/opensearch-1.2.0.yml")
+        data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
+        path = os.path.join(data_path, "opensearch-1.2.0.yml")
         manifest = InputManifest.from_path(path)
         self.assertEqual(manifest.version, "1.0")
         self.assertEqual(manifest.build.name, "OpenSearch")
@@ -174,7 +175,7 @@ class TestInputManifest(unittest.TestCase):
         self.assertEqual(opensearch.ref, "updated")
 
     @patch("subprocess.check_output")
-    @patch("git.git_repository.GitRepository.stable_ref", return_value=('abcd', '1234'))
+    @patch("git.git_repository.GitRepository.stable_ref", return_value=("abcd", "1234"))
     def test_stable_override_build(self, git_repo: Mock, mock_output: Mock) -> None:
         mock_output.return_value.decode.return_value = "updated\tHEAD"
         path = os.path.join(self.manifests_path, "1.1.0", "opensearch-1.1.0.yml")


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

The manifest checks will continue taking longer and longer because we keep shipping releases. As of now, the 31 checks in https://github.com/opensearch-project/opensearch-build/actions/runs/1685288124 took 14m. It's not bad because the checks are parallelized.

We have suggested in https://github.com/opensearch-project/opensearch-build/issues/1335 to skip checking manifests for already released versions, but this PR proposes a better solution. 

- Only check that a ref exists without checking out the entire source if there are no actual checks to be performed.
- Update any refs that weren't using tags in manifests for shipped releases.
- Remove checks from components in released manifests to avoid re-running the same checks on stable targets.

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/1335.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
