### PR TITLE
Change to double quote for manifest ref

### DIFF
--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-v1
@@ -22,7 +22,7 @@ components:
       - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: '1.3'
+    ref: "1.3"
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -52,7 +52,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: '1.3'
+    ref: "1.3"
     platforms:
       - darwin
       - linux
@@ -61,7 +61,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '1.3'
+    ref: "1.3"
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: main

--- a/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 build:
   name: OpenSearch Dashboards
   version: 1.3.0


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Change the ref in 1.3 manifest to use double quote for consistency. 
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
