### PR TITLE
Added version qualifier support for OpenSearch.

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -7,6 +7,7 @@ ci:
 build:
   name: OpenSearch
   version: 2.0.0
+  qualifier: alpha1
 components:
   - name: OpenSearch
     ref: main

--- a/scripts/default/install.sh
+++ b/scripts/default/install.sh
@@ -21,7 +21,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:p:a:f:" arg; do
+while getopts ":h:v:q:s:o:p:a:f:" arg; do
     case $arg in
         h)
             usage
@@ -29,6 +29,9 @@ while getopts ":h:v:s:o:p:a:f:" arg; do
             ;;
         v)
             VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
             ;;
         s)
             SNAPSHOT=$OPTARG

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -20,7 +20,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:p:a:" arg; do
+while getopts ":h:v:q:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -28,6 +28,9 @@ while getopts ":h:v:s:o:p:a:" arg; do
             ;;
         v)
             VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
             ;;
         s)
             SNAPSHOT=$OPTARG

--- a/scripts/default/opensearch/build.sh
+++ b/scripts/default/opensearch/build.sh
@@ -20,7 +20,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:p:a:" arg; do
+while getopts ":h:v:q:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -28,6 +28,9 @@ while getopts ":h:v:s:o:p:a:" arg; do
             ;;
         v)
             VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
             ;;
         s)
             SNAPSHOT=$OPTARG

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -15,6 +15,7 @@ class BuildTarget:
     build_id: str
     name: str
     version: str
+    qualifier: str
     platform: str
     architecture: str
     distribution: str
