### PR TITLE
Stop building 1.4.0

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -10,8 +10,6 @@ pipeline {
             H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.3.1/opensearch-dashboards-1.3.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H/10 * * * * %INPUT_MANIFEST=1.2.5/opensearch-1.2.5.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=1.4.0/opensearch-1.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=1.4.0/opensearch-dashboards-1.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H/10 * * * * %INPUT_MANIFEST=2.0.0/opensearch-2.0.0.yml;TEST_MANIFEST=2.0.0/opensearch-2.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=2.0.0/opensearch-dashboards-2.0.0.yml;TEST_MANIFEST=2.0.0/opensearch-dashboards-2.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H 1 * * * %INPUT_MANIFEST=1.2.1/opensearch-1.2.1.yml;TEST_MANIFEST=1.2.1/opensearch-1.2.1-test.yml;TARGET_JOB_NAME=distribution-build-opensearch


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Looking at https://github.com/opensearch-project/opensearch-build/issues/1749 we are not going ahead with 1.4.0, hence removing opensearch and dashboards from check build
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
