### PR TITLE
Update k-NN 1.3 manifest to 1.x

### DIFF
--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -46,7 +46,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: main
+    ref: 1.x
     platforms:
       - darwin
       - linux


### PR DESCRIPTION
Updates k-NN manifest to 1.x for 1.3 release. We recently setup main to
develop against 2.0, causing 1.3 build to break.

Related commit: https://github.com/opensearch-project/k-NN/commit/b22a2dc44ee93464bf4c5d17cf26d126854060cd

@gaiksaya - anywhere else I would need to update?

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
