### PR TITLE
Add job scheduler and common-utils to 1.3.2 manifest

### DIFF
--- a/manifests/1.3.2/opensearch-1.3.2.yml
+++ b/manifests/1.3.2/opensearch-1.3.2.yml
@@ -13,3 +13,15 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: '1.3'
+    checks:
+      - gradle:publish
+      - gradle:properties:version
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: '1.3'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Add job scheduler and common-utils to 1.3.2 manifest. Waiting on https://github.com/opensearch-project/common-utils/pull/148 to be merged before this PR can be merged
 
### Issues Resolved
Post release #1805 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
