### PR TITLE
Update ci docker image in input manifest workflow

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -114,7 +114,7 @@ class InputManifests(Manifests):
             },
             "ci": {
                 "image": {
-                    "name": "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028"
+                    "name": "opensearchstaging/ci-runner:ci-runner-centos7-v1"
                 }
             },
             "components": [],

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -24,7 +24,7 @@ class TestInputManifests(unittest.TestCase):
             {
                 "schema-version": "1.0",
                 "build": {"name": "test", "version": "1.2.3"},
-                "ci": {"image": {"name": "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028"}},
+                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-v1"}},
             },
         )
 


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
We saw that automated creation of input manifest was still using old ci images. This PR updates the image to most recent one
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/pull/1868
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
