### PR TITLE
Add AD Dashboards to 1.3.1 manifest

### DIFF
--- a/manifests/1.3.1/opensearch-dashboards-1.3.1.yml
+++ b/manifests/1.3.1/opensearch-dashboards-1.3.1.yml
@@ -16,3 +16,6 @@ components:
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
     ref: '1.3'
+  - name: anomalyDetectionDashboards
+    repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
+    ref: '1.3'


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Add AD Dashboards to 1.3.1 manifest.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
