### PR TITLE
Added remaining 2.0 plugins.

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -10,8 +10,8 @@ build:
   qualifier: alpha1
 components:
   - name: OpenSearch
-    ref: '2.0'
     repository: https://github.com/opensearch-project/OpenSearch.git
+    ref: '2.0'
     checks:
       - gradle:publish
       - gradle:properties:version
@@ -33,6 +33,24 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: main
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting
+  - name: asynchronous-search
+    repository: https://github.com/opensearch-project/asynchronous-search.git
+    ref: main
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: index-management
+    repository: https://github.com/opensearch-project/index-management.git
+    ref: main
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
     ref: main
@@ -42,21 +60,47 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
-  - name: alerting
-    repository: https://github.com/opensearch-project/alerting.git
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: main
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: main
     checks:
       - gradle:properties:version
-      - gradle:dependencies:opensearch.version: alerting
+      - gradle:dependencies:opensearch.version
+    platforms:
+      - darwin
+      - linux
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
     ref: main
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
-  - name: asynchronous-search
-    repository: https://github.com/opensearch-project/asynchronous-search.git
+  - name: cross-cluster-replication
+    repository: https://github.com/opensearch-project/cross-cluster-replication.git
     ref: main
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: sql
+    repository: https://github.com/opensearch-project/sql.git
+    ref: main
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: plugin
+  - name: dashboards-reports
+    repository: https://github.com/opensearch-project/dashboards-reports.git
+    ref: main
+    working_directory: reports-scheduler
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: opensearch-observability
+    repository: https://github.com/opensearch-project/observability
+    ref: main
+    working_directory: opensearch-observability
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

This is what's left to be added to OpenSearch 2.0 manifest.

### In progress but blocking:

- [ ] https://github.com/opensearch-project/security/pull/1698
- [ ] https://github.com/opensearch-project/performance-analyzer/pull/175
- [ ] https://github.com/opensearch-project/dashboards-reports/pull/325
- [ ] https://github.com/opensearch-project/sql/issues/528

### Not started?

- [ ] https://github.com/opensearch-project/cross-cluster-replication/issues?q=is%3Aissue+is%3Aopen+label%3Av2.0.0

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