@@ -24,6 +25,7 @@ class BuildTarget:
     def __init__(
         self,
         version: str,
+        qualifier: str = None,
         patches: List[str] = [],
         platform: str = None,
         architecture: str = None,
@@ -36,6 +38,7 @@ class BuildTarget:
         self.build_id = os.getenv("BUILD_NUMBER") or build_id or uuid.uuid4().hex
         self.name = name
         self.version = version
+        self.qualifier = qualifier
         self.patches = patches
         self.snapshot = snapshot
         self.architecture = architecture or current_architecture()
@@ -45,27 +48,35 @@ class BuildTarget:
 
     @property
     def opensearch_version(self) -> str:
-        return self.version + "-SNAPSHOT" if self.snapshot else self.version
+        return BuildTarget.__qualify_version(
+            self.version,
+            self.qualifier,
+            self.snapshot
+        )
 
     @property
     def compatible_opensearch_versions(self) -> List[str]:
         return (
-            [self.version + "-SNAPSHOT" if self.snapshot else self.version]
+            [BuildTarget.__qualify_version(self.version, self.qualifier, self.snapshot)]
             + self.patches
-            + list(map(lambda version: version + "-SNAPSHOT", self.patches))
+            + list(map(lambda version: BuildTarget.__qualify_version(version, self.qualifier, True), self.patches))
         )
 
     @property
     def component_version(self) -> str:
         # BUG: the 4th digit is dictated by the component, it's not .0, this will break for 1.1.0.1
-        return self.version + ".0-SNAPSHOT" if self.snapshot else f"{self.version}.0"
+        return BuildTarget.__qualify_version(
+            self.version + ".0",
+            self.qualifier,
+            self.snapshot
+        )
 
     @property
     def compatible_component_versions(self) -> List[str]:
         return (
-            [self.version + ".0-SNAPSHOT" if self.snapshot else f"{self.version}.0"]
-            + list(map(lambda version: version + ".0", self.patches))
-            + list(map(lambda version: version + ".0-SNAPSHOT", self.patches))
+            [BuildTarget.__qualify_version(self.version + ".0", self.qualifier, self.snapshot)]
+            + list(map(lambda version: BuildTarget.__qualify_version(version + ".0", self.qualifier, False), self.patches))
+            + list(map(lambda version: BuildTarget.__qualify_version(version + ".0", self.qualifier, True), self.patches))
         )
 
     @property
@@ -73,3 +84,12 @@ class BuildTarget:
         versions = [self.version]
         versions.extend(self.patches)
         return versions
+
+    @classmethod
+    def __qualify_version(cls, unqualified_version: str, qualifier: str = None, snapshot: bool = False) -> str:
+        version = unqualified_version
+        if qualifier:
+            version += f"-{qualifier}"
+        if snapshot:
+            version += "-SNAPSHOT"
+        return version

--- a/src/build_workflow/builder_from_source.py
+++ b/src/build_workflow/builder_from_source.py
@@ -42,6 +42,7 @@ class BuilderFromSource(Builder):
                     "bash",
                     build_script,
                     f"-v {self.target.version}",
+                    f"-q {self.target.qualifier}" if self.target.qualifier else None,
                     f"-p {self.target.platform}",
                     f"-a {self.target.architecture}",
                     f"-d {self.target.distribution}" if self.target.distribution and (self.component.name in DISTRIBUTION_SUPPORTED_COMPONENTS) else None,

--- a/src/manifests/input_manifest.py
+++ b/src/manifests/input_manifest.py
@@ -54,6 +54,7 @@ class InputManifest(ComponentManifest['InputManifest', 'InputComponents']):
             "schema": {
                 "name": {"required": True, "type": "string"},
                 "version": {"required": True, "type": "string"},
+                "qualifier": {"type": "string"},
                 "patches": {"type": "list", "schema": {"type": "string"}},
                 "platform": {"type": "string"},
                 "architecture": {"type": "string"},
@@ -143,6 +144,7 @@ class InputManifest(ComponentManifest['InputManifest', 'InputComponents']):
         def __init__(self, data: Any):
             self.name: str = data["name"]
             self.version = data["version"]
+            self.qualifier = data.get("qualifier", None)
             self.platform = data.get("platform", None)
             self.architecture = data.get("architecture", None)
             self.snapshot = data.get("snapshot", None)
@@ -152,6 +154,7 @@ class InputManifest(ComponentManifest['InputManifest', 'InputComponents']):
             return {
                 "name": self.name,
                 "version": self.version,
+                "qualifier": self.qualifier,
                 "patches": self.patches,
                 "platform": self.platform,
                 "architecture": self.architecture,

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -46,6 +46,7 @@ def main():
         target = BuildTarget(
             name=manifest.build.name,
             version=manifest.build.version,
+            qualifier=manifest.build.qualifier,
             patches=manifest.build.patches,
             snapshot=args.snapshot if args.snapshot is not None else manifest.build.snapshot,
             output_dir=output_dir,

--- a/tests/tests_build_workflow/test_build_target.py
+++ b/tests/tests_build_workflow/test_build_target.py
@@ -34,10 +34,34 @@ class TestBuildTarget(unittest.TestCase):
             "1.1.0",
         )
 
+    def test_opensearch_version_snapshot(self) -> None:
+        self.assertEqual(
+            BuildTarget(version="1.1.0", architecture="x86", snapshot=True).opensearch_version,
+            "1.1.0-SNAPSHOT",
+        )
+
+    def test_opensearch_version_qualifier(self) -> None:
+        self.assertEqual(
+            BuildTarget(version="1.1.0", architecture="x86", snapshot=False, qualifier="alpha1").opensearch_version,
+            "1.1.0-alpha1",
+        )
+
+    def test_opensearch_version_snapshot_qualifier(self) -> None:
+        self.assertEqual(
+            BuildTarget(version="1.1.0", architecture="x86", snapshot=True, qualifier="alpha1").opensearch_version,
+            "1.1.0-alpha1-SNAPSHOT",
+        )
+
     def test_compatible_opensearch_versions(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_opensearch_versions,
             ['1.1.2', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
+        )
+
+    def test_compatible_opensearch_versions_qualifier(self) -> None:
+        self.assertEqual(
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False, qualifier="alpha1").compatible_opensearch_versions,
+            ['1.1.2-alpha1', '1.1.0', '1.1.1', '1.1.0-alpha1-SNAPSHOT', '1.1.1-alpha1-SNAPSHOT'],
         )
 
     def test_compatible_opensearch_versions_snapshot(self) -> None:
@@ -46,10 +70,10 @@ class TestBuildTarget(unittest.TestCase):
             ['1.1.2-SNAPSHOT', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
-    def test_opensearch_version_snapshot(self) -> None:
+    def test_compatible_opensearch_versions_snapshot_qualifier(self) -> None:
         self.assertEqual(
-            BuildTarget(version="1.1.0", architecture="x86", snapshot=True).opensearch_version,
-            "1.1.0-SNAPSHOT",
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True, qualifier="alpha1").compatible_opensearch_versions,
+            ['1.1.2-alpha1-SNAPSHOT', '1.1.0', '1.1.1', '1.1.0-alpha1-SNAPSHOT', '1.1.1-alpha1-SNAPSHOT'],
         )
 
     def test_component_version(self) -> None:
@@ -58,16 +82,34 @@ class TestBuildTarget(unittest.TestCase):
             "1.1.0.0",
         )
 
+    def test_component_version_qualifier(self) -> None:
+        self.assertEqual(
+            BuildTarget(version="1.1.0", architecture="x86", qualifier="alpha1", snapshot=False).component_version,
+            "1.1.0.0-alpha1",
+        )
+
     def test_compatible_component_versions(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_component_versions,
             ['1.1.2.0', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
         )
 
+    def test_compatible_component_versions_qualifier(self) -> None:
+        self.assertEqual(
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False, qualifier="alpha1").compatible_component_versions,
+            ['1.1.2.0-alpha1', '1.1.0.0-alpha1', '1.1.1.0-alpha1', '1.1.0.0-alpha1-SNAPSHOT', '1.1.1.0-alpha1-SNAPSHOT'],
+        )
+
     def test_compatible_component_versions_snapshot(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_component_versions,
             ['1.1.2.0-SNAPSHOT', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
+        )
+
+    def test_compatible_component_versions_snapshot_qualifier(self) -> None:
+        self.assertEqual(
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True, qualifier="alpha1").compatible_component_versions,
+            ['1.1.2.0-alpha1-SNAPSHOT', '1.1.0.0-alpha1', '1.1.1.0-alpha1', '1.1.0.0-alpha1-SNAPSHOT', '1.1.1.0-alpha1-SNAPSHOT'],
         )
 
     def test_component_version_snapshot(self) -> None:

--- a/tests/tests_build_workflow/test_builder_from_source.py
+++ b/tests/tests_build_workflow/test_builder_from_source.py
@@ -141,6 +141,30 @@ class TestBuilderFromSource(unittest.TestCase):
         )
         build_recorder.record_component.assert_called_with("common-utils", self.builder.git_repo)
 
+    @patch("build_workflow.builder_from_source.GitRepository")
+    def test_build_snapshot_qualiier(self, mock_git_repo: Mock) -> None:
+        self.builder.target.snapshot = True
+        self.builder.target.qualifier = "alpha1"
+        mock_git_repo.return_value = MagicMock(working_directory="dir")
+        build_recorder = MagicMock()
+        self.builder.checkout("dir")
+        self.builder.build(build_recorder)
+        mock_git_repo.return_value.execute.assert_called_with(
+            " ".join(
+                [
+                    "bash",
+                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "common-utils", "build.sh")),
+                    "-v 1.1.0",
+                    "-q alpha1",
+                    "-p linux",
+                    "-a x64",
+                    "-s true",
+                    "-o builds",
+                ]
+            )
+        )
+        build_recorder.record_component.assert_called_with("common-utils", self.builder.git_repo)
+
     def mock_os_walk(self, artifact_path: str) -> List[Any]:
         if artifact_path.endswith(os.path.join("dir", "builds", "core-plugins")):
             return [["core-plugins", [], ["plugin1.zip"]]]


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Adds an optional build version qualifier to the input manifest that is passed onto OpenSearch, which already supports qualified version numbers (currently only `alpha`, `beta` and `rc`). 
 
### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-build/issues/1632.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
