### PR TITLE
Add python typechecking for mypy on src/manifests_workflow and tests/tests_manifests_workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -32,7 +32,7 @@ jobs:
           pipenv run flake8 .
       - name: Run Type Checker
         run: |
-          pipenv run mypy src/build_workflow tests/tests_build_workflow src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests src/paths tests/tests_paths src/system tests/tests_system src/ci_workflow tests/tests_ci_workflow
+          pipenv run mypy src/build_workflow tests/tests_build_workflow src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests src/paths tests/tests_paths src/system tests/tests_system src/ci_workflow tests/tests_ci_workflow src/manifests_workflow tests/tests_manifests_workflow
       - name: Run Tests with Coverage
         run: |
           pipenv run coverage run -m pytest --cov=./src --cov-report=xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: mypy
         stages: [commit]
         name: mypy
-        entry: bash -c 'pipenv run mypy src/build_workflow tests/tests_build_workflow src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests src/paths tests/tests_paths src/system tests/tests_system src/ci_workflow tests/tests_ci_workflow'
+        entry: bash -c 'pipenv run mypy src/build_workflow tests/tests_build_workflow src/checkout_workflow tests/tests_checkout_workflow src/run_assemble.py tests/test_run_assemble.py src/assemble_workflow tests/tests_assemble_workflow src/manifests tests/tests_manifests src/paths tests/tests_paths src/system tests/tests_system src/ci_workflow tests/tests_ci_workflow src/manifests_workflow tests/tests_manifests_workflow'
         language: system
       - id: pytest
         stages: [commit]

--- a/src/manifests_workflow/component.py
+++ b/src/manifests_workflow/component.py
@@ -6,26 +6,28 @@
 
 import re
 import subprocess
+from typing import Any, List
 
+from git.git_repository import GitRepository
 from manifests.manifest import Manifest
 
 
 class Component:
-    def __init__(self, name, repo, snapshot=False, checks=[]):
+    def __init__(self, name: str, repo: GitRepository, snapshot: bool = False, checks: List = []) -> None:
         self.name = name
         self.git_repo = repo
         self.snapshot = snapshot
         self.checks = checks
 
     @classmethod
-    def branches(self, uri):
+    def branches(self, url: str) -> List[str]:
         """Return main or any x.y branches."""
         branches = ["main"]
-        remote_branches = subprocess.check_output(f"git ls-remote {uri} refs/heads/* | cut -f2 | cut -d/ -f3", shell=True).decode().split("\n")
+        remote_branches = subprocess.check_output(f"git ls-remote {url} refs/heads/* | cut -f2 | cut -d/ -f3", shell=True).decode().split("\n")
         branches.extend(filter(lambda b: re.match(r"[\d]+.[\dx]*", b), remote_branches))
         return branches
 
