### PR TITLE
Revert "Build security-dashboards-plugin 1.3 branch for 1.3.0 release(#1684)"

### DIFF
--- a/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
@@ -20,7 +20,7 @@ components:
     ref: "main"
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: "1.3"
+    ref: main
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     ref: main


### PR DESCRIPTION
This reverts commit fbf167fb282843247ac251834bc7e8837f1596f6.

### Description
1.3 branch is not needed at this point in security-dashboards-plugin. In order to avoid unnecessary backport, we will create it when it is needed and all commits for 1.3.0 release are merged to main branch.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/pull/1693#issuecomment-1057453492
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
