### PR TITLE
Ymllint / Flake8 add ignores for developer folders

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,9 @@
 [flake8]
 ignore = E722,W503
 max-line-length = 200
+exclude =
+    bin
+    builds
+    dist
+    test-results
+    deployment/node_modules

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,6 +3,12 @@ yaml-files:
   - '*.yaml'
   - '*.yml'
   - .yamllint.yml
+ignore: |
+  bin
+  builds
+  dist
+  test-results
+  deployment/node_modules
 rules:
   document-start: enable
   line-length: disable


### PR DESCRIPTION
### Description
Ymllint / Flake8 add ignores for developer folders

Noticed this while the [precommit checks](https://github.com/opensearch-project/opensearch-build/blob/main/DEVELOPER_GUIDE.md#pre-commit-cheatsheet) were running on my local desktop, it was causing failures that should not have block commits from being created.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
