### PR TITLE
Fix Jenkins junit and mailer CVEs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,8 @@ sharedLibrary {
         dependency('org.jenkins-ci.plugins', 'script-security', '1.78')
         dependency('org.jenkins-ci.plugins', 'credentials', '2.6.2')
         dependency('org.jenkins-ci.plugins', 'git-client', '3.10.1')
+        dependency('org.jenkins-ci.plugins', 'junit', '1.53')
+        dependency('org.jenkins-ci.plugins', 'mailer', '1.34.2')
     }
 }
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Knocking out more CVEs reported by WhiteSource.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
