### PR TITLE
replace ci prefix only at rewriting part

### DIFF
--- a/deployment/lambdas/cf-url-rewriter/cf-url-rewriter.ts
+++ b/deployment/lambdas/cf-url-rewriter/cf-url-rewriter.ts
@@ -4,6 +4,11 @@ import { httpsGet } from './https-get';
 export async function handler(event: CloudFrontRequestEvent, context: Context, callback: CloudFrontRequestCallback) {
     const request = event.Records[0].cf.request;
 
+    if (!request.uri.includes('/ci/dbc/')) {
+        callback(null, errorResponse());
+        return;
+    }
+
     if (request.uri.includes("/latest/")) {
 
         const indexUri = request.uri.replace(/\/latest\/.*/, '/index.json');

--- a/deployment/lambdas/cf-url-rewriter/cf-url-rewriter.ts
+++ b/deployment/lambdas/cf-url-rewriter/cf-url-rewriter.ts
@@ -3,8 +3,6 @@ import { httpsGet } from './https-get';
 
 export async function handler(event: CloudFrontRequestEvent, context: Context, callback: CloudFrontRequestCallback) {
     const request = event.Records[0].cf.request;
-    // Incoming URLs from ci.opensearch.org will have a '/ci/123/' prefix, remove the prefix path from requests into S3.
-    request.uri = request.uri.replace(/^\/ci\/...\//, '\/');
 
     if (request.uri.includes("/latest/")) {
 
@@ -24,6 +22,8 @@ export async function handler(event: CloudFrontRequestEvent, context: Context, c
         }
 
     } else {
+        // Incoming URLs from ci.opensearch.org will have a '/ci/123/' prefix, remove the prefix path from requests into S3.
+        request.uri = request.uri.replace(/^\/ci\/...\//, '\/');
         callback(null, request);
     }
 }

--- a/deployment/test/lambdas/cf-url-rewriter/cf-url-rewriter.test.ts
+++ b/deployment/test/lambdas/cf-url-rewriter/cf-url-rewriter.test.ts
@@ -9,31 +9,6 @@ beforeEach(() => {
 
 test('handler with latest url and valid latest field', async () => {
 
-    const event = createTestEvent('/bundle-build-dashboards/1.2.0/latest/linux/x64/');
-    const context = {} as Context;
-    const callback = jest.fn() as CloudFrontRequestCallback;
-
-    (httpsGet as unknown as jest.Mock).mockReturnValue({ latest: '123' });
-
-    await handler(event, context, callback);
-
-    expect(httpsGet).toBeCalledWith('https://test.cloudfront.net/bundle-build-dashboards/1.2.0/index.json');
-
-    expect(callback).toHaveBeenCalledWith(
-        null,
-        {
-            "headers": {
-                "cache-control": [{ "key": "Cache-Control", "value": "max-age=3600" }],
-                "location": [{ "key": "Location", "value": "/bundle-build-dashboards/1.2.0/123/linux/x64/" }]
-            },
-            "status": "302",
-            "statusDescription": "Moved temporarily"
-        }
-    );
-});
-
-test('handler with latest url and with ci keyword and valid latest field', async () => {
-
     const event = createTestEvent('/ci/dbc/bundle-build-dashboards/1.2.0/latest/linux/x64/');
     const context = {} as Context;
     const callback = jest.fn() as CloudFrontRequestCallback;
@@ -57,41 +32,17 @@ test('handler with latest url and with ci keyword and valid latest field', async
     );
 });
 
-test('handler with latest url and empty latest field', async () => {
+test('handler with latest url and without ci keyword and valid latest field', async () => {
 
     const event = createTestEvent('/bundle-build-dashboards/1.2.0/latest/linux/x64/');
     const context = {} as Context;
     const callback = jest.fn() as CloudFrontRequestCallback;
 
-    (httpsGet as unknown as jest.Mock).mockReturnValue({ latest: '' });
+    (httpsGet as unknown as jest.Mock).mockReturnValue({ latest: '123' });
 
     await handler(event, context, callback);
 
-    expect(httpsGet).toBeCalledWith('https://test.cloudfront.net/bundle-build-dashboards/1.2.0/index.json');
-
-    expect(callback).toHaveBeenCalledWith(
-        null,
-        {
-            "body": "The page is not found!",
-            "status": "404",
-            "statusDescription": "Not found"
-        }
-    );
-});
-
-test('handler with latest url and exception when getting index.json', async () => {
-
-    const event = createTestEvent('/bundle-build-dashboards/1.2.0/latest/linux/x64/');
-    const context = {} as Context;
-    const callback = jest.fn() as CloudFrontRequestCallback;
-
-    (httpsGet as unknown as jest.Mock).mockImplementation(() => {
-        throw new Error('Error getting!');
-    });
-
-    await handler(event, context, callback);
-
-    expect(httpsGet).toBeCalledWith('https://test.cloudfront.net/bundle-build-dashboards/1.2.0/index.json');
+    expect(httpsGet).not.toHaveBeenCalled();
 
     expect(callback).toHaveBeenCalledWith(
         null,
@@ -116,15 +67,62 @@ test('handler without latest url and without ci keyword', async () => {
     expect(callback).toHaveBeenCalledWith(
         null,
         {
-            "headers": { "host": [{ "key": "Host", "value": "test.cloudfront.net" }] },
-            "uri": "/bundle-build-dashboards/1.2.0/456/linux/x64/"
+            "body": "The page is not found!",
+            "status": "404",
+            "statusDescription": "Not found"
         }
     );
 
     expect(httpsGet).not.toHaveBeenCalled();
 })
 
-test('handler without latest url and with ci keyword', async () => {
+test('handler with latest url and without ci keyword', async () => {
+
+    const event = createTestEvent('/bundle-build-dashboards/1.2.0/latest/linux/x64/');
+    const context = {} as Context;
+    const callback = jest.fn() as CloudFrontRequestCallback;
+
+    (httpsGet as unknown as jest.Mock).mockReturnValue({ latest: '' });
+
+    await handler(event, context, callback);
+
+    expect(callback).toHaveBeenCalledWith(
+        null,
+        {
+            "body": "The page is not found!",
+            "status": "404",
+            "statusDescription": "Not found"
+        }
+    );
+
+    expect(httpsGet).not.toHaveBeenCalled();
+});
+
+test('handler with latest url and exception when getting index.json', async () => {
+
+    const event = createTestEvent('/ci/dbc/bundle-build-dashboards/1.2.0/latest/linux/x64/');
+    const context = {} as Context;
+    const callback = jest.fn() as CloudFrontRequestCallback;
+
+    (httpsGet as unknown as jest.Mock).mockImplementation(() => {
+        throw new Error('Error getting!');
+    });
+
+    await handler(event, context, callback);
+
+    expect(httpsGet).toBeCalledWith('https://test.cloudfront.net/ci/dbc/bundle-build-dashboards/1.2.0/index.json');
+
+    expect(callback).toHaveBeenCalledWith(
+        null,
+        {
+            "body": "The page is not found!",
+            "status": "404",
+            "statusDescription": "Not found"
+        }
+    );
+});
+
+test('handler without latest url', async () => {
 
     const event = createTestEvent('/ci/dbc/bundle-build-dashboards/1.2.0/456/linux/x64/');
     const context = {} as Context;
@@ -147,7 +145,7 @@ test('handler without latest url and with ci keyword', async () => {
 
 test('handler with /fool(latest)bar/ keyword', async () => {
 
-    const event = createTestEvent('/bundle-build-dashboards/1.2.0/456/linux/x64/foollatestbar/');
+    const event = createTestEvent('/ci/dbc/bundle-build-dashboards/1.2.0/456/linux/x64/foollatestbar/');
     const context = {} as Context;
     const callback = jest.fn() as CloudFrontRequestCallback;
 

--- a/deployment/test/lambdas/cf-url-rewriter/cf-url-rewriter.test.ts
+++ b/deployment/test/lambdas/cf-url-rewriter/cf-url-rewriter.test.ts
@@ -42,14 +42,14 @@ test('handler with latest url and with ci keyword and valid latest field', async
 
     await handler(event, context, callback);
 
-    expect(httpsGet).toBeCalledWith('https://test.cloudfront.net/bundle-build-dashboards/1.2.0/index.json');
+    expect(httpsGet).toBeCalledWith('https://test.cloudfront.net/ci/dbc/bundle-build-dashboards/1.2.0/index.json');
 
     expect(callback).toHaveBeenCalledWith(
         null,
         {
             "headers": {
                 "cache-control": [{ "key": "Cache-Control", "value": "max-age=3600" }],
-                "location": [{ "key": "Location", "value": "/bundle-build-dashboards/1.2.0/123/linux/x64/" }]
+                "location": [{ "key": "Location", "value": "/ci/dbc/bundle-build-dashboards/1.2.0/123/linux/x64/" }]
             },
             "status": "302",
             "statusDescription": "Moved temporarily"

--- a/deployment/test/lambdas/cf-url-rewriter/cf-url-rewriter.test.ts
+++ b/deployment/test/lambdas/cf-url-rewriter/cf-url-rewriter.test.ts
@@ -32,28 +32,6 @@ test('handler with latest url and valid latest field', async () => {
     );
 });
 
-test('handler with latest url and without ci keyword and valid latest field', async () => {
-
-    const event = createTestEvent('/bundle-build-dashboards/1.2.0/latest/linux/x64/');
-    const context = {} as Context;
-    const callback = jest.fn() as CloudFrontRequestCallback;
-
-    (httpsGet as unknown as jest.Mock).mockReturnValue({ latest: '123' });
-
-    await handler(event, context, callback);
-
-    expect(httpsGet).not.toHaveBeenCalled();
-
-    expect(callback).toHaveBeenCalledWith(
-        null,
-        {
-            "body": "The page is not found!",
-            "status": "404",
-            "statusDescription": "Not found"
-        }
-    );
-});
-
 test('handler without latest url and without ci keyword', async () => {
 
     const event = createTestEvent('/bundle-build-dashboards/1.2.0/456/linux/x64/');

--- a/deployment/test/lambdas/cf-url-rewriter/cf-url-rewriter.test.ts
+++ b/deployment/test/lambdas/cf-url-rewriter/cf-url-rewriter.test.ts
@@ -32,6 +32,28 @@ test('handler with latest url and valid latest field', async () => {
     );
 });
 
+test('handler with latest url and empty latest field', async () => {
+
+    const event = createTestEvent('/ci/dbc/bundle-build-dashboards/1.2.0/latest/linux/x64/');
+    const context = {} as Context;
+    const callback = jest.fn() as CloudFrontRequestCallback;
+
+    (httpsGet as unknown as jest.Mock).mockReturnValue({ latest: '' });
+
+    await handler(event, context, callback);
+
+    expect(httpsGet).toBeCalledWith('https://test.cloudfront.net/ci/dbc/bundle-build-dashboards/1.2.0/index.json');
+
+    expect(callback).toHaveBeenCalledWith(
+        null,
+        {
+            "body": "The page is not found!",
+            "status": "404",
+            "statusDescription": "Not found"
+        }
+    );
+});
+
 test('handler without latest url and without ci keyword', async () => {
 
     const event = createTestEvent('/bundle-build-dashboards/1.2.0/456/linux/x64/');


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
We observed that https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.0/latest/linux/arm64/builds/opensearch/manifest.yml
is being redirected to 
https://ci.opensearch.org/distribution-build-opensearch/1.3.0/1204/linux/arm64/builds/opensearch/manifest.yml

and ended up with `AccessDenied` error. Thus we shall not remove `ci/dbc` during redirect. Instead, it shall only happen at the rewrite part.
 
### Issues Resolved

### Test
update unit test for this.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
