### PR TITLE
Remove alt postfix in rpm assemble

### DIFF
--- a/src/assemble_workflow/bundle_rpm.py
+++ b/src/assemble_workflow/bundle_rpm.py
@@ -99,7 +99,7 @@ class BundleRpm:
                 '-bb',
                 f"--define '_topdir {ext_dest}'",
                 f"--define '_version {build_cls.version}'",
-                f"--define '_architecture_alt {rpm_architecture(build_cls.architecture)}'",
+                f"--define '_architecture {rpm_architecture(build_cls.architecture)}'",
                 f"{self.filename}.rpm.spec",
             ]
         )

--- a/tests/tests_assemble_workflow/test_bundle_rpm.py
+++ b/tests/tests_assemble_workflow/test_bundle_rpm.py
@@ -52,5 +52,5 @@ class TestBundleRpm(unittest.TestCase):
 
         self.assertRaises(KeyError, lambda: os.environ['OPENSEARCH_PATH_CONF'])
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"rpmbuild -bb --define '_topdir {self.artifacts_path}' --define '_version 1.3.0' --define '_architecture_alt x86_64' opensearch.rpm.spec", args_list[0][0][0])
+        self.assertEqual(f"rpmbuild -bb --define '_topdir {self.artifacts_path}' --define '_version 1.3.0' --define '_architecture x86_64' opensearch.rpm.spec", args_list[0][0][0])
         self.assertEqual(shutil_move_mock.call_count, 3)


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove alt postfix in rpm assemble
 
### Issues Resolved
#1545
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
