### PR TITLE
Add wget for fetching manifests

### DIFF
--- a/docker/ci/dockerfiles/ci-runner.al2.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.al2.dockerfile
@@ -19,7 +19,7 @@ RUN echo -e "[AdoptOpenJDK]\nname=AdoptOpenJDK\nbaseurl=http://adoptopenjdk.jfro
 # Add normal dependencies
 RUN yum clean all && \
     yum update -y && \
-    yum install -y adoptopenjdk-14-hotspot which curl python git gnupg2 tar net-tools procps-ng python3 python3-pip python3-devel && \
+    yum install -y adoptopenjdk-14-hotspot which curl python git gnupg2 tar net-tools procps-ng python3 python3-pip python3-devel wget && \
     ln -sfn `which pip3` /usr/bin/pip && pip3 install pipenv && pipenv --version 
 
 # Create user group

--- a/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
+++ b/docker/ci/dockerfiles/ci-runner.centos7.dockerfile
@@ -27,7 +27,7 @@ RUN echo "export LC_ALL=en_US.utf-8" >> /etc/profile.d/python3_ascii.sh && \
 # Add normal dependencies
 RUN yum clean all && \
     yum update -y && \
-    yum install -y adoptopenjdk-14-hotspot which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip
+    yum install -y adoptopenjdk-14-hotspot which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip wget
 
 # Create user group
 RUN groupadd -g 1000 opensearch && \


### PR DESCRIPTION
Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

### Description
- Add `wget` as a normal dependency to fetch bundle manifests for performance tests
- [Related script](https://github.com/opensearch-project/opensearch-build/blob/main/vars/downloadBuildManifest.groovy)
 
### Issues Resolved
- https://github.com/opensearch-project/opensearch-build/issues/129
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
