### PR TITLE
[OpenSearch] removed colon from `beforeAgent` in docker step

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -218,7 +218,7 @@ pipeline {
         }
         stage('docker build') {
             when {
-                beforeAgent: true
+                beforeAgent true
                 equals expected: true, actual: BUILD_DOCKER
             }
             steps {


### PR DESCRIPTION
### Description
Incorrectly added the colon to beforeAgent in the docker build step
for OpenSearch.

Error added in this PR:
https://github.com/opensearch-project/opensearch-build/pull/1785

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
