### PR TITLE
Disable propagate argument when triggering child job

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -72,16 +72,19 @@ pipeline {
                                 TARGET_JOB_NAME != 'distribution-build-opensearch-dashboards') {
                                 error "Job ${TARGET_JOB_NAME} is invalid"
                             }
-                            build job: "${TARGET_JOB_NAME}", parameters: [
-                            string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
-                            string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
-                            ], wait: true
-                            
-                            echo "Build succeeded, uploading build SHA for that job"
-                            buildUploadManifestSHA(
-                                inputManifest: "manifests/${INPUT_MANIFEST}",
-                                jobName: "${TARGET_JOB_NAME}"
-                            )
+                            try {
+                                build job: "${TARGET_JOB_NAME}", parameters: [
+                                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
+                                    string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
+                                ], wait: true
+                                echo "Build succeeded, uploading build SHA for that job"
+                                buildUploadManifestSHA(
+                                    inputManifest: "manifests/${INPUT_MANIFEST}",
+                                    jobName: "${TARGET_JOB_NAME}"
+                                )
+                            } catch(err) {
+                                echo "${TARGET_JOB_NAME} failed"
+                            }
                         }
                     }
                 }

--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -72,19 +72,15 @@ pipeline {
                                 TARGET_JOB_NAME != 'distribution-build-opensearch-dashboards') {
                                 error "Job ${TARGET_JOB_NAME} is invalid"
                             }
-                            try {
-                                build job: "${TARGET_JOB_NAME}", parameters: [
-                                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
-                                    string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
-                                ], wait: true
-                                echo "Build succeeded, uploading build SHA for that job"
-                                buildUploadManifestSHA(
-                                    inputManifest: "manifests/${INPUT_MANIFEST}",
-                                    jobName: "${TARGET_JOB_NAME}"
-                                )
-                            } catch(err) {
-                                echo "${TARGET_JOB_NAME} failed"
-                            }
+                            build job: "${TARGET_JOB_NAME}", parameters: [
+                                string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
+                                string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
+                            ], wait: true, propagate: false
+                            echo "Build succeeded, uploading build SHA for that job"
+                            buildUploadManifestSHA(
+                                inputManifest: "manifests/${INPUT_MANIFEST}",
+                                jobName: "${TARGET_JOB_NAME}"
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Currently our check-for-build jenkins job will fail if its child job fails, which also sends out failure notification. Disabled propagate argument will not propagate the results of child job and continue the workflow on the current job. This job only fails if there is an issue in check-for-build itself.


### Issues Resolved
#1627 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
