### PR TITLE
Fix #1521: use a test build manifest.

### DIFF
--- a/tests/jenkins/TestBuildAssembleUpload.groovy
+++ b/tests/jenkins/TestBuildAssembleUpload.groovy
@@ -44,11 +44,15 @@ class TestBuildAssembleUpload extends BuildPipelineTest {
     }
 
     @Test
-    @Ignore("https://github.com/opensearch-project/opensearch-build/issues/1521")
     public void testJenkinsfile() {
         helper.registerAllowedMethod("s3DoesObjectExist", [Map], { args ->
             return true
         })
+
+        Path sourceBuildManifest = Path.of("tests/data/opensearch-build-1.1.0.yml")
+        Path targetBuildManifest = Path.of("builds/opensearch/manifest.yml")
+        Files.createDirectories(targetBuildManifest.getParent())
+        Files.copy(sourceBuildManifest, targetBuildManifest, StandardCopyOption.REPLACE_EXISTING)
 
         super.testPipeline("tests/jenkins/jobs/BuildAssembleUpload_Jenkinsfile")
     }


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

The test calls build and assemble and uses the output of build in assemble.  Thus depending on what you have in `builds/opensearch/manifest.yml` the test will succeed or fail. To reproduce #1521 `rm builds/opensearch/manifest.yml`.

The test used to work because another test output a `builds/opensearch/manifest.yml`, but the execution order of tests is not predictable. The fix is to copy a well known manifest.yml before running the test.

### Issues Resolved

Closes #1521.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
