### PR TITLE
[BUILD][OSD] Support version qualifier

### DIFF
--- a/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
@@ -3,6 +3,7 @@ schema-version: '1.0'
 build:
   name: OpenSearch Dashboards
   version: 2.0.0
+  qualifier: alpha1
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build

--- a/scripts/components/ganttChartDashboards/build.sh
+++ b/scripts/components/ganttChartDashboards/build.sh
@@ -13,6 +13,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
@@ -20,7 +21,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:p:a:" arg; do
+while getopts ":h:v:q:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -28,6 +29,9 @@ while getopts ":h:v:s:o:p:a:" arg; do
             ;;
         v)
             VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
             ;;
         s)
             SNAPSHOT=$OPTARG
@@ -60,6 +64,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
+[ ! -z "$QUALIFIER" ] && QUALIFIER_IDENTIFIER="-$QUALIFIER"
 
 mkdir -p $OUTPUT/plugins
 # For hybrid plugin it actually resides in 'ganttChartDashboards/gantt-chart'
@@ -71,7 +76,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build)
+(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
-cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/
+cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER

--- a/scripts/components/notebooksDashboards/build.sh
+++ b/scripts/components/notebooksDashboards/build.sh
@@ -13,6 +13,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
@@ -20,7 +21,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:p:a:" arg; do
+while getopts ":h:v:q:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -28,6 +29,9 @@ while getopts ":h:v:s:o:p:a:" arg; do
             ;;
         v)
             VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
             ;;
         s)
             SNAPSHOT=$OPTARG
@@ -60,6 +64,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
+[ ! -z "$QUALIFIER" ] && QUALIFIER_IDENTIFIER="-$QUALIFIER"
 
 mkdir -p $OUTPUT/plugins
 # For hybrid plugin it actually resides in 'notebooksDashboards/dashboards-notebooks'
@@ -71,7 +76,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build)
+(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
-cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/
+cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER

--- a/scripts/components/notificationsDashboards/build.sh
+++ b/scripts/components/notificationsDashboards/build.sh
@@ -13,6 +13,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
@@ -20,7 +21,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:p:a:" arg; do
+while getopts ":h:v:q:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -28,6 +29,9 @@ while getopts ":h:v:s:o:p:a:" arg; do
             ;;
         v)
             VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
             ;;
         s)
             SNAPSHOT=$OPTARG
@@ -60,6 +64,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
+[ ! -z "$QUALIFIER" ] && QUALIFIER_IDENTIFIER="-$QUALIFIER"
 
 mkdir -p $OUTPUT/plugins
 # For hybrid plugin it actually resides in 'notificationsDashboards/dashboards-notifications'
@@ -71,7 +76,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build)
+(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
-cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/
+cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER

--- a/scripts/components/observabilityDashboards/build.sh
+++ b/scripts/components/observabilityDashboards/build.sh
@@ -13,6 +13,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
@@ -20,7 +21,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:p:a:" arg; do
+while getopts ":h:v:q:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -28,6 +29,9 @@ while getopts ":h:v:s:o:p:a:" arg; do
             ;;
         v)
             VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
             ;;
         s)
             SNAPSHOT=$OPTARG
@@ -60,6 +64,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
+[ ! -z "$QUALIFIER" ] && QUALIFIER_IDENTIFIER="-$QUALIFIER"
 
 mkdir -p $OUTPUT/plugins
 # For hybrid plugin it actually resides in 'observability/dashboards-observability'
@@ -71,7 +76,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build)
+(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
-cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/
+cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER

--- a/scripts/components/queryWorkbenchDashboards/build.sh
+++ b/scripts/components/queryWorkbenchDashboards/build.sh
@@ -13,6 +13,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
@@ -20,7 +21,7 @@ function usage() {
     echo -e "-h help"
 }
 
-while getopts ":h:v:s:o:p:a:" arg; do
+while getopts ":h:v:q:s:o:p:a:" arg; do
     case $arg in
         h)
             usage
@@ -28,6 +29,9 @@ while getopts ":h:v:s:o:p:a:" arg; do
             ;;
         v)
             VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
             ;;
         s)
             SNAPSHOT=$OPTARG
