### PR TITLE
Only retain 7 days of logs

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -1,6 +1,9 @@
 lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
 
 pipeline {
+    options {
+        buildDiscarder(logRotator(daysToKeepStr: '7'))
+    }
     agent none
     triggers {
         parameterizedCron '''


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
The check for build job is run often, and the logs are not very useful in the distant past, make sure that we aren't using up disk space keeping this information around

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
