### PR TITLE
Revert "Disable propagate argument when triggering child job (#1628)"

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -73,9 +73,10 @@ pipeline {
                                 error "Job ${TARGET_JOB_NAME} is invalid"
                             }
                             build job: "${TARGET_JOB_NAME}", parameters: [
-                                string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
-                                string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
-                            ], wait: true, propagate: false
+                            string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
+                            string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}")
+                            ], wait: true
+                            
                             echo "Build succeeded, uploading build SHA for that job"
                             buildUploadManifestSHA(
                                 inputManifest: "manifests/${INPUT_MANIFEST}",


### PR DESCRIPTION
This reverts commit e0a34ebdac134144be2794f63609358ac5ea7d0b.

Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
After that commit, we realized no matter success or failure of `distribution-build`, Jenkins would always execute the command below: 
```
buildUploadManifestSHA(
    inputManifest: "manifests/${INPUT_MANIFEST}",
    jobName: "${TARGET_JOB_NAME}"
)
```
which is not expected. It's meaningless to update and upload the SHA if the build fails. Hence this PR is to revert that change. This will reopen the issue #1627 and I will have a PR WIP #1630 with test cases to resolve this issue. 

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
