### PR TITLE
[Tests][Integ] Fix without-security logic if no security plugin

### DIFF
--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -33,8 +33,9 @@ class ServiceOpenSearch(Service):
         self.__download()
 
         self.opensearch_yml_dir = os.path.join(self.install_dir, "config", "opensearch.yml")
+        self.security_plugin_dir = os.path.join(self.install_dir, "plugins", "opensearch-security")
 
-        if not self.security_enabled:
+        if not self.security_enabled and os.path.isfile(self.security_plugin_dir):
             self.__add_plugin_specific_config({"plugins.security.disabled": "true"})
 
         if self.additional_config:

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -51,7 +51,9 @@ class ServiceOpenSearchDashboards(Service):
         self.additional_config["logging.dest"] = os.path.join(self.log_dir, "opensearch_dashboards.log")
 
     def __remove_security(self):
-        subprocess.check_call("./opensearch-dashboards-plugin remove securityDashboards", cwd=self.executable_dir, shell=True)
+        self.security_plugin_dir = os.path.join(self.install_dir, "plugins", "securityDashboards")
+        if os.path.isfile(self.security_plugin_dir):
+            subprocess.check_call("./opensearch-dashboards-plugin remove securityDashboards", cwd=self.executable_dir, shell=True)
 
         with open(self.opensearch_dashboards_yml_dir, "w") as yamlfile:
             yamlfile.close()

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
@@ -64,12 +64,13 @@ class ServiceOpenSearchTests(unittest.TestCase):
 
         self.assertEqual(mock_pid.call_count, 1)
 
+    @patch("os.path.isfile")
     @patch("test_workflow.integ_test.service.Process.start")
     @patch('test_workflow.integ_test.service.Process.pid', new_callable=PropertyMock, return_value=12345)
     @patch("builtins.open", new_callable=mock_open)
     @patch("yaml.dump")
     @patch("tarfile.open")
-    def test_start_security_disabled(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process):
+    def test_start_security_disabled(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_os_isfile):
 
         dependency_installer = MagicMock()
 
@@ -92,11 +93,13 @@ class ServiceOpenSearchTests(unittest.TestCase):
         mock_bundle_tar = MagicMock()
         mock_tarfile_open.return_value = mock_bundle_tar
 
-        mock_file_hanlder_for_security = mock_open().return_value
-        mock_file_hanlder_for_additional_config = mock_open().return_value
+        mock_file_handler_for_security = mock_open().return_value
+        mock_file_handler_for_additional_config = mock_open().return_value
 
         # open() will be called twice, one for disabling security, second for additional_config
-        mock_file.side_effect = [mock_file_hanlder_for_security, mock_file_hanlder_for_additional_config]
+        mock_file.side_effect = [mock_file_handler_for_security, mock_file_handler_for_additional_config]
+
+        mock_os_isfile.return_value = True
 
         # call test target function
         service.start()
@@ -107,8 +110,56 @@ class ServiceOpenSearchTests(unittest.TestCase):
             [call(os.path.join(self.work_dir, "opensearch-1.1.0", "config", "opensearch.yml"), "a")],
             [call(os.path.join(self.work_dir, "opensearch-1.1.0", "config", "opensearch.yml"), "a")],
         )
-        mock_file_hanlder_for_security.write.assert_called_once_with(mock_dump_result_for_security)
-        mock_file_hanlder_for_additional_config.write.assert_called_once_with(mock_dump_result_for_additional_config)
+        mock_file_handler_for_security.write.assert_called_once_with(mock_dump_result_for_security)
+        mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result_for_additional_config)
+
+    @patch("os.path.isfile")
+    @patch("test_workflow.integ_test.service.Process.start")
+    @patch('test_workflow.integ_test.service.Process.pid', new_callable=PropertyMock, return_value=12345)
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("yaml.dump")
+    @patch("tarfile.open")
+    def test_start_security_disabled_and_not_installed(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_os_isfile):
+
+        dependency_installer = MagicMock()
+
+        service = ServiceOpenSearch(
+            self.version,
+            self.additional_config,
+            False,
+            dependency_installer,
+            self.work_dir
+        )
+
+        bundle_full_name = "test_bundle_name"
+        dependency_installer.download_dist.return_value = bundle_full_name
+
+        mock_dump_result_for_additional_config = MagicMock()
+
+        mock_dump.side_effect = [mock_dump_result_for_additional_config]
+
+        mock_bundle_tar = MagicMock()
+        mock_tarfile_open.return_value = mock_bundle_tar
+
+        mock_file_handler_for_security = mock_open().return_value
+        mock_file_handler_for_additional_config = mock_open().return_value
+
+        # open() will be called twice, one for disabling security, second for additional_config
+        mock_file.side_effect = [mock_file_handler_for_additional_config]
+
+        mock_os_isfile.return_value = False
+
+        # call test target function
+        service.start()
+
+        mock_dump.assert_has_calls([call(self.additional_config)])
+
+        mock_file.assert_has_calls(
+            [call(os.path.join(self.work_dir, "opensearch-1.1.0", "config", "opensearch.yml"), "a")],
+            [call(os.path.join(self.work_dir, "opensearch-1.1.0", "config", "opensearch.yml"), "a")],
+        )
+        mock_file_handler_for_security.write.assert_not_called()
+        mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result_for_additional_config)
 
     @patch("test_workflow.integ_test.service.Process.terminate", return_value=123)
     @patch('test_workflow.integ_test.service.Process.started', new_callable=PropertyMock, return_value=True)

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -64,13 +64,14 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_process.assert_called_once_with("./opensearch-dashboards", os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "bin"))
         self.assertEqual(mock_pid.call_count, 1)
 
