### PR TITLE
Remove other plugins to allow opensearch 2.0.0 snapshot clean push

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -15,36 +15,9 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
-#  - name: common-utils
-#    repository: https://github.com/opensearch-project/common-utils.git
-#    ref: main
-#    checks:
-#      - gradle:publish
-#      - gradle:properties:version
-#  - name: job-scheduler
-#    repository: https://github.com/opensearch-project/job-scheduler.git
-#    ref: main
-#    checks:
-#      - gradle:properties:version
-#      - gradle:dependencies:opensearch.version
-#  - name: k-NN
-#    repository: https://github.com/opensearch-project/k-NN.git
-#    ref: main
-#    platforms:
-#      - darwin
-#      - linux
-#    checks:
-#      - gradle:properties:version
-#      - gradle:dependencies:opensearch.version
-#  - name: anomaly-detection
-#    repository: https://github.com/opensearch-project/anomaly-detection.git
-#    ref: main
-#    checks:
-#      - gradle:properties:version
-#      - gradle:dependencies:opensearch.version
-#  - name: ml-commons
-#    repository: https://github.com/opensearch-project/ml-commons.git
-#    ref: main
-#    checks:
-#      - gradle:properties:version
-#      - gradle:dependencies:opensearch.version: opensearch-ml-plugin
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: main
+    checks:
+      - gradle:publish
+      - gradle:properties:version

--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -15,36 +15,36 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
-  - name: common-utils
-    repository: https://github.com/opensearch-project/common-utils.git
-    ref: main
-    checks:
-      - gradle:publish
-      - gradle:properties:version
-  - name: job-scheduler
-    repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: main
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
-  - name: k-NN
-    repository: https://github.com/opensearch-project/k-NN.git
-    ref: main
-    platforms:
-      - darwin
-      - linux
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
-  - name: anomaly-detection
-    repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: main
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
-  - name: ml-commons
-    repository: https://github.com/opensearch-project/ml-commons.git
-    ref: main
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: opensearch-ml-plugin
+#  - name: common-utils
+#    repository: https://github.com/opensearch-project/common-utils.git
+#    ref: main
+#    checks:
+#      - gradle:publish
+#      - gradle:properties:version
+#  - name: job-scheduler
+#    repository: https://github.com/opensearch-project/job-scheduler.git
+#    ref: main
+#    checks:
+#      - gradle:properties:version
+#      - gradle:dependencies:opensearch.version
+#  - name: k-NN
+#    repository: https://github.com/opensearch-project/k-NN.git
+#    ref: main
+#    platforms:
+#      - darwin
+#      - linux
+#    checks:
+#      - gradle:properties:version
+#      - gradle:dependencies:opensearch.version
+#  - name: anomaly-detection
+#    repository: https://github.com/opensearch-project/anomaly-detection.git
+#    ref: main
+#    checks:
+#      - gradle:properties:version
+#      - gradle:dependencies:opensearch.version
+#  - name: ml-commons
+#    repository: https://github.com/opensearch-project/ml-commons.git
+#    ref: main
+#    checks:
+#      - gradle:properties:version
+#      - gradle:dependencies:opensearch.version: opensearch-ml-plugin


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove other plugins to allow opensearch 2.0.0 snapshot clean push
 
### Issues Resolved
Part of #1624
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
