### PR TITLE
updated promote artifacts lib s3 upload

### DIFF
--- a/tests/jenkins/jobs/PromoteArtifacts_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifacts_Jenkinsfile.txt
@@ -35,4 +35,3 @@
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/plugins/repository-gcs-1.1.0.zip/1.3.0/, workingDir=workspace/artifacts/vars-build/1.3.0/33/linux/x64/builds/opensearch/core-plugins/, includePathPattern=**/repository-gcs-1.1.0.zip*})
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/core/opensearch/1.3.0/, workingDir=workspace/artifacts/vars-build/1.3.0/33/linux/x64/builds/opensearch/dist/, includePathPattern=**/opensearch-min-1.3.0*})
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch/1.3.0/, workingDir=workspace/artifacts/vars-build/1.3.0/33/linux/x64/dist/opensearch/, includePathPattern=**/opensearch-1.3.0*})
-                     promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/1.3.0/linux/x64/, workingDir=workspace/artifacts/vars-build/1.3.0/33/linux/x64/, includePathPattern=**/})

--- a/tests/jenkins/jobs/PromoteArtifacts_OpenSearch_Dashboards_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifacts_OpenSearch_Dashboards_Jenkinsfile.txt
@@ -15,4 +15,3 @@
                   promoteArtifacts.withAWS({role=artifactPromotionRole, roleAccount=artifactsAccount, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/core/opensearch-dashboards/1.2.0/, workingDir=workspace/artifacts/vars-build/1.2.0/33/linux/x64/builds/opensearch-dashboards/dist/, includePathPattern=**/opensearch-dashboards-min-1.2.0*})
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch-dashboards/1.2.0/, workingDir=workspace/artifacts/vars-build/1.2.0/33/linux/x64/dist/opensearch-dashboards/, includePathPattern=**/opensearch-dashboards-1.2.0*})
-                     promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/1.2.0/linux/x64/, workingDir=workspace/artifacts/vars-build/1.2.0/33/linux/x64/, includePathPattern=**/})

--- a/tests/jenkins/jobs/PromoteArtifacts_actions_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifacts_actions_Jenkinsfile.txt
@@ -88,4 +88,3 @@
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/plugins/repository-gcs-1.1.0.zip/1.3.0/, workingDir=workspace/artifacts/vars-build/1.3.0/33/linux/x64/builds/opensearch/core-plugins/, includePathPattern=**/repository-gcs-1.1.0.zip*})
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/core/opensearch/1.3.0/, workingDir=workspace/artifacts/vars-build/1.3.0/33/linux/x64/builds/opensearch/dist/, includePathPattern=**/opensearch-min-1.3.0*})
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch/1.3.0/, workingDir=workspace/artifacts/vars-build/1.3.0/33/linux/x64/dist/opensearch/, includePathPattern=**/opensearch-1.3.0*})
-                     promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/1.3.0/linux/x64/, workingDir=workspace/artifacts/vars-build/1.3.0/33/linux/x64/, includePathPattern=**/})

--- a/tests/jenkins/jobs/PromoteArtifacts_actions_OpenSearch_Dashboards_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifacts_actions_OpenSearch_Dashboards_Jenkinsfile.txt
@@ -61,4 +61,3 @@
                   promoteArtifacts.withAWS({role=artifactPromotionRole, roleAccount=artifactsAccount, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/core/opensearch-dashboards/1.2.0/, workingDir=workspace/artifacts/vars-build/1.2.0/33/linux/x64/builds/opensearch-dashboards/dist/, includePathPattern=**/opensearch-dashboards-min-1.2.0*})
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch-dashboards/1.2.0/, workingDir=workspace/artifacts/vars-build/1.2.0/33/linux/x64/dist/opensearch-dashboards/, includePathPattern=**/opensearch-dashboards-1.2.0*})
-                     promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/1.2.0/linux/x64/, workingDir=workspace/artifacts/vars-build/1.2.0/33/linux/x64/, includePathPattern=**/})

--- a/vars/promoteArtifacts.groovy
+++ b/vars/promoteArtifacts.groovy
@@ -75,7 +75,7 @@ void call(Map args = [:]) {
                 )
             }
         }
-      
+
         s3Upload(
             bucket: "${ARTIFACT_PRODUCTION_BUCKET_NAME}",
             path: "releases/$coreFullPath/",
@@ -89,11 +89,5 @@ void call(Map args = [:]) {
             workingDir: "$WORKSPACE/artifacts/$artifactPath/dist/$filename/",
             includePathPattern: "**/${filename}-${version}*")
 
-        // upload build and dist
-        s3Upload(
-            bucket: "${ARTIFACT_PRODUCTION_BUCKET_NAME}",
-            path: "releases/$version/${DISTRIBUTION_PLATFORM}/${DISTRIBUTION_ARCHITECTURE}/",
-            workingDir: "$WORKSPACE/artifacts/$artifactPath/",
-            includePathPattern: "**/")
     }
 }


### PR DESCRIPTION
Signed-off-by: Abhinav Gupta <abhng@amazon.com>

### Description
Remove s3 upload to `builds` and `dist` directly from `promoteArtifacts.groovy`
 
### Issues Resolved
Remove stray artifacts from release folder
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
