### PR TITLE
Fix typo in common-utils build scripts

### DIFF
--- a/scripts/components/common-utils/build.sh
+++ b/scripts/components/common-utils/build.sh
@@ -10,6 +10,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
@@ -27,7 +28,7 @@ while getopts ":h:v:q:s:o:p:a:" arg; do
             VERSION=$OPTARG
             ;;
         q)
-            QUALIIFIER=$OPTARG
+            QUALIFIER=$OPTARG
             ;;
         s)
             SNAPSHOT=$OPTARG


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Fix typo in common-utils build scripts
 
### Issues Resolved
Part of #1624
#1790
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
