### PR TITLE
[2.0.0][OSD] Remove alerting dashboards plugin

### DIFF
--- a/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
@@ -15,6 +15,3 @@ components:
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
     ref: main
-  - name: alertingDashboards
-    repository: https://github.com/opensearch-project/alerting-dashboards-plugin
-    ref: main


### PR DESCRIPTION
### Description
Alerting Dashboards plugin is not ready to onboard to 2.0.0.
Plugins should bump their versions before adding to the manifest
and ensure that their 2.0.0 package builds with core components
prior to adding to the manifest since this will break the builds
and any automation.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
