### PR TITLE
Modify yaml linter to enforce double quotes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,6 +5,6 @@ coverage:
       default:
         target: 98%
 ignore:
-  - '**/tests/*.py'
-  - '**/test/*.js'
-  - '**/test/*.ts'
+  - "**/tests/*.py"
+  - "**/test/*.js"
+  - "**/test/*.ts"

--- a/.github/ISSUE_TEMPLATE/bug_template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yaml
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 description: File a bug report
-title: '[Bug]: '
+title: "[Bug]: "
 labels: [bug, untriaged]
 body:
   - type: markdown

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -42,9 +42,9 @@ jobs:
 
             Signed-off-by: opensearch-ci-bot <opensearch-infra@amazon.com>
           delete-branch: true
-          title: '[AUTO] Updated input manifests.'
+          title: "[AUTO] Updated input manifests."
           body: |
-            I've noticed that a repo has incremented a version and have made some updates to input manifests.
+            I"ve noticed that a repo has incremented a version and have made some updates to input manifests.
       - name: Check outputs
         run: |-
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/versions.yml
+++ b/.github/workflows/versions.yml
@@ -44,7 +44,7 @@ jobs:
           delete-branch: true
           title: "[AUTO] Updated input manifests."
           body: |
-            I"ve noticed that a repo has incremented a version and have made some updates to input manifests.
+            I've noticed that a repo has incremented a version and have made some updates to input manifests.
       - name: Check outputs
         run: |-
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,7 +1,7 @@
 ---
 yaml-files:
-  - '*.yaml'
-  - '*.yml'
+  - "*.yaml"
+  - "*.yml"
   - .yamllint.yml
 ignore: |
   bin
@@ -30,6 +30,8 @@ rules:
   new-line-at-end-of-file: enable
   new-lines: enable
   octal-values: disable
-  quoted-strings: disable
+  quoted-strings:
+    quote-type: double
+    required: false
   trailing-spaces: enable
   truthy: disable

--- a/docker/release/config/opensearch-dashboards/opensearch_dashboards.yml
+++ b/docker/release/config/opensearch-dashboards/opensearch_dashboards.yml
@@ -5,7 +5,7 @@
 # Description:
 # Default configuration for OpenSearch Dashboards
 
