### PR TITLE
Created a new Data Prepper release job

### DIFF
--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -18,9 +18,10 @@ pipeline {
                 script {
                     archivePath = "${DATA_PREPPER_ARTIFACT_STAGING_SITE}/${VERSION}/${DATA_PREPPER_BUILD_NUMBER}/archive"
 
-                    sh 'mkdir archive'
-                    sh "curl -sSL ${archivePath}/opensearch-data-prepper-${VERSION}-linux-x64.tar.gz -o archive/opensearch-data-prepper-${VERSION}-linux-x64.tar.gz"
-                    sh "curl -sSL ${archivePath}/opensearch-data-prepper-jdk-${VERSION}-linux-x64.tar.gz -o archive/opensearch-data-prepper-jdk-${VERSION}-linux-x64.tar.gz"
+                    dir('archive') {
+                        sh "curl -sSL ${archivePath}/opensearch-data-prepper-${VERSION}-linux-x64.tar.gz -o opensearch-data-prepper-${VERSION}-linux-x64.tar.gz"
+                        sh "curl -sSL ${archivePath}/opensearch-data-prepper-jdk-${VERSION}-linux-x64.tar.gz -o opensearch-data-prepper-jdk-${VERSION}-linux-x64.tar.gz"
+                    }
                 }
             }
         }

