### PR TITLE
Use docker entrypoint instead of command.

### DIFF
--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
@@ -3,8 +3,8 @@
 # Copyright OpenSearch Contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# 
-# Run OpenSearch-Dashboards, using environment variables to 
+#
+# Run OpenSearch-Dashboards, using environment variables to
 # set longopts defining OpenSearch-Dashboards's configuration.
 #
 # eg. Setting the environment variable:
@@ -153,50 +153,70 @@ opensearch_dashboards_vars=(
     telemetry.sendUsageFrom
 )
 
-longopts=''
-for opensearch_dashboards_var in ${opensearch_dashboards_vars[*]}; do
-    # 'opensearch.hosts' -> 'OPENSEARCH_URL'
-    env_var=$(echo ${opensearch_dashboards_var^^} | tr . _)
+function setupSecurityDashboardsPlugin {
+    SECURITY_DASHBOARDS_PLUGIN="securityDashboards"
 
-    # Indirectly lookup env var values via the name of the var.
-    # REF: http://tldp.org/LDP/abs/html/bashver2.html#EX78
-    value=${!env_var}
-    if [[ -n $value ]]; then
-      longopt="--${opensearch_dashboards_var}=${value}"
-      longopts+=" ${longopt}"
+    if [ -d "$OPENSEARCH_DASHBOARDS_HOME/plugins/$SECURITY_DASHBOARDS_PLUGIN" ]; then
+        if [ "$DISABLE_SECURITY_DASHBOARDS_PLUGIN" = "true" ]; then
+            echo "Disabling OpenSearch Security Dashboards Plugin"
+            ./bin/opensearch-dashboards-plugin remove securityDashboards
+            cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "/^opensearch_security/d" | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
+            cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "s/https/http/g" | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
+        fi
     fi
-done
+}
 