-    def to_dict(self):
+    def to_dict(self) -> Any:
         return Manifest.compact({
             "name": self.name,
             "repository": self.git_repo.url,

--- a/src/manifests_workflow/component_opensearch.py
+++ b/src/manifests_workflow/component_opensearch.py
@@ -6,6 +6,7 @@
 
 import logging
 import subprocess
+from typing import Any
 
 from git.git_repository import GitRepository
 from manifests_workflow.component import Component
@@ -16,13 +17,13 @@ class ComponentOpenSearch(Component):
     @classmethod
     def checkout(
         self,
-        name,
-        path,
-        opensearch_version,
-        branch="main",
-        snapshot=False,
-        working_directory=None,
-    ):
+        name: str,
+        path: str,
+        opensearch_version: str,
+        branch: str = "main",
+        snapshot: bool = False,
+        working_directory: str = None,
+    ) -> 'ComponentOpenSearch':
         with GitRepository(
             f"https://github.com/opensearch-project/{name}.git",
             branch,
@@ -36,12 +37,12 @@ class ComponentOpenSearch(Component):
                 snapshot,
             )
 
-    def __init__(self, name, repo, opensearch_version, snapshot=False):
+    def __init__(self, name: str, repo: GitRepository, opensearch_version: str, snapshot: bool = False) -> None:
         super().__init__(name, repo, snapshot)
         self.opensearch_version = opensearch_version
 
     @property
-    def properties(self):
+    def properties(self) -> PropertiesFile:
         cmd = ComponentOpenSearch.gradle_cmd(
             "properties",
             {
@@ -52,7 +53,7 @@ class ComponentOpenSearch(Component):
         return PropertiesFile(self.git_repo.output(cmd))
 
     @property
-    def version(self):
+    def version(self) -> Any:
         try:
             return self.properties.get_value("version")
         except subprocess.CalledProcessError as err:
@@ -60,7 +61,7 @@ class ComponentOpenSearch(Component):
             return None
 
     @classmethod
-    def gradle_cmd(self, target, props={}):
+    def gradle_cmd(self, target: str, props: dict = {}) -> str:
         cmd = [f"./gradlew {target}"]
         cmd.extend([f"-D{k}={v}" for k, v in props.items()])
         return " ".join(cmd)

--- a/src/manifests_workflow/component_opensearch_dashboards_min.py
+++ b/src/manifests_workflow/component_opensearch_dashboards_min.py
@@ -5,6 +5,7 @@
 # compatible open source license.
 
 import os
+from typing import Any, List
 
 from git.git_repository import GitRepository
 from manifests_workflow.component import Component
@@ -12,15 +13,15 @@ from system.config_file import ConfigFile
 
 
 class ComponentOpenSearchDashboardsMin(Component):
-    def __init__(self, repo, snapshot=False):
+    def __init__(self, repo: GitRepository, snapshot: bool = False) -> None:
         super().__init__("OpenSearch-Dashboards", repo, snapshot, [])
 
     @classmethod
-    def branches(self):
-        return Component.branches("https://github.com/opensearch-project/OpenSearch-Dashboards.git")
+    def branches(self, url: str = "https://github.com/opensearch-project/OpenSearch-Dashboards.git") -> List[str]:
+        return Component.branches(url)
 
     @classmethod
-    def checkout(self, path, branch="main", snapshot=False):
+    def checkout(self, path: str, branch: str = "main", snapshot: bool = False) -> 'ComponentOpenSearchDashboardsMin':
         with GitRepository(
             "https://github.com/opensearch-project/OpenSearch-Dashboards.git",
             branch,
@@ -32,10 +33,10 @@ class ComponentOpenSearchDashboardsMin(Component):
             )
 
     @property
-    def properties(self):
+    def properties(self) -> ConfigFile:
         path = os.path.join(self.git_repo.working_directory, "package.json")
         return ConfigFile.from_file(path)
 
     @property
-    def version(self):
+    def version(self) -> Any:
         return self.properties.get_value("version")

--- a/src/manifests_workflow/component_opensearch_min.py
+++ b/src/manifests_workflow/component_opensearch_min.py
@@ -4,6 +4,8 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+from typing import Any, List
+
 from git.git_repository import GitRepository
 from manifests_workflow.component import Component
 from manifests_workflow.component_opensearch import ComponentOpenSearch
@@ -11,7 +13,7 @@ from system.properties_file import PropertiesFile
 
 
 class ComponentOpenSearchMin(Component):
-    def __init__(self, repo, snapshot=False):
+    def __init__(self, repo: GitRepository, snapshot: bool = False) -> None:
         super().__init__(
             "OpenSearch",
             repo,
@@ -20,34 +22,26 @@ class ComponentOpenSearchMin(Component):
         )
 
     @classmethod
-    def branches(self):
-        return Component.branches("https://github.com/opensearch-project/OpenSearch.git")
+    def branches(self, url: str = "https://github.com/opensearch-project/OpenSearch.git") -> List[str]:
+        return Component.branches(url)
 
     @classmethod
-    def versions(self, work_dir=None):
-        return Component.versions(
-            "OpenSearch",
-            "https://github.com/opensearch-project/OpenSearch.git",
-            work_dir,
-        )
-
-    @classmethod
-    def checkout(self, path, branch="main", snapshot=False):
+    def checkout(self, path: str, branch: str = "main", snapshot: bool = False) -> 'ComponentOpenSearchMin':
         return ComponentOpenSearchMin(
             GitRepository("https://github.com/opensearch-project/OpenSearch.git", branch, path),
             snapshot,
         )
 
-    def publish_to_maven_local(self):
+    def publish_to_maven_local(self) -> None:
         cmd = ComponentOpenSearch.gradle_cmd("publishToMavenLocal", {"build.snapshot": str(self.snapshot).lower()})
         self.git_repo.execute_silent(cmd)
 
     @property
-    def properties(self):
+    def properties(self) -> PropertiesFile:
         cmd = ComponentOpenSearch.gradle_cmd("properties", {"build.snapshot": str(self.snapshot).lower()})
         return PropertiesFile(self.git_repo.output(cmd))
 
     @property
-    def version(self):
+    def version(self) -> Any:
         self.publish_to_maven_local()
         return self.properties.get_value("version")

--- a/src/manifests_workflow/input_manifests_opensearch.py
+++ b/src/manifests_workflow/input_manifests_opensearch.py
@@ -3,23 +3,23 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
+from typing import List, Type, Union
 
 from manifests_workflow.component_opensearch import ComponentOpenSearch
+from manifests_workflow.component_opensearch_dashboards_min import ComponentOpenSearchDashboardsMin
 from manifests_workflow.component_opensearch_min import ComponentOpenSearchMin
 from manifests_workflow.input_manifests import InputManifests
 
 
 class InputManifestsOpenSearch(InputManifests):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("OpenSearch")
 
     @classmethod
-    def files(self):
-        return InputManifests.files("opensearch")
+    def files(self, name: str = "opensearch") -> List:
+        return InputManifests.files(name)
 
-    def update(self, keep=False):
-        super().update(
-            min_klass=ComponentOpenSearchMin,
-            component_klass=ComponentOpenSearch,
-            keep=keep,
-        )
+    def update(self, min_klass: Union[Type[ComponentOpenSearchMin], Type[ComponentOpenSearchDashboardsMin]] =
+               ComponentOpenSearchMin, component_klass: Type[ComponentOpenSearch] = ComponentOpenSearch,
+               keep: bool = False) -> None:
+        super().update(min_klass, component_klass, keep)

--- a/src/manifests_workflow/input_manifests_opensearch.py
+++ b/src/manifests_workflow/input_manifests_opensearch.py
@@ -22,4 +22,4 @@ class InputManifestsOpenSearch(InputManifests):
     def update(self, min_klass: Union[Type[ComponentOpenSearchMin], Type[ComponentOpenSearchDashboardsMin]] =
                ComponentOpenSearchMin, component_klass: Type[ComponentOpenSearch] = ComponentOpenSearch,
                keep: bool = False) -> None:
-        super().update(min_klass, component_klass, keep)
+        super().update(min_klass=ComponentOpenSearchMin, component_klass=ComponentOpenSearch, keep=keep)

--- a/src/manifests_workflow/input_manifests_opensearch_dashboards.py
+++ b/src/manifests_workflow/input_manifests_opensearch_dashboards.py
@@ -22,4 +22,4 @@ class InputManifestsOpenSearchDashboards(InputManifests):
     def update(self, min_klass: Union[Type[ComponentOpenSearchMin], Type[ComponentOpenSearchDashboardsMin]] =
                ComponentOpenSearchDashboardsMin, component_klass: Type[ComponentOpenSearch] = None,
                keep: bool = False) -> None:
-        super().update(min_klass, component_klass, keep=keep)
+        super().update(min_klass=ComponentOpenSearchDashboardsMin, component_klass=None, keep=keep)

--- a/src/manifests_workflow/input_manifests_opensearch_dashboards.py
+++ b/src/manifests_workflow/input_manifests_opensearch_dashboards.py
@@ -3,18 +3,23 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
+from typing import List, Type, Union
 
+from manifests_workflow.component_opensearch import ComponentOpenSearch
 from manifests_workflow.component_opensearch_dashboards_min import ComponentOpenSearchDashboardsMin
+from manifests_workflow.component_opensearch_min import ComponentOpenSearchMin
 from manifests_workflow.input_manifests import InputManifests
 
 
 class InputManifestsOpenSearchDashboards(InputManifests):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("OpenSearch Dashboards")
 
     @classmethod
-    def files(self):
-        return InputManifests.files("opensearch-dashboards")
+    def files(self, name: str = "opensearch-dashboards") -> List:
+        return InputManifests.files(name)
 
-    def update(self, keep=False):
-        super().update(min_klass=ComponentOpenSearchDashboardsMin, component_klass=None, keep=keep)
+    def update(self, min_klass: Union[Type[ComponentOpenSearchMin], Type[ComponentOpenSearchDashboardsMin]] =
+               ComponentOpenSearchDashboardsMin, component_klass: Type[ComponentOpenSearch] = None,
+               keep: bool = False) -> None:
+        super().update(min_klass, component_klass, keep=keep)

--- a/src/manifests_workflow/manifests_args.py
+++ b/src/manifests_workflow/manifests_args.py
@@ -6,13 +6,14 @@
 
 import argparse
 import logging
+from typing import Any, Optional
 
 from manifests_workflow.input_manifests_opensearch import InputManifestsOpenSearch
 from manifests_workflow.input_manifests_opensearch_dashboards import InputManifestsOpenSearchDashboards
 
 
 class ManifestsArgs:
-    def __init__(self):
+    def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="Manifest management")
         parser.add_argument("action", choices=["list", "update"], help="Operation to perform.")
         parser.add_argument(
@@ -43,7 +44,7 @@ class ManifestsArgs:
         self.manifests = ManifestsArgs.__get_manifests(args.type)
 
     @classmethod
-    def __get_manifests(self, type):
+    def __get_manifests(self, type: Optional[str]) -> Any:
         if type == "opensearch":
             return [InputManifestsOpenSearch]
         elif type == "opensearch-dashboards":

--- a/tests/tests_manifests_workflow/test_component_opensearch.py
+++ b/tests/tests_manifests_workflow/test_component_opensearch.py
@@ -14,24 +14,24 @@ from manifests_workflow.component_opensearch import ComponentOpenSearch
 class TestComponentOpenSearch(unittest.TestCase):
     @patch("os.makedirs")
     @patch.object(GitRepository, "__checkout__")
-    def test_checkout(self, *mocks):
+    def test_checkout(self, *mocks: MagicMock) -> None:
         component = ComponentOpenSearch.checkout("common-utils", "path", "1.1.0")
         self.assertEqual(component.name, "common-utils")
         self.assertFalse(component.snapshot)
 
-    def test_version(self):
+    def test_version(self) -> None:
         repo = MagicMock()
         repo.output.return_value = "version=2.1"
         component = ComponentOpenSearch("common-utils", repo, "1.1.0")
         self.assertEqual(component.version, "2.1")
 
-    def test_properties(self):
+    def test_properties(self) -> None:
         repo = MagicMock()
         repo.output.return_value = "version=2.1"
         component = ComponentOpenSearch("common-utils", repo, "1.1.0")
         self.assertEqual(component.properties.get_value("version"), "2.1")
 
-    def test_to_dict(self):
+    def test_to_dict(self) -> None:
         repo = MagicMock(ref="ref", url="repo")
         repo.output.return_value = "version=2.1"
         component = ComponentOpenSearch("common-utils", repo, "1.1.0")
@@ -40,16 +40,16 @@ class TestComponentOpenSearch(unittest.TestCase):
             {"name": "common-utils", "ref": "ref", "repository": "repo"},
         )
 
-    def test_gradle_cmd_target(self):
+    def test_gradle_cmd_target(self) -> None:
         self.assertEqual(ComponentOpenSearch.gradle_cmd("properties"), "./gradlew properties")
 
-    def test_gradle_cmd_prop(self):
+    def test_gradle_cmd_prop(self) -> None:
         self.assertEqual(
             ComponentOpenSearch.gradle_cmd("properties", {"build.snapshot": "false"}),
             "./gradlew properties -Dbuild.snapshot=false",
         )
 
-    def test_gradle_cmd_props(self):
+    def test_gradle_cmd_props(self) -> None:
         self.assertEqual(
             ComponentOpenSearch.gradle_cmd("properties", {"build.snapshot": "false", "opensearch.version": "1.0"}),
             "./gradlew properties -Dbuild.snapshot=false -Dopensearch.version=1.0",

--- a/tests/tests_manifests_workflow/test_component_opensearch_dashboards_min.py
+++ b/tests/tests_manifests_workflow/test_component_opensearch_dashboards_min.py
@@ -14,7 +14,7 @@ from system.config_file import ConfigFile
 
 class TestComponentOpenSearchDashboardsMin(unittest.TestCase):
     @patch("subprocess.check_output")
-    def test_branches(self, mock):
+    def test_branches(self, mock: MagicMock) -> None:
         mock.return_value = "\n".join(["main", "1.x", "1.21", "20.1", "something", "else"]).encode()
         self.assertEqual(ComponentOpenSearchDashboardsMin.branches(), ["main", "1.x", "1.21", "20.1"])
         mock.assert_called_with(
@@ -24,25 +24,25 @@ class TestComponentOpenSearchDashboardsMin(unittest.TestCase):
 
     @patch("os.makedirs")
     @patch.object(GitRepository, "__checkout__")
-    def test_checkout(self, *mocks):
+    def test_checkout(self, *mocks: MagicMock) -> None:
         component = ComponentOpenSearchDashboardsMin.checkout("path")
         self.assertEqual(component.name, "OpenSearch-Dashboards")
         self.assertFalse(component.snapshot)
 
     @patch.object(ConfigFile, "from_file")
-    def test_version(self, mock_config):
+    def test_version(self, mock_config: MagicMock) -> None:
         mock_config.return_value = ConfigFile('{"version":"2.1"}')
         component = ComponentOpenSearchDashboardsMin(MagicMock(working_directory="path"))
         self.assertEqual(component.version, "2.1")
 
     @patch.object(ConfigFile, "from_file")
-    def test_properties(self, mock_config):
+    def test_properties(self, mock_config: MagicMock) -> None:
         mock_config.return_value = ConfigFile('{"version":"2.1"}')
         component = ComponentOpenSearchDashboardsMin(MagicMock(working_directory="path"))
         self.assertEqual(component.properties.get_value("version"), "2.1")
 
     @patch.object(ConfigFile, "from_file")
-    def test_to_dict(self, mock_config):
+    def test_to_dict(self, mock_config: MagicMock) -> None:
         mock_config.return_value = ConfigFile('{"version":"2.1"}')
         repo = MagicMock(ref="ref", url="repo")
         component = ComponentOpenSearchDashboardsMin(repo)

--- a/tests/tests_manifests_workflow/test_component_opensearch_min.py
+++ b/tests/tests_manifests_workflow/test_component_opensearch_min.py
@@ -13,7 +13,7 @@ from manifests_workflow.component_opensearch_min import ComponentOpenSearchMin
 
 class TestComponentOpenSearchMin(unittest.TestCase):
     @patch("subprocess.check_output")
-    def test_branches(self, mock):
+    def test_branches(self, mock: MagicMock) -> None:
         mock.return_value = "\n".join(["main", "1.x", "1.21", "20.1", "something", "else"]).encode()
         self.assertEqual(ComponentOpenSearchMin.branches(), ["main", "1.x", "1.21", "20.1"])
         mock.assert_called_with(
@@ -23,29 +23,30 @@ class TestComponentOpenSearchMin(unittest.TestCase):
 
     @patch("os.makedirs")
     @patch.object(GitRepository, "__checkout__")
-    def test_checkout(self, *mocks):
+    def test_checkout(self, *mocks: MagicMock) -> None:
         component = ComponentOpenSearchMin.checkout("path")
         self.assertEqual(component.name, "OpenSearch")
         self.assertFalse(component.snapshot)
 
-    def test_publish_to_maven_local(self):
+    def test_publish_to_maven_local(self) -> None:
         component = ComponentOpenSearchMin(MagicMock())
         component.publish_to_maven_local()
-        component.git_repo.execute_silent.assert_called_with("./gradlew publishToMavenLocal -Dbuild.snapshot=false")
+        execute_silent = unittest.mock.create_autospec(component.git_repo.execute_silent)
+        execute_silent.assert_called_with("./gradlew publishToMavenLocal -Dbuild.snapshot=false")
 
-    def test_version(self):
+    def test_version(self) -> None:
         repo = MagicMock()
         repo.output.return_value = "version=2.1"
         component = ComponentOpenSearchMin(repo)
         self.assertEqual(component.version, "2.1")
 
-    def test_properties(self):
+    def test_properties(self) -> None:
         repo = MagicMock()
         repo.output.return_value = "version=2.1"
         component = ComponentOpenSearchMin(repo)
         self.assertEqual(component.properties.get_value("version"), "2.1")
 
-    def test_to_dict(self):
+    def test_to_dict(self) -> None:
         repo = MagicMock(ref="ref", url="repo")
         repo.output.return_value = "version=2.1"
         component = ComponentOpenSearchMin(repo)

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -6,17 +6,17 @@
 
 import os
 import unittest
-from unittest.mock import call, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch
 
 from manifests_workflow.input_manifests import InputManifests
 
 
 class TestInputManifests(unittest.TestCase):
-    def test_manifests_path(self):
+    def test_manifests_path(self) -> None:
         path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "manifests"))
         self.assertEqual(path, InputManifests.manifests_path())
 
-    def test_create_manifest(self):
+    def test_create_manifest(self) -> None:
         input_manifests = InputManifests("test")
         input_manifest = input_manifests.create_manifest("1.2.3", [])
         self.assertEqual(
@@ -30,7 +30,7 @@ class TestInputManifests(unittest.TestCase):
 
     @patch("os.makedirs")
     @patch("manifests_workflow.input_manifests.InputManifests.create_manifest")
-    def test_write_manifest(self, mock_create_manifest, mock_makedirs):
+    def test_write_manifest(self, mock_create_manifest: MagicMock, mock_makedirs: MagicMock) -> None:
         input_manifests = InputManifests("test")
         input_manifests.write_manifest('0.1.2', [])
         mock_create_manifest.assert_called_with('0.1.2', [])
@@ -39,7 +39,7 @@ class TestInputManifests(unittest.TestCase):
             os.path.join(InputManifests.manifests_path(), '0.1.2', 'test-0.1.2.yml')
         )
 
-    def test_jenkins_path(self):
+    def test_jenkins_path(self) -> None:
         self.assertEqual(
             InputManifests.jenkins_path(),
             os.path.realpath(
@@ -49,14 +49,14 @@ class TestInputManifests(unittest.TestCase):
             )
         )
 
-    def test_cron_jenkinsfile(self):
+    def test_cron_jenkinsfile(self) -> None:
         self.assertEqual(
             InputManifests.cron_jenkinsfile(),
             os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "jenkins", "check-for-build.jenkinsfile"))
         )
 
     @patch("builtins.open", new_callable=mock_open)
-    def test_add_to_cron(self, mock_open):
+    def test_add_to_cron(self, mock_open: MagicMock) -> None:
         mock_open().read.return_value = "parameterizedCron '''\n"
         input_manifests = InputManifests("test")
         input_manifests.add_to_cron('0.1.2')
@@ -66,5 +66,5 @@ class TestInputManifests(unittest.TestCase):
             f"parameterizedCron '''\n{' ' * 12}H/10 * * * * %INPUT_MANIFEST=0.1.2/test-0.1.2.yml;TARGET_JOB_NAME=distribution-build-test\n"
         )
 