-server.host: '0'
+server.host: "0"
 opensearch.hosts: [https://localhost:9200]
 opensearch.ssl.verificationMode: none
 opensearch.username: kibanaserver

--- a/docker/release/dockercomposefiles/docker-compose.yml
+++ b/docker/release/dockercomposefiles/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3'
+version: "3"
 services:
   opensearch-node1:
     image: opensearchproject/opensearch:latest
@@ -52,7 +52,7 @@ services:
     ports:
       - 5601:5601
     expose:
-      - '5601'
+      - "5601"
     environment:
       OPENSEARCH_HOSTS: https://opensearch-node1:9200
     networks:

--- a/manifests/1.0.0/opensearch-1.0.0-maven.yml
+++ b/manifests/1.0.0/opensearch-1.0.0-maven.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.0.0

--- a/manifests/1.0.0/opensearch-1.0.0-test.yml
+++ b/manifests/1.0.0/opensearch-1.0.0-test.yml
@@ -88,4 +88,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.0.0/opensearch-1.0.0.yml
+++ b/manifests/1.0.0/opensearch-1.0.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.0.0

--- a/manifests/1.0.1/manifest.linux.arm64.1.0.1.yml
+++ b/manifests/1.0.1/manifest.linux.arm64.1.0.1.yml
@@ -1,6 +1,6 @@
 ---
 manifest:
-  schema-version: '1.0'
+  schema-version: "1.0"
 build:
   version: 1.0.1
   platform: linux

--- a/manifests/1.0.1/manifest.linux.x64.1.0.1.yml
+++ b/manifests/1.0.1/manifest.linux.x64.1.0.1.yml
@@ -1,6 +1,6 @@
 ---
 manifest:
-  schema-version: '1.0'
+  schema-version: "1.0"
 build:
   version: 1.0.1
   platform: linux

--- a/manifests/1.0.1/opensearch-1.0.1-test.yml
+++ b/manifests/1.0.1/opensearch-1.0.1-test.yml
@@ -88,4 +88,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.0.1/opensearch-1.0.1.yml
+++ b/manifests/1.0.1/opensearch-1.0.1.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.0.1

--- a/manifests/1.0.1/opensearch-dashboards-1.0.1.yml
+++ b/manifests/1.0.1/opensearch-dashboards-1.0.1.yml
@@ -4,6 +4,6 @@ build:
   version: 1.0.1
 components:
   - name: OpenSearch-Dashboards
-    ref: '1.0'
+    ref: "1.0"
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.1.0/manifest.linux.arm64.1.1.0.yml
+++ b/manifests/1.1.0/manifest.linux.arm64.1.1.0.yml
@@ -1,6 +1,6 @@
 ---
 manifest:
-  schema-version: '1.0'
+  schema-version: "1.0"
 build:
   version: 1.1.0
   platform: linux

--- a/manifests/1.1.0/manifest.linux.x64.1.1.0.yml
+++ b/manifests/1.1.0/manifest.linux.x64.1.1.0.yml
@@ -1,6 +1,6 @@
 ---
 manifest:
-  schema-version: '1.0'
+  schema-version: "1.0"
 build:
   version: 1.1.0
   platform: linux

--- a/manifests/1.1.0/opensearch-1.1.0-test.yml
+++ b/manifests/1.1.0/opensearch-1.1.0-test.yml
@@ -88,4 +88,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.1.0/opensearch-1.1.0.yml
+++ b/manifests/1.1.0/opensearch-1.1.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.1.0

--- a/manifests/1.1.0/opensearch-dashboards-1.1.0-test.yml
+++ b/manifests/1.1.0/opensearch-dashboards-1.1.0-test.yml
@@ -6,4 +6,4 @@ components:
       test-configs:
         - with-security
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.1.0/opensearch-dashboards-1.1.0.yml
+++ b/manifests/1.1.0/opensearch-dashboards-1.1.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028

--- a/manifests/1.1.1/opensearch-1.1.1-test.yml
+++ b/manifests/1.1.1/opensearch-1.1.1-test.yml
@@ -88,4 +88,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.1.1/opensearch-1.1.1.yml
+++ b/manifests/1.1.1/opensearch-1.1.1.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028
@@ -24,7 +24,7 @@ components:
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
     working_directory: reports-scheduler
-    ref: '1.1'
+    ref: "1.1"
     platforms:
       - linux
     checks:

--- a/manifests/1.1.1/opensearch-dashboards-1.1.1-test.yml
+++ b/manifests/1.1.1/opensearch-dashboards-1.1.1-test.yml
@@ -6,4 +6,4 @@ components:
       test-configs:
         - with-security
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.1.1/opensearch-dashboards-1.1.1.yml
+++ b/manifests/1.1.1/opensearch-dashboards-1.1.1.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028
@@ -11,7 +11,7 @@ build:
 components:
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reports
-    ref: '1.1'
+    ref: "1.1"
     working_directory: dashboards-reports
     platforms:
       - linux

--- a/manifests/1.2.0/opensearch-1.2.0-test.yml
+++ b/manifests/1.2.0/opensearch-1.2.0-test.yml
@@ -88,4 +88,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.2.0/opensearch-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-1.2.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028

--- a/manifests/1.2.0/opensearch-dashboards-1.2.0-test.yml
+++ b/manifests/1.2.0/opensearch-dashboards-1.2.0-test.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 name: OpenSearch Dashboards
 components:
   - name: functionalTestDashboards

--- a/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
+++ b/manifests/1.2.0/opensearch-dashboards-1.2.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028

--- a/manifests/1.2.1/opensearch-1.2.1-test.yml
+++ b/manifests/1.2.1/opensearch-1.2.1-test.yml
@@ -88,4 +88,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.2.1/opensearch-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-1.2.1.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028

--- a/manifests/1.2.2/opensearch-1.2.2-test.yml
+++ b/manifests/1.2.2/opensearch-1.2.2-test.yml
@@ -88,4 +88,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.2.2/opensearch-1.2.2.yml
+++ b/manifests/1.2.2/opensearch-1.2.2.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028

--- a/manifests/1.2.3/opensearch-1.2.3-test.yml
+++ b/manifests/1.2.3/opensearch-1.2.3-test.yml
@@ -88,4 +88,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.2.3/opensearch-1.2.3.yml
+++ b/manifests/1.2.3/opensearch-1.2.3.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028

--- a/manifests/1.2.4/opensearch-1.2.4-test.yml
+++ b/manifests/1.2.4/opensearch-1.2.4-test.yml
@@ -88,4 +88,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.2.4/opensearch-1.2.4.yml
+++ b/manifests/1.2.4/opensearch-1.2.4.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028

--- a/manifests/1.2.5/opensearch-1.2.5.yml
+++ b/manifests/1.2.5/opensearch-1.2.5.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.2.5
@@ -9,7 +9,7 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: '1.2'
+    ref: "1.2"
     checks:
       - gradle:publish
       - gradle:properties:version

--- a/manifests/1.3.0/opensearch-1.3.0-test.yml
+++ b/manifests/1.3.0/opensearch-1.3.0-test.yml
@@ -98,4 +98,4 @@ components:
       test-configs:
         - with-security
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -73,13 +73,13 @@ components:
       - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: '1.3'
+    ref: "1.3"
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '1.3'
+    ref: "1.3"
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/1.3.0/opensearch-dashboards-1.3.0-test.yml
+++ b/manifests/1.3.0/opensearch-dashboards-1.3.0-test.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 name: OpenSearch Dashboards
 components:
   - name: functionalTestDashboards

--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-v1

--- a/manifests/2.0.0/opensearch-dashboards-2.0.0-test.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0-test.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 name: OpenSearch Dashboards
 components:
   - name: OpenSearch-Dashboards

--- a/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 build:
   name: OpenSearch Dashboards
   version: 2.0.0

--- a/tests/data/opensearch-build-1.1.0.yml
+++ b/tests/data/opensearch-build-1.1.0.yml
@@ -2482,4 +2482,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/data/opensearch-dashboards-build-1.2.0.yml
+++ b/tests/data/opensearch-dashboards-build-1.2.0.yml
@@ -32,7 +32,7 @@ components:
         - plugins/securityDashboards-1.2.0.zip
     commit_id: 960ef753f74dceb793e8936a40ac8c6cbec88dd1
     name: securityDashboards
-    ref: '1.2'
+    ref: "1.2"
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
     version: 1.2.0.0
   - artifacts:
@@ -40,7 +40,7 @@ components:
         - plugins/indexManagementDashboards-1.2.0.zip
     commit_id: 6748b18ee172138b4811a459053f4a43c1486821
     name: indexManagementDashboards
-    ref: '1.2'
+    ref: "1.2"
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
     version: 1.2.0.0
   - artifacts:
@@ -83,4 +83,4 @@ components:
     ref: tags/1.2.0.0
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     version: 1.2.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/jenkins/data/opensearch-1.3.0-build.yml
+++ b/tests/jenkins/data/opensearch-1.3.0-build.yml
@@ -2,7 +2,7 @@
 build:
   platform: linux
   architecture: x64
-  id: '717'
+  id: "717"
   name: OpenSearch
   version: 1.3.0
 components:
@@ -2336,4 +2336,4 @@ components:
     ref: 1.x
     repository: https://github.com/opensearch-project/OpenSearch.git
     version: 1.3.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/jenkins/data/opensearch-1.3.0-test.yml
+++ b/tests/jenkins/data/opensearch-1.3.0-test.yml
@@ -88,4 +88,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/jenkins/data/opensearch-1.3.0.yml
+++ b/tests/jenkins/data/opensearch-1.3.0.yml
@@ -1,9 +1,9 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.3.0
-  id: '717'
+  id: "717"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028

--- a/tests/jenkins/data/opensearch-1.3.0.yml.lock
+++ b/tests/jenkins/data/opensearch-1.3.0.yml.lock
@@ -2,7 +2,7 @@ build:
   architecture: x64
   name: OpenSearch
   version: 1.3.0
-  id: '717'
+  id: "717"
 ci:
   image:
     args: -e JAVA_HOME=/opt/java/openjdk-11
@@ -14,4 +14,4 @@ components:
   name: OpenSearch
   ref: 83e005b287816c0135d0a9b762054eaf5dcfe9df
   repository: https://github.com/opensearch-project/OpenSearch.git
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/jenkins/data/opensearch-dashboards-1.2.0-build.yml
+++ b/tests/jenkins/data/opensearch-dashboards-1.2.0-build.yml
@@ -1,7 +1,7 @@
 ---
 build:
   architecture: x64
-  id: '215'
+  id: "215"
   name: OpenSearch Dashboards
   platform: linux
   version: 1.2.0
@@ -32,7 +32,7 @@ components:
         - plugins/securityDashboards-1.2.0.zip
     commit_id: 960ef753f74dceb793e8936a40ac8c6cbec88dd1
     name: securityDashboards
-    ref: '1.2'
+    ref: "1.2"
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
     version: 1.2.0.0
   - artifacts:
@@ -40,7 +40,7 @@ components:
         - plugins/indexManagementDashboards-1.2.0.zip
     commit_id: 6748b18ee172138b4811a459053f4a43c1486821
     name: indexManagementDashboards
-    ref: '1.2'
+    ref: "1.2"
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
     version: 1.2.0.0
   - artifacts:
@@ -83,4 +83,4 @@ components:
     ref: tags/1.2.0.0
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     version: 1.2.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml
+++ b/tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 name: OpenSearch Dashboards
 components:
   - name: functionalTestDashboards

--- a/tests/jenkins/data/opensearch-dashboards-1.2.0.yml
+++ b/tests/jenkins/data/opensearch-dashboards-1.2.0.yml
@@ -9,4 +9,4 @@ components:
   - name: OpenSearch-Dashboards
     ref: tags/1.2.0
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_assemble_workflow/data/opensearch-build-linux-1.1.0.yml
+++ b/tests/tests_assemble_workflow/data/opensearch-build-linux-1.1.0.yml
@@ -2482,4 +2482,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_assemble_workflow/data/opensearch-build-linux-1.1.1.yml
+++ b/tests/tests_assemble_workflow/data/opensearch-build-linux-1.1.1.yml
@@ -11,12 +11,12 @@ components:
         - dist/opensearch-min-1.1.0-linux-x64.tar.gz
     commit_id: 15e9f137622d878b79103df8f82d78d782b686a1
     name: OpenSearch
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/OpenSearch.git
     version: 1.1.1.0-SNAPSHOT
   - commit_id: 8d05d8a55ac0e70ba68569f872ad32f8aa32c0ea
     name: common-utils
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/common-utils.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -24,7 +24,7 @@ components:
         - plugins/opensearch-job-scheduler-1.1.0.0.zip
     commit_id: 0a4ce10a812165e95801b77ede689064ffee2188
     name: job-scheduler
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/job-scheduler.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -32,7 +32,7 @@ components:
         - plugins/opensearch-reports-scheduler-1.1.1.0-SNAPSHOT.zip
     commit_id: d33924fb14086ebb47df8cafce528393a4aaa015
     name: dashboards-reports
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/dashboards-reports.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -40,7 +40,7 @@ components:
         - plugins/opensearch-sql-1.1.0.0.zip
     commit_id: ceedf9a1da2c35f64e5aa95077098baa71df46f0
     name: sql
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/sql.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -48,7 +48,7 @@ components:
         - plugins/opensearch-alerting-1.1.0.0.zip
     commit_id: 3a8b8748e0dc01c3418f50143cdd651e66b78557
     name: alerting
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/alerting.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -56,7 +56,7 @@ components:
         - plugins/opensearch-security-1.1.0.0.zip
     commit_id: 6436c155347355292ed91c108eade5f6f119c40b
     name: security
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/security.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -64,7 +64,7 @@ components:
         - plugins/opensearch-cross-cluster-replication-1.1.0.0.zip
     commit_id: 7e16c39ab0197acd865e1b501955306cb32a0150
     name: cross-cluster-replication
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -72,7 +72,7 @@ components:
         - plugins/opensearch-performance-analyzer-1.1.0.0.zip
     commit_id: e921d570d9af4a82aafc981e6a41591ded4fa7d3
     name: performance-analyzer
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/performance-analyzer.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -80,7 +80,7 @@ components:
         - plugins/opensearch-index-management-1.1.0.0.zip
     commit_id: 1d8fbd404a7a4b226cd1d42877b51776ba127cdb
     name: index-management
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/index-management.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -90,7 +90,7 @@ components:
         - plugins/opensearch-knn-1.1.0.0.zip
     commit_id: 9fa629073365d34b2450428b33405c8d36fb6c5b
     name: k-NN
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/k-NN.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -98,7 +98,7 @@ components:
         - plugins/opensearch-anomaly-detection-1.1.0.0.zip
     commit_id: 569cedeedab46167614fb0148db37b35cd648712
     name: anomaly-detection
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/anomaly-detection.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -106,7 +106,7 @@ components:
         - plugins/opensearch-asynchronous-search-1.1.0.0.zip
     commit_id: 83492829b92b222d25551375ba5277c28bf13005
     name: asynchronous-search
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/asynchronous-search.git
     version: 1.1.1.0-SNAPSHOT
   - artifacts:
@@ -114,7 +114,7 @@ components:
         - plugins/opensearch-notebooks-1.1.0.0.zip
     commit_id: 0d498b10f62f0cc3896b736651af5103132200e1
     name: dashboards-notebooks
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.1.0-SNAPSHOT
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_assemble_workflow/data/opensearch-build-windows-1.1.0.yml
+++ b/tests/tests_assemble_workflow/data/opensearch-build-windows-1.1.0.yml
@@ -2482,4 +2482,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_assemble_workflow/data/opensearch-build-windows-1.3.0.yml
+++ b/tests/tests_assemble_workflow/data/opensearch-build-windows-1.3.0.yml
@@ -2483,4 +2483,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.3.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_assemble_workflow/data/opensearch-dashboards-build-1.1.0.yml
+++ b/tests/tests_assemble_workflow/data/opensearch-dashboards-build-1.1.0.yml
@@ -11,7 +11,7 @@ components:
         - dist/opensearch-dashboards-min-1.1.0-linux-x64.tar.gz
     commit_id: 635db6a8d42cb517109721e438d39500a8f453a9
     name: OpenSearch-Dashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     version: 1.1.0.0
   - artifacts:
@@ -22,4 +22,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_assemble_workflow/data/opensearch-dashboards-build-windows-1.3.0.yml
+++ b/tests/tests_assemble_workflow/data/opensearch-dashboards-build-windows-1.3.0.yml
@@ -12,7 +12,7 @@ components:
         - dist/opensearch-dashboards-min-1.3.0-windows-x64.zip
     commit_id: 635db6a8d42cb517109721e438d39500a8f453a9
     name: OpenSearch-Dashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     version: 1.3.0.0
   - artifacts:
@@ -23,4 +23,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin
     version: 1.3.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_build_workflow/data/opensearch-build-windows-1.1.0.yml
+++ b/tests/tests_build_workflow/data/opensearch-build-windows-1.1.0.yml
@@ -2482,4 +2482,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_ci_workflow/data/opensearch-1.1.0-x64-build-manifest.yml
+++ b/tests/tests_ci_workflow/data/opensearch-1.1.0-x64-build-manifest.yml
@@ -1,7 +1,7 @@
 ---
 build:
   architecture: x64
-  id: '405'
+  id: "405"
   name: OpenSearch
   version: 1.1.0
 components:
@@ -2362,7 +2362,7 @@ components:
         - maven/org/opensearch/opensearch-upgrade-cli/1.1.0/opensearch-upgrade-cli-1.1.0-javadoc.jar.sha512
     commit_id: 15e9f137622d878b79103df8f82d78d782b686a1
     name: OpenSearch
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/OpenSearch.git
     version: 1.1.0.0
   - artifacts:
@@ -2374,7 +2374,7 @@ components:
         - maven/org/opensearch/common-utils/1.1.0.0/common-utils-1.1.0.0-javadoc.jar
     commit_id: 8d05d8a55ac0e70ba68569f872ad32f8aa32c0ea
     name: common-utils
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/common-utils.git
     version: 1.1.0.0
   - artifacts:
@@ -2394,7 +2394,7 @@ components:
         - plugins/opensearch-job-scheduler-1.1.0.0.zip
     commit_id: 0a4ce10a812165e95801b77ede689064ffee2188
     name: job-scheduler
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/job-scheduler.git
     version: 1.1.0.0
   - artifacts:
@@ -2402,7 +2402,7 @@ components:
         - plugins/opensearch-sql-1.1.0.0.zip
     commit_id: ceedf9a1da2c35f64e5aa95077098baa71df46f0
     name: sql
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/sql.git
     version: 1.1.0.0
   - artifacts:
@@ -2416,7 +2416,7 @@ components:
         - plugins/opensearch-alerting-1.1.0.0.zip
     commit_id: 3a8b8748e0dc01c3418f50143cdd651e66b78557
     name: alerting
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/alerting.git
     version: 1.1.0.0
   - artifacts:
@@ -2424,7 +2424,7 @@ components:
         - plugins/opensearch-security-1.1.0.0.zip
     commit_id: 6436c155347355292ed91c108eade5f6f119c40b
     name: security
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/security.git
     version: 1.1.0.0
   - artifacts:
@@ -2432,7 +2432,7 @@ components:
         - plugins/opensearch-cross-cluster-replication-1.1.0.0.zip
     commit_id: 7e16c39ab0197acd865e1b501955306cb32a0150
     name: cross-cluster-replication
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
     version: 1.1.0.0
   - artifacts:
@@ -2443,7 +2443,7 @@ components:
         - maven/org/opensearch/performanceanalyzer-rca/1.1.0.0/performanceanalyzer-rca-1.1.0.0.module
     commit_id: 3304d31fe8d8c064f5ed38601c5d1d9ca4c28682
     name: performance-analyzer-rca
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/performance-analyzer-rca.git
     version: 1.1.0.0
   - artifacts:
@@ -2458,7 +2458,7 @@ components:
         - plugins/opensearch-performance-analyzer-1.1.0.0.zip
     commit_id: e921d570d9af4a82aafc981e6a41591ded4fa7d3
     name: performance-analyzer
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/performance-analyzer.git
     version: 1.1.0.0
   - artifacts:
@@ -2466,7 +2466,7 @@ components:
         - plugins/opensearch-index-management-1.1.0.0.zip
     commit_id: 1d8fbd404a7a4b226cd1d42877b51776ba127cdb
     name: index-management
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/index-management.git
     version: 1.1.0.0
   - artifacts:
@@ -2476,7 +2476,7 @@ components:
         - plugins/opensearch-knn-1.1.0.0.zip
     commit_id: 9fa629073365d34b2450428b33405c8d36fb6c5b
     name: k-NN
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/k-NN.git
     version: 1.1.0.0
   - artifacts:
@@ -2484,7 +2484,7 @@ components:
         - plugins/opensearch-anomaly-detection-1.1.0.0.zip
     commit_id: 569cedeedab46167614fb0148db37b35cd648712
     name: anomaly-detection
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/anomaly-detection.git
     version: 1.1.0.0
   - artifacts:
@@ -2492,7 +2492,7 @@ components:
         - plugins/opensearch-asynchronous-search-1.1.0.0.zip
     commit_id: 83492829b92b222d25551375ba5277c28bf13005
     name: asynchronous-search
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/asynchronous-search.git
     version: 1.1.0.0
   - artifacts:
@@ -2500,7 +2500,7 @@ components:
         - plugins/opensearch-reports-scheduler-1.1.0.0.zip
     commit_id: 8df794287ae8c83acc5c96a90f4cd606e720e015
     name: dashboards-reports
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/dashboards-reports.git
     version: 1.1.0.0
   - artifacts:
@@ -2508,7 +2508,7 @@ components:
         - plugins/opensearch-notebooks-1.1.0.0.zip
     commit_id: 0d498b10f62f0cc3896b736651af5103132200e1
     name: dashboards-notebooks
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_manifests/data/build/opensearch-build-schema-version-1.0.yml
+++ b/tests/tests_manifests/data/build/opensearch-build-schema-version-1.0.yml
@@ -2481,4 +2481,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_manifests/data/build/opensearch-build-schema-version-1.1.yml
+++ b/tests/tests_manifests/data/build/opensearch-build-schema-version-1.1.yml
@@ -2481,4 +2481,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.2.0.0
-schema-version: '1.1'
+schema-version: "1.1"

--- a/tests/tests_manifests/data/build/opensearch-build-schema-version-1.2.yml
+++ b/tests/tests_manifests/data/build/opensearch-build-schema-version-1.2.yml
@@ -2482,4 +2482,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_manifests/data/bundle/opensearch-bundle-schema-version-1.0.yml
+++ b/tests/tests_manifests/data/bundle/opensearch-bundle-schema-version-1.0.yml
@@ -71,4 +71,4 @@ components:
     name: dashboards-notebooks
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_manifests/data/bundle/opensearch-bundle-schema-version-1.1.yml
+++ b/tests/tests_manifests/data/bundle/opensearch-bundle-schema-version-1.1.yml
@@ -10,7 +10,7 @@ components:
   - commit_id: b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583
     location: artifacts/dist/opensearch-min-1.1.0-linux-x64.tar.gz
     name: OpenSearch
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/OpenSearch.git
   - commit_id: 4504dabfc67dd5628c1451e91e9a1c3c4ca71525
     location: artifacts/plugins/opensearch-job-scheduler-1.1.0.0.zip
@@ -72,4 +72,4 @@ components:
     name: dashboards-notebooks
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.1'
+schema-version: "1.1"

--- a/tests/tests_manifests/data/formatted.yml
+++ b/tests/tests_manifests/data/formatted.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 2.0.0

--- a/tests/tests_manifests/data/invalid-ref.yml
+++ b/tests/tests_manifests/data/invalid-ref.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 build:
   name: OpenSearch
   version: 1.1.0

--- a/tests/tests_manifests/data/invalid-schema-version-empty.yml
+++ b/tests/tests_manifests/data/invalid-schema-version-empty.yml
@@ -1,2 +1,2 @@
 ---
-schema-version: ''
+schema-version: ""

--- a/tests/tests_manifests/data/min.yml
+++ b/tests/tests_manifests/data/min.yml
@@ -1,2 +1,2 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_manifests/data/opensearch-1.2.0.yml
+++ b/tests/tests_manifests/data/opensearch-1.2.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028

--- a/tests/tests_manifests/data/opensearch-build-1.1.0.yml
+++ b/tests/tests_manifests/data/opensearch-build-1.1.0.yml
@@ -2482,4 +2482,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_manifests/data/opensearch-build-1.2.0.yml
+++ b/tests/tests_manifests/data/opensearch-build-1.2.0.yml
@@ -2482,4 +2482,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.2.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_manifests/data/opensearch-build-1.3.0.yml
+++ b/tests/tests_manifests/data/opensearch-build-1.3.0.yml
@@ -2483,4 +2483,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.3.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_manifests/data/opensearch-bundle-1.1.0.yml
+++ b/tests/tests_manifests/data/opensearch-bundle-1.1.0.yml
@@ -10,7 +10,7 @@ components:
   - commit_id: b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583
     location: artifacts/dist/opensearch-min-1.1.0-linux-x64.tar.gz
     name: OpenSearch
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/OpenSearch.git
   - commit_id: 4504dabfc67dd5628c1451e91e9a1c3c4ca71525
     location: artifacts/plugins/opensearch-job-scheduler-1.1.0.0.zip
@@ -72,4 +72,4 @@ components:
     name: dashboards-notebooks
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.1'
+schema-version: "1.1"

--- a/tests/tests_manifests/data/opensearch-bundle-1.3.0.yml
+++ b/tests/tests_manifests/data/opensearch-bundle-1.3.0.yml
@@ -11,7 +11,7 @@ components:
   - commit_id: b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583
     location: artifacts/dist/opensearch-min-1.3.0-linux-x64.tar.gz
     name: OpenSearch
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/OpenSearch.git
   - commit_id: 4504dabfc67dd5628c1451e91e9a1c3c4ca71525
     location: artifacts/plugins/opensearch-job-scheduler-1.3.0.0.zip
@@ -73,4 +73,4 @@ components:
     name: dashboards-notebooks
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.1'
+schema-version: "1.1"

--- a/tests/tests_manifests/data/opensearch-dashboards-build-1.1.0.yml
+++ b/tests/tests_manifests/data/opensearch-dashboards-build-1.1.0.yml
@@ -1,7 +1,7 @@
 ---
 build:
   architecture: x64
-  id: '524'
+  id: "524"
   name: OpenSearch Dashboards
   version: 1.1.0
 components:
@@ -10,7 +10,7 @@ components:
         - dist/opensearch-dashboards-min-1.1.0-linux-x64.tar.gz
     commit_id: 44d2cb5b4f9a7c641c1fef32ec569bc48ec46979
     name: OpenSearch-Dashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     version: 1.1.0.0
   - artifacts:
@@ -18,7 +18,7 @@ components:
         - plugins/alertingDashboards-1.1.0.zip
     commit_id: ff9edaab1c7baf9c72192d9e8c6965886ce80b24
     name: alertingDashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin
     version: 1.1.0.0
   - artifacts:
@@ -26,7 +26,7 @@ components:
         - plugins/securityDashboards-1.1.0.zip
     commit_id: 67b540831b5b5b987090bfb887ab3402b9acbdda
     name: securityDashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
     version: 1.1.0.0
   - artifacts:
@@ -34,7 +34,7 @@ components:
         - plugins/indexManagementDashboards-1.1.0.zip
     commit_id: 7d50077be789d812626f1c3228c9052b8bbc7ba1
     name: indexManagementDashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
     version: 1.1.0.0
   - artifacts:
@@ -42,7 +42,7 @@ components:
         - plugins/queryWorkbenchDashboards-1.1.0.zip
     commit_id: ceedf9a1da2c35f64e5aa95077098baa71df46f0
     name: queryWorkbenchDashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/sql.git
     version: 1.1.0.0
   - artifacts:
@@ -50,7 +50,7 @@ components:
         - plugins/notebooksDashboards-1.1.0.zip
     commit_id: 0d498b10f62f0cc3896b736651af5103132200e1
     name: notebooksDashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
   - artifacts:
@@ -58,7 +58,7 @@ components:
         - plugins/reportsDashboards-1.1.0.zip
     commit_id: 8df794287ae8c83acc5c96a90f4cd606e720e015
     name: reportsDashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/dashboards-reports.git
     version: 1.1.0.0
   - artifacts:
@@ -66,7 +66,7 @@ components:
         - plugins/traceAnalyticsDashboards-1.1.0.zip
     commit_id: 58237889693bc46abd0d19e27a13b363018d07f9
     name: traceAnalyticsDashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/trace-analytics.git
     version: 1.1.0.0
   - artifacts:
@@ -74,7 +74,7 @@ components:
         - plugins/ganttChartDashboards-1.1.0.zip
     commit_id: ba2911ec4f4273dd784272ce62842ccbdbb93da7
     name: ganttChartDashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
     version: 1.1.0.0
   - artifacts:
@@ -82,7 +82,7 @@ components:
         - plugins/anomalyDetectionDashboards-1.1.0.zip
     commit_id: 569cedeedab46167614fb0148db37b35cd648712
     name: anomalyDetectionDashboards
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     version: 1.1.0.0
-schema-version: '1.1'
+schema-version: "1.1"

--- a/tests/tests_manifests/data/opensearch-dashboards-from-dist-1.1.1.yml
+++ b/tests/tests_manifests/data/opensearch-dashboards-from-dist-1.1.1.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: '1.0'
+schema-version: "1.0"
 ci:
   image:
     name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028
@@ -31,7 +31,7 @@ components:
       - manifest:component
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reports
-    ref: '1.1'
+    ref: "1.1"
     working_directory: dashboards-reports
     platforms:
       - linux

--- a/tests/tests_manifests/data/opensearch-test-1.1.0.yml
+++ b/tests/tests_manifests/data/opensearch-test-1.1.0.yml
@@ -18,4 +18,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_manifests/data/test/opensearch-test-schema-version-1.0.yml
+++ b/tests/tests_manifests/data/test/opensearch-test-schema-version-1.0.yml
@@ -18,4 +18,4 @@ components:
     bwc-test:
       test-configs:
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_sign_workflow/data/opensearch-build-1.1.0.yml
+++ b/tests/tests_sign_workflow/data/opensearch-build-1.1.0.yml
@@ -187,4 +187,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_test_workflow/data/test-manifest-opensearch-dashboards.yml
+++ b/tests/tests_test_workflow/data/test-manifest-opensearch-dashboards.yml
@@ -10,4 +10,4 @@ components:
       test-configs:
         - with-security
         - without-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_test_workflow/data/test_manifest.yml
+++ b/tests/tests_test_workflow/data/test_manifest.yml
@@ -41,4 +41,4 @@ components:
     bwc-test:
       test-configs:
         - with-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/data/build_manifest.yml
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/data/build_manifest.yml
@@ -2482,4 +2482,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/data/bundle_manifest.yml
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/data/bundle_manifest.yml
@@ -10,7 +10,7 @@ components:
   - commit_id: b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583
     location: artifacts/bundle/opensearch-min-1.1.0-linux-x64.tar.gz
     name: OpenSearch
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/OpenSearch.git
   - commit_id: 4504dabfc67dd5628c1451e91e9a1c3c4ca71525
     location: artifacts/plugins/opensearch-job-scheduler-1.1.0.0.zip
@@ -72,4 +72,4 @@ components:
     name: dashboards-notebooks
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.1'
+schema-version: "1.1"

--- a/tests/tests_test_workflow/test_bwc_workflow/bwc_test/data/test_manifest.yml
+++ b/tests/tests_test_workflow/test_bwc_workflow/bwc_test/data/test_manifest.yml
@@ -41,4 +41,4 @@ components:
     bwc-test:
       test-configs:
         - with-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/data/build_manifest.yml
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/data/build_manifest.yml
@@ -2482,4 +2482,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/data/build_manifest_missing_components.yml
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/data/build_manifest_missing_components.yml
@@ -2462,4 +2462,4 @@ components:
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
     version: 1.1.0.0
-schema-version: '1.2'
+schema-version: "1.2"

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/data/bundle_manifest.yml
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/data/bundle_manifest.yml
@@ -10,7 +10,7 @@ components:
   - commit_id: b7334f49d530ffd1a3f7bd0e5832b9b2a9caa583
     location: artifacts/bundle/opensearch-min-1.1.0-linux-x64.tar.gz
     name: OpenSearch
-    ref: '1.1'
+    ref: "1.1"
     repository: https://github.com/opensearch-project/OpenSearch.git
   - commit_id: 4504dabfc67dd5628c1451e91e9a1c3c4ca71525
     location: artifacts/plugins/opensearch-job-scheduler-1.1.0.0.zip
@@ -72,4 +72,4 @@ components:
     name: dashboards-notebooks
     ref: main
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.1'
+schema-version: "1.1"

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/data/test_manifest.yml
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/data/test_manifest.yml
@@ -41,4 +41,4 @@ components:
     bwc-test:
       test-configs:
         - with-security
-schema-version: '1.0'
+schema-version: "1.0"

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/data/bundle_manifest.yml
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/data/bundle_manifest.yml
@@ -10,7 +10,7 @@ components:
   - commit_id: fb25458f38c30a7ab06de21b0068f1fe3ad56134
     location: https://artifacts.opensearch.org/builds/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/bundle/opensearch-min-1.0.0-linux-x64.tar.gz
     name: OpenSearch
-    ref: '1.0'
+    ref: "1.0"
     repository: https://github.com/saratvemulapalli/OpenSearch.git
   - commit_id: 7fad9529358259de529763c1c923fd947817a3bd
     location: https://artifacts.opensearch.org/builds/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/plugins/opensearch-job-scheduler-1.0.0.0.zip
@@ -45,7 +45,7 @@ components:
   - commit_id: 502c96e54fae1cec9fee1fafd77ad92fde9d2459
     location: https://artifacts.opensearch.org/builds/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/plugins/opensearch-anomaly-detection-1.0.0.0.zip
     name: anomaly-detection
-    ref: '1.0'
+    ref: "1.0"
     repository: https://github.com/opensearch-project/anomaly-detection.git
   - commit_id: bd31e80adf6d52c1b4662d0d2cc9b30d8ae14309
     location: https://artifacts.opensearch.org/builds/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/plugins/opensearch-asynchronous-search-1.0.0.0.zip
@@ -62,4 +62,4 @@ components:
     name: dashboards-notebooks
     ref: 1.0.0.0
     repository: https://github.com/opensearch-project/dashboards-notebooks.git
-schema-version: '1.1'
+schema-version: "1.1"


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
We had inconsistencies in yamls through out the repo with single and double quotes especially the manifests.
Added the config in `.yamllint` that will check during CI now.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/pull/1734#issuecomment-1063460367
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
