### PR TITLE
Changes job scheduler ref branch to 1.3 from main for 1.3.0 manifest

### DIFF
--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -22,7 +22,7 @@ components:
       - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: main
+    ref: '1.3'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: Drew Baugher <dbbaughe@amazon.com>

### Description
Job scheduler main represents 2.0 now, updating 1.3.0 manifest to point to 1.3 branch.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
