### PR TITLE
Signing by ASC should be supported

### DIFF
--- a/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
+++ b/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
@@ -19,15 +19,17 @@ pipeline {
                 trim: true,
                 description: 'Path to upload to artifacts and signatures on s3. Eg: dummy_project/1.0'
         )
-        choice(
-                choices: ['linux'],
+        string(
+                defaultValue: 'linux',
                 name: 'DISTRIBUTION_PLATFORM',
+                trim: true,
                 description: 'What platform is this distribution build for?'
         )
-        choice(
-                choices: ['.sig'],
+        string(
+                defaultValue: '.sig',
                 name: 'SIGNATURE_TYPE',
-                description: 'What is signature file type?'
+                trim: true,
+                description: 'What is signature file type?  See https://github.com/opensearch-project/opensearch-build/blob/main/src/sign_workflow/README.md for all options'
         )
     }
     stages {

--- a/src/run_sign.py
+++ b/src/run_sign.py
@@ -15,7 +15,7 @@ from sign_workflow.sign_artifacts import SignArtifacts
 from sign_workflow.signer import Signer
 from system import console
 
-ACCEPTED_SIGNATURE_FILE_TYPES = [".sig"]
+ACCEPTED_SIGNATURE_FILE_TYPES = [".sig", ".asc"]
 
 
 def main():

--- a/src/sign_workflow/README.md
+++ b/src/sign_workflow/README.md
@@ -13,10 +13,12 @@ The signing step (optional) takes the manifest file created from the build step 
 
 The following options are available. 
 
-| name          | description                                                                           |
-|---------------|---------------------------------------------------------------------------------------|
-| --component   | The component name of the component whose artifacts will be signed.                   |
-| --type        | The artifact type to be signed. Currently one of 3 options: [plugins, maven, bundle]. |
-| -v, --verbose | Show more verbose output.                                                             |
+| name          | description                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| target        | Path to local manifest file or artifact directory.                                           |
+| --component   | The name of the component whose artifacts will be signed, if using a manifest target.        |
+| --type        | The artifact type to be signed, if using a manifest target, can be [plugins, maven, bundle]. |
+| --sigtype     | Type of Signature file, can be [.asc, .sig].                                                 |
+| -v, --verbose | Show more verbose output.                                                                    |
 
 The signed artifacts (<artifact>.asc) will be found in the same location as the original artifact. 


### PR DESCRIPTION
### Description
Removing 'choice' parameters that are hiding potential parameters used
in downstream systems.  Ran into this while running a deployment and had to fall back to manual
steps.

Cleaned up the documentation and provided links to lookup the available
options.

Signed-off-by: Peter Nied <petern@amazon.com>
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
