### PR TITLE
Change consumers of knn zip to expect libs in lib directory

### DIFF
--- a/docker/release/dockerfiles/opensearch.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2.dockerfile
@@ -75,7 +75,7 @@ ENV JAVA_HOME=$OPENSEARCH_HOME/jdk
 ENV PATH=$PATH:$JAVA_HOME/bin:$OPENSEARCH_HOME/bin
 
 # Add k-NN lib directory to library loading path variable
-ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENSEARCH_HOME/plugins/opensearch-knn/knnlib"
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENSEARCH_HOME/plugins/opensearch-knn/lib"
 
 # Change user
 USER $UID

--- a/scripts/legacy/tar/linux/opensearch-tar-install.sh
+++ b/scripts/legacy/tar/linux/opensearch-tar-install.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 OPENSEARCH_HOME=`dirname $(realpath $0)`; cd $OPENSEARCH_HOME
-KNN_LIB_DIR=$OPENSEARCH_HOME/plugins/opensearch-knn/knnlib
+KNN_LIB_DIR=$OPENSEARCH_HOME/plugins/opensearch-knn/lib
 ##Security Plugin
 bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s
 


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Updates all consumers of k-NN zip to expect the libs in the lib directory as opposed to knnlib. 

Question:  Is [this file](https://github.com/opensearch-project/opensearch-build/blob/main/scripts/legacy/tar/linux/opensearch-tar-build.sh) still in use? I did not update it because for k-NN we have a separate build script. 

Also, this PR is tied to this PR: https://github.com/opensearch-project/k-NN/pull/345. They need to be merged around the same time or else build will break.
 
### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/314
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
