### PR TITLE
[Tests] Run integ and BWC tests in parrallel

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -85,45 +85,50 @@ pipeline {
                             echo "buildManifestUrl (x64): ${buildManifestUrl}"
                             echo "artifactUrl (x64): ${artifactUrl}"
 
-                            Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                            echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                            if (!skipIntegTests) {
-                                def integTestResults =
-                                    build job: INTEG_TEST_JOB_NAME,
-                                    propagate: false,
-                                    wait: true,
-                                    parameters: [
-                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                        string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                    ]
+                            parallel([
+                                'integ-test': {
+                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    if (!skipIntegTests) {
+                                        def integTestResults =
+                                            build job: INTEG_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
 
-                                createTestResultsMessage(
-                                    testType: "Integ Tests (x64)",
-                                    status: integTestResults.getResult(),
-                                    absoluteUrl: integTestResults.getAbsoluteUrl()
-                                )
-                            }
+                                        createTestResultsMessage(
+                                            testType: "Integ Tests (x64)",
+                                            status: integTestResults.getResult(),
+                                            absoluteUrl: integTestResults.getAbsoluteUrl()
+                                        )
+                                    } 
+                                },
+                                'bwc-test': {
+                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    if (!skipBwcTests) {
+                                        def bwcTestResults =
+                                            build job: BWC_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
 
-                            Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                            echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                            if (!skipBwcTests) {
-                                def bwcTestResults =
-                                    build job: BWC_TEST_JOB_NAME,
-                                    propagate: false,
-                                    wait: true,
-                                    parameters: [
-                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                        string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                    ]
-
-                                createTestResultsMessage(
-                                    testType: "BWC Tests (x64)",
-                                    status: bwcTestResults.getResult(),
-                                    absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                )
-                            }
+                                        createTestResultsMessage(
+                                            testType: "BWC Tests (x64)",
+                                            status: bwcTestResults.getResult(),
+                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                }
+                            ])
                         }
                     }
                     post {
@@ -182,45 +187,50 @@ pipeline {
                                     echo "buildManifestUrl (arm64): ${buildManifestUrl}"
                                     echo "artifactUrl (arm64): ${artifactUrl}"
 
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults = 
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                            ]
+                                    parallel([
+                                        'integ-test': {
+                                            Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                            echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                            if (!skipIntegTests) {
+                                                def integTestResults = 
+                                                    build job: INTEG_TEST_JOB_NAME,
+                                                    propagate: false,
+                                                    wait: true,
+                                                    parameters: [
+                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                                    ]
 
-                                        createTestResultsMessage(
-                                            testType: "Integ Tests (arm64)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
-                                    }
+                                                createTestResultsMessage(
+                                                    testType: "Integ Tests (arm64)",
+                                                    status: integTestResults.getResult(),
+                                                    absoluteUrl: integTestResults.getAbsoluteUrl()
+                                                )
+                                            }
+                                        },
+                                        'bwc-test': {
+                                            Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                            echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                            if (!skipBwcTests) {
+                                                def bwcTestResults =
+                                                    build job: BWC_TEST_JOB_NAME,
+                                                    propagate: false,
+                                                    wait: true,
+                                                    parameters: [
+                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                                    ]
 
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                            ]
-
-                                        createTestResultsMessage(
-                                            testType: "BWC Tests (arm64)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
-                                    }
+                                                createTestResultsMessage(
+                                                    testType: "BWC Tests (arm64)",
+                                                    status: bwcTestResults.getResult(),
+                                                    absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                                )
+                                            }
+                                        }
+                                    ])
                                 }
                             }
                             post {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -145,45 +145,50 @@ pipeline {
                             echo "buildManifestUrl (x64): ${buildManifestUrl}"
                             echo "artifactUrl (x64): ${artifactUrl}"
 
-                            Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                            echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                            if (!skipIntegTests) {
-                                def integTestResults =
-                                    build job: INTEG_TEST_JOB_NAME,
-                                    propagate: false,
-                                    wait: true,
-                                    parameters: [
-                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                        string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                    ]
+                            parallel([
+                                'integ-test': {
+                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    if (!skipIntegTests) {
+                                        def integTestResults =
+                                            build job: INTEG_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
 
-                                createTestResultsMessage(
-                                    testType: "Integ Tests (x64)",
-                                    status: integTestResults.getResult(),
-                                    absoluteUrl: integTestResults.getAbsoluteUrl()
-                                )
-                            }
+                                        createTestResultsMessage(
+                                            testType: "Integ Tests (x64)",
+                                            status: integTestResults.getResult(),
+                                            absoluteUrl: integTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                },
+                                'bwc-test': {
+                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    if (!skipBwcTests) {
+                                        def bwcTestResults =
+                                            build job: BWC_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
 
-                            Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                            echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                            if (!skipBwcTests) {
-                                def bwcTestResults =
-                                    build job: BWC_TEST_JOB_NAME,
-                                    propagate: false,
-                                    wait: true,
-                                    parameters: [
-                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                        string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                    ]
-
-                                createTestResultsMessage(
-                                    testType: "BWC Tests (x64)",
-                                    status: bwcTestResults.getResult(),
-                                    absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                )
-                            }
+                                        createTestResultsMessage(
+                                            testType: "BWC Tests (x64)",
+                                            status: bwcTestResults.getResult(),
+                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                }
+                            ])
                         }
                     }
                     post {
@@ -213,45 +218,50 @@ pipeline {
                             echo "buildManifestUrl (arm64): ${buildManifestUrl}"
                             echo "artifactUrl (arm64): ${artifactUrl}"
 
-                            Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                            echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                            if (!skipIntegTests) {
-                                def integTestResults =
-                                    build job: INTEG_TEST_JOB_NAME,
-                                    propagate: false,
-                                    wait: true,
-                                    parameters: [
-                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                    ]
+                            parallel([
+                                'integ-test': {
+                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    if (!skipIntegTests) {
+                                        def integTestResults =
+                                            build job: INTEG_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                            ]
 
-                                createTestResultsMessage(
-                                    testType: "Integ Tests (arm64)",
-                                    status: integTestResults.getResult(),
-                                    absoluteUrl: integTestResults.getAbsoluteUrl()
-                                )
-                            }
+                                        createTestResultsMessage(
+                                            testType: "Integ Tests (arm64)",
+                                            status: integTestResults.getResult(),
+                                            absoluteUrl: integTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                },
+                                'bwc-test': {
+                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    if (!skipBwcTests) {
+                                        def bwcTestResults =
+                                            build job: BWC_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                            ]
 
-                            Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                            echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                            if (!skipBwcTests) {
-                                def bwcTestResults =
-                                    build job: BWC_TEST_JOB_NAME,
-                                    propagate: false,
-                                    wait: true,
-                                    parameters: [
-                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                    ]
-
-                                createTestResultsMessage(
-                                    testType: "BWC Tests (arm64)",
-                                    status: bwcTestResults.getResult(),
-                                    absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                )
-                            }
+                                        createTestResultsMessage(
+                                            testType: "BWC Tests (arm64)",
+                                            status: bwcTestResults.getResult(),
+                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                }
+                            ])
                         }
                     }
                     post {


### PR DESCRIPTION
### Description
Integ tests and BWC tests for distributions were actually scheduled
to run sequentially. To match the diagram of test workflow here:

https://github.com/opensearch-project/opensearch-build/blob/main/src/test_workflow/img/test_workflow.png

Add the parrallel for the two test jobs.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
