### PR TITLE
Remove PA-RCA files from OS home dir

### DIFF
--- a/scripts/components/performance-analyzer/install.sh
+++ b/scripts/components/performance-analyzer/install.sh
@@ -68,6 +68,14 @@ fi
 [ -z "$ARCHITECTURE" ] && ARCHITECTURE=`uname -m`
 
 ## Setup Performance Analyzer Agent
-mv $OUTPUT/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OUTPUT/
+PA_PLUGIN_PATH=$OUTPUT/plugins/opensearch-performance-analyzer
+RCA_LIB_PATH=$OUTPUT/plugins/opensearch-performance-analyzer/rca_lib
+# Remove common lib files between PA plugin and RCA reader process
+for f in `ls -1 $PA_PLUGIN_PATH`; do
+    if [[ $(diff $RCA_LIB_PATH/$f $PA_PLUGIN_PATH/$f | wc -c) -eq 0 ]]; then
+        rm -rf $RCA_LIB_PATH/$f;
+    fi
+done;
+
 mv $OUTPUT/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli $OUTPUT/bin
 rm -rf $OUTPUT/bin/opensearch-performance-analyzer


### PR DESCRIPTION
Signed-off-by: Karishma Joseph <karisjos@amazon.com>

###  [Merge only when PA is stable]

### Description
Remove the`<OS_HOME>/performance-analyzer-rca` folder from the OS home directory. This way there is only one location for PA plugin and PA-RCA process: `<OS_HOME>/plugins/opensearch-performance-analyzer`. 

Contents of `<OS_HOME>/performance-analyzer-rca` before:
```
bin  lib  pa_bin  pa_config
```


`pa_bin` and `pa_config` in `<OS_HOME>/performance-analyzer-rca` and `<OS_HOME>/plugins/opensearch-performance-analyzer` were exactly the same. Hence, no action needs to be taken for these two folders.

Copy `bin` into `<OS_HOME>/plugins/opensearch-performance-analyzer` and rename as `rca_bin`.

Copy `lib` into `<OS_HOME>/plugins/opensearch-performance-analyzer` and rename as `rca_lib`. Remove all the common library files between `<OS_HOME>/plugins/opensearch-performance-analyzer` and `<OS_HOME>/plugins/opensearch-performance-analyzer/rca_lib` so as to reduce the memory footprint.
 
### Issues Resolved
https://github.com/opensearch-project/performance-analyzer/issues/82
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
