### PR TITLE
Update security to use gradle instead of maven build

### DIFF
--- a/scripts/components/security/build.sh
+++ b/scripts/components/security/build.sh
@@ -17,7 +17,6 @@ function usage() {
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
-    echo -e "-d DASHBOARDS\t[Optional] Build OpenSearch Dashboards, default is 'false'."
     echo -e "-h help"
 }
 

--- a/scripts/components/security/build.sh
+++ b/scripts/components/security/build.sh
@@ -60,10 +60,16 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+OPENSEARCH_RELEASE=$VERSION
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-mkdir -p $OUTPUT
+# see https://github.com/opensearch-project/security/pull/1409
+PLUGIN_VERSION=$(cat plugin-descriptor.properties | grep ^version= | cut -d= -f2 | sed "s/-SNAPSHOT//")
+[[ "$SNAPSHOT" == "true" ]] && PLUGIN_VERSION=$PLUGIN_VERSION-SNAPSHOT
+
+sed -i -e "s/\(^opensearch\.version=\).*\$/\1${OPENSEARCH_RELEASE}/" plugin-descriptor.properties
+sed -i -e "s/\(^version=\).*\$/\1${PLUGIN_VERSION}/" plugin-descriptor.properties
 
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dopensearch_version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 

--- a/scripts/components/security/build.sh
+++ b/scripts/components/security/build.sh
@@ -68,9 +68,6 @@ OPENSEARCH_RELEASE=$VERSION
 PLUGIN_VERSION=$(cat plugin-descriptor.properties | grep ^version= | cut -d= -f2 | sed "s/-SNAPSHOT//")
 [[ "$SNAPSHOT" == "true" ]] && PLUGIN_VERSION=$PLUGIN_VERSION-SNAPSHOT
 
-sed -i -e "s/\(^opensearch\.version=\).*\$/\1${OPENSEARCH_RELEASE}/" plugin-descriptor.properties
-sed -i -e "s/\(^version=\).*\$/\1${PLUGIN_VERSION}/" plugin-descriptor.properties
-
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dopensearch_version=$VERSION -Dbuild.snapshot=$SNAPSHOT
 
 zipPath=$(find . -path \*build/distributions/*.zip -not -name "*standalone.zip")


### PR DESCRIPTION
### Description
Update security to use gradle instead of maven build
 
### Issues Resolved
Fixed the distribution build break
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
