### PR TITLE
[Dashboards] include output integ test for arm64

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -151,10 +151,13 @@ pipeline {
                                             string(name: 'CONTAINER_IMAGE', value: dockerAgent.image)
                                         ]
 
-                                    // TODO: consume results once ARM64 works
-                                    // https://github.com/opensearch-project/opensearch-build/issues/1381
                                     String status = integTestResults.getResult()
-                                    echo "${status}"
+                                    String icon = status == 'SUCCESS' ? ':white_check_mark:' : ':warning:'
+                                    lib.jenkins.Messages.new(this).add(
+                                        STAGE_NAME,
+                                        lib.jenkins.Messages.new(this).get([STAGE_NAME]) + 
+                                            "\nInteg Tests (arm64): ${icon} ${status} ${integTestResults.getAbsoluteUrl()}"
+                                    )
                                 }
                             }
                             post {


### PR DESCRIPTION
### Description
Originally when adding integ tests to OpenSearch Dashboards
I didn't want to the pipeline to showed as failed because
arm64 couldn't run the automated testing.

But after:
https://github.com/opensearch-project/opensearch-build/pull/1715

ARM64 tests can run in the CI. So this adds outputing the results
of tests for ARM64 OSD.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
