### PR TITLE
Change isfile to isdir for security config

### DIFF
--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -35,7 +35,7 @@ class ServiceOpenSearch(Service):
         self.opensearch_yml_dir = os.path.join(self.install_dir, "config", "opensearch.yml")
         self.security_plugin_dir = os.path.join(self.install_dir, "plugins", "opensearch-security")
 
-        if not self.security_enabled and os.path.isfile(self.security_plugin_dir):
+        if not self.security_enabled and os.path.isdir(self.security_plugin_dir):
             self.__add_plugin_specific_config({"plugins.security.disabled": "true"})
 
         if self.additional_config:

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -52,7 +52,7 @@ class ServiceOpenSearchDashboards(Service):
 
     def __remove_security(self):
         self.security_plugin_dir = os.path.join(self.install_dir, "plugins", "securityDashboards")
-        if os.path.isfile(self.security_plugin_dir):
+        if os.path.isdir(self.security_plugin_dir):
             subprocess.check_call("./opensearch-dashboards-plugin remove securityDashboards", cwd=self.executable_dir, shell=True)
 
         with open(self.opensearch_dashboards_yml_dir, "w") as yamlfile:

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
@@ -64,13 +64,13 @@ class ServiceOpenSearchTests(unittest.TestCase):
 
         self.assertEqual(mock_pid.call_count, 1)
 
-    @patch("os.path.isfile")
+    @patch("os.path.isdir")
     @patch("test_workflow.integ_test.service.Process.start")
     @patch('test_workflow.integ_test.service.Process.pid', new_callable=PropertyMock, return_value=12345)
     @patch("builtins.open", new_callable=mock_open)
     @patch("yaml.dump")
     @patch("tarfile.open")
-    def test_start_security_disabled(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_os_isfile):
+    def test_start_security_disabled(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_os_isdir):
 
         dependency_installer = MagicMock()
 
@@ -99,7 +99,7 @@ class ServiceOpenSearchTests(unittest.TestCase):
         # open() will be called twice, one for disabling security, second for additional_config
         mock_file.side_effect = [mock_file_handler_for_security, mock_file_handler_for_additional_config]
 
-        mock_os_isfile.return_value = True
+        mock_os_isdir.return_value = True
 
         # call test target function
         service.start()
@@ -113,13 +113,13 @@ class ServiceOpenSearchTests(unittest.TestCase):
         mock_file_handler_for_security.write.assert_called_once_with(mock_dump_result_for_security)
         mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result_for_additional_config)
 
-    @patch("os.path.isfile")
+    @patch("os.path.isdir")
     @patch("test_workflow.integ_test.service.Process.start")
     @patch('test_workflow.integ_test.service.Process.pid', new_callable=PropertyMock, return_value=12345)
     @patch("builtins.open", new_callable=mock_open)
     @patch("yaml.dump")
     @patch("tarfile.open")
-    def test_start_security_disabled_and_not_installed(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_os_isfile):
+    def test_start_security_disabled_and_not_installed(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_os_isdir):
 
         dependency_installer = MagicMock()
 
@@ -147,7 +147,7 @@ class ServiceOpenSearchTests(unittest.TestCase):
         # open() will be called twice, one for disabling security, second for additional_config
         mock_file.side_effect = [mock_file_handler_for_additional_config]
 
-        mock_os_isfile.return_value = False
+        mock_os_isdir.return_value = False
 
         # call test target function
         service.start()

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -154,12 +154,12 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_dump_result = MagicMock()
         mock_dump.return_value = mock_dump_result
 
-        mock_os_isdir.return_value = False
+        mock_os_isdir.return_value = True
 
         # call the target test function
         service.start()
 
-        mock_check_call.assert_not_called()
+        mock_check_call.assert_called()
 
         mock_file.assert_has_calls(
             [call(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "config", "opensearch_dashboards.yml"), "w")],

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -64,14 +64,14 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_process.assert_called_once_with("./opensearch-dashboards", os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "bin"))
         self.assertEqual(mock_pid.call_count, 1)
 
-    @patch("os.path.isfile")
+    @patch("os.path.isdir")
     @patch("subprocess.check_call")
     @patch("test_workflow.integ_test.service.Process.start")
     @patch('test_workflow.integ_test.service.Process.pid', new_callable=PropertyMock, return_value=12345)
     @patch("builtins.open", new_callable=mock_open)
     @patch("yaml.dump")
     @patch("tarfile.open")
-    def test_start_without_security(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_check_call, mock_os_isfile):
+    def test_start_without_security(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_check_call, mock_os_isdir):
 
         mock_dependency_installer = MagicMock()
 
@@ -98,7 +98,7 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_dump_result = MagicMock()
         mock_dump.return_value = mock_dump_result
 
-        mock_os_isfile.return_value = True
+        mock_os_isdir.return_value = True
 
         # call the target test function
         service.start()
@@ -120,14 +120,14 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_file_handler_for_security.close.assert_called_once()
         mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result)
 
-    @patch("os.path.isfile")
+    @patch("os.path.isdir")
     @patch("subprocess.check_call")
     @patch("test_workflow.integ_test.service.Process.start")
     @patch('test_workflow.integ_test.service.Process.pid', new_callable=PropertyMock, return_value=12345)
     @patch("builtins.open", new_callable=mock_open)
     @patch("yaml.dump")
     @patch("tarfile.open")
-    def test_start_without_security_and_not_installed(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_check_call, mock_os_isfile):
+    def test_start_without_security_and_not_installed(self, mock_tarfile_open, mock_dump, mock_file, mock_pid, mock_process, mock_check_call, mock_os_isdir):
 
         mock_dependency_installer = MagicMock()
 
@@ -154,7 +154,7 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_dump_result = MagicMock()
         mock_dump.return_value = mock_dump_result
 
-        mock_os_isfile.return_value = False
+        mock_os_isdir.return_value = False
 
         # call the target test function
         service.start()


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Cluster was not coming up as security disable config was not getting implemented while running integ-test. This PR fixes the bug
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
