### PR TITLE
Extend the timeout for WhiteSource offline scan.

### DIFF
--- a/jenkins/vulnerability-scan/whitesource-scan.jenkinsfile
+++ b/jenkins/vulnerability-scan/whitesource-scan.jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent none
     options {
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 5, unit: 'HOURS')
     }
     triggers {
         cron('H 3 * * *')


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Currently our offline WhiteSource scan hits the timeout limit at 3 hours because of the dependency issues with SQL plugin. Temporarily extend the timeout to 5 hours to unblock the scan on the rest of repos. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
