### PR TITLE
Publish all components, not just plugins.

### DIFF
--- a/src/assemble_workflow/bundle.py
+++ b/src/assemble_workflow/bundle.py
@@ -45,6 +45,7 @@ class Bundle(ABC):
         self.artifacts_dir = artifacts_dir
         self.bundle_recorder = bundle_recorder
         self.tmp_dir = TemporaryDirectory(keep=keep)
+        self.min_bundle = self.__get_min_bundle(build_manifest.components)
         self.min_dist = self.__get_min_dist(build_manifest.components)
         self.installed_plugins: List[str] = []
 
@@ -70,7 +71,9 @@ class Bundle(ABC):
 
     def install_components(self) -> None:
         for c in self.components.values():
-            if "plugins" in c.artifacts:
+            if self.min_bundle == c:
+                pass
+            elif "plugins" in c.artifacts:
                 logging.info(f"Installing {c.name}")
                 self.install_plugin(c)
             else:
@@ -127,18 +130,18 @@ class Bundle(ABC):
         else:
             raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), local_path)
 
-    def __get_plugins(self, build_components: BuildComponents) -> List[BuildComponent]:
-        return [c for c in build_components.values() if "plugins" in c.artifacts]
-
-    def __get_min_dist(self, build_components: BuildComponents) -> Dist:
+    def __get_min_bundle(self, build_components: BuildComponents) -> BuildComponent:
         min_bundle = next(iter([c for c in build_components.values() if "dist" in c.artifacts]), None)
         if min_bundle is None:
             raise ValueError('Missing min "dist" in input artifacts.')
-        min_dist_path = self._copy_component(min_bundle, "dist")
+        return min_bundle
+
+    def __get_min_dist(self, build_components: BuildComponents) -> Dist:
+        min_dist_path = self._copy_component(self.min_bundle, "dist")
         logging.info(f"Copied min bundle to {min_dist_path}.")
         min_path = f"{self.build.filename}-{self.build.version}".replace("-SNAPSHOT", "")
-        logging.info(f"Start creating distribution {self.build.distribution} for {min_bundle.name}.")
-        min_dist = Dists.create_dist(min_bundle.name, min_dist_path, min_path, self.build.distribution)
+        logging.info(f"Start creating distribution {self.build.distribution} for {self.min_bundle.name}.")
+        min_dist = Dists.create_dist(self.min_bundle.name, min_dist_path, min_path, self.build.distribution)
         logging.info(f"Extracting dist into {self.tmp_dir.name}.")
         min_dist.extract(self.tmp_dir.name)
         logging.info(f"Extracted dist into {self.tmp_dir.name}.")

