### PR TITLE
[Dashboards] add test manifest to build checker

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -8,13 +8,13 @@ pipeline {
     triggers {
         parameterizedCron '''
             H/10 * * * * %INPUT_MANIFEST=1.2.5/opensearch-1.2.5.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=1.3.0/opensearch-dashboards-1.3.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
+            H/10 * * * * %INPUT_MANIFEST=1.3.0/opensearch-dashboards-1.3.0.yml;TEST_MANIFEST=1.3.0/opensearch-dashboards-1.3.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H/10 * * * * %INPUT_MANIFEST=1.3.0/opensearch-1.3.0.yml;TEST_MANIFEST=1.3.0/opensearch-1.3.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=1.2.1/opensearch-1.2.1.yml;TEST_MANIFEST=1.2.1/opensearch-1.2.1-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=1.2.2/opensearch-1.2.2.yml;TEST_MANIFEST=1.2.2/opensearch-1.2.2-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=1.2.3/opensearch-1.2.3.yml;TEST_MANIFEST=1.2.3/opensearch-1.2.3-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=2.0.0/opensearch-2.0.0.yml;TEST_MANIFEST=2.0.0/opensearch-2.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H 1 * * * %INPUT_MANIFEST=2.0.0/opensearch-dashboards-2.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
+            H 1 * * * %INPUT_MANIFEST=2.0.0/opensearch-dashboards-2.0.0.yml;TEST_MANIFEST=2.0.0/opensearch-dashboards-2.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
         '''
     }
     parameters {


### PR DESCRIPTION
### Description
OpenSearch Dashboards supports integration tests, but for new commits
needed add the build checker to get the manifest.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
