### PR TITLE
Remove 1.1.1 jobs in check-for-build

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -10,8 +10,6 @@ pipeline {
             H/10 * * * * %INPUT_MANIFEST=1.2.5/opensearch-1.2.5.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.3.0/opensearch-dashboards-1.3.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H/10 * * * * %INPUT_MANIFEST=1.3.0/opensearch-1.3.0.yml;TEST_MANIFEST=1.3.0/opensearch-1.3.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H 1 * * * %INPUT_MANIFEST=1.1.1/opensearch-1.1.1.yml;TEST_MANIFEST=1.1.1/opensearch-1.1.1-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H 1 * * * %INPUT_MANIFEST=1.1.1/opensearch-dashboards-1.1.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H 1 * * * %INPUT_MANIFEST=1.2.1/opensearch-1.2.1.yml;TEST_MANIFEST=1.2.1/opensearch-1.2.1-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=1.2.2/opensearch-1.2.2.yml;TEST_MANIFEST=1.2.2/opensearch-1.2.2-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=1.2.3/opensearch-1.2.3.yml;TEST_MANIFEST=1.2.3/opensearch-1.2.3-test.yml;TARGET_JOB_NAME=distribution-build-opensearch


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Removes cron schedules for leftover 1.1.1 jobs, since 1.1.1 release isn't happening. This will also help clean up noisy notification failures.
 
### Issues Resolved
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