--- a/src/assemble_workflow/bundle.py
+++ b/src/assemble_workflow/bundle.py
@@ -41,7 +41,7 @@ class Bundle(ABC):
         :param bundle_recorder: The bundle recorder that will capture and build a BundleManifest
         """
         self.build = build_manifest.build
-        self.plugins = self.__get_plugins(build_manifest.components)
+        self.components = build_manifest.components
         self.artifacts_dir = artifacts_dir
         self.bundle_recorder = bundle_recorder
         self.tmp_dir = TemporaryDirectory(keep=keep)
@@ -68,10 +68,14 @@ class Bundle(ABC):
         )
         self._execute(install_command)
 
-    def install_plugins(self) -> None:
-        for plugin in self.plugins:
-            logging.info(f"Installing {plugin.name}")
-            self.install_plugin(plugin)
+    def install_components(self) -> None:
+        for c in self.components.values():
+            if "plugins" in c.artifacts:
+                logging.info(f"Installing {c.name}")
+                self.install_plugin(c)
+            else:
+                logging.info(f"Recording {c.name}")
+                self.bundle_recorder.record_component(c)
         plugins_path = os.path.join(self.min_dist.archive_path, "plugins")
         if os.path.isdir(plugins_path):
             self.installed_plugins = os.listdir(plugins_path)

--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -11,6 +11,7 @@ from assemble_workflow.bundle_location import BundleLocation
 from assemble_workflow.dists import Dists
 from manifests.build_manifest import BuildComponent, BuildManifest
 from manifests.bundle_manifest import BundleManifest
+from manifests.manifest import Manifest
 
 
 class BundleRecorder:
@@ -52,9 +53,9 @@ class BundleRecorder:
     # Build artifacts are expected to be served from a "builds" folder
     # Example: https://ci.opensearch.org/ci/dbc/bundle-build/1.2.0/build-id/linux/x64/builds/
     def __get_component_location(self, component_rel_path: str) -> str:
-        return self.bundle_location.get_build_location(component_rel_path)
+        return self.bundle_location.get_build_location(component_rel_path) if component_rel_path else None
 
-    def record_component(self, component: BuildComponent, rel_path: str) -> None:
+    def record_component(self, component: BuildComponent, rel_path: str = None) -> None:
         self.bundle_manifest.append_component(
             component.name,
             component.repository,
@@ -86,14 +87,14 @@ class BundleRecorder:
             # When we convert to a BundleManifest this will get converted back into a list
             self.data["components"] = []
 
-        def append_component(self, name: str, repository_url: str, ref: str, commit_id: str, location: str) -> None:
-            component = {
+        def append_component(self, name: str, repository_url: str, ref: str, commit_id: str, location: str = None) -> None:
+            component = Manifest.compact({
                 "name": name,
                 "repository": repository_url,
                 "ref": ref,
                 "commit_id": commit_id,
                 "location": location,
-            }
+            })
             self.data["components"].append(component)
 
         def to_manifest(self) -> BundleManifest:

--- a/src/manifests/bundle_manifest.py
+++ b/src/manifests/bundle_manifest.py
@@ -56,7 +56,7 @@ class BundleManifest(ComponentManifest['BundleManifest', 'BundleComponents']):
                 "type": "dict",
                 "schema": {
                     "commit_id": {"required": True, "type": "string"},
-                    "location": {"required": True, "type": "string"},
+                    "location": {"type": "string"},  # optional in 1.1
                     "name": {"required": True, "type": "string"},
                     "ref": {"required": True, "type": "string"},
                     "repository": {"required": True, "type": "string"},
@@ -115,7 +115,7 @@ class BundleComponent(Component):
         self.repository = data["repository"]
         self.ref = data["ref"]
         self.commit_id = data["commit_id"]
-        self.location = data["location"]
+        self.location = data.get("location", None)
 
     def __to_dict__(self) -> dict:
         return {

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -41,7 +41,7 @@ def main() -> int:
 
     with Bundles.create(build_manifest, artifacts_dir, bundle_recorder, args.keep) as bundle:
         bundle.install_min()
-        bundle.install_plugins()
+        bundle.install_components()
         logging.info(f"Installed plugins: {bundle.installed_plugins}")
 
         #  Save a copy of the manifest inside of the tar

--- a/tests/test_run_assemble.py
+++ b/tests/test_run_assemble.py
@@ -41,7 +41,7 @@ class TestRunAssemble(unittest.TestCase):
         main()
 
         mock_bundle.install_min.assert_called()
-        mock_bundle.install_plugins.assert_called()
+        mock_bundle.install_components.assert_called()
 
         mock_bundle.package.assert_called_with(os.path.join("curdir", "dist", "opensearch"))
 

--- a/tests/tests_assemble_workflow/test_bundle.py
+++ b/tests/tests_assemble_workflow/test_bundle.py
@@ -26,7 +26,7 @@ class TestBundle(unittest.TestCase):
         self.assertEqual(bundle.min_dist.__class__.__name__, "DistTar")
         self.assertEqual(bundle.build.distribution, None)
         self.assertEqual(bundle.build.platform, "linux")
-        self.assertEqual(len(bundle.plugins), 12)
+        self.assertEqual(len(bundle.components), 15)
         self.assertEqual(bundle.artifacts_dir, artifacts_path)
         self.assertIsNotNone(bundle.bundle_recorder)
         self.assertEqual(bundle.installed_plugins, [])

--- a/tests/tests_assemble_workflow/test_bundle_opensearch.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch.py
@@ -21,7 +21,7 @@ class TestBundleOpenSearch(unittest.TestCase):
         artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = BundleOpenSearch(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertEqual(bundle.min_dist.name, "OpenSearch")
-        self.assertEqual(len(bundle.plugins), 12)
+        self.assertEqual(len(bundle.components), 15)
         self.assertEqual(bundle.artifacts_dir, artifacts_path)
         self.assertIsNotNone(bundle.bundle_recorder)
         self.assertEqual(bundle.installed_plugins, [])
@@ -59,6 +59,22 @@ class TestBundleOpenSearch(unittest.TestCase):
                     ),
                 ]
             )
+
+    @patch("subprocess.check_call")
+    @patch("os.path.isfile", return_value=True)
+    def test_bundle_include_common_utils(self, mock_path_isile: Mock, mock_check_call: Mock) -> None:
+        manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-linux-1.1.0.yml")
+        artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
+        bundle_recorder = MagicMock()
+        bundle = BundleOpenSearch(BuildManifest.from_path(manifest_path), artifacts_path, bundle_recorder)
+        with patch("shutil.copyfile"):
+            bundle.install_components()
+        bundle_recorder.record_component.assert_has_calls([
+            call(bundle.components["common-utils"]),
+            call(bundle.components["job-scheduler"], "plugins/opensearch-job-scheduler-1.1.0.0.zip"),
+        ])
+        mock_path_isile.assert_called()
+        mock_check_call.assert_called()
 
     @patch("subprocess.check_call")
     @patch("os.rename")
@@ -109,7 +125,7 @@ class TestBundleOpenSearch(unittest.TestCase):
         )
 
     @patch.object(BundleOpenSearch, "install_plugin")
-    def test_bundle_install_plugins(self, bundle_install_plugin: Mock) -> None:
+    def test_bundle_install_components(self, bundle_install_plugin: Mock) -> None:
         manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-build-linux-1.1.0.yml")
         bundle = BundleOpenSearch(
             BuildManifest.from_path(manifest_path),
@@ -117,7 +133,7 @@ class TestBundleOpenSearch(unittest.TestCase):
             MagicMock(),
         )
 
-        bundle.install_plugins()
+        bundle.install_components()
         self.assertEqual(bundle_install_plugin.call_count, 12)
 
     @patch("os.path.isfile", return_value=True)
@@ -126,7 +142,7 @@ class TestBundleOpenSearch(unittest.TestCase):
         artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = BundleOpenSearch(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
 
-        plugin = bundle.plugins[0]  # job-scheduler
+        plugin = bundle.components['job-scheduler']
 
         with patch("shutil.copyfile") as mock_copyfile:
             with patch("subprocess.check_call") as mock_check_call:

--- a/tests/tests_assemble_workflow/test_bundle_opensearch.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch.py
@@ -70,6 +70,9 @@ class TestBundleOpenSearch(unittest.TestCase):
         with patch("shutil.copyfile"):
             bundle.install_components()
         bundle_recorder.record_component.assert_has_calls([
+            call(bundle.components["OpenSearch"], "dist/opensearch-min-1.1.0-linux-x64.tar.gz"),
+        ])
+        bundle_recorder.record_component.assert_has_calls([
             call(bundle.components["common-utils"]),
             call(bundle.components["job-scheduler"], "plugins/opensearch-job-scheduler-1.1.0.0.zip"),
         ])

--- a/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch_dashboards.py
@@ -19,7 +19,7 @@ class TestBundleOpenSearchDashboards(unittest.TestCase):
         artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = BundleOpenSearchDashboards(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
         self.assertEqual(bundle.min_dist.name, "OpenSearch-Dashboards")
-        self.assertEqual(len(bundle.plugins), 1)
+        self.assertEqual(len(bundle.components), 2)
         self.assertEqual(bundle.artifacts_dir, artifacts_path)
         self.assertIsNotNone(bundle.bundle_recorder)
         self.assertEqual(bundle.installed_plugins, [])
@@ -63,7 +63,7 @@ class TestBundleOpenSearchDashboards(unittest.TestCase):
         artifacts_path = os.path.join(os.path.dirname(__file__), "data", "artifacts")
         bundle = BundleOpenSearchDashboards(BuildManifest.from_path(manifest_path), artifacts_path, MagicMock())
 
-        plugin = bundle.plugins[0]  # alertingDashboards
+        plugin = bundle.components['alertingDashboards']
 
         with patch("shutil.copyfile") as mock_copyfile:
             with patch("subprocess.check_call") as mock_check_call:


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Include components such as common-utils into the distribution manifest, without a path since there are no bundled binaries.
 
### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/1703
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