--- a/tests/jenkins/TestDataPrepperReleaseArtifacts.groovy
+++ b/tests/jenkins/TestDataPrepperReleaseArtifacts.groovy
@@ -26,7 +26,7 @@ class TestDataPrepperReleaseArtifacts extends BuildPipelineTest {
 
         this.registerLibTester(new SignArtifactsLibTester( '.sig', 'linux',  'archive', null, null))
 
-        this.registerLibTester(new CopyContainerLibTester("${sourceImageRepository}/data-prepper:${version}",
+        this.registerLibTester(new CopyContainerLibTester("${sourceImageRepository}/data-prepper:${version}-997908",
                 "opensearchproject/data-prepper:${version}",
                 'docker',
                 'jenkins-staging-docker-prod-token'))
@@ -54,7 +54,7 @@ class TestDataPrepperReleaseArtifacts extends BuildPipelineTest {
     @Test
     void 'release-data-prepper-all-artifacts builds consistently with same inputs'() {
         testPipeline('jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile',
-                'tests/jenkins/jobs/data-prepper/release-data-prepper-all-artifacts.jenkinsfile')
+                'tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile')
     }
 
     @Test
@@ -70,10 +70,10 @@ class TestDataPrepperReleaseArtifacts extends BuildPipelineTest {
         }
 
         assertThat(curlCommands, hasItem(
-                "curl -sSL http://staging-artifacts.cloudfront.net/${version}/997908/archive/opensearch-data-prepper-${version}-linux-x64.tar.gz -o archive/opensearch-data-prepper-${version}-linux-x64.tar.gz".toString()
+                "curl -sSL http://staging-artifacts.cloudfront.net/${version}/997908/archive/opensearch-data-prepper-${version}-linux-x64.tar.gz -o opensearch-data-prepper-${version}-linux-x64.tar.gz".toString()
         ))
         assertThat(curlCommands, hasItem(
-                "curl -sSL http://staging-artifacts.cloudfront.net/${version}/997908/archive/opensearch-data-prepper-jdk-${version}-linux-x64.tar.gz -o archive/opensearch-data-prepper-jdk-${version}-linux-x64.tar.gz".toString()
+                "curl -sSL http://staging-artifacts.cloudfront.net/${version}/997908/archive/opensearch-data-prepper-jdk-${version}-linux-x64.tar.gz -o opensearch-data-prepper-jdk-${version}-linux-x64.tar.gz".toString()
         ))
     }
 

--- a/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
@@ -5,9 +5,9 @@
          release-data-prepper-all-artifacts.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-centos7-v1, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
          release-data-prepper-all-artifacts.stage(Download Archives, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
-               release-data-prepper-all-artifacts.sh(mkdir archive)
-               release-data-prepper-all-artifacts.sh(curl -sSL http://staging-artifacts.cloudfront.net/0.22.1/997908/archive/opensearch-data-prepper-0.22.1-linux-x64.tar.gz -o archive/opensearch-data-prepper-0.22.1-linux-x64.tar.gz)
-               release-data-prepper-all-artifacts.sh(curl -sSL http://staging-artifacts.cloudfront.net/0.22.1/997908/archive/opensearch-data-prepper-jdk-0.22.1-linux-x64.tar.gz -o archive/opensearch-data-prepper-jdk-0.22.1-linux-x64.tar.gz)
+               release-data-prepper-all-artifacts.dir(archive, groovy.lang.Closure)
+                  release-data-prepper-all-artifacts.sh(curl -sSL http://staging-artifacts.cloudfront.net/0.22.1/997908/archive/opensearch-data-prepper-0.22.1-linux-x64.tar.gz -o opensearch-data-prepper-0.22.1-linux-x64.tar.gz)
+                  release-data-prepper-all-artifacts.sh(curl -sSL http://staging-artifacts.cloudfront.net/0.22.1/997908/archive/opensearch-data-prepper-jdk-0.22.1-linux-x64.tar.gz -o opensearch-data-prepper-jdk-0.22.1-linux-x64.tar.gz)
          release-data-prepper-all-artifacts.stage(Sign Archives, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
                release-data-prepper-all-artifacts.signArtifacts({artifactPath=archive, sigtype=.sig, platform=linux})
@@ -32,14 +32,14 @@
                   release-data-prepper-all-artifacts.s3Upload({file=archive/, bucket=production-s3-bucket-name, path=data-prepper/0.22.1/})
          release-data-prepper-all-artifacts.stage(Release Docker Image to DockerHub, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
-               release-data-prepper-all-artifacts.copyContainer({sourceImagePath=http://public.ecr.aws/data-prepper-container-repository/data-prepper:0.22.1, destinationImagePath=opensearchproject/data-prepper:0.22.1, destinationType=docker, destinationCredentialIdentifier=jenkins-staging-docker-prod-token})
+               release-data-prepper-all-artifacts.copyContainer({sourceImagePath=http://public.ecr.aws/data-prepper-container-repository/data-prepper:0.22.1-997908, destinationImagePath=opensearchproject/data-prepper:0.22.1, destinationType=docker, destinationCredentialIdentifier=jenkins-staging-docker-prod-token})
                   copyContainer.sh({script=test -f /usr/local/bin/gcrane && echo '1' || echo '0' , returnStdout=true})
                   copyContainer.sh(docker logout)
                   copyContainer.usernamePassword({credentialsId=jenkins-staging-docker-prod-token, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                   copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                      copyContainer.sh(
                 docker login -u DOCKER_USERNAME -p DOCKER_PASSWORD
-                gcrane cp http://public.ecr.aws/data-prepper-container-repository/data-prepper:0.22.1 opensearchproject/data-prepper:0.22.1
+                gcrane cp http://public.ecr.aws/data-prepper-container-repository/data-prepper:0.22.1-997908 opensearchproject/data-prepper:0.22.1
             )
          release-data-prepper-all-artifacts.script(groovy.lang.Closure)
             release-data-prepper-all-artifacts.postCleanup()


### PR DESCRIPTION
### Description

This is a draft PR of what the job that I'd like to use to release artifacts from the Data Prepper staging environment. The design for this job is in https://github.com/opensearch-project/data-prepper/issues/977.

This job currently deploys two of the three artifacts:
* Archive files (.tar.gz)
* Docker image

Future changes will include deploying Maven artifacts.

This PR also introduces two new environments that I'd like to have added to the Jenkins server.

* `DATA_PREPPER_ARTIFACT_STAGING_SITE` - A CloudFront URL
* `DATA_PREPPER_STAGING_CONTAINER_REPOSITORY` - An public ECR container repository URL

I do not yet know the values for these two constants. Thus, this PR is not ready to merge. However, I'd like to get feedback on the approach early.
 
### Issues Resolved

Resolves #1594
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
