### PR TITLE
Readme update for opensearch-1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ The distribution workflow builds a complete OpenSearch and OpenSearch Dashboards
 #### Building from Source
 
 ```bash
-./build.sh manifests/1.2.0/opensearch-1.2.0.yml
+./build.sh manifests/1.3.0/opensearch-1.3.0.yml 
 ```
 
-This builds OpenSearch 1.2.0 from source, placing the output into `./builds/opensearch`. 
+This builds OpenSearch 1.3.0 from source, placing the output into `./builds/opensearch`. 
 
 See [build workflow](src/build_workflow) for more information.
 
@@ -124,7 +124,7 @@ At this moment there's no official MacOS distribution. However, this project doe
 The [checkout workflow](src/checkout_workflow) checks out source code for a given manifest for further examination.
 
 ```bash
-./checkout.sh manfiests/1.2.0/opensearch-1.2.0.yml
+./checkout.sh manfiests/1.3.0/opensearch-1.3.0.yml
 ```
 
 See [src/checkout_workflow](./src/checkout_workflow) for more information.
@@ -135,20 +135,20 @@ You can perform cross-platform builds. For example, build and assemble a Windows
 
 ```bash
 export JAVA_HOME=$(/usr/libexec/java_home) # required by OpenSearch install-plugin during assemble
-./build.sh manifests/1.2.0/opensearch-1.2.0.yml --snapshot --platform windows
+./build.sh manifests/1.3.0/opensearch-1.3.0.yml --snapshot --platform windows
 ./assemble.sh builds/opensearch/manifest.yml
 ```
 
-This will produce `dist/opensearch-1.2.0-SNAPSHOT-windows-x64.zip` on Linux and MacOS.
+This will produce `dist/opensearch-1.3.0-SNAPSHOT-windows-x64.zip` on Linux and MacOS.
 
 #### Sanity Checking the Bundle
 
 This workflow runs sanity checks on every component present in the bundle, executed as part of the [manifests workflow](.github/workflows/manifests.yml) in this repository. It ensures that the component GitHub repositories are correct and versions in those components match the OpenSearch version.
 
-The following example sanity-checks components in the the OpenSearch 1.2.0 manifest.
+The following example sanity-checks components in the the OpenSearch 1.3.0 manifest.
 
 ```bash
-./ci.sh manifests/1.2.0/opensearch-1.2.0.yml --snapshot
+./ci.sh manifests/1.3.0/opensearch-1.3.0.yml --snapshot
 ```
 
 See [src/ci_workflow](./src/ci_workflow) for more information.


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>
### Description
 This PR addresses #1810 where while following the build instructions from README for Opensearch-1.2.0 the job-scheduler build is failing due to missing `platform` parameters in the build.sh file for tag 1.2.0.0. More details are present in the issue raised. 

### Issues Resolved
#1810 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