@@ -60,6 +64,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
+[ ! -z "$QUALIFIER" ] && QUALIFIER_IDENTIFIER="-$QUALIFIER"
 
 mkdir -p $OUTPUT/plugins
 # For hybrid plugin it actually resides in 'queryWorkbenchDashboards/workbench'
@@ -71,7 +76,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build)
+(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
-cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/
+cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -13,6 +13,7 @@ function usage() {
     echo ""
     echo "Arguments:"
     echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
     echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
     echo -e "-p PLATFORM\t[Optional] Platform, ignored."
     echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
@@ -63,6 +64,7 @@ if [ -z "$VERSION" ]; then
 fi
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
+[ ! -z "$QUALIFIER" ] && QUALIFIER_IDENTIFIER="-$QUALIFIER"
 
 mkdir -p $OUTPUT/plugins
 PLUGIN_NAME=$(basename "$PWD")
@@ -72,7 +74,7 @@ cp -r ../$PLUGIN_NAME/ ../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../OpenSearch-Dashboards && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME && yarn plugin-helpers build)
+(cd ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
-cp -r ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME/build/$PLUGIN_NAME-$VERSION.zip $OUTPUT/plugins/
+cp -r ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -55,7 +55,7 @@ class BuildTarget:
         )
 
     @property
-    def compatible_core_versions(self) -> List[str]:
+    def compatible_min_versions(self) -> List[str]:
         return (
             [BuildTarget.__qualify_version(self.version, self.qualifier, self.snapshot)]
             + self.patches

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -81,7 +81,7 @@ class BuildTarget:
 
     @property
     def compatible_opensearch_dashboards_component_versions(self) -> List[str]:
-        versions = self.compatible_component_versions 
+        versions = self.compatible_component_versions
         versions.extend([self.version + ".0"] if self.version + ".0" not in self.compatible_component_versions else [])
         return versions
 

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -55,7 +55,7 @@ class BuildTarget:
         )
 
     @property
-    def compatible_opensearch_versions(self) -> List[str]:
+    def compatible_core_versions(self) -> List[str]:
         return (
             [BuildTarget.__qualify_version(self.version, self.qualifier, self.snapshot)]
             + self.patches
@@ -78,6 +78,10 @@ class BuildTarget:
             + list(map(lambda version: BuildTarget.__qualify_version(version + ".0", self.qualifier, False), self.patches))
             + list(map(lambda version: BuildTarget.__qualify_version(version + ".0", self.qualifier, True), self.patches))
         )
+
+    @property
+    def compatible_opensearch_dashboards_component_versions(self) -> List[str]:
+        return list(set([self.version + ".0"] + self.compatible_component_versions))
 
     @property
     def compatible_versions(self) -> List[str]:

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -80,12 +80,6 @@ class BuildTarget:
         )
 
     @property
-    def compatible_opensearch_dashboards_component_versions(self) -> List[str]:
-        versions = self.compatible_component_versions
-        versions.extend([self.version + ".0"] if self.version + ".0" not in self.compatible_component_versions else [])
-        return versions
-
-    @property
     def compatible_versions(self) -> List[str]:
         versions = [self.version]
         versions.extend(self.patches)

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -81,7 +81,9 @@ class BuildTarget:
 
     @property
     def compatible_opensearch_dashboards_component_versions(self) -> List[str]:
-        return list(set([self.version + ".0"] + self.compatible_component_versions))
+        versions = self.compatible_component_versions 
+        versions.extend([self.version + ".0"] if self.version + ".0" not in self.compatible_component_versions else [])
+        return versions
 
     @property
     def compatible_versions(self) -> List[str]:

--- a/src/build_workflow/opensearch/build_artifact_check_maven.py
+++ b/src/build_workflow/opensearch/build_artifact_check_maven.py
@@ -37,7 +37,7 @@ class BuildArtifactOpenSearchCheckMaven(BuildArtifactCheck):
                 try:
                     versions: List[Any] = [None]
                     versions.extend(self.target.compatible_component_versions)
