### PR TITLE
add permissions for index.json

### DIFF
--- a/deployment/lib/identities.ts
+++ b/deployment/lib/identities.ts
@@ -48,6 +48,9 @@ export class Identities {
     props.buildBucket.grantRead(bundleRole, '*/dist/*');
     props.buildBucket.grantPut(bundleRole, '*/dist/*');
 
+    props.buildBucket.grantRead(bundleRole, '*/index.json');
+    props.buildBucket.grantPut(bundleRole, '*/index.json');
+
     props.buildBucket.grantRead(testRole, '*/dist/*');
     props.buildBucket.grantPut(testRole, '*/dist/*/tests/*');
     props.buildBucket.grantPut(testRole, '*/test-results/*');


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
As https://github.com/opensearch-project/opensearch-build/pull/1569 grows, I want to commit by phases and also make it easy for me to test by using infra's Jenkins. Without this change, I have to test my Jenkins changes by uploading to `dist/index.json`.

Thank @peternied for showing me the location of the change in https://github.com/tianleh/opensearch-build/pull/3

Post merge, I may need to perform `cdk deploy` (https://github.com/opensearch-project/opensearch-build/tree/main/deployment). Currently I do not have permission for performing such. **I may need either 1) be granted such permission 2) have an infra team member with such permission to run `cdk deploy` for me.**
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1601

### Test
Since this is a config change, I didn't add a unit test for this. Let me know if it is ok. 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
