### PR TITLE
remove 1.2.4 from autobuild

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     triggers {
         parameterizedCron '''
             H/10 * * * * %INPUT_MANIFEST=1.3.0/opensearch-dashboards-1.3.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
-            H/10 * * * * %INPUT_MANIFEST=1.2.4/opensearch-1.2.4.yml;TEST_MANIFEST=1.2.4/opensearch-1.2.4-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.3.0/opensearch-1.3.0.yml;TEST_MANIFEST=1.3.0/opensearch-1.3.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=1.1.1/opensearch-1.1.1.yml;TEST_MANIFEST=1.1.1/opensearch-1.1.1-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=1.1.1/opensearch-dashboards-1.1.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
@@ -46,7 +45,7 @@ pipeline {
                 }
             }
             steps {
-                script { 
+                script {
                     dockerAgent = detectDockerAgent()
                 }
             }


### PR DESCRIPTION
Signed-off-by: Abhinav Gupta <abhng@amazon.com>

### Description
remove `1.2.4` from autobuild
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