-                    versions.extend(self.target.compatible_core_versions)
+                    versions.extend(self.target.compatible_min_versions)
                     properties.check_value_in("Implementation-Version", versions)
                 except PropertiesFile.CheckError as e:
                     raise BuildArtifactCheck.BuildArtifactInvalidError(path, str(e))

--- a/src/build_workflow/opensearch/build_artifact_check_maven.py
+++ b/src/build_workflow/opensearch/build_artifact_check_maven.py
@@ -37,7 +37,7 @@ class BuildArtifactOpenSearchCheckMaven(BuildArtifactCheck):
                 try:
                     versions: List[Any] = [None]
                     versions.extend(self.target.compatible_component_versions)
-                    versions.extend(self.target.compatible_opensearch_versions)
+                    versions.extend(self.target.compatible_core_versions)
                     properties.check_value_in("Implementation-Version", versions)
                 except PropertiesFile.CheckError as e:
                     raise BuildArtifactCheck.BuildArtifactInvalidError(path, str(e))

--- a/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
+++ b/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
@@ -33,10 +33,10 @@ class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
             config = ConfigFile(data)
             try:
                 config.check_value_in("version", self.target.compatible_opensearch_dashboards_component_versions)
-                config.check_value_in("opensearchDashboardsVersion", self.target.compatible_core_versions)
+                config.check_value_in("opensearchDashboardsVersion", self.target.compatible_min_versions)
             except ConfigFile.CheckError as e:
                 raise BuildArtifactCheck.BuildArtifactInvalidError(path, e.__str__())
             logging.info(f'Checked {path} ({config.get_value("version", "N/A")})')
 
     def __valid_paths(self, pluginName: str) -> List[str]:
-        return list(map(lambda version: f"{pluginName}-{version}.zip", self.target.compatible_core_versions))
+        return list(map(lambda version: f"{pluginName}-{version}.zip", self.target.compatible_min_versions))

--- a/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
+++ b/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
@@ -19,7 +19,7 @@ class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
         if os.path.splitext(path)[1] != ".zip":
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Not a zip file.")
 
-        match = re.search(r"^(\w+)-[\d\.]*.*.zip$", os.path.basename(path))
+        match = re.search(r"^(\w+)-[\d\.]*.*(-*)?.zip$", os.path.basename(path))
         if not match:
             raise BuildArtifactCheck.BuildArtifactInvalidError(path, "Expected filename to be in the format of pluginName-1.1.0.zip.")
 
@@ -32,11 +32,11 @@ class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
             data = zip.read(f"opensearch-dashboards/{plugin_name}/opensearch_dashboards.json").decode("UTF-8")
             config = ConfigFile(data)
             try:
-                config.check_value_in("version", self.target.compatible_component_versions)
-                config.check_value_in("opensearchDashboardsVersion", self.target.compatible_versions)
+                config.check_value_in("version", self.target.compatible_opensearch_dashboards_component_versions)
+                config.check_value_in("opensearchDashboardsVersion", self.target.compatible_core_versions)
             except ConfigFile.CheckError as e:
                 raise BuildArtifactCheck.BuildArtifactInvalidError(path, e.__str__())
             logging.info(f'Checked {path} ({config.get_value("version", "N/A")})')
 
     def __valid_paths(self, pluginName: str) -> List[str]:
-        return list(map(lambda version: f"{pluginName}-{version}.zip", self.target.compatible_versions))
+        return list(map(lambda version: f"{pluginName}-{version}.zip", self.target.compatible_core_versions))

--- a/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
+++ b/src/build_workflow/opensearch_dashboards/build_artifact_check_plugin.py
@@ -32,7 +32,7 @@ class BuildArtifactOpenSearchDashboardsCheckPlugin(BuildArtifactCheck):
             data = zip.read(f"opensearch-dashboards/{plugin_name}/opensearch_dashboards.json").decode("UTF-8")
             config = ConfigFile(data)
             try:
-                config.check_value_in("version", self.target.compatible_opensearch_dashboards_component_versions)
+                config.check_value_in("version", self.target.compatible_component_versions)
                 config.check_value_in("opensearchDashboardsVersion", self.target.compatible_min_versions)
             except ConfigFile.CheckError as e:
                 raise BuildArtifactCheck.BuildArtifactInvalidError(path, e.__str__())

