### PR TITLE
refactor TestUploadToS3LibTester filename to match convention

### DIFF
--- a/tests/jenkins/TestDataPrepperDistributionArtifacts.groovy
+++ b/tests/jenkins/TestDataPrepperDistributionArtifacts.groovy
@@ -24,7 +24,7 @@ class TestDataPrepperDistributionArtifacts extends BuildPipelineTest {
 
         this.registerLibTester(new SignArtifactsLibTester( '.sig', 'linux',  artifactsPath))
 
-        this.registerLibTester(new TestUploadToS3LibTester( artifactsPath, bucketName, 'data-prepper-distribution-artifacts/0.22.1/51/builds/signed'))
+        this.registerLibTester(new UploadToS3LibTester( artifactsPath, bucketName, 'data-prepper-distribution-artifacts/0.22.1/51/builds/signed'))
 
         this.registerLibTester(new PrintArtifactDownloadUrlsForStagingLibTester( filenamesForUrls, 'data-prepper-distribution-artifacts/0.22.1/51/builds/signed'))
 

--- a/tests/jenkins/TestSignStandaloneArtifactsJob.groovy
+++ b/tests/jenkins/TestSignStandaloneArtifactsJob.groovy
@@ -18,7 +18,7 @@ class TestSignStandaloneArtifactsJob extends BuildPipelineTest {
 
         this.registerLibTester(new PrintArtifactDownloadUrlsForStagingLibTester(filenamesForUrls, 'sign_artifacts_job/dummy/upload/path/20/dist/signed'))
 
-        this.registerLibTester(new TestUploadToS3LibTester(artifactPath, 'dummy_bucket_name', 'sign_artifacts_job/dummy/upload/path/20/dist/signed'))
+        this.registerLibTester(new UploadToS3LibTester(artifactPath, 'dummy_bucket_name', 'sign_artifacts_job/dummy/upload/path/20/dist/signed'))
 
         super.setUp()
 

--- a/tests/jenkins/TestUploadToS3.groovy
+++ b/tests/jenkins/TestUploadToS3.groovy
@@ -8,7 +8,7 @@ class TestUploadToS3 extends BuildPipelineTest {
     @Before
     void setUp() {
 
-        this.registerLibTester(new TestUploadToS3LibTester( '/tmp/src/path', 'dummy_bucket', '/upload/path' ))
+        this.registerLibTester(new UploadToS3LibTester( '/tmp/src/path', 'dummy_bucket', '/upload/path' ))
 
         super.setUp()
     }

--- a/tests/jenkins/lib-testers/UploadToS3LibTester.groovy
+++ b/tests/jenkins/lib-testers/UploadToS3LibTester.groovy
@@ -1,13 +1,13 @@
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 
-class TestUploadToS3LibTester extends LibFunctionTester {
+class UploadToS3LibTester extends LibFunctionTester {
 
     private String sourcePath
     private String bucket
     private String path
 
-    public TestUploadToS3LibTester(sourcePath, bucket, path){
+    public UploadToS3LibTester(sourcePath, bucket, path){
         this.sourcePath = sourcePath
         this.bucket = bucket
         this.path = path


### PR DESCRIPTION
Signed-off-by: Abhinav Gupta <abhng@amazon.com>

### Description
Refactor TestUploadToS3LibTester filename to match convention 

### Issues Resolved
Refactors libtester filename
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
