### PR TITLE
Temporarily remove Alerting and Index Management from 1.3.0 manifest

### DIFF
--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -26,20 +26,8 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
-  - name: alerting
-    repository: https://github.com/opensearch-project/alerting.git
-    ref: main
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: alerting
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: main
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
-  - name: index-management
-    repository: https://github.com/opensearch-project/index-management.git
     ref: main
     checks:
       - gradle:properties:version


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Alerting is failing in the build and it's suspected it could be related to some dependency in OpenSearch itself since the snapshot version succeeds. However, since Alerting is causing the overall build to fail, changes are not being published. To attempt to remediate this, Alerting will been removed from the 1.3.0 manifest (along with Index Management since it might fail without notification subproject being published locally by Alerting) and we'll see if adding them back after successful builds resolves the situation.
 
### Issues Resolved
Related to https://github.com/opensearch-project/alerting/issues/312
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
