### PR TITLE
Add support for signing whl files used in python releases

### DIFF
--- a/src/sign_workflow/signer.py
+++ b/src/sign_workflow/signer.py
@@ -18,7 +18,7 @@ The signed artifacts will be found in the same location as the original artifact
 
 
 class Signer:
-    ACCEPTED_FILE_TYPES = [".zip", ".jar", ".war", ".pom", ".module", ".tar.gz"]
+    ACCEPTED_FILE_TYPES = [".zip", ".jar", ".war", ".pom", ".module", ".tar.gz", ".whl"]
 
     def __init__(self):
         self.git_repo = GitRepository(self.get_repo_url(), "HEAD", working_subdirectory="src")

--- a/tests/tests_sign_workflow/test_signer.py
+++ b/tests/tests_sign_workflow/test_signer.py
@@ -45,6 +45,7 @@ class TestSigner(unittest.TestCase):
             "the-tar.tar.gz",
             "random-file.txt",
             "something-1.0.0.0.jar",
+            "opensearch_sql_cli-1.0.0-py3-none-any.whl"
         ]
         expected = [
             call(os.path.join("path", "the-jar.jar"), ".sig"),
@@ -54,6 +55,7 @@ class TestSigner(unittest.TestCase):
             call(os.path.join("path", "the-module.module"), ".sig"),
             call(os.path.join("path", "the-tar.tar.gz"), ".sig"),
             call(os.path.join("path", "something-1.0.0.0.jar"), ".sig"),
+            call(os.path.join("path", "opensearch_sql_cli-1.0.0-py3-none-any.whl"), ".asc"),
         ]
         signer = Signer()
         signer.sign = MagicMock()

--- a/tests/tests_sign_workflow/test_signer.py
+++ b/tests/tests_sign_workflow/test_signer.py
@@ -55,7 +55,7 @@ class TestSigner(unittest.TestCase):
             call(os.path.join("path", "the-module.module"), ".sig"),
             call(os.path.join("path", "the-tar.tar.gz"), ".sig"),
             call(os.path.join("path", "something-1.0.0.0.jar"), ".sig"),
-            call(os.path.join("path", "opensearch_sql_cli-1.0.0-py3-none-any.whl"), ".asc"),
+            call(os.path.join("path", "opensearch_sql_cli-1.0.0-py3-none-any.whl"), ".sig"),
         ]
         signer = Signer()
         signer.sign = MagicMock()


### PR DESCRIPTION
Signed-off-by: Peter Nied <petern@amazon.com>

### Description
Add support for `whl` files that are part of python release

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
