### PR TITLE
Including DCO with automated manifest updates

### DIFF
--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: Updated manifests.
+          commit-message: |
+            Updated manifests.
+            Signed-off-by: Peter Nied <petern@amazon.com>
           delete-branch: true
           title: '[AUTO] Updated input manifests.'
           body: |

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           commit-message: |
             Updated manifests.
-            Signed-off-by: Peter Nied <petern@amazon.com>
+
+            Signed-off-by: opensearch-ci-bot <opensearch-infra@amazon.com>
           delete-branch: true
           title: '[AUTO] Updated input manifests.'
           body: |


### PR DESCRIPTION
### Description
Including DCO with automated manifest updates 

### Issues Resolved
- Can be used to avoid a rebase like was done in https://github.com/opensearch-project/opensearch-build/pull/1515
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
