### PR TITLE
Modify yaml linter to enforce single quotes

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -30,6 +30,8 @@ rules:
   new-line-at-end-of-file: enable
   new-lines: enable
   octal-values: disable
-  quoted-strings: disable
+  quoted-strings:
+    quote-type: single
+    required: false
   trailing-spaces: enable
   truthy: disable

--- a/manifests/1.3.0/opensearch-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-1.3.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: "1.0"
+schema-version: '1.0'
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-v1
@@ -10,31 +10,31 @@ build:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: "1.3"
+    ref: '1.3'
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: "1.3"
+    ref: '1.3'
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: "1.3"
+    ref: '1.3'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: "1.3"
+    ref: '1.3'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: "1.3"
+    ref: '1.3'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
@@ -46,13 +46,13 @@ components:
       - gradle:dependencies:opensearch.version
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: "1.3"
+    ref: '1.3'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: "1.3"
+    ref: '1.3'
     platforms:
       - darwin
       - linux
@@ -61,7 +61,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: "1.3"
+    ref: '1.3'
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: main
@@ -85,20 +85,20 @@ components:
       - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: "1.3"
+    ref: '1.3'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: "1.3"
+    ref: '1.3'
     working_directory: reports-scheduler
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability
-    ref: "1.3"
+    ref: '1.3'
     working_directory: opensearch-observability
     checks:
       - gradle:properties:version

--- a/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
+++ b/manifests/1.3.0/opensearch-dashboards-1.3.0.yml
@@ -1,5 +1,5 @@
 ---
-schema-version: "1.0"
+schema-version: '1.0'
 build:
   name: OpenSearch Dashboards
   version: 1.3.0
@@ -9,35 +9,35 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: "1.3"
+    ref: '1.3'
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
     ref: main
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/sql.git
     working_directory: workbench
-    ref: "1.3"
+    ref: '1.3'
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/observability.git
     working_directory: dashboards-observability
-    ref: "1.3"
+    ref: '1.3'
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: "1.3"
+    ref: '1.3'
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: "1.3"
+    ref: '1.3'
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reports.git
     working_directory: dashboards-reports
-    ref: "1.3"
+    ref: '1.3'
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
     working_directory: gantt-chart
-    ref: "1.3"
+    ref: '1.3'
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
-    ref: "1.3"
+    ref: '1.3'
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin
-    ref: "1.3"
+    ref: '1.3'


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
We had inconsistencies in yamls through out the repo with single and double quotes especially the manifests.
Added the config in .yamllint that will check during CI now.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/pull/1734#issuecomment-1063460367
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
