### PR TITLE
[Build] fix expression for when for docker build

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -190,7 +190,9 @@ pipeline {
         stage('docker build') {
             when {
                 beforeAgent true
-                equals expected: true, actual: BUILD_DOCKER
+                expression { 
+                    return params.BUILD_DOCKER
+                }
             }
             steps {
                 node(AGENT_X64) {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -219,7 +219,9 @@ pipeline {
         stage('docker build') {
             when {
                 beforeAgent true
-                equals expected: true, actual: BUILD_DOCKER
+                expression { 
+                    return params.BUILD_DOCKER
+                }
             }
             steps {
                 node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {


### PR DESCRIPTION
### Description
Originally verified only with it skipping and it was skipping but
it was always skipping. It would appear that I can't just use
BUILD_DOCKER. It request params.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
