### PR TITLE
Change the issue title for release to be 'proposed'

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -1,6 +1,6 @@
 ---
 name: Release
-title: "[RELEASE] Release version {{ env.VERSION }}"
+title: "[RELEASE] Release proposal version {{ env.VERSION }}"
 labels: untriaged, release, v{{ env.VERSION }}
 ---
 


### PR DESCRIPTION
The current langauge makes the autocut release tickets seem like a
commitment for a release, whereas they are a best guess effort
that a release could happen.  E.g. there might ne a patch release in
flight and then don't release that in favor of a minor release that
also includes the contents as the patch release.

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
