### PR TITLE
[RPM M1] Combine two map into one for distribution class/extension

### DIFF
--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -41,7 +41,7 @@ class BundleRecorder:
             build.platform,
             build.architecture,
         ]
-        extension = Dists().DISTRIBUTIONS_MAP[self.distribution][1] if self.distribution else Dists().DISTRIBUTIONS_MAP['tar'][1]
+        extension = Dists.DISTRIBUTIONS_MAP[self.distribution]['extension'] if self.distribution else Dists().DISTRIBUTIONS_MAP['tar']['extension']
         return "-".join(parts) + extension
 
     # Assembled output are expected to be served from a separate "dist" folder

--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -41,7 +41,7 @@ class BundleRecorder:
             build.platform,
             build.architecture,
         ]
-        extension = Dists.DISTRIBUTIONS_MAP[self.distribution]['extension'] if self.distribution else Dists().DISTRIBUTIONS_MAP['tar']['extension']
+        extension = Dists.DISTRIBUTIONS_MAP[self.distribution].extension if self.distribution else Dists.DISTRIBUTIONS_MAP['tar'].extension
         return "-".join(parts) + extension
 
     # Assembled output are expected to be served from a separate "dist" folder

--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -8,15 +8,12 @@ import os
 from typing import Any, Dict
 
 from assemble_workflow.bundle_location import BundleLocation
+from assemble_workflow.dists import Dists
 from manifests.build_manifest import BuildComponent, BuildManifest
 from manifests.bundle_manifest import BundleManifest
 
 
 class BundleRecorder:
-    EXTENSIONS = {
-        "tar": ".tar.gz",
-        "zip": ".zip",
-    }
 
     def __init__(self, build: BuildManifest.Build, output_dir: str, artifacts_dir: str, bundle_location: BundleLocation) -> None:
         self.output_dir = output_dir
@@ -44,7 +41,7 @@ class BundleRecorder:
             build.platform,
             build.architecture,
         ]
-        extension = self.EXTENSIONS[self.distribution] if self.distribution else self.EXTENSIONS['tar']
+        extension = Dists().DISTRIBUTIONS_MAP[self.distribution][1] if self.distribution else Dists().DISTRIBUTIONS_MAP['tar'][1]
         return "-".join(parts) + extension
 
     # Assembled output are expected to be served from a separate "dist" folder

--- a/src/assemble_workflow/dist.py
+++ b/src/assemble_workflow/dist.py
@@ -70,6 +70,16 @@ class Dist(ABC):
         logging.info(f"Published {path}.")
 
 
+class DistTar(Dist):
+    def __extract__(self, dest: str) -> None:
+        with tarfile.open(self.path, "r:gz") as tar:
+            tar.extractall(dest)
+
+    def __build__(self, name: str, dest: str) -> None:
+        with tarfile.open(name, "w:gz") as tar:
+            tar.add(self.archive_path, arcname=os.path.basename(self.archive_path))
+
+
 class DistZip(Dist):
     def __extract__(self, dest: str) -> None:
         with ZipFile(self.path, "r") as zip:
@@ -82,13 +92,3 @@ class DistZip(Dist):
                 for file in files:
                     fn = os.path.join(base, file)
                     zip.write(fn, fn[rootlen:])
-
-
-class DistTar(Dist):
-    def __extract__(self, dest: str) -> None:
-        with tarfile.open(self.path, "r:gz") as tar:
-            tar.extractall(dest)
-
-    def __build__(self, name: str, dest: str) -> None:
-        with tarfile.open(name, "w:gz") as tar:
-            tar.add(self.archive_path, arcname=os.path.basename(self.archive_path))

--- a/src/assemble_workflow/dists.py
+++ b/src/assemble_workflow/dists.py
@@ -10,9 +10,10 @@ from assemble_workflow.dist import Dist, DistTar, DistZip
 
 
 class Dists:
