### PR TITLE
Permanent fix for OpenSearch and temp fix for Dashboards startup configurations

### DIFF
--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
@@ -160,8 +160,12 @@ function setupSecurityDashboardsPlugin {
         if [ "$DISABLE_SECURITY_DASHBOARDS_PLUGIN" = "true" ]; then
             echo "Disabling OpenSearch Security Dashboards Plugin"
             ./bin/opensearch-dashboards-plugin remove securityDashboards
-            cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "/^opensearch_security/d" | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
-            cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "s/https/http/g" | tee $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
+
+            # Remove all security related parameters as well as changing HTTPS to HTTP
+            # Temporary fix before security-dashboards plugin implement a parameter to disable the plugin entirely
+            # https://github.com/opensearch-project/security-dashboards-plugin/issues/896
+            NEW_CONFIG=`cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "/^opensearch_security/d" | sed "s/https/http/g"`
+            echo "$NEW_CONFIG" > $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
         fi
     fi
 }

--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
@@ -164,8 +164,8 @@ function setupSecurityDashboardsPlugin {
             # Remove all security related parameters as well as changing HTTPS to HTTP
             # Temporary fix before security-dashboards plugin implement a parameter to disable the plugin entirely
             # https://github.com/opensearch-project/security-dashboards-plugin/issues/896
-            NEW_CONFIG=`cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "/^opensearch_security/d" | sed "s/https/http/g"`
-            echo "$NEW_CONFIG" > $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
+            UPDATED_CONFIG=`cat $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml | sed "/^opensearch_security/d" | sed "s/https/http/g"`
+            echo "$UPDATED_CONFIG" > $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml
         fi
     fi
 }

--- a/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
@@ -43,11 +43,10 @@ function setupSecurityPlugin {
 
         if [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
             echo "Disabling OpenSearch Security Plugin"
-            cat $OPENSEARCH_HOME/config/opensearch.yml | sed "/plugins.security.disabled/d" | tee $OPENSEARCH_HOME/config/opensearch.yml
-            echo "plugins.security.disabled: true" >> $OPENSEARCH_HOME/config/opensearch.yml
+            opensearch_opt="-Eplugins.security.disabled=true"
+            opensearch_opts+=("${opensearch_opt}")
         else
             echo "Enabling OpenSearch Security Plugin"
-            cat $OPENSEARCH_HOME/config/opensearch.yml | sed "/plugins.security.disabled/d" | tee $OPENSEARCH_HOME/config/opensearch.yml
         fi
     fi
 }
@@ -82,7 +81,7 @@ function runOpensearch {
     #
     # e.g. Setting the env var cluster.name=testcluster
     # will cause OpenSearch to be invoked with -Ecluster.name=testcluster
-    local opensearch_opts=()
+    opensearch_opts=()
     while IFS='=' read -r envvar_key envvar_value
     do
         # OpenSearch settings need to have at least two dot separated lowercase


### PR DESCRIPTION


Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Permanent fix for OpenSearch and temp fix for Dashboards startup configurations.

This PR utilize internal parsing of env var to permanently allow security plugin to be disabled, without the need of tweaking the config file on the fly for OpenSearch.

As for Dashboards, we still need to tweak the configuration file if we want to disable security plugin, so a new tweak is added to temporarily resolve the race condition introduced in #1130 #1458.

As for permanent fix for Dashboards I have opened an issue with Security Dashboards Plugin repo:
https://github.com/opensearch-project/security-dashboards-plugin/issues/896

Thanks.
 
### Issues Resolved
#1529 
#1567
https://github.com/opensearch-project/helm-charts/issues/198
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
