### PR TITLE
bring osd 2.0.0 back to ci-runner-centos7-opensearch-dashboards-build…

### DIFF
--- a/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
@@ -5,7 +5,7 @@ build:
   version: 2.0.0
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-centos7-v1
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build
 components:
   - name: OpenSearch-Dashboards
     ref: main


### PR DESCRIPTION
… due to node version

Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
Follow up on @kavilla 's comment https://github.com/opensearch-project/opensearch-build/pull/1715#issuecomment-1062102716

The V1 [image](https://hub.docker.com/layers/opensearchstaging/ci-runner/ci-runner-centos7-v1/images/sha256-23757e1ca2ec1dd03959f334245de73b300a92d56190f92f5cc3fe18e54666e0?context=explore) has node 10.24.1

The osd [image](https://hub.docker.com/layers/opensearchstaging/ci-runner/ci-runner-centos7-opensearch-dashboards-build/images/sha256-538617148f0046979a9cef4159b7067e97b7cd5d11c1e907de6d548ceb829af4?context=explore) has node 14.18.2 This is needed by OSD 2.0 to run
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