+
     DISTRIBUTIONS_MAP = {
-        "tar": DistTar,
-        "zip": DistZip,
+        "tar": [DistTar, ".tar.gz"],
+        "zip": [DistZip, ".zip"],
     }
 
     @classmethod
@@ -21,4 +22,4 @@ class Dists:
             logging.info("Distribution not specified, default to tar")
             distribution = 'tar'
 
-        return cls.DISTRIBUTIONS_MAP[distribution](name, path, min_path)
+        return cls.DISTRIBUTIONS_MAP[distribution][0](name, path, min_path)

--- a/src/assemble_workflow/dists.py
+++ b/src/assemble_workflow/dists.py
@@ -12,16 +12,16 @@ from assemble_workflow.dist import Dist, DistTar, DistZip
 
 class Distribution:
 
-    def __init__(self, klass: Type[Dist], extension: str) -> None:
-        self.klass = klass
+    def __init__(self, cls: Type[Dist], extension: str) -> None:
+        self.cls = cls
         self.extension = extension
 
 
 class Dists:
 
     DISTRIBUTIONS_MAP = {
-        "tar": Distribution(klass=DistTar, extension=".tar.gz"),
-        "zip": Distribution(klass=DistZip, extension=".zip"),
+        "tar": Distribution(cls=DistTar, extension=".tar.gz"),
+        "zip": Distribution(cls=DistZip, extension=".zip"),
     }
 
     @classmethod
@@ -30,6 +30,6 @@ class Dists:
             logging.info("Distribution not specified, default to tar")
             distribution = 'tar'
 
-        dist_cls = cls.DISTRIBUTIONS_MAP[distribution].klass
+        dist_cls = cls.DISTRIBUTIONS_MAP[distribution].cls
 
         return dist_cls(name, path, min_path)

--- a/src/assemble_workflow/dists.py
+++ b/src/assemble_workflow/dists.py
@@ -5,9 +5,7 @@
 # compatible open source license.
 
 import logging
-from typing import Dict, Type
-
-from mypy_extensions import TypedDict
+from typing import Type
 
 from assemble_workflow.dist import Dist, DistTar, DistZip
 

--- a/src/assemble_workflow/dists.py
+++ b/src/assemble_workflow/dists.py
@@ -12,8 +12,14 @@ from assemble_workflow.dist import Dist, DistTar, DistZip
 class Dists:
 
     DISTRIBUTIONS_MAP = {
-        "tar": [DistTar, ".tar.gz"],
-        "zip": [DistZip, ".zip"],
+        "tar": {
+            "klass": DistTar,
+            "extension": ".tar.gz"
+        },
+        "zip": {
+            "klass": DistZip,
+            "extension": ".zip"
+        }
     }
 
     @classmethod
@@ -22,4 +28,6 @@ class Dists:
             logging.info("Distribution not specified, default to tar")
             distribution = 'tar'
 
-        return cls.DISTRIBUTIONS_MAP[distribution][0](name, path, min_path)
+        dist_cls = cls.DISTRIBUTIONS_MAP[distribution]['klass']
+
+        return dist_cls(name, path, min_path)

--- a/src/assemble_workflow/dists.py
+++ b/src/assemble_workflow/dists.py
@@ -7,19 +7,21 @@
 import logging
 
 from assemble_workflow.dist import Dist, DistTar, DistZip
+from mypy_extensions import TypedDict
+from typing import Dict, Type
+
+class Distribution:
+
+    def __init__(self, klass: Type[Dist], extension: str) -> None:
+        self.klass = klass
+        self.extension = extension
 
 
 class Dists:
 
     DISTRIBUTIONS_MAP = {
-        "tar": {
-            "klass": DistTar,
-            "extension": ".tar.gz"
-        },
-        "zip": {
-            "klass": DistZip,
-            "extension": ".zip"
-        }
+        "tar": Distribution(klass=DistTar, extension=".tar.gz"),
+        "zip": Distribution(klass=DistZip, extension=".zip"),
     }
 
     @classmethod
