### PR TITLE
Data Prepper release fixes

### DIFF
--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
             label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
             image 'opensearchstaging/ci-runner:ci-runner-centos7-v1'
             alwaysPull true
+            args '-u root'
         }
     }
     parameters {

--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                 script {
                     signatureType = '.sig'
                     signArtifacts(
-                            artifactPath: 'archive',
+                            artifactPath: "${WORKSPACE}/archive",
                             sigtype: signatureType,
                             platform: 'linux'
                     )
@@ -55,7 +55,7 @@ pipeline {
                 script {
                     signatureType = '.sig'
                     signArtifacts(
-                            artifactPath: 'maven',
+                            artifactPath: "${WORKSPACE}/maven",
                             sigtype: signatureType,
                             platform: 'linux'
                     )

--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -1,6 +1,9 @@
 lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
 
 pipeline {
+    options {
+        timeout(time: 1, unit: 'HOURS')
+    }
     agent {
         docker {
             label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'

--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -94,9 +94,6 @@ pipeline {
             }
         }
         stage('Upload Artifacts to Sonatype') {
-            tools {
-                maven "maven-3.8.2"
-            }
             environment {
                 REPO_URL = "https://aws.oss.sonatype.org/"
                 STAGING_PROFILE_ID = "${SONATYPE_STAGING_PROFILE_ID}"

--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     agent {
         docker {
             label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
-            image 'opensearchstaging/ci-runner:ci-runner-centos7-v1'
+            image 'opensearchstaging/ci-runner:ci-runner-ubuntu2004-data-prepper-pipeline-v1'
             alwaysPull true
             args '-u root'
         }

--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -106,7 +106,7 @@ pipeline {
     post() {
         always {
             script {
-                sh "rm -rf $WORKSPACE/*"
+                sh("rm -rf $WORKSPACE/*")
                 postCleanup()
             }
         }

--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -106,6 +106,7 @@ pipeline {
     post() {
         always {
             script {
+                sh "rm -rf $WORKSPACE/*"
                 postCleanup()
             }
         }

--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -84,6 +84,12 @@ pipeline {
                         destinationType: 'docker',
                         destinationCredentialIdentifier: 'jenkins-staging-docker-prod-token'
                     )
+                    copyContainer(
+                        sourceImagePath: "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}/data-prepper:${VERSION}-${DATA_PREPPER_BUILD_NUMBER}",
+                        destinationImagePath: "opensearchproject/data-prepper:latest",
+                        destinationType: 'docker',
+                        destinationCredentialIdentifier: 'jenkins-staging-docker-prod-token'
+                    )
                 }
             }
         }

--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -57,10 +57,9 @@ pipeline {
         stage('Sign Maven Artifacts') {
             steps {
                 script {
-                    signatureType = '.sig'
                     signArtifacts(
                             artifactPath: "${WORKSPACE}/maven",
-                            sigtype: signatureType,
+                            type: 'maven',
                             platform: 'linux'
                     )
                 }

--- a/tests/jenkins/TestDataPrepperReleaseArtifacts.groovy
+++ b/tests/jenkins/TestDataPrepperReleaseArtifacts.groovy
@@ -25,7 +25,7 @@ class TestDataPrepperReleaseArtifacts extends BuildPipelineTest {
 
         String sourceImageRepository = 'http://public.ecr.aws/data-prepper-container-repository'
 
-        this.registerLibTester(new SignArtifactsLibTester( '.sig', 'linux',  'archive', null, null))
+        this.registerLibTester(new SignArtifactsLibTester( '.sig', 'linux', "${workspace}/archive", null, null))
 
         this.registerLibTester(new CopyContainerLibTester("${sourceImageRepository}/data-prepper:${version}-997908",
                 "opensearchproject/data-prepper:${version}",

--- a/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
@@ -58,7 +58,7 @@
         )
          release-data-prepper-all-artifacts.stage(Sign Maven Artifacts, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
-               release-data-prepper-all-artifacts.signArtifacts({artifactPath=/tmp/workspace/maven, sigtype=.sig, platform=linux})
+               release-data-prepper-all-artifacts.signArtifacts({artifactPath=/tmp/workspace/maven, type=maven, platform=linux})
                   signArtifacts.fileExists(/tmp/workspace/sign.sh)
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
@@ -72,7 +72,7 @@
             export UNSIGNED_BUCKET=signer_client_unsigned_bucket
             export SIGNED_BUCKET=signer_client_signed_bucket
 
-            /tmp/workspace/sign.sh /tmp/workspace/maven --sigtype=.sig --platform=linux
+            /tmp/workspace/sign.sh /tmp/workspace/maven --type=maven --platform=linux
         )
          release-data-prepper-all-artifacts.stage(Release Archives to Production Distribution Bucket, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
@@ -2,6 +2,7 @@
       release-data-prepper-all-artifacts.legacySCM(groovy.lang.Closure)
       release-data-prepper-all-artifacts.library({identifier=jenkins@20211123, retriever=null})
       release-data-prepper-all-artifacts.pipeline(groovy.lang.Closure)
+         release-data-prepper-all-artifacts.timeout({time=1, unit=HOURS})
          release-data-prepper-all-artifacts.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-ubuntu2004-data-prepper-pipeline-v1, reuseNode:false, stages:[:], args:-u root, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
          release-data-prepper-all-artifacts.stage(Download Archives, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
@@ -88,11 +89,21 @@
                 docker login -u DOCKER_USERNAME -p DOCKER_PASSWORD
                 gcrane cp http://public.ecr.aws/data-prepper-container-repository/data-prepper:0.22.1-997908 opensearchproject/data-prepper:0.22.1
             )
+               release-data-prepper-all-artifacts.copyContainer({sourceImagePath=http://public.ecr.aws/data-prepper-container-repository/data-prepper:0.22.1-997908, destinationImagePath=opensearchproject/data-prepper:latest, destinationType=docker, destinationCredentialIdentifier=jenkins-staging-docker-prod-token})
+                  copyContainer.sh({script=test -f /usr/local/bin/gcrane && echo '1' || echo '0' , returnStdout=true})
+                  copyContainer.sh(docker logout)
+                  copyContainer.usernamePassword({credentialsId=jenkins-staging-docker-prod-token, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                  copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                     copyContainer.sh(
+                docker login -u DOCKER_USERNAME -p DOCKER_PASSWORD
+                gcrane cp http://public.ecr.aws/data-prepper-container-repository/data-prepper:0.22.1-997908 opensearchproject/data-prepper:latest
+            )
          release-data-prepper-all-artifacts.stage(Upload Artifacts to Sonatype, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
                release-data-prepper-all-artifacts.usernamePassword({credentialsId=Sonatype, usernameVariable=SONATYPE_USERNAME, passwordVariable=SONATYPE_PASSWORD})
                release-data-prepper-all-artifacts.withCredentials([[SONATYPE_USERNAME, SONATYPE_PASSWORD]], groovy.lang.Closure)
                   release-data-prepper-all-artifacts.sh($WORKSPACE/publish/stage-maven-release.sh $WORKSPACE/maven)
          release-data-prepper-all-artifacts.script(groovy.lang.Closure)
+            release-data-prepper-all-artifacts.sh(rm -rf /tmp/workspace/*)
             release-data-prepper-all-artifacts.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
@@ -2,7 +2,7 @@
       release-data-prepper-all-artifacts.legacySCM(groovy.lang.Closure)
       release-data-prepper-all-artifacts.library({identifier=jenkins@20211123, retriever=null})
       release-data-prepper-all-artifacts.pipeline(groovy.lang.Closure)
-         release-data-prepper-all-artifacts.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-centos7-v1, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
+         release-data-prepper-all-artifacts.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-ubuntu2004-data-prepper-pipeline-v1, reuseNode:false, stages:[:], args:-u root, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
          release-data-prepper-all-artifacts.stage(Download Archives, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
                release-data-prepper-all-artifacts.dir(archive, groovy.lang.Closure)
@@ -39,7 +39,7 @@
                   release-data-prepper-all-artifacts.sh(curl -sSL http://staging-artifacts.cloudfront.net/0.22.1/997908/maven/org/opensearch/dataprepper/data-prepper-api/0.22.1/data-prepper-api-0.22.1.module.sha512 -o org/opensearch/dataprepper/data-prepper-api/0.22.1/data-prepper-api-0.22.1.module.sha512)
          release-data-prepper-all-artifacts.stage(Sign Archives, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
-               release-data-prepper-all-artifacts.signArtifacts({artifactPath=archive, sigtype=.sig, platform=linux})
+               release-data-prepper-all-artifacts.signArtifacts({artifactPath=/tmp/workspace/archive, sigtype=.sig, platform=linux})
                   signArtifacts.fileExists(/tmp/workspace/sign.sh)
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
@@ -53,11 +53,11 @@
             export UNSIGNED_BUCKET=signer_client_unsigned_bucket
             export SIGNED_BUCKET=signer_client_signed_bucket
 
-            /tmp/workspace/sign.sh archive --sigtype=.sig --platform=linux
+            /tmp/workspace/sign.sh /tmp/workspace/archive --sigtype=.sig --platform=linux
         )
          release-data-prepper-all-artifacts.stage(Sign Maven Artifacts, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
-               release-data-prepper-all-artifacts.signArtifacts({artifactPath=maven, sigtype=.sig, platform=linux})
+               release-data-prepper-all-artifacts.signArtifacts({artifactPath=/tmp/workspace/maven, sigtype=.sig, platform=linux})
                   signArtifacts.fileExists(/tmp/workspace/sign.sh)
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
@@ -71,7 +71,7 @@
             export UNSIGNED_BUCKET=signer_client_unsigned_bucket
             export SIGNED_BUCKET=signer_client_signed_bucket
 
-            /tmp/workspace/sign.sh maven --sigtype=.sig --platform=linux
+            /tmp/workspace/sign.sh /tmp/workspace/maven --sigtype=.sig --platform=linux
         )
          release-data-prepper-all-artifacts.stage(Release Archives to Production Distribution Bucket, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)

--- a/tests/jenkins/lib-testers/SignArtifactsLibTester.groovy
+++ b/tests/jenkins/lib-testers/SignArtifactsLibTester.groovy
@@ -34,7 +34,7 @@ class SignArtifactsLibTester extends LibFunctionTester {
         assertThat(call.args.platform.first(), notNullValue())
         if(call.args.artifactPath.first().toString().endsWith(".yml")){
             assertThat(call.args.type.first(), notNullValue())
-        } else {
+        } else if(call.args.type.first() != 'maven'){
             assertThat(call.args.sigtype.first(), notNullValue())
         }
     }


### PR DESCRIPTION
### Description

Bug fixes to the Data Prepper release process. These worked to release Data Prepper 1.3.0.
 
### Issues Resolved

Resolves #1673 
Resolves #1751
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