-    def test_create_manifest_with_components(self):
+    def test_create_manifest_with_components(self) -> None:
         pass

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
@@ -13,7 +13,7 @@ from manifests_workflow.input_manifests_opensearch import InputManifestsOpenSear
 
 
 class TestInputManifestsOpenSearch(unittest.TestCase):
-    def test_files(self):
+    def test_files(self) -> None:
         files = InputManifestsOpenSearch.files()
         self.assertTrue(len(files) >= 2)
         manifest = os.path.realpath(
@@ -35,7 +35,9 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearchMin")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearch")
     @patch("manifests_workflow.input_manifests.InputManifest")
-    def test_update(self, mock_input_manifest, mock_component_opensearch, mock_component_opensearch_min, mock_input_manifest_from_path, mock_add_to_cron, *mocks):
+    def test_update(self, mock_input_manifest: MagicMock, mock_component_opensearch: MagicMock,
+                    mock_component_opensearch_min: MagicMock, mock_input_manifest_from_path: MagicMock,
+                    mock_add_to_cron: MagicMock, *mocks: MagicMock) -> None:
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
         mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
@@ -75,7 +77,9 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearchMin")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearch")
     @patch("manifests_workflow.input_manifests_opensearch.InputManifestsOpenSearch.write_manifest")
-    def test_update_with_latest_manifest(self, mock_write_manifest, mock_component_opensearch, mock_component_opensearch_min, mock_add_to_cron, *mocks):
+    def test_update_with_latest_manifest(self, mock_write_manifest: MagicMock, mock_component_opensearch: MagicMock,
+                                         mock_component_opensearch_min: MagicMock, mock_add_to_cron: MagicMock,
+                                         *mocks: MagicMock) -> None:
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
         mock_component_opensearch_min.branches.return_value = ["main"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
@@ -12,7 +12,7 @@ from manifests_workflow.input_manifests_opensearch_dashboards import InputManife
 
 
 class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
-    def test_files(self):
+    def test_files(self) -> None:
         files = InputManifestsOpenSearchDashboards.files()
         self.assertTrue(len(files) >= 1)
         manifest = os.path.realpath(
@@ -33,7 +33,8 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
     @patch("manifests_workflow.input_manifests.InputManifest.from_path")
     @patch("manifests_workflow.input_manifests_opensearch_dashboards.ComponentOpenSearchDashboardsMin")
     @patch("manifests_workflow.input_manifests.InputManifest")
-    def test_update(self, mock_input_manifest, mock_component_opensearch_min, mock_input_manifest_from_path, mock_add_to_cron, *mocks):
+    def test_update(self, mock_input_manifest: MagicMock, mock_component_opensearch_min: MagicMock,
+                    mock_input_manifest_from_path: MagicMock, mock_add_to_cron: MagicMock, *mocks: MagicMock) -> None:
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch-Dashboards")
         mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")

--- a/tests/tests_manifests_workflow/test_manifests_args.py
+++ b/tests/tests_manifests_workflow/test_manifests_args.py
@@ -17,30 +17,30 @@ class TestManifestsArgs(unittest.TestCase):
     MANIFESTS_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "manifests.py"))
 
     @patch("argparse._sys.argv", [MANIFESTS_PY, "list"])
