### PR TITLE
Lower the frequency of checking for builds of already released versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -71,6 +71,7 @@ __REPLACE with OpenSearch wide initiatives to improve quality and consistency.__
 - [ ] Create [release tags](https://github.com/opensearch-project/opensearch-build/issues/378#issuecomment-999700848) for each component.
 - [ ] Replace refs in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}) with tags.
 - [ ] Prepare [for next patch release](https://github.com/opensearch-project/opensearch-plugins/blob/main/META.md#increment-a-version-in-every-plugin) by incrementing patch versions for each component.
+- [ ] Lower the [frequency of builds](https://github.com/opensearch-project/opensearch-build/pull/1475) for this OpenSearch and/or OpenSearch Dashboards.
 - [ ] Update [this template](https://github.com/opensearch-project/opensearch-build/blob/main/.github/ISSUE_TEMPLATE/release_template.md) with any new or missed steps.
 - [ ] Create an issue for a retrospective, solicit feedback, and publish a summary.
 

--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -71,7 +71,7 @@ __REPLACE with OpenSearch wide initiatives to improve quality and consistency.__
 - [ ] Create [release tags](https://github.com/opensearch-project/opensearch-build/issues/378#issuecomment-999700848) for each component.
 - [ ] Replace refs in [manifests/{{ env.VERSION }}](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}) with tags.
 - [ ] Prepare [for next patch release](https://github.com/opensearch-project/opensearch-plugins/blob/main/META.md#increment-a-version-in-every-plugin) by incrementing patch versions for each component.
-- [ ] Lower the [frequency of builds](https://github.com/opensearch-project/opensearch-build/pull/1475) for this OpenSearch and/or OpenSearch Dashboards.
+- [ ] Lower the [frequency of builds](https://github.com/opensearch-project/opensearch-build/pull/1475) for this version of OpenSearch and/or OpenSearch Dashboards.
 - [ ] Update [this template](https://github.com/opensearch-project/opensearch-build/blob/main/.github/ISSUE_TEMPLATE/release_template.md) with any new or missed steps.
 - [ ] Create an issue for a retrospective, solicit feedback, and publish a summary.
 

--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -5,12 +5,12 @@ pipeline {
     triggers {
         parameterizedCron '''
             H/10 * * * * %INPUT_MANIFEST=1.2.4/opensearch-1.2.4.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=1.1.1/opensearch-1.1.1.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=1.1.1/opensearch-dashboards-1.1.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
-            H/10 * * * * %INPUT_MANIFEST=1.2.1/opensearch-1.2.1.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=1.2.2/opensearch-1.2.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=1.2.3/opensearch-1.2.3.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.3.0/opensearch-1.3.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
+            H 1 * * * %INPUT_MANIFEST=1.1.1/opensearch-1.1.1.yml;TARGET_JOB_NAME=distribution-build-opensearch
+            H 1 * * * %INPUT_MANIFEST=1.1.1/opensearch-dashboards-1.1.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
+            H 1 * * * %INPUT_MANIFEST=1.2.1/opensearch-1.2.1.yml;TARGET_JOB_NAME=distribution-build-opensearch
+            H 1 * * * %INPUT_MANIFEST=1.2.2/opensearch-1.2.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
+            H 1 * * * %INPUT_MANIFEST=1.2.3/opensearch-1.2.3.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=2.0.0/opensearch-2.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=2.0.0/opensearch-dashboards-2.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
         '''


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Builds that have already been released should not be checked so often, following https://github.com/opensearch-project/opensearch-build/tree/main/jenkins#add-periodically-run-jobs set cron to `H 1 * * *`
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