--- a/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
+++ b/tests/tests_build_workflow/opensearch_dashboards/test_build_artifact_opensearch_dashboards_check_plugin.py
@@ -63,7 +63,7 @@ class TestBuildArtifactOpenSearchDashboardsCheckPlugin(unittest.TestCase):
             with self.__mock(snapshot=False) as mock:
                 mock.check("pluginName-1.2.3.zip")
         self.assertEqual(
-            "Artifact pluginName-1.2.3.zip is invalid. Expected filename to to be one of ['pluginName-1.1.0.zip', 'pluginName-1.0.0.zip'].",
+            "Artifact pluginName-1.2.3.zip is invalid. Expected filename to to be one of ['pluginName-1.1.0.zip', 'pluginName-1.0.0.zip', 'pluginName-1.0.0-SNAPSHOT.zip'].",
             str(context.exception),
         )
 

--- a/tests/tests_build_workflow/test_build_target.py
+++ b/tests/tests_build_workflow/test_build_target.py
@@ -94,22 +94,10 @@ class TestBuildTarget(unittest.TestCase):
             ['1.1.2.0', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
         )
 
-    def test_compatible_opensearch_dashboards_component_versions(self) -> None:
-        self.assertCountEqual(
-            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_opensearch_dashboards_component_versions,
-            ['1.1.2.0', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
-        )
-
     def test_compatible_component_versions_qualifier(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False, qualifier="alpha1").compatible_component_versions,
             ['1.1.2.0-alpha1', '1.1.0.0-alpha1', '1.1.1.0-alpha1', '1.1.0.0-alpha1-SNAPSHOT', '1.1.1.0-alpha1-SNAPSHOT'],
-        )
-
-    def test_compatible_opensearch_dashboards_component_versions_qualifier(self) -> None:
-        self.assertCountEqual(
-            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False, qualifier="alpha1").compatible_opensearch_dashboards_component_versions,
-            ['1.1.2.0', '1.1.2.0-alpha1', '1.1.0.0-alpha1', '1.1.1.0-alpha1', '1.1.0.0-alpha1-SNAPSHOT', '1.1.1.0-alpha1-SNAPSHOT'],
         )
 
     def test_compatible_component_versions_snapshot(self) -> None:

--- a/tests/tests_build_workflow/test_build_target.py
+++ b/tests/tests_build_workflow/test_build_target.py
@@ -52,27 +52,27 @@ class TestBuildTarget(unittest.TestCase):
             "1.1.0-alpha1-SNAPSHOT",
         )
 
-    def test_compatible_opensearch_versions(self) -> None:
+    def test_compatible_core_versions(self) -> None:
         self.assertEqual(
-            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_opensearch_versions,
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_core_versions,
             ['1.1.2', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
-    def test_compatible_opensearch_versions_qualifier(self) -> None:
+    def test_compatible_core_versions_qualifier(self) -> None:
         self.assertEqual(
-            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False, qualifier="alpha1").compatible_opensearch_versions,
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False, qualifier="alpha1").compatible_core_versions,
             ['1.1.2-alpha1', '1.1.0', '1.1.1', '1.1.0-alpha1-SNAPSHOT', '1.1.1-alpha1-SNAPSHOT'],
         )
 
-    def test_compatible_opensearch_versions_snapshot(self) -> None:
+    def test_compatible_core_versions_snapshot(self) -> None:
         self.assertEqual(
-            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_opensearch_versions,
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_core_versions,
             ['1.1.2-SNAPSHOT', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
-    def test_compatible_opensearch_versions_snapshot_qualifier(self) -> None:
+    def test_compatible_core_versions_snapshot_qualifier(self) -> None:
         self.assertEqual(
-            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True, qualifier="alpha1").compatible_opensearch_versions,
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True, qualifier="alpha1").compatible_core_versions,
             ['1.1.2-alpha1-SNAPSHOT', '1.1.0', '1.1.1', '1.1.0-alpha1-SNAPSHOT', '1.1.1-alpha1-SNAPSHOT'],
         )
 
