### PR TITLE
Add TEST_MANIFEST param to check-for-build jenkins job

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -26,6 +26,11 @@ pipeline {
             trim: true
         )
         string(
+            name: 'TEST_MANIFEST',
+            description: 'Test manifest under the manifests folder, e.g. 2.0.0/opensearch-2.0.0-test.yml. Currently only applicable for distribution-build-opensearch job',
+            trim: true
+        )
+        string(
             name: 'TARGET_JOB_NAME',
             description: 'Job to trigger if build has changed',
             trim: true
@@ -66,9 +71,17 @@ pipeline {
                             echo "Skipping, ${sha.path} already exists."
                         } else {
                             try {
-                                build job: "${TARGET_JOB_NAME}", parameters: [
-                                string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}")
-                                ], wait: true
+                                // Currently only opensearch build takes an additional test manifest parameter
+                                if (TARGET_JOB_NAME == 'distribution-build-opensearch') {
+                                    build job: "${TARGET_JOB_NAME}", parameters: [
+                                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
+                                    string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
+                                    ], wait: true
+                                } else if (TARGET_JOB_NAME == 'distribution-build-opensearch-dashboards') {
+                                    build job: "${TARGET_JOB_NAME}", parameters: [
+                                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}")
+                                    ], wait: true
+                                }
                                 echo "Build succeeded, uploading build SHA for that job"
                                 buildUploadManifestSHA(
                                     inputManifest: "manifests/${INPUT_MANIFEST}",


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Currently distribution builds are broken due to a missing `TEST_MANIFEST` parameter in the check-for-build jenkins job, which was introduced in the `distribution-build-opensearch` job as part of #1517. This PR adds that.

Note that only `distribution-build-opensearch` is using a test manifest, so there's separate logic for the `distribution-build-opensearch-dashboards` job to exclude that parameter for know. In the future these may get merged back, once Dashboards supports integ tests and using a test manifest.
 
### Issues Resolved
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