+    @patch("os.path.isfile")
     @patch("subprocess.check_call")
     @patch("test_workflow.integ_test.service.Process.start")
     @patch('test_workflow.integ_test.service.Process.pid', new_callable=PropertyMock, return_value=12345)
     @patch("builtins.open", new_callable=mock_open)
     @patch("yaml.dump")
     @patch("tarfile.open")
-    def test_start_without_security(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_check_call):
+    def test_start_without_security(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_check_call, mock_os_isfile):
 
         mock_dependency_installer = MagicMock()
 
@@ -88,14 +89,16 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_bundle_tar = MagicMock()
         mock_tarfile_open.return_value.__enter__.return_value = mock_bundle_tar
 
-        mock_file_hanlder_for_security = mock_open().return_value
-        mock_file_hanlder_for_additional_config = mock_open().return_value
+        mock_file_handler_for_security = mock_open().return_value
+        mock_file_handler_for_additional_config = mock_open().return_value
 
         # open() will be called twice, one for disabling security, second for additional_config
-        mock_file.side_effect = [mock_file_hanlder_for_security, mock_file_hanlder_for_additional_config]
+        mock_file.side_effect = [mock_file_handler_for_security, mock_file_handler_for_additional_config]
 
         mock_dump_result = MagicMock()
         mock_dump.return_value = mock_dump_result
+
+        mock_os_isfile.return_value = True
 
         # call the target test function
         service.start()
@@ -114,8 +117,60 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_dump.assert_called_once_with({"logging.dest": os.path.join(
             self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log")})
 
-        mock_file_hanlder_for_security.close.assert_called_once()
-        mock_file_hanlder_for_additional_config.write.assert_called_once_with(mock_dump_result)
+        mock_file_handler_for_security.close.assert_called_once()
+        mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result)
+
+    @patch("os.path.isfile")
+    @patch("subprocess.check_call")
+    @patch("test_workflow.integ_test.service.Process.start")
+    @patch('test_workflow.integ_test.service.Process.pid', new_callable=PropertyMock, return_value=12345)
+    @patch("builtins.open", new_callable=mock_open)
+    @patch("yaml.dump")
+    @patch("tarfile.open")
+    def test_start_without_security_and_not_installed(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_check_call, mock_os_isfile):
+
+        mock_dependency_installer = MagicMock()
+
+        service = ServiceOpenSearchDashboards(
+            self.version,
+            {},
+            False,
+            mock_dependency_installer,
+            self.work_dir
+        )
+
+        bundle_full_name = "test_bundle_name"
+        mock_dependency_installer.download_dist.return_value = bundle_full_name
+
+        mock_bundle_tar = MagicMock()
+        mock_tarfile_open.return_value.__enter__.return_value = mock_bundle_tar
+
+        mock_file_handler_for_security = mock_open().return_value
+        mock_file_handler_for_additional_config = mock_open().return_value
+
+        # open() will be called twice, one for disabling security, second for additional_config
+        mock_file.side_effect = [mock_file_handler_for_security, mock_file_handler_for_additional_config]
+
+        mock_dump_result = MagicMock()
+        mock_dump.return_value = mock_dump_result
+
+        mock_os_isfile.return_value = False
+
+        # call the target test function
+        service.start()
+
+        mock_check_call.assert_not_called()
+
+        mock_file.assert_has_calls(
+            [call(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "config", "opensearch_dashboards.yml"), "w")],
+            [call(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "config", "opensearch_dashboards.yml"), "a")],
+        )
+
+        mock_dump.assert_called_once_with({"logging.dest": os.path.join(
+            self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log")})
+
+        mock_file_handler_for_security.close.assert_called_once()
+        mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result)
 
     def test_endpoint_port_url(self):
         service = ServiceOpenSearchDashboards(


### PR DESCRIPTION
### Description
When the integ test workflow runs it needs to start a cluster for
OpenSearch tests, it needs to start a cluster and an
OpenSearch Dashboards for OpenSearch Dashboards tests.

During this workflow, even if we pass `without-security` to the
test manifest for `integ-test` config the workflow makes the
assumption that the security plugin is actually there and tries
to uninstall it or add configs to a plugin that isn't there. Which
fails to start a cluster or a cluster and OpenSearch Dashboards

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1814
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