@@ -94,10 +94,22 @@ class TestBuildTarget(unittest.TestCase):
             ['1.1.2.0', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
         )
 
+    def test_compatible_opensearch_dashboards_component_versions(self) -> None:
+        self.assertCountEqual(
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_opensearch_dashboards_component_versions,
+            ['1.1.2.0', '1.1.0.0', '1.1.1.0', '1.1.0.0-SNAPSHOT', '1.1.1.0-SNAPSHOT'],
+        )
+
     def test_compatible_component_versions_qualifier(self) -> None:
         self.assertEqual(
             BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False, qualifier="alpha1").compatible_component_versions,
             ['1.1.2.0-alpha1', '1.1.0.0-alpha1', '1.1.1.0-alpha1', '1.1.0.0-alpha1-SNAPSHOT', '1.1.1.0-alpha1-SNAPSHOT'],
+        )
+
+    def test_compatible_opensearch_dashboards_component_versions_qualifier(self) -> None:
+        self.assertCountEqual(
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False, qualifier="alpha1").compatible_opensearch_dashboards_component_versions,
+            ['1.1.2.0', '1.1.2.0-alpha1', '1.1.0.0-alpha1', '1.1.1.0-alpha1', '1.1.0.0-alpha1-SNAPSHOT', '1.1.1.0-alpha1-SNAPSHOT'],
         )
 
     def test_compatible_component_versions_snapshot(self) -> None:

--- a/tests/tests_build_workflow/test_build_target.py
+++ b/tests/tests_build_workflow/test_build_target.py
@@ -52,27 +52,27 @@ class TestBuildTarget(unittest.TestCase):
             "1.1.0-alpha1-SNAPSHOT",
         )
 
-    def test_compatible_core_versions(self) -> None:
+    def test_compatible_min_versions(self) -> None:
         self.assertEqual(
-            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_core_versions,
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False).compatible_min_versions,
             ['1.1.2', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
-    def test_compatible_core_versions_qualifier(self) -> None:
+    def test_compatible_min_versions_qualifier(self) -> None:
         self.assertEqual(
-            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False, qualifier="alpha1").compatible_core_versions,
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=False, qualifier="alpha1").compatible_min_versions,
             ['1.1.2-alpha1', '1.1.0', '1.1.1', '1.1.0-alpha1-SNAPSHOT', '1.1.1-alpha1-SNAPSHOT'],
         )
 
-    def test_compatible_core_versions_snapshot(self) -> None:
+    def test_compatible_min_versions_snapshot(self) -> None:
         self.assertEqual(
-            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_core_versions,
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True).compatible_min_versions,
             ['1.1.2-SNAPSHOT', '1.1.0', '1.1.1', '1.1.0-SNAPSHOT', '1.1.1-SNAPSHOT'],
         )
 
-    def test_compatible_core_versions_snapshot_qualifier(self) -> None:
+    def test_compatible_min_versions_snapshot_qualifier(self) -> None:
         self.assertEqual(
-            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True, qualifier="alpha1").compatible_core_versions,
+            BuildTarget(version="1.1.2", architecture="x86", patches=["1.1.0", "1.1.1"], snapshot=True, qualifier="alpha1").compatible_min_versions,
             ['1.1.2-alpha1-SNAPSHOT', '1.1.0', '1.1.1', '1.1.0-alpha1-SNAPSHOT', '1.1.1-alpha1-SNAPSHOT'],
         )
 


### PR DESCRIPTION
### Description
Support version qualifier builds for OpenSearch Dashboards and
OpenSearch Dashboards Plugins.

This will create a zip for plugins with the OpenSearch Dashboards
version + qualifier. But the version of the plugin will remain the
same whilst opensearchDashboardsVersion in the opensearch_dashboards.json
will be the OpenSearch Dashboards version, eg, 1.3.0-alpha1. This is why
the version check needed to be modified a little to ensure that it can
get the version + qualifier and the default version of the plugin.

Updated for plugins as well.

Was able to successfully build and connect OSD 1.3.0-alpha1 to
the release version of OS 1.3.0.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1340

### Issue partially resolved:
https://github.com/opensearch-project/opensearch-build/issues/1632
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
