### PR TITLE
[Cleanup] Remove DASHBOARD from default OpenSearch script

### DIFF
--- a/scripts/default/opensearch/build.sh
+++ b/scripts/default/opensearch/build.sh
@@ -17,7 +17,6 @@ function usage() {
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
     echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
-    echo -e "-d DASHBOARDS\t[Optional] Build OpenSearch Dashboards, default is 'false'."
     echo -e "-h help"
 }
 


### PR DESCRIPTION
### Description
This was added here:
https://github.com/opensearch-project/opensearch-build/pull/590/files

When the default script was shared. This removes this unused legacy
code.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1634
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