-# Files created at run-time should be group-writable, for Openshift's sake.
-umask 0002
+function runOpensearchDashboards {
+    longopts=()
+    for opensearch_dashboards_var in ${opensearch_dashboards_vars[*]}; do
+        # 'opensearch.hosts' -> 'OPENSEARCH_URL'
+        env_var=$(echo ${opensearch_dashboards_var^^} | tr . _)
 
-##Security Dashboards Plugin
-SECURITY_DASHBOARDS_PLUGIN="securityDashboards"
-if [ -d "$OPENSEARCH_DASHBOARDS_HOME/plugins/$SECURITY_DASHBOARDS_PLUGIN" ]; then
+        # Indirectly lookup env var values via the name of the var.
+        # REF: http://tldp.org/LDP/abs/html/bashver2.html#EX78
+        value=${!env_var}
+        if [[ -n $value ]]; then
+            longopt="--${opensearch_dashboards_var}=${value}"
+            longopts+=("${longopt}")
+        fi
+    done
 
-    if [ "$DISABLE_SECURITY_DASHBOARDS_PLUGIN" = "true" ]; then
-        echo "Disabling OpenSearch Security Dashboards Plugin"
-        ./bin/opensearch-dashboards-plugin remove securityDashboards
-        cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "/^opensearch_security/d" | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
-        cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "s/https/http/g" | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
-    fi
+    # Files created at run-time should be group-writable, for Openshift's sake.
+    umask 0002
+
+    ##Security Dashboards Plugin
+    setupSecurityDashboardsPlugin
+
+    # TO DO:
+    # Confirm with Mihir if this is necessary
+
+    # The virtual file /proc/self/cgroup should list the current cgroup
+    # membership. For each hierarchy, you can follow the cgroup path from
+    # this file to the cgroup filesystem (usually /sys/fs/cgroup/) and
+    # introspect the statistics for the cgroup for the given
+    # hierarchy. Alas, Docker breaks this by mounting the container
+    # statistics at the root while leaving the cgroup paths as the actual
+    # paths. Therefore, OpenSearch-Dashboards provides a mechanism to override
+    # reading the cgroup path from /proc/self/cgroup and instead uses the
+    # cgroup path defined the configuration properties
+    # cpu.cgroup.path.override and cpuacct.cgroup.path.override.
+    # Therefore, we set this value here so that cgroup statistics are
+    # available for the container this process will run in.
+
+    exec "$@" \
+        --cpu.cgroup.path.override=/ \
+        --cpuacct.cgroup.path.override=/ \
+        "${longopts[@]}"
+}
+
+# Prepend "opensearch-dashboards" command if no argument was provided or if the
+# first argument looks like a flag (i.e. starts with a dash).
+if [ $# -eq 0 ] || [ "${1:0:1}" = '-' ]; then
+    set -- opensearch-dashboards "$@"
 fi
 
-
-# TO DO:
-# Confirm with Mihir if this is necessary
-
-# The virtual file /proc/self/cgroup should list the current cgroup
-# membership. For each hierarchy, you can follow the cgroup path from
-# this file to the cgroup filesystem (usually /sys/fs/cgroup/) and
-# introspect the statistics for the cgroup for the given
-# hierarchy. Alas, Docker breaks this by mounting the container
-# statistics at the root while leaving the cgroup paths as the actual
-# paths. Therefore, OpenSearch-Dashboards provides a mechanism to override
-# reading the cgroup path from /proc/self/cgroup and instead uses the
-# cgroup path defined the configuration properties
-# cpu.cgroup.path.override and cpuacct.cgroup.path.override.
-# Therefore, we set this value here so that cgroup statistics are
-# available for the container this process will run in.
-
-exec /usr/share/opensearch-dashboards/bin/opensearch-dashboards --cpu.cgroup.path.override=/ --cpuacct.cgroup.path.override=/ ${longopts} "$@"
+if [ "$1" = "opensearch-dashboards" ]; then
+    runOpensearchDashboards "$@"
+else
+    exec "$@"
+fi

--- a/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
@@ -62,6 +62,9 @@ COPY --from=linux_stage_0 --chown=$UID:$GID $OPENSEARCH_DASHBOARDS_HOME $OPENSEA
 # Setup OpenSearch-dashboards
 WORKDIR $OPENSEARCH_DASHBOARDS_HOME
 
+# Set PATH
+ENV PATH=$PATH:$OPENSEARCH_DASHBOARDS_HOME/bin
+
 # Change user
 USER $UID
 
@@ -84,4 +87,5 @@ LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.build-date="$BUILD_DATE"
 
 # CMD to run
-CMD ["./opensearch-dashboards-docker-entrypoint.sh"]
+ENTRYPOINT ["./opensearch-dashboards-docker-entrypoint.sh"]
+CMD ["opensearch-dashboards"]

--- a/docker/release/dockerfiles/opensearch.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2.dockerfile
@@ -72,7 +72,7 @@ RUN echo "export JAVA_HOME=$OPENSEARCH_HOME/jdk" >> /etc/profile.d/java_home.sh 
     echo "export PATH=\$PATH:\$JAVA_HOME/bin" >> /etc/profile.d/java_home.sh
 
 ENV JAVA_HOME=$OPENSEARCH_HOME/jdk
-ENV PATH=$PATH:$JAVA_HOME/bin
+ENV PATH=$PATH:$JAVA_HOME/bin:$OPENSEARCH_HOME/bin
 
 # Add k-NN lib directory to library loading path variable
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENSEARCH_HOME/plugins/opensearch-knn/knnlib"
@@ -106,4 +106,5 @@ LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.build-date="$BUILD_DATE"
 
 # CMD to run
-CMD ["./opensearch-docker-entrypoint.sh"]
+ENTRYPOINT ["./opensearch-docker-entrypoint.sh"]
+CMD ["opensearch"]


### PR DESCRIPTION
_To reviewers:_ for an easier review, consider ignoring whitespace changes: https://github.com/opensearch-project/opensearch-build/pull/1507/files?diff=unified&w=1

### Description

This allows to use the entrypoints:

- as a standalone command ("./opensearch-docker-entrypoint.sh") which
  runs the setup procedure and starts opensearch just like before
- as an opensearch wrapper ("./opensearch-docker-entrypoint.sh
  opensearch" which does the exactly the same
- as a wrapper of any other command ("./opensearch-docker-entrypoint.sh
  bash") which just execs the command without the setup procedure

When wrapping the opensearch or opensearch-dashboard command, it'll also
forward the arguments:

- Option 1: "./opensearch-docker-entrypoint.sh -Ediscovery.type=single-node"
- Option 2: "./opensearch-docker-entrypoint.sh opensearch -Ediscovery.type=single-node"


### Issues Resolved

Fixes #1486
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
