### PR TITLE
Resolve #1130 where sed and tee is trying to access files at the same time

### DIFF
--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
@@ -177,8 +177,8 @@ if [ -d "$OPENSEARCH_DASHBOARDS_HOME/plugins/$SECURITY_DASHBOARDS_PLUGIN" ]; the
     if [ "$DISABLE_SECURITY_DASHBOARDS_PLUGIN" = "true" ]; then
         echo "Disabling OpenSearch Security Dashboards Plugin"
         ./bin/opensearch-dashboards-plugin remove securityDashboards
-        sed "/^opensearch_security/d" $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
-        sed "s/https/http/" $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
+        cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "/^opensearch_security/d" | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
+        cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "s/https/http/g" | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
     fi
 fi
 

--- a/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
@@ -66,10 +66,11 @@ if [ -d "$OPENSEARCH_HOME/plugins/$SECURITY_PLUGIN" ]; then
 
     if [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
         echo "Disabling OpenSearch Security Plugin"
-        sed "s/plugins.security.disabled.*$/plugins.security.disabled: true" $OPENSEARCH_HOME/config/opensearch.yml | tee $OPENSEARCH_HOME/config/opensearch.yml
+        cat $OPENSEARCH_HOME/config/opensearch.yml | sed "/plugins.security.disabled/d" | tee $OPENSEARCH_HOME/config/opensearch.yml
+        echo "plugins.security.disabled: true" >> $OPENSEARCH_HOME/config/opensearch.yml
     else
         echo "Enabling OpenSearch Security Plugin"
-        sed "/plugins.security.disabled/d" $OPENSEARCH_HOME/config/opensearch.yml | tee $OPENSEARCH_HOME/config/opensearch.yml
+        cat $OPENSEARCH_HOME/config/opensearch.yml | sed "/plugins.security.disabled/d" | tee $OPENSEARCH_HOME/config/opensearch.yml
     fi
 fi
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Resolve #1130 where sed and tee is trying to access files at the same time.
If we use sed to access file while tee, it would sometimes cause a conflict and result in tee creating empty file due to file is then being held by sed.
Therefore, we cat the file, pipe to sed, then tee, would resolve issue.

Also, fixed an error where sed is not correctly setup for the pattern.
 
### Issues Resolved
#1454
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
