### PR TITLE
Fixed buildFailureMessage.groovy

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -240,7 +240,7 @@ and outputs [Hello_Jenkinsfile.txt](tests/jenkins/jobs/Hello_Jenkinsfile.txt). I
 
 - To update the recorded .txt file run `./gradlew test -info -Ppipeline.stack.write=true` or update its value in [gradle.properties](gradle.properties).
 
-- To run a specific test case, run `./gradlew test -info -tests=TestCaseClassName`
+- To run a specific test case, run `./gradlew test -info --tests=TestCaseClassName`
 
 #### Tests for jenkins job
 Each jenkins job should have a test case associated with it. 

--- a/vars/buildFailureMessage.groovy
+++ b/vars/buildFailureMessage.groovy
@@ -2,18 +2,22 @@ import com.cloudbees.groovy.cps.NonCPS
 import org.apache.commons.io.IOUtils
 @NonCPS
 def call(){
-    String ERROR_STRING = "ERROR"
+    String ERROR_STRING = "Error building"
     List<String> message = []
     Reader performance_log = currentBuild.getRawBuild().getLogReader()
     String logContent = IOUtils.toString(performance_log)
     performance_log.close()
     performance_log = null
     logContent.eachLine() { line ->
-        if (line.matches(".*?$ERROR_STRING(.*?)")) {
-            line=line.replace("\"", "")
+        line=line.replace("\"", "")
+        //Gets the exact match for Error building
+        def java.util.regex.Matcher match = (line =~ /$ERROR_STRING.*/) 
+        if (match.find()) {
+            line=match[0]
             message.add(line)
         }
     }
+    //if no match returns as Build failed
     if(message.isEmpty()){
         message=["Build failed"]
     }


### PR DESCRIPTION
Signed-off-by: pgodithi <pgodithi@amazon.com>

### Description
This change will eliminate the bug of adding all ERROR messages upon build failure

Added Exact match patter
Changed to Error Building from ERROR
Used java.util.regex.Matcher for match identifier
Removes build date timestamp from error parser
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1801
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
