### PR TITLE
Updates 1.3 dashboards manifest to have security-dashboards-plugin reference 1.3 instead of main

### DIFF
--- a/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
@@ -23,7 +23,7 @@ components:
     ref: "main"
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: main
+    ref: "1.3"
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     ref: "1.3"


### PR DESCRIPTION
### Description
Security-dashboards-plugin currently point to `main` branch . This PR updates it to now point to `1.3` branch in the yml file
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