@@ -28,6 +30,6 @@ class Dists:
             logging.info("Distribution not specified, default to tar")
             distribution = 'tar'
 
-        dist_cls = cls.DISTRIBUTIONS_MAP[distribution]['klass']
+        dist_cls = cls.DISTRIBUTIONS_MAP[distribution].klass
 
         return dist_cls(name, path, min_path)

--- a/src/assemble_workflow/dists.py
+++ b/src/assemble_workflow/dists.py
@@ -5,10 +5,12 @@
 # compatible open source license.
 
 import logging
+from typing import Dict, Type
+
+from mypy_extensions import TypedDict
 
 from assemble_workflow.dist import Dist, DistTar, DistZip
-from mypy_extensions import TypedDict
-from typing import Dict, Type
+
 
 class Distribution:
 

--- a/tests/tests_assemble_workflow/test_dists.py
+++ b/tests/tests_assemble_workflow/test_dists.py
@@ -16,10 +16,10 @@ class TestDists(unittest.TestCase):
         self.dists = Dists
 
     def test_distribution_map(self) -> None:
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar']['klass'].__name__, 'DistTar')
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar']['extension'], '.tar.gz')
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip']['klass'].__name__, 'DistZip')
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip']['extension'], '.zip')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar'].klass.__name__, 'DistTar')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar'].extension, '.tar.gz')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip'].klass.__name__, 'DistZip')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip'].extension, '.zip')
 
     def test_create_dist(self) -> None:
         return_cls_tar = self.dists.create_dist("OpenSearch", "artifacts/dist", "opensearch-1.3.0", 'tar')

--- a/tests/tests_assemble_workflow/test_dists.py
+++ b/tests/tests_assemble_workflow/test_dists.py
@@ -16,9 +16,9 @@ class TestDists(unittest.TestCase):
         self.dists = Dists
 
     def test_distribution_map(self) -> None:
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar'].klass.__name__, 'DistTar')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar'].cls.__name__, 'DistTar')
         self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar'].extension, '.tar.gz')
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip'].klass.__name__, 'DistZip')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip'].cls.__name__, 'DistZip')
         self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip'].extension, '.zip')
 
     def test_create_dist(self) -> None:

--- a/tests/tests_assemble_workflow/test_dists.py
+++ b/tests/tests_assemble_workflow/test_dists.py
@@ -16,8 +16,10 @@ class TestDists(unittest.TestCase):
         self.dists = Dists
 
     def test_distribution_map(self) -> None:
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar'].__name__, 'DistTar')
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip'].__name__, 'DistZip')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar'][0].__name__, 'DistTar')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar'][1], '.tar.gz')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip'][0].__name__, 'DistZip')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip'][1], '.zip')
 
     def test_create_dist(self) -> None:
         return_cls_tar = self.dists.create_dist("OpenSearch", "artifacts/dist", "opensearch-1.3.0", 'tar')

--- a/tests/tests_assemble_workflow/test_dists.py
+++ b/tests/tests_assemble_workflow/test_dists.py
@@ -16,10 +16,10 @@ class TestDists(unittest.TestCase):
         self.dists = Dists
 
     def test_distribution_map(self) -> None:
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar'][0].__name__, 'DistTar')
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar'][1], '.tar.gz')
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip'][0].__name__, 'DistZip')
-        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip'][1], '.zip')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar']['klass'].__name__, 'DistTar')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['tar']['extension'], '.tar.gz')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip']['klass'].__name__, 'DistZip')
+        self.assertEqual(self.dists.DISTRIBUTIONS_MAP['zip']['extension'], '.zip')
 
     def test_create_dist(self) -> None:
         return_cls_tar = self.dists.create_dist("OpenSearch", "artifacts/dist", "opensearch-1.3.0", 'tar')


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Combine two map into one for distribution class/extension
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/pull/1659#discussion_r813427771
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
