### PR TITLE
Update 2.0.0 opensearch manifest to use jdk17

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -3,7 +3,7 @@ schema-version: '1.0'
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-v1
-    args: -e JAVA_HOME=/opt/java/openjdk-11
+    args: -e JAVA_HOME=/opt/java/openjdk-17
 build:
   name: OpenSearch
   version: 2.0.0


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Update 2.0.0 opensearch manifest to use jdk17
 
### Issues Resolved
Part of #1624
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
