### PR TITLE
[WIP] Refractor the check-for-build method and tests

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -72,16 +72,19 @@ pipeline {
                                 TARGET_JOB_NAME != 'distribution-build-opensearch-dashboards') {
                                 error "Job ${TARGET_JOB_NAME} is invalid"
                             }
-                            build job: "${TARGET_JOB_NAME}", parameters: [
-                            string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
-                            string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
-                            ], wait: true
-                            
-                            echo "Build succeeded, uploading build SHA for that job"
-                            buildUploadManifestSHA(
-                                inputManifest: "manifests/${INPUT_MANIFEST}",
-                                jobName: "${TARGET_JOB_NAME}"
-                            )
+                            try {
+                                build job: "${TARGET_JOB_NAME}", parameters: [
+                                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
+                                    string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
+                                ], wait: true
+                                echo "Build succeeded, uploading build SHA for that job"
+                                buildUploadManifestSHA(
+                                    inputManifest: "manifests/${INPUT_MANIFEST}",
+                                    jobName: "${TARGET_JOB_NAME}"
+                                )
+                            } catch(err) {
+                                echo "${TARGET_JOB_NAME} failed"
+                            }
                         }
                     }
                 }

--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -72,19 +72,10 @@ pipeline {
                                 TARGET_JOB_NAME != 'distribution-build-opensearch-dashboards') {
                                 error "Job ${TARGET_JOB_NAME} is invalid"
                             }
-                            try {
-                                build job: "${TARGET_JOB_NAME}", parameters: [
-                                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
-                                    string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
-                                ], wait: true
-                                echo "Build succeeded, uploading build SHA for that job"
-                                buildUploadManifestSHA(
-                                    inputManifest: "manifests/${INPUT_MANIFEST}",
-                                    jobName: "${TARGET_JOB_NAME}"
-                                )
-                            } catch(err) {
-                                echo "${TARGET_JOB_NAME} failed"
-                            }
+                            build job: "${TARGET_JOB_NAME}", parameters: [
+                                string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
+                                string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
+                            ], wait: true, propagate: false
                         }
                     }
                 }

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -133,6 +133,18 @@ pipeline {
                 }
             }
         }
+        stage('SHA upload') {
+            steps {
+                node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                    script {
+                        buildUploadManifestSHA(
+                            inputManifest: "manifests/${INPUT_MANIFEST}",
+                            jobName: "${env.JOB_BASE_NAME}"
+                        )
+                    }
+                }
+            }
+        }
     }
     post {
         success {
@@ -151,7 +163,6 @@ pipeline {
                         credentialsId: 'BUILD_NOTICE_WEBHOOK',
                         manifest: "${INPUT_MANIFEST}"
                     )
-
                     postCleanup()
                 }
             }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -214,6 +214,18 @@ pipeline {
                 }
             }
         }
+        stage('SHA upload') {
+            steps {
+                node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
+                    script {
+                        buildUploadManifestSHA(
+                            inputManifest: "manifests/${INPUT_MANIFEST}",
+                            jobName: "${env.JOB_BASE_NAME}"
+                        )
+                    }
+                }
+            }
+        }
     }
     post {
         success {


### PR DESCRIPTION
### Description
I found out a problem regarding of the PR just merged #1628. When we disable `propagate` when trigger the job, the following 
```
echo "Build succeeded, uploading build SHA for that job"
buildUploadManifestSHA(
    inputManifest: "manifests/${INPUT_MANIFEST}",
    jobName: "${TARGET_JOB_NAME}"
)
``` 
will be executed after triggered job failed which not what we expected. We shouldn't upload it if the distribution-build failed. 

The use of try-catch block will avoid this situation, if the `distribution-build` failed, nothing below the job call in the try block will be executed. 
 
### Issues Resolved
continue on #1627 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
