### PR TITLE
Add distribution supported components list so only specific scripts can take -d parameter

### DIFF
--- a/src/build_workflow/builder_from_source.py
+++ b/src/build_workflow/builder_from_source.py
@@ -19,8 +19,6 @@ Artifacts found in "<build root>/artifacts/<maven|plugins|libs|dist|core-plugins
 
 
 class BuilderFromSource(Builder):
-
-
     def checkout(self, work_dir: str) -> None:
         self.git_repo = GitRepository(
             self.component.repository,

--- a/src/build_workflow/builder_from_source.py
+++ b/src/build_workflow/builder_from_source.py
@@ -19,6 +19,8 @@ Artifacts found in "<build root>/artifacts/<maven|plugins|libs|dist|core-plugins
 
 
 class BuilderFromSource(Builder):
+
+
     def checkout(self, work_dir: str) -> None:
         self.git_repo = GitRepository(
             self.component.repository,
@@ -28,6 +30,11 @@ class BuilderFromSource(Builder):
         )
 
     def build(self, build_recorder: BuildRecorder) -> None:
+
+        # List of components whose build scripts support `-d` parameter
+        # Bundled plugins do not need `-d` as they are java based zips
+        DISTRIBUTION_SUPPORTED_COMPONENTS = ["OpenSearch", "OpenSearch-Dashboards"]
+
         build_script = ScriptFinder.find_build_script(self.target.name, self.component.name, self.git_repo.working_directory)
 
         build_command = " ".join(
@@ -39,7 +46,7 @@ class BuilderFromSource(Builder):
                     f"-v {self.target.version}",
                     f"-p {self.target.platform}",
                     f"-a {self.target.architecture}",
-                    f"-d {self.target.distribution}" if self.target.distribution else None,
+                    f"-d {self.target.distribution}" if self.target.distribution and (self.component.name in DISTRIBUTION_SUPPORTED_COMPONENTS) else None,
                     f"-s {str(self.target.snapshot).lower()}",
                     f"-o {self.output_path}",
                 ]

--- a/tests/tests_build_workflow/test_builder_from_source.py
+++ b/tests/tests_build_workflow/test_builder_from_source.py
@@ -40,6 +40,18 @@ class TestBuilderFromSource(unittest.TestCase):
             ),
         )
 
+        self.builder_distribution_support = BuilderFromSource(
+            InputComponentFromSource({"name": "common-utils", "repository": "url", "ref": "ref"}),
+            BuildTarget(
+                name="OpenSearch",
+                version="1.3.0",
+                platform="linux",
+                architecture="x64",
+                distribution="rpm",
+                snapshot=False,
+            ),
+        )
+
     def test_builder(self) -> None:
         self.assertEqual(self.builder.component.name, "common-utils")
 
@@ -85,6 +97,27 @@ class TestBuilderFromSource(unittest.TestCase):
             )
         )
         build_recorder.record_component.assert_called_with("OpenSearch", mock_git_repo.return_value)
+
+    @patch("build_workflow.builder_from_source.GitRepository")
+    def test_build_distribution_support(self, mock_git_repo: Mock) -> None:
+        mock_git_repo.return_value = MagicMock(working_directory="dir")
+        build_recorder = MagicMock()
+        self.builder_distribution_support.checkout("dir")
+        self.builder_distribution_support.build(build_recorder)
+        mock_git_repo.return_value.execute.assert_called_with(
+            " ".join(
+                [
+                    "bash",
+                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "common-utils", "build.sh")),
+                    "-v 1.3.0",
+                    "-p linux",
+                    "-a x64",
+                    "-s false",
+                    "-o builds",
+                ]
+            )
+        )
+        build_recorder.record_component.assert_called_with("common-utils", mock_git_repo.return_value)
 
     @patch("build_workflow.builder_from_source.GitRepository")
     def test_build_snapshot(self, mock_git_repo: Mock) -> None:


### PR DESCRIPTION


Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add distribution supported components list so only specific scripts can take -d parameter
 
### Issues Resolved
#1651
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