-    def test_action_list(self):
+    def test_action_list(self) -> None:
         self.assertEqual(ManifestsArgs().action, "list")
 
     @patch("argparse._sys.argv", [MANIFESTS_PY, "update"])
-    def test_action_update(self):
+    def test_action_update(self) -> None:
         self.assertEqual(ManifestsArgs().action, "update")
 
     @patch("argparse._sys.argv", [MANIFESTS_PY, "invalid"])
-    def test_action_invalid(self):
+    def test_action_invalid(self) -> None:
         with self.assertRaises(SystemExit):
             self.assertEqual(ManifestsArgs().action, "invalid")
 
     @patch("argparse._sys.argv", [MANIFESTS_PY, "list"])
-    def test_verbose_default(self):
+    def test_verbose_default(self) -> None:
         self.assertTrue(ManifestsArgs().logging_level, logging.INFO)
 
     @patch("argparse._sys.argv", [MANIFESTS_PY, "list", "--verbose"])
-    def test_verbose_true(self):
+    def test_verbose_true(self) -> None:
         self.assertTrue(ManifestsArgs().logging_level, logging.DEBUG)
 
     @patch("argparse._sys.argv", [MANIFESTS_PY, "list"])
-    def test_keep_default(self):
+    def test_keep_default(self) -> None:
         self.assertFalse(ManifestsArgs().keep)
 
     @patch("argparse._sys.argv", [MANIFESTS_PY, "list", "--keep"])
-    def test_keep_true(self):
+    def test_keep_true(self) -> None:
         self.assertTrue(ManifestsArgs().keep)


### PR DESCRIPTION
### Description
` pipenv run mypy src/manifests_workflow tests/tests_manifests_workflow` passes without error

### Issues Resolved
#1509 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
