### PR TITLE
Added ubuntu dockerfile to run gradle check in OpenSearch

### DIFF
--- a/docker/ci/dockerfiles/build.ubuntu18.opensearch.x64.dockerfile
+++ b/docker/ci/dockerfiles/build.ubuntu18.opensearch.x64.dockerfile
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This is a docker image specifically for running gradle check of OpenSearch repository
+
+FROM ubuntu:18.04
+
+# Install necessary packages
+
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y docker.io curl && apt clean -y 
+
+
+# Create user group
+RUN groupadd -g 1000 opensearch && \
+    useradd -u 1000 -g 1000 -d /usr/share/opensearch opensearch && \
+    mkdir -p /usr/share/opensearch && \
+    chown -R 1000:1000 /usr/share/opensearch
+
+
+# Downloads JDK-8, JDK-11 and JDK-17 distributions using Eclipse Adoptium project.
+# The distributions are extracted to /opt/java/ folder with environment variables JAVA8_HOME,
+# JAVA11_HOME and JAVA17_HOME exported and pointing at respective ones.
+
+# JDK 8
+RUN curl -SL https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz -o /opt/jdk8.tar.gz && \
+    mkdir -p /opt/java/openjdk-8 && \
+    tar -xzf /opt/jdk8.tar.gz --strip-components 1 -C /opt/java/openjdk-8/ && \
+    rm /opt/jdk8.tar.gz
+# JDK 11
+RUN curl -SL https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.12_7.tar.gz -o /opt/jdk11.tar.gz && \
+    mkdir -p /opt/java/openjdk-11 && \
+    tar -xzf /opt/jdk11.tar.gz --strip-components 1 -C /opt/java/openjdk-11/ && \
+    rm /opt/jdk11.tar.gz
+# JDK 14
+RUN curl -SL https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz -o /opt/jdk14.tar.gz && \
+    mkdir -p /opt/java/openjdk-14 && \
+    tar -xzf /opt/jdk14.tar.gz --strip-components 1 -C /opt/java/openjdk-14/ && \
+    rm /opt/jdk14.tar.gz
+# JDK 17
+RUN curl -SL https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz -o /opt/jdk17.tar.gz && \
+    mkdir -p /opt/java/openjdk-17 && \
+    tar -xzf /opt/jdk17.tar.gz --strip-components 1 -C /opt/java/openjdk-17/ && \
+    rm /opt/jdk17.tar.gz
+
+# ENV JDK
+ENV JAVA_HOME=/opt/java/openjdk-14 \
+    PATH=$PATH:$JAVA_HOME/bin \
+    JAVA14_HOME=/opt/java/openjdk-14 \
+    JAVA8_HOME=/opt/java/openjdk-8 \
+    JAVA11_HOME=/opt/java/openjdk-11 \
+    JAVA17_HOME=/opt/java/openjdk-17
+
+# Sets user to opensearch as gradle check requires non-root user
+USER opensearch
+
+# Sets working directory with write permission to clone OpenSearch
+WORKDIR /usr/share/opensearch


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Created ubuntu dockerfile and pull it to run the gradle check in OpenSearch jenkinsfile. 
Tested docker image locally and gradle check was successful. 
<img width="2242" alt="Screen Shot 2022-03-21 at 11 41 02 PM" src="https://user-images.githubusercontent.com/16099877/159534582-5364f98b-7745-4e44-a428-1d9de0c38868.png">
 
### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/2507

### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
