### PR TITLE
Add job-scheduler and common-utils to 1.4 manifest

### DIFF
--- a/manifests/1.4.0/opensearch-1.4.0.yml
+++ b/manifests/1.4.0/opensearch-1.4.0.yml
@@ -13,3 +13,15 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: 1.x
+    checks:
+      - gradle:publish
+      - gradle:properties:version
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: 1.x
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Adds job-scheduler and common-utils to 1.4 manifest. These are used by many other components and should unblock `1.x` CI/CD for those that are currently failing due to missing SNAPSHOT artifacts.
 
### Issues Resolved
None
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
