### PR TITLE
Remove AD from manifest to get job-scheduler SPI uploaded to maven.

### DIFF
--- a/manifests/1.2.4/opensearch-1.2.4.yml
+++ b/manifests/1.2.4/opensearch-1.2.4.yml
@@ -65,12 +65,6 @@ components:
     platforms:
       - darwin
       - linux
-  - name: anomaly-detection
-    repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: "1.2"
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
     ref: "1.2"


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

We have a chicken-egg problem where without building a successful distribution we don't get a job-scheduler-spi in maven, see https://github.com/opensearch-project/opensearch-build/issues/1463. This is blocking https://github.com/opensearch-project/anomaly-detection/pull/360.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
