### PR TITLE
Add JS deployment tests to code coverage.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,5 @@ coverage:
         target: 98%
 ignore:
   - '**/tests/*.py'
+  - '**/test/*.js'
+  - '**/test/*.ts'

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -17,4 +17,6 @@ jobs:
           node-version: 12.x
           cache: npm
       - run: yarn install
-      - run: yarn test
+      - run: yarn test -- --coverage
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 
 .coverage
 coverage.xml
+coverage/
 
 .gradle/
 .settings/


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Add JS deployment tests to code coverage.
See https://codecov.io/gh/dblock/opensearch-build/tree/f5591b8514ffdbe6ef8c25ceb294382e6a8875d6 for a successful upload.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
