### PR TITLE
configure DefaultTTL for CloudFront

### DIFF
--- a/deployment/lib/artifacts-public-access.ts
+++ b/deployment/lib/artifacts-public-access.ts
@@ -5,7 +5,7 @@ import { CanonicalUserPrincipal, PolicyStatement } from '@aws-cdk/aws-iam';
 import { Architecture, Runtime } from '@aws-cdk/aws-lambda';
 import { NodejsFunction } from '@aws-cdk/aws-lambda-nodejs';
 import { IBucket } from '@aws-cdk/aws-s3';
-import { CfnOutput } from '@aws-cdk/core';
+import { CfnOutput, Duration } from '@aws-cdk/core';
 import { BuildArtifactStack } from './build-artifact-stack';
 
 export class ArtifactsPublicAccess {
@@ -47,6 +47,10 @@ export class ArtifactsPublicAccess {
                 eventType: LambdaEdgeEventType.VIEWER_REQUEST,
                 lambdaFunction: urlRewriter.currentVersion,
               }],
+              // set ttl to 5mins. Note that changing minTtl or maxTtl may have co-related impact on actual values being used by CloudFront between defaultTtl, maxTtl and minTtl.
+              // Make sure that you understand https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesObjectCaching 
+              // before changing minTtl or maxTtl.
+              defaultTtl: Duration.seconds(300)
             },
           ],
         },

--- a/deployment/test/build-artifact-stack.test.ts
+++ b/deployment/test/build-artifact-stack.test.ts
@@ -1,6 +1,4 @@
-import {
-  expect, countResources, haveOutput, not, haveResourceLike, haveResource,
-} from '@aws-cdk/assert';
+import { countResources, expect, haveOutput, haveResourceLike, not } from '@aws-cdk/assert';
 import { App } from '@aws-cdk/core';
 import { BuildArtifactStack } from '../lib/build-artifact-stack';
 

--- a/deployment/test/build-artifact-stack.test.ts
+++ b/deployment/test/build-artifact-stack.test.ts
@@ -1,5 +1,5 @@
 import {
-  expect, countResources, haveOutput, not,
+  expect, countResources, haveOutput, not, haveResourceLike, haveResource,
 } from '@aws-cdk/assert';
 import { App } from '@aws-cdk/core';
 import { BuildArtifactStack } from '../lib/build-artifact-stack';
@@ -14,7 +14,16 @@ test('Fresh BuildArtifact Stack', () => {
   expect(stack).to(countResources('AWS::S3::Bucket', 1));
   expect(stack).to(countResources('AWS::IAM::Role', 4));
   expect(stack).to(countResources('AWS::CloudFront::CloudFrontOriginAccessIdentity', 1));
+
   expect(stack).to(countResources('AWS::CloudFront::Distribution', 1));
+  expect(stack).to(haveResourceLike('AWS::CloudFront::Distribution', {
+    DistributionConfig: {
+      DefaultCacheBehavior: {
+        DefaultTTL: 300
+      }
+    }
+  }));
+
   expect(stack).to(countResources('AWS::Lambda::Function', 1));
   expect(stack).to(haveOutput({ outputName: 'BuildDistributionDomainName' }));
   expect(stack).to(not(haveOutput({ outputName: 'OriginAccessIdentityS3Identifier' })));
@@ -30,7 +39,16 @@ test('Existing BuildArtifact Stack', () => {
   expect(stack).to(countResources('AWS::S3::Bucket', 0));
   expect(stack).to(countResources('AWS::IAM::Role', 1));
   expect(stack).to(countResources('AWS::CloudFront::CloudFrontOriginAccessIdentity', 1));
+
   expect(stack).to(countResources('AWS::CloudFront::Distribution', 1));
+  expect(stack).to(haveResourceLike('AWS::CloudFront::Distribution', {
+    DistributionConfig: {
+      DefaultCacheBehavior: {
+        DefaultTTL: 300
+      }
+    }
+  }));
+
   expect(stack).to(countResources('AWS::Lambda::Function', 1));
   expect(stack).to(haveOutput({ outputName: 'BuildDistributionDomainName' }));
   expect(stack).to(haveOutput({ outputName: 'OriginAccessIdentityS3Identifier' }));


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
As related issue states https://github.com/opensearch-project/opensearch-build/issues/1690, we observed that the latest build number is not updating even though the index.json file has changed content. After researching around, figure that the DefaultTTL shall be set to avoid the default behavior of caching for 1 day. Currently I set it to be 5mins to both get a recent build and also low the traffic impact to S3.
 
### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/1690

### Tests
1. unit test
2. Deployed to my personal AWS account and verify the DefaultTTL change and also update the same file to see the change taking effect.

<img width="1534" alt="Screen Shot 2022-03-02 at 12 58 27 PM" src="https://user-images.githubusercontent.com/60111637/156448575-452f13f2-49ef-4a42-8d71-fd121e27b235.png">

Current value of index.json https://d17qm4xnop70sv.cloudfront.net/ci/dbc/distribution-build-opensearch/2.0.0/index.json
<img width="1247" alt="Screen Shot 2022-03-02 at 12 59 29 PM" src="https://user-images.githubusercontent.com/60111637/156448723-fb587681-418b-4144-a9da-6a330a7d0d0c.png">

updating the index.json to be 188.

confirm S3 has the new value.
<img width="1283" alt="Screen Shot 2022-03-02 at 1 01 18 PM" src="https://user-images.githubusercontent.com/60111637/156449065-cf317d17-85a1-413e-b544-06de9955d0a2.png">

Refreshing https://d17qm4xnop70sv.cloudfront.net/ci/dbc/distribution-build-opensearch/2.0.0/index.json and still get 166

<img width="1141" alt="Screen Shot 2022-03-02 at 1 01 48 PM" src="https://user-images.githubusercontent.com/60111637/156449142-878ca991-7370-4313-acd7-5a099b496510.png">

waiting for 5min and will check again.

<img width="1178" alt="Screen Shot 2022-03-02 at 1 07 00 PM" src="https://user-images.githubusercontent.com/60111637/156449757-7aea70ea-2c90-4ffb-aa02-9983ce0f1a4b.png">

We can see that 188 is showing!

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
