### PR TITLE
Forward entrypoint arguments to opensearch command.

### DIFF
--- a/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
@@ -39,6 +39,7 @@ do
         fi
     fi
 done < <(env)
+opensearch_opts+=("$@")
 
 # The virtual file /proc/self/cgroup should list the current cgroup
 # membership. For each hierarchy, you can follow the cgroup path from


### PR DESCRIPTION
### Description

Forward entrypoint arguments to opensearch command.

Some environments don't allow dots in environment variable names. In
such case, it is not possible to override OpenSearch's config using
environment variables. This turns out particularly inconvenient in
[Gitlab-CI](https://docs.gitlab.com/ee/ci/) where you always want to
start OpenSearch with `-Ediscovery.type=single-node`, which is not
doable with the current docker image (see
https://gitlab.com/gitlab-org/gitlab-foss/-/issues/42214).

This commit allows the user to override the configuration through
command arguments instead of environment variables. One can set
"./opensearch-docker-entrypoint.sh -Ediscovery.type=single-node" as
command to override the default configuration.

### Additional context

It should be noted that currently, the so-called entrypoint script is
not invoked as an actual docker entrypoint but as a docker command. As far
as I know, this is misleading and quite uncommon for docker images. The
entrypoint should rather be an actual entrypoint, and if any command is
specified by the user, that command should be called **instead of**
"opensearch". I did not fix that issue in this PR because it would be a lot more
invasive, but I reported it in #1486 for further discussions. There shouldn't be any
incompatibility between this PR and the suggestion I made in #1486, however, it
would supersede this PR.
 
### Issues Resolved

None (let me know if I should open one). Related to #1486.
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
