### PR TITLE
[OSD][Build] nvm use

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -79,6 +79,12 @@ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 nvm install v14.18.2
 ```
 
+Add the lines below to the correct profile file (`~/.zshrc`, `~/.bashrc`, etc.).
+```
+export NVM_DIR="$([ -z "${XDG_CONFIG_HOME-}" ] && printf %s "${HOME}/.nvm" || printf %s "${XDG_CONFIG_HOME}/nvm")"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+```
+
 #### Yarn
 
 [Yarn](https://classic.yarnpkg.com/en/docs/install) is required for building and running the OpenSearch Dashboards and plugins

--- a/manifests/1.3.1/opensearch-dashboards-1.3.1.yml
+++ b/manifests/1.3.1/opensearch-dashboards-1.3.1.yml
@@ -6,7 +6,6 @@ build:
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v1
-    args: -e NODE_VERSION=10.24.1
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git

--- a/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
@@ -7,7 +7,6 @@ build:
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v1
-    args: -e NODE_VERSION=14.18.2
 components:
   - name: OpenSearch-Dashboards
     ref: main

--- a/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/scripts/components/OpenSearch-Dashboards/build.sh
@@ -5,6 +5,8 @@
 
 set -ex
 
+source $NVM_DIR/nvm.sh
+
 function usage() {
     echo "Usage: $0 [args]"
     echo ""

--- a/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/scripts/components/OpenSearch-Dashboards/build.sh
@@ -109,6 +109,9 @@ case $PLATFORM-$DISTRIBUTION-$ARCHITECTURE in
         ;;
 esac
 
+echo "Setting node version"
+nvm use
+
 echo "Building node modules for core with $PLATFORM-$DISTRIBUTION-$ARCHITECTURE"
 yarn osd bootstrap
 

--- a/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/scripts/components/OpenSearch-Dashboards/build.sh
@@ -5,8 +5,6 @@
 
 set -ex
 
-source $NVM_DIR/nvm.sh
-
 function usage() {
     echo "Usage: $0 [args]"
     echo ""
@@ -112,6 +110,7 @@ case $PLATFORM-$DISTRIBUTION-$ARCHITECTURE in
 esac
 
 echo "Setting node version"
+source $NVM_DIR/nvm.sh
 nvm use
 
 echo "Building node modules for core with $PLATFORM-$DISTRIBUTION-$ARCHITECTURE"

--- a/scripts/components/ganttChartDashboards/build.sh
+++ b/scripts/components/ganttChartDashboards/build.sh
@@ -74,7 +74,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/components/ganttChartDashboards/build.sh
+++ b/scripts/components/ganttChartDashboards/build.sh
@@ -76,7 +76,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && cd plugins/$PLUGIN_FOLDER && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
 cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER

--- a/scripts/components/ganttChartDashboards/build.sh
+++ b/scripts/components/ganttChartDashboards/build.sh
@@ -8,6 +8,8 @@
 
 set -ex
 
+source $NVM_DIR/nvm.sh
+
 function usage() {
     echo "Usage: $0 [args]"
     echo ""

--- a/scripts/components/ganttChartDashboards/build.sh
+++ b/scripts/components/ganttChartDashboards/build.sh
@@ -8,8 +8,6 @@
 
 set -ex
 
-source $NVM_DIR/nvm.sh
-
 function usage() {
     echo "Usage: $0 [args]"
     echo ""
@@ -76,7 +74,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/components/notebooksDashboards/build.sh
+++ b/scripts/components/notebooksDashboards/build.sh
@@ -74,7 +74,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/components/notebooksDashboards/build.sh
+++ b/scripts/components/notebooksDashboards/build.sh
@@ -76,7 +76,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && cd plugins/$PLUGIN_FOLDER && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
 cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER

--- a/scripts/components/notebooksDashboards/build.sh
+++ b/scripts/components/notebooksDashboards/build.sh
@@ -8,6 +8,8 @@
 
 set -ex
 
+source $NVM_DIR/nvm.sh
+
 function usage() {
     echo "Usage: $0 [args]"
     echo ""

--- a/scripts/components/notebooksDashboards/build.sh
+++ b/scripts/components/notebooksDashboards/build.sh
@@ -8,8 +8,6 @@
 
 set -ex
 
-source $NVM_DIR/nvm.sh
-
 function usage() {
     echo "Usage: $0 [args]"
     echo ""
@@ -76,7 +74,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/components/notificationsDashboards/build.sh
+++ b/scripts/components/notificationsDashboards/build.sh
@@ -8,8 +8,6 @@
 
 set -ex
 
-source $NVM_DIR/nvm.sh
-
 function usage() {
     echo "Usage: $0 [args]"
     echo ""
@@ -76,7 +74,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/components/notificationsDashboards/build.sh
+++ b/scripts/components/notificationsDashboards/build.sh
@@ -74,7 +74,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/components/notificationsDashboards/build.sh
+++ b/scripts/components/notificationsDashboards/build.sh
@@ -8,6 +8,8 @@
 
 set -ex
 
+source $NVM_DIR/nvm.sh
+
 function usage() {
     echo "Usage: $0 [args]"
     echo ""

--- a/scripts/components/notificationsDashboards/build.sh
+++ b/scripts/components/notificationsDashboards/build.sh
@@ -76,7 +76,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && cd plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
 cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER

--- a/scripts/components/observabilityDashboards/build.sh
+++ b/scripts/components/observabilityDashboards/build.sh
@@ -8,8 +8,6 @@
 
 set -ex
 
-source $NVM_DIR/nvm.sh
-
 function usage() {
     echo "Usage: $0 [args]"
     echo ""
@@ -76,7 +74,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/components/observabilityDashboards/build.sh
+++ b/scripts/components/observabilityDashboards/build.sh
@@ -74,7 +74,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/components/observabilityDashboards/build.sh
+++ b/scripts/components/observabilityDashboards/build.sh
@@ -8,6 +8,8 @@
 
 set -ex
 
+source $NVM_DIR/nvm.sh
+
 function usage() {
     echo "Usage: $0 [args]"
     echo ""

--- a/scripts/components/observabilityDashboards/build.sh
+++ b/scripts/components/observabilityDashboards/build.sh
@@ -76,7 +76,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && cd plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
 cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER

--- a/scripts/components/queryWorkbenchDashboards/build.sh
+++ b/scripts/components/queryWorkbenchDashboards/build.sh
@@ -8,8 +8,6 @@
 
 set -ex
 
-source $NVM_DIR/nvm.sh
-
 function usage() {
     echo "Usage: $0 [args]"
     echo ""
@@ -76,7 +74,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/components/queryWorkbenchDashboards/build.sh
+++ b/scripts/components/queryWorkbenchDashboards/build.sh
@@ -74,7 +74,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/components/queryWorkbenchDashboards/build.sh
+++ b/scripts/components/queryWorkbenchDashboards/build.sh
@@ -8,6 +8,8 @@
 
 set -ex
 
+source $NVM_DIR/nvm.sh
+
 function usage() {
     echo "Usage: $0 [args]"
     echo ""

--- a/scripts/components/queryWorkbenchDashboards/build.sh
+++ b/scripts/components/queryWorkbenchDashboards/build.sh
@@ -76,7 +76,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && cd plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
 cp -r ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER

--- a/scripts/components/reportsDashboards/build.sh
+++ b/scripts/components/reportsDashboards/build.sh
@@ -102,7 +102,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 ZIP_NAME=`ls ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build | grep .zip`

--- a/scripts/components/reportsDashboards/build.sh
+++ b/scripts/components/reportsDashboards/build.sh
@@ -8,6 +8,8 @@
 
 set -ex
 
+source $NVM_DIR/nvm.sh
+
 function usage() {
     echo "Usage: $0 [args]"
     echo ""

--- a/scripts/components/reportsDashboards/build.sh
+++ b/scripts/components/reportsDashboards/build.sh
@@ -104,7 +104,7 @@ cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && cd plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 ZIP_NAME=`ls ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build | grep .zip`
 unzip ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/$ZIP_NAME -d ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build/
 # Reporting uses headless chromium to generate reports, which needs to be included in its artifact

--- a/scripts/components/reportsDashboards/build.sh
+++ b/scripts/components/reportsDashboards/build.sh
@@ -8,8 +8,6 @@
 
 set -ex
 
-source $NVM_DIR/nvm.sh
-
 function usage() {
     echo "Usage: $0 [args]"
     echo ""
@@ -104,7 +102,7 @@ PLUGIN_NAME=$(basename $(dirname "$PWD"))
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_FOLDER/ ../../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER && yarn plugin_helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 ZIP_NAME=`ls ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER/build | grep .zip`

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -74,7 +74,7 @@ cp -r ../$PLUGIN_NAME/ ../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 (cd ../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
-(cd ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
+(cd ../../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && cd plugins/$PLUGIN_NAME && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"
 cp -r ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME/build/$PLUGIN_NAME-$VERSION$QUALIFIER_IDENTIFIER.zip $OUTPUT/plugins/
 rm -rf ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -72,7 +72,7 @@ PLUGIN_NAME=$(basename "$PWD")
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_NAME/ ../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../OpenSearch-Dashboards && yarn osd bootstrap)
+(cd ../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -8,6 +8,8 @@
 
 set -ex
 
+source $NVM_DIR/nvm.sh
+
 function usage() {
     echo "Usage: $0 [args]"
     echo ""

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -8,8 +8,6 @@
 
 set -ex
 
-source $NVM_DIR/nvm.sh
-
 function usage() {
     echo "Usage: $0 [args]"
     echo ""
@@ -74,7 +72,7 @@ PLUGIN_NAME=$(basename "$PWD")
 # This makes it so there is a dependency on having Dashboards pulled already.
 cp -r ../$PLUGIN_NAME/ ../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
-(cd ../OpenSearch-Dashboards && nvm use && yarn osd bootstrap)
+(cd ../OpenSearch-Dashboards && source $NVM_DIR/nvm.sh && nvm use && yarn osd bootstrap)
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 (cd ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME && yarn plugin-helpers build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER)
 echo "COPY $PLUGIN_NAME.zip"


### PR DESCRIPTION
### Description
Within OSD we have a .nvmrc file that is used when `nvm use`
is executing. So we can use the right node version for the
build.

Issue:
n/a

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
