### PR TITLE
Added job-scheduler to OpenSearch 2.0.

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -21,3 +21,9 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: main
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Adding job-scheduler to 2.0. 

Following https://github.com/opensearch-project/job-scheduler/pull/139. 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
