### PR TITLE
Add invalid job case & improve error handling in check-for-build

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -70,30 +70,20 @@ pipeline {
                         if (sha.exists) {
                             echo "Skipping, ${sha.path} already exists."
                         } else {
-                            try {
-                                // TEST_MANIFEST param isn't applicable for distribution-build-opensearch-dashboards job yet,
-                                // so we don't pass it to that job to prevent confusion from Jenkins UI
-                                if (TARGET_JOB_NAME == 'distribution-build-opensearch') {
-                                    build job: "${TARGET_JOB_NAME}", parameters: [
-                                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
-                                    string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
-                                    ], wait: true
-                                } else if (TARGET_JOB_NAME == 'distribution-build-opensearch-dashboards') {
-                                    build job: "${TARGET_JOB_NAME}", parameters: [
-                                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}")
-                                    ], wait: true
-                                } else {
-                                    throw new Exception("Job ${TARGET_JOB_NAME} is not a valid option")
-                                }
-                                echo "Build succeeded, uploading build SHA for that job"
-                                buildUploadManifestSHA(
-                                    inputManifest: "manifests/${INPUT_MANIFEST}",
-                                    jobName: "${TARGET_JOB_NAME}"
-                                )
-                            } catch (err) {
-                                echo "${TARGET_JOB_NAME} failed"
-                                echo "Exception: ${err.getMessage()}"
+                            if (TARGET_JOB_NAME != 'distribution-build-opensearch' &&
+                                TARGET_JOB_NAME != 'distribution-build-opensearch-dashboards') {
+                                error "Job ${TARGET_JOB_NAME} is invalid"
                             }
+                            build job: "${TARGET_JOB_NAME}", parameters: [
+                            string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
+                            string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
+                            ], wait: true
+                            
+                            echo "Build succeeded, uploading build SHA for that job"
+                            buildUploadManifestSHA(
+                                inputManifest: "manifests/${INPUT_MANIFEST}",
+                                jobName: "${TARGET_JOB_NAME}"
+                            )
                         }
                     }
                 }

--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -71,7 +71,8 @@ pipeline {
                             echo "Skipping, ${sha.path} already exists."
                         } else {
                             try {
-                                // Currently only opensearch build takes an additional test manifest parameter
+                                // TEST_MANIFEST param isn't applicable for distribution-build-opensearch-dashboards job yet,
+                                // so we don't pass it to that job to prevent confusion from Jenkins UI
                                 if (TARGET_JOB_NAME == 'distribution-build-opensearch') {
                                     build job: "${TARGET_JOB_NAME}", parameters: [
                                     string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
@@ -81,6 +82,8 @@ pipeline {
                                     build job: "${TARGET_JOB_NAME}", parameters: [
                                     string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}")
                                     ], wait: true
+                                } else {
+                                    throw new Exception("Job ${TARGET_JOB_NAME} is not a valid option")
                                 }
                                 echo "Build succeeded, uploading build SHA for that job"
                                 buildUploadManifestSHA(
@@ -89,6 +92,7 @@ pipeline {
                                 )
                             } catch (err) {
                                 echo "${TARGET_JOB_NAME} failed"
+                                echo "Exception: ${err.getMessage()}"
                             }
                         }
                     }


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Adds a check for handling invalid jobs passed. Properly fails the job if there is any failure seen in the build or uploading steps. Follow-up to #1585 

Sanity test with job name `distribution-build-invalid` (Jenkins job `Playground/ohltyler-check-for-build-2` `#3`):
```
ERROR: Job invalid-job is invalid
```
 
### Issues Resolved
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
