### PR TITLE
Support for Plugin Performance tests

### DIFF
--- a/src/run_perf_test.py
+++ b/src/run_perf_test.py
@@ -5,26 +5,11 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-
-import argparse
-import os
 import sys
 
-import yaml
-from retry.api import retry_call
-
-from git.git_repository import GitRepository
 from manifests.bundle_manifest import BundleManifest
-from system.temporary_directory import TemporaryDirectory
-from system.working_directory import WorkingDirectory
-from test_workflow.perf_test.perf_test_cluster import PerfTestCluster
-from test_workflow.perf_test.perf_test_suite import PerfTestSuite
-
-
-def get_infra_repo_url():
-    if "GITHUB_TOKEN" in os.environ:
-        return "https://${GITHUB_TOKEN}@github.com/opensearch-project/opensearch-infra.git"
-    return "https://github.com/opensearch-project/opensearch-infra.git"
+from test_workflow.perf_test.perf_args import PerfArgs
+from test_workflow.perf_test.perf_test_runners import PerfTestRunners
 
 
 def main():
@@ -32,41 +17,9 @@ def main():
         Entry point for Performance Test with bundle manifest, config file containing the required arguments for running
         rally test and the stack name for the cluster. Will call out in test.sh with perf as argument
     """
-    parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
-    parser.add_argument("--bundle-manifest", type=argparse.FileType("r"), help="Bundle Manifest file.", required=True)
-    parser.add_argument("--stack", dest="stack", help="Stack name for performance test")
-    parser.add_argument("--config", type=argparse.FileType("r"), help="Config file.", required=True)
-    parser.add_argument("--without-security", dest="insecure", action="store_true",
-                        help="Force the security of the cluster to be disabled.",
-                        default=False)
-    parser.add_argument("--keep", dest="keep", action="store_true", help="Do not delete the working temporary directory.")
-    parser.add_argument("--workload", default="nyc_taxis", help="Mensor (internal client) param - Workload name from OpenSeach Benchmark Workloads")
-    parser.add_argument("--workload-options", default="{}", help="Mensor (internal client) param - Json object with OpenSearch Benchmark arguments")
-    parser.add_argument("--warmup-iters", default=0, help="Mensor (internal client) param - Number of times to run a workload before collecting data")
-    parser.add_argument("--test-iters", default=1, help="Mensor (internal client) param - Number of times to run a workload")
-    args = parser.parse_args()
-
-    manifest = BundleManifest.from_file(args.bundle_manifest)
-    config = yaml.safe_load(args.config)
-
-    security = "security" in manifest.components and not args.insecure
-    tests_dir = os.path.join(os.getcwd(), "test-results", "perf-test", f"{'with' if security else 'without'}-security")
-    os.makedirs(tests_dir, exist_ok=True)
-
-    with TemporaryDirectory(keep=args.keep, chdir=True) as work_dir:
-        current_workspace = os.path.join(work_dir.name, "infra")
-        with GitRepository(get_infra_repo_url(), "main", current_workspace):
-            with WorkingDirectory(current_workspace):
-                with PerfTestCluster.create(
-                        manifest,
-                        config,
-                        args.stack,
-                        security,
-                        current_workspace) as (test_cluster_endpoint, test_cluster_port):
-                    perf_test_suite = PerfTestSuite(manifest, test_cluster_endpoint, security,
-                                                    current_workspace, tests_dir, args)
-                    retry_call(perf_test_suite.execute, tries=3, delay=60, backoff=2)
-
+    perf_args = PerfArgs()
+    manifest = BundleManifest.from_file(perf_args.bundle_manifest)
+    PerfTestRunners.from_args(perf_args, manifest).run()
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/test_workflow/perf_test/perf_args.py
+++ b/src/test_workflow/perf_test/perf_args.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+
+import argparse
+
+
+# Contains the arguments required to run a perf test.
+class PerfArgs:
+    def __init__(self):
+        parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle")
+        parser.add_argument("--bundle-manifest", type=argparse.FileType("r"), help="Bundle Manifest file.", required=True)
+        parser.add_argument("--stack", dest="stack", help="Stack name for performance test")
+        parser.add_argument("--component", dest="component", default="OpenSearch", help="Component name that needs to be performance tested")
+        parser.add_argument("--config", type=argparse.FileType("r"), help="Config file.", required=True)
+        parser.add_argument("--without-security", dest="insecure", action="store_true",
+            help="Force the security of the cluster to be disabled.", default=False)
+        parser.add_argument("--keep", dest="keep", action="store_true", help="Do not delete the working temporary directory.")
+        parser.add_argument("--workload", default="nyc_taxis", help="Mensor (internal client) param - Workload name from OpenSeach Benchmark Workloads")
+        parser.add_argument("--workload-options", default="{}", help="Mensor (internal client) param - Json object with OpenSearch Benchmark arguments")
+        parser.add_argument("--warmup-iters", default=0, help="Mensor (internal client) param - Number of times to run a workload before collecting data")
+        parser.add_argument("--test-iters", default=1, help="Mensor (internal client) param - Number of times to run a workload")
+        args = parser.parse_args()
+        self.bundle_manifest = args.bundle_manifest
+        self.stack = args.stack
+        self.config = args.config
+        self.keep = args.keep
+        self.workload = args.workload
+        self.workload_options = args.workload_options
+        self.warmup_iters = args.warmup_iters
+        self.test_iters = args.test_iters
+        self.component = args.component
+        self.insecure = args.insecure

--- a/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/src/test_workflow/perf_test/perf_test_cluster.py
@@ -2,6 +2,11 @@ import json
 import logging
 import os
 import subprocess
+import time
+from contextlib import contextmanager
+
+import requests
+from requests.auth import HTTPBasicAuth
 
 from test_workflow.test_cluster import TestCluster
 
@@ -13,14 +18,14 @@ class PerfTestCluster(TestCluster):
 
     def __init__(self, bundle_manifest, config, stack_name, security, current_workspace):
         self.manifest = bundle_manifest
-        self.work_dir = os.path.join("opensearch-cluster", "cdk", "single-node")
+        self.work_dir = os.path.join(current_workspace, "opensearch-cluster", "cdk", "single-node")
         self.current_workspace = current_workspace
         self.stack_name = stack_name
         self.cluster_endpoint = None
         self.cluster_port = None
         self.output_file = "output.json"
-        self.ip_address = None
-        self.security = "enable" if security else "disable"
+        self.private_ip = None
+        self.security = security
         role = config["Constants"]["Role"]
         params_dict = {
             "url": self.manifest.build.location,
@@ -29,9 +34,10 @@ class PerfTestCluster(TestCluster):
             "account_id": config["Constants"]["AccountId"],
             "region": config["Constants"]["Region"],
             "stack_name": self.stack_name,
-            "security": self.security,
+            "security": "enable" if self.security else "disable",
             "platform": self.manifest.build.platform,
             "architecture": self.manifest.build.architecture,
+            "public_ip": config["Constants"].get("PublicIp", "disable")
         }
         params_list = []
         for key, value in params_dict.items():
@@ -41,6 +47,8 @@ class PerfTestCluster(TestCluster):
             f" -c assume-role-credentials:writeIamRoleName={role} -c assume-role-credentials:readIamRoleName={role} "
         )
         self.params = "".join(params_list) + role_params
+        self.cluster_endpoint = None
+        self.public_ip = None
 
     def start(self):
         os.chdir(self.work_dir)
@@ -49,15 +57,21 @@ class PerfTestCluster(TestCluster):
         subprocess.check_call(command, cwd=os.getcwd(), shell=True)
         with open(self.output_file, "r") as read_file:
             load_output = json.load(read_file)
-        self.ip_address = load_output[self.stack_name]["PrivateIp"]
-        logging.info(f"Private IP: {self.ip_address}")
+        self.private_ip = load_output[self.stack_name]["PrivateIp"]
+        logging.info(f"Private IP: {self.private_ip}")
+        self.public_ip = load_output[self.stack_name].get("PublicIp", None)
 
     def endpoint(self):
-        self.cluster_endpoint = self.ip_address
+        if self.cluster_endpoint is None:
+            scheme = "https://" if self.security else "http://"
+            # If instances are configured to have public ip, use that instead.
+            host = self.private_ip if self.public_ip is None else self.public_ip
+            if host is not None:
+                self.cluster_endpoint = "".join([scheme, host, ":", str(self.port())])
         return self.cluster_endpoint
 
     def port(self):
-        self.cluster_port = 443 if self.security == "enable" else 9200
+        self.cluster_port = 443 if self.security else 9200
         return self.cluster_port
 
     def terminate(self):
@@ -71,3 +85,34 @@ class PerfTestCluster(TestCluster):
 
     def dependencies(self):
         return []
+
+    def wait_for_processing(self, max_wait_sec = 60):
+        if self.public_ip is None:
+            return
+        url = "".join([self.endpoint(), "/_cluster/health"])
+        end_time = time.time() + max_wait_sec
+        while(True):
+            try:
+                r = requests.get(url=url, auth=HTTPBasicAuth('admin', 'admin'), verify=False)
+                return
+            except Exception as e:
+                if time.time() > end_time:
+                    raise e
+                else:
+                    logging.info("Waiting for cluster to be up...")
+                    time.sleep(15)
+
+    @classmethod
+    @contextmanager
+    def create(cls, *args):
+        """
+        Set up the cluster. When this method returns, the cluster must be available to take requests.
+        Throws ClusterCreationException if the cluster could not start for some reason. If this exception is thrown, the caller does not need to call "destroy".
+        """
+        cluster = cls(*args)
+
+        try:
+            cluster.start()
+            yield cluster
+        finally:
+            cluster.terminate()

--- a/src/test_workflow/perf_test/perf_test_runner.py
+++ b/src/test_workflow/perf_test/perf_test_runner.py
@@ -20,8 +20,8 @@ class PerfTestRunner(abc.ABC):
         self.test_manifest = test_manifest
 
         self.security = "security" in self.test_manifest.components and not self.args.insecure
-        tests_dir = os.path.join(os.getcwd(), "test-results", "perf-test", f"{'with' if security else 'without'}-security")
-        os.makedirs(tests_dir, exist_ok=True)
+        self.tests_dir = os.path.join(os.getcwd(), "test-results", "perf-test", f"{'with' if self.security else 'without'}-security")
+        os.makedirs(self.tests_dir, exist_ok=True)
 
     def run(self):
         self.run_tests()

--- a/src/test_workflow/perf_test/perf_test_runner.py
+++ b/src/test_workflow/perf_test/perf_test_runner.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import abc
+import logging
+import os
+
+from manifests.bundle_manifest import BundleManifest
+from test_workflow.perf_test.perf_args import PerfArgs
+from test_workflow.test_recorder.test_recorder import TestRecorder
+from test_workflow.test_result.test_suite_results import TestSuiteResults
+
+
+class PerfTestRunner(abc.ABC):
+    def __init__(self, args: PerfArgs, test_manifest: BundleManifest):
+        self.args = args
+        self.test_manifest = test_manifest
+
+        self.security = "security" in self.test_manifest.components and not self.args.insecure
+        tests_dir = os.path.join(os.getcwd(), "test-results", "perf-test", f"{'with' if security else 'without'}-security")
+        os.makedirs(tests_dir, exist_ok=True)
+
+    def run(self):
+        self.run_tests()

--- a/src/test_workflow/perf_test/perf_test_runner_opensearch.py
+++ b/src/test_workflow/perf_test/perf_test_runner_opensearch.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import logging
+import os
+
+import yaml
+from retry.api import retry_call
+
+from git.git_repository import GitRepository
+from manifests.bundle_manifest import BundleManifest
+from system.temporary_directory import TemporaryDirectory
+from system.working_directory import WorkingDirectory
+from test_workflow.perf_test.perf_args import PerfArgs
+from test_workflow.perf_test.perf_test_cluster import PerfTestCluster
+from test_workflow.perf_test.perf_test_runner import PerfTestRunner
+from test_workflow.perf_test.perf_test_suite import PerfTestSuite
+
+"""
+  Runner to execute the performance tests for opensearch.
+"""
+class PerfTestRunnerOpenSearch(PerfTestRunner):
+    def __init__(self, args: PerfArgs, test_manifest: BundleManifest):
+        super().__init__(args, test_manifest)
+        logging.info("Running opensearch tests")
+
+    def get_infra_repo_url(self):
+        if "GITHUB_TOKEN" in os.environ:
+            return "https://${GITHUB_TOKEN}@github.com/opensearch-project/opensearch-infra.git"
+        return "https://github.com/opensearch-project/opensearch-infra.git"
+
+    def run_tests(self):
+        config = yaml.safe_load(self.args.config)
+        with TemporaryDirectory(keep=self.args.keep, chdir=True) as work_dir:
+            current_workspace = os.path.join(work_dir.name, "infra")
+            logging.info("current_workspace is " + str(current_workspace))
+            with GitRepository(self.get_infra_repo_url(), "main", current_workspace):
+                with WorkingDirectory(current_workspace):
+                    with PerfTestCluster.create(self.test_manifest, config, self.args.stack, self.security, current_workspace, self.args.keep) as test_cluster:
+                        perf_test_suite = PerfTestSuite(self.test_manifest, test_cluster.endpoint(), self.security, current_workspace, tests_dir, self.args)
+                        retry_call(perf_test_suite.execute, tries=3, delay=60, backoff=2)

--- a/src/test_workflow/perf_test/perf_test_runner_opensearch.py
+++ b/src/test_workflow/perf_test/perf_test_runner_opensearch.py
@@ -40,5 +40,5 @@ class PerfTestRunnerOpenSearch(PerfTestRunner):
             with GitRepository(self.get_infra_repo_url(), "main", current_workspace):
                 with WorkingDirectory(current_workspace):
                     with PerfTestCluster.create(self.test_manifest, config, self.args.stack, self.security, current_workspace, self.args.keep) as test_cluster:
-                        perf_test_suite = PerfTestSuite(self.test_manifest, test_cluster.endpoint(), self.security, current_workspace, tests_dir, self.args)
+                        perf_test_suite = PerfTestSuite(self.test_manifest, test_cluster.endpoint(), self.security, current_workspace, self.tests_dir, self.args)
                         retry_call(perf_test_suite.execute, tries=3, delay=60, backoff=2)

--- a/src/test_workflow/perf_test/perf_test_runner_opensearch_plugins.py
+++ b/src/test_workflow/perf_test/perf_test_runner_opensearch_plugins.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import argparse
+import os
+import subprocess
+import sys
+
+import yaml
+
+from git.git_repository import GitRepository
+from manifests.bundle_manifest import BundleManifest
+from system.temporary_directory import TemporaryDirectory
+from system.working_directory import WorkingDirectory
+from test_workflow.perf_test.perf_args import PerfArgs
+from test_workflow.perf_test.perf_test_cluster import PerfTestCluster
+from test_workflow.perf_test.perf_test_runner import PerfTestRunner
+from test_workflow.perf_test.perf_test_suite import PerfTestSuite
+
+"""
+  Runner to execute the performance tests for opensearch plugins. The plugins need to define the test suite
+"""
+class PerfTestRunnerOpenSearchPlugins(PerfTestRunner):
+    def __init__(self, args: PerfArgs, test_manifest: BundleManifest):
+        super().__init__(args, test_manifest)
+        self.command = (
+            f"python3 run_perf_test.py --config {yaml.safe_load(self.args.config)} "
+            f"--bundle-manifest {str(self.args.bundle_manifest.name)}"
+        )
+
+    def get_plugin_repo_url(self):
+        if "GITHUB_TOKEN" in os.environ:
+            return f"https://${GITHUB_TOKEN}@github.com/opensearch-project/${self.args.component}.git"
+        return f"https://github.com/opensearch-project/${self.args.component}.git"
+
+    def run_tests(self):
+        with TemporaryDirectory(keep=self.args.keep, chdir=True) as work_dir:
+            current_workspace = os.path.join(work_dir.name, "plugin")
+            with GitRepository(self.get_plugin_repo_url(), "perf", current_workspace):
+                with WorkingDirectory(current_workspace):
+                    if self.security:
+                        subprocess.check_call(f"{self.command} -s", cwd=os.getcwd(), shell=True)
+                    else:
+                        subprocess.check_call(f"{self.command}", cwd=os.getcwd(), shell=True)

--- a/src/test_workflow/perf_test/perf_test_runner_opensearch_plugins.py
+++ b/src/test_workflow/perf_test/perf_test_runner_opensearch_plugins.py
@@ -33,13 +33,13 @@ class PerfTestRunnerOpenSearchPlugins(PerfTestRunner):
 
     def get_plugin_repo_url(self):
         if "GITHUB_TOKEN" in os.environ:
-            return f"https://${GITHUB_TOKEN}@github.com/opensearch-project/${self.args.component}.git"
-        return f"https://github.com/opensearch-project/${self.args.component}.git"
+            return f"https://${GITHUB_TOKEN}@github.com/opensearch-project/{self.args.component}.git"
+        return f"https://github.com/opensearch-project/{self.args.component}.git"
 
     def run_tests(self):
         with TemporaryDirectory(keep=self.args.keep, chdir=True) as work_dir:
             current_workspace = os.path.join(work_dir.name, "plugin")
-            with GitRepository(self.get_plugin_repo_url(), "perf", current_workspace):
+            with GitRepository(self.get_plugin_repo_url(), "main", current_workspace):
                 with WorkingDirectory(current_workspace):
                     if self.security:
                         subprocess.check_call(f"{self.command} -s", cwd=os.getcwd(), shell=True)

--- a/src/test_workflow/perf_test/perf_test_runners.py
+++ b/src/test_workflow/perf_test/perf_test_runners.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+from manifests.bundle_manifest import BundleManifest
+from test_workflow.perf_test.perf_args import PerfArgs
+from test_workflow.perf_test.perf_test_runner_opensearch import PerfTestRunnerOpenSearch
+from test_workflow.perf_test.perf_test_runner_opensearch_plugins import PerfTestRunnerOpenSearchPlugins
+
+
+class PerfTestRunners:
+    RUNNERS = {
+        "OpenSearch": PerfTestRunnerOpenSearch,
+        "OpenSearch Plugin": PerfTestRunnerOpenSearchPlugins
+    }
+
+    @classmethod
+    def from_args(cls, args: PerfArgs, test_manifest: BundleManifest):
+        return cls.RUNNERS.get(args.component, PerfTestRunnerOpenSearchPlugins)(args, test_manifest)

--- a/src/test_workflow/perf_test/perf_test_suite.py
+++ b/src/test_workflow/perf_test/perf_test_suite.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 
@@ -8,18 +9,26 @@ class PerfTestSuite:
     """
     Represents a performance test suite. This class runs rally test on the deployed cluster with the provided IP.
     """
-    def __init__(self, bundle_manifest, endpoint, security, current_workspace, test_results_path, args):
+    def __init__(self, bundle_manifest, endpoint, security, current_workspace, test_results_path, args,
+                owner="opensearch-devops", scenario="DEFAULT"):
         self.manifest = bundle_manifest
-        self.work_dir = "mensor/"
+        self.work_dir = current_workspace + "/mensor/"
         self.endpoint = endpoint
         self.security = security
         self.current_workspace = current_workspace
         self.args = args
+        endpoint_arg = ""
+        # Pass the cluster endpoints with -t for multi-cluster use cases(e.g. cross-cluster-replication)
+        if type(self.endpoint) is dict:
+            endpoint_arg = "-t '{}'".format(json.dumps(self.endpoint))
+        else:
+            endpoint_arg = "-e {}".format(self.endpoint)
         self.command = (
-            f"pipenv run python test_config.py -i {self.endpoint} -b {self.manifest.build.id}"
+            f"pipenv run python test_config.py {endpoint_arg} -b {self.manifest.build.id}"
             f" -a {self.manifest.build.architecture} -p {os.getcwd() if test_results_path is None else test_results_path}"
             f" --workload {self.args.workload} --workload-options '{self.args.workload_options}'"
             f" --warmup-iters {self.args.warmup_iters} --test-iters {self.args.test_iters}"
+            f" --scenario-type {scenario} --owner {owner}"
         )
 
     def execute(self):

--- a/tests/test_run_perf_test.py
+++ b/tests/test_run_perf_test.py
@@ -43,7 +43,7 @@ class TestRunPerfTest(unittest.TestCase):
 
     @patch("argparse._sys.argv", ["run_perf_test.py", "--bundle-manifest", OPENSEARCH_BUNDLE_MANIFEST,
                                   "--stack", "test-stack", "--config", PERF_TEST_CONFIG])
-    @patch("run_perf_test.PerfTestRunners.from_test_manifest")
+    @patch("run_perf_test.PerfTestRunners.from_args")
     def test_default_execute_perf_test(self, mock_runner, *mocks):
         main()
         self.assertEqual(1, mock_runner.call_count)

--- a/tests/test_run_perf_test.py
+++ b/tests/test_run_perf_test.py
@@ -43,50 +43,7 @@ class TestRunPerfTest(unittest.TestCase):
 
     @patch("argparse._sys.argv", ["run_perf_test.py", "--bundle-manifest", OPENSEARCH_BUNDLE_MANIFEST,
                                   "--stack", "test-stack", "--config", PERF_TEST_CONFIG])
-    @patch("run_perf_test.PerfTestCluster.create")
-    @patch("run_perf_test.PerfTestSuite")
-    @patch("run_perf_test.WorkingDirectory")
-    @patch("run_perf_test.TemporaryDirectory")
-    @patch("run_perf_test.GitRepository")
-    def test_default_execute_perf_test(self, mock_git, mock_temp, mock_working_dir, mock_suite, mock_cluster, *mocks):
-        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
-        mock_create = Mock()
-        mock_create.__enter__ = Mock(return_value=('test-endpoint', 1234))
-        mock_create.__exit__ = Mock(return_value=None)
-        mock_cluster.return_value = mock_create
-
-        mock_execute = Mock()
-        mock_suite.return_value.execute = mock_execute
-
+    @patch("run_perf_test.PerfTestRunners.from_test_manifest")
+    def test_default_execute_perf_test(self, mock_runner, *mocks):
         main()
-        self.assertEqual(1, mock_cluster.call_count)
-        self.assertEqual(1, mock_suite.call_count)
-        self.assertEqual(1, mock_git.call_count)
-        self.assertEqual(1, mock_execute.call_count)
-        self.assertEqual([], mock_execute.call_args)
-        self.assertIn(True, mock_suite.call_args[0])
-
-    @patch("argparse._sys.argv", ["run_perf_test.py", "--bundle-manifest", OPENSEARCH_BUNDLE_MANIFEST,
-                                  "--stack", "test-stack", "--config", PERF_TEST_CONFIG, "--without-security"])
-    @patch("run_perf_test.PerfTestCluster.create")
-    @patch("run_perf_test.PerfTestSuite")
-    @patch("run_perf_test.WorkingDirectory")
-    @patch("run_perf_test.TemporaryDirectory")
-    @patch("run_perf_test.GitRepository")
-    def test_with_security_execute_perf_test(self, mock_git, mock_temp, mock_working_dir, mock_suite, mock_cluster, *mocks):
-        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
-        mock_create = Mock()
-        mock_create.__enter__ = Mock(return_value=('test-endpoint', 1234))
-        mock_create.__exit__ = Mock(return_value=None)
-        mock_cluster.return_value = mock_create
-
-        mock_execute = Mock()
-        mock_suite.return_value.execute = mock_execute
-
-        main()
-        self.assertEqual(1, mock_cluster.call_count)
-        self.assertEqual(1, mock_suite.call_count)
-        self.assertEqual(1, mock_git.call_count)
-        self.assertEqual(1, mock_execute.call_count)
-        self.assertEqual([], mock_execute.call_args)
-        self.assertIn(False, mock_suite.call_args[0])
+        self.assertEqual(1, mock_runner.call_count)

--- a/tests/tests_manifests/test_manifest.py
+++ b/tests/tests_manifests/test_manifest.py
@@ -44,7 +44,7 @@ class TestManifest(unittest.TestCase):
         with self.assertRaises(TypeError) as context:
             Manifest(None)  # type: ignore[abstract]
         self.assertEqual(
-            "Can't instantiate abstract class Manifest with abstract methods __init__",
+            "Can't instantiate abstract class Manifest with abstract method __init__",
             context.exception.__str__(),
         )
 

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -32,7 +32,7 @@ class TestPerfTestCluster(unittest.TestCase):
                 with patch("builtins.open", MagicMock()):
                     with patch("json.load", mock_file):
                         self.perf_test_cluster.start()
-                        mock_chdir.assert_called_once_with(os.path.join("opensearch-cluster", "cdk", "single-node"))
+                        mock_chdir.assert_called_once_with(os.path.join(self.perf_test_cluster.current_workspace, "opensearch-cluster", "cdk", "single-node"))
                         self.assertEqual(mock_check_call.call_count, 1)
 
     def test_endpoint(self):
@@ -45,5 +45,5 @@ class TestPerfTestCluster(unittest.TestCase):
         with patch("test_workflow.perf_test.perf_test_cluster.os.chdir") as mock_chdir:
             with patch("subprocess.check_call") as mock_check_call:
                 self.perf_test_cluster.terminate()
-                mock_chdir.assert_called_once_with(os.path.join("current_workspace", "opensearch-cluster", "cdk", "single-node"))
+                mock_chdir.assert_called_once_with(os.path.join(self.perf_test_cluster.current_workspace, "current_workspace", "opensearch-cluster", "cdk", "single-node"))
                 self.assertEqual(mock_check_call.call_count, 1)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_runner_opensearch.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_runner_opensearch.py
@@ -45,13 +45,10 @@ class PerfTestRunnerOpenSearch(unittest.TestCase):
 
         perf_args = PerfArgs()
         test_manifest = BundleManifest.from_file(perf_args.bundle_manifest)
-        #runner = PerfTestRunnerOpenSearch(self, args=perf_args, test_manifest=test_manifest)
         runner = PerfTestRunners.from_args(perf_args, test_manifest)
         runner.run()
 
-        #mock_git.assert_called_with("https://github.com/opensearch-project/opensearch-infra.git", "main",
-        #    os.path.join(tempfile.gettempdir(), "infra"))
-        mock_git.assert_called_with("https://github.com/ankitkala/opensearch-infra.git", "endpoint",
+        mock_git.assert_called_with("https://github.com/opensearch-project/opensearch-infra.git", "main",
             os.path.join(tempfile.gettempdir(), "infra"))
         self.assertEqual(mock_suite.call_count, 1)
         self.assertEqual(mock_cluster.call_count, 1)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_runner_opensearch.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_runner_opensearch.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from manifests.bundle_manifest import BundleManifest
+from test_workflow.perf_test.perf_args import PerfArgs
+from test_workflow.perf_test.perf_test_runner_opensearch import PerfTestRunnerOpenSearch
+from test_workflow.perf_test.perf_test_runners import PerfTestRunners
+
+
+class PerfTestRunnerOpenSearch(unittest.TestCase):
+
+    @patch(
+            "argparse._sys.argv",
+            [
+                "run_perf_test.py",
+                "--bundle-manifest",
+                os.path.join(os.path.dirname(__file__), "data", "bundle_manifest.yml"),
+                "--config",
+                os.path.join(os.path.dirname(__file__), "data", "cluster_config.yml"),
+                "--workload",
+                "nyc_taxis",
+                "--workload-options",
+                "{\"workload-params\":\"number_of_shards:5,number_of_replicas:0,bulk_size:2500\"}",
+                "--warmup-iters",
+                "2",
+                "--test-iters",
+                "3"
+            ],
+        )
+    @patch("os.chdir")
+    @patch("test_workflow.perf_test.perf_test_runner_opensearch.TemporaryDirectory")
+    @patch("test_workflow.perf_test.perf_test_runner_opensearch.GitRepository")
+    @patch("test_workflow.perf_test.perf_test_runner_opensearch.PerfTestCluster.create")
+    @patch("test_workflow.perf_test.perf_test_runner_opensearch.PerfTestSuite")
+    def test_run(self, mock_suite, mock_cluster, mock_git, mock_temp_directory, *mocks):
+        mock_temp_directory.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        mock_cluster.return_value.__enter__.return_value = mock_cluster
+
+        perf_args = PerfArgs()
+        test_manifest = BundleManifest.from_file(perf_args.bundle_manifest)
+        #runner = PerfTestRunnerOpenSearch(self, args=perf_args, test_manifest=test_manifest)
+        runner = PerfTestRunners.from_args(perf_args, test_manifest)
+        runner.run()
+
+        #mock_git.assert_called_with("https://github.com/opensearch-project/opensearch-infra.git", "main",
+        #    os.path.join(tempfile.gettempdir(), "infra"))
+        mock_git.assert_called_with("https://github.com/ankitkala/opensearch-infra.git", "endpoint",
+            os.path.join(tempfile.gettempdir(), "infra"))
+        self.assertEqual(mock_suite.call_count, 1)
+        self.assertEqual(mock_cluster.call_count, 1)
+        self.assertEqual(mock_git.call_count, 1)
+        self.assertEqual(mock_temp_directory.call_count, 1)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_runner_opensearch_plugins.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_runner_opensearch_plugins.py
@@ -6,10 +6,12 @@
 
 import os
 import unittest
+import tempfile
 from unittest.mock import patch
 
+from manifests.bundle_manifest import BundleManifest
 from test_workflow.perf_test.perf_args import PerfArgs
-
+from test_workflow.perf_test.perf_test_runners import PerfTestRunners
 
 class PerfTestRunnerOpenSearchPlugins(unittest.TestCase):
 
@@ -35,11 +37,11 @@ class PerfTestRunnerOpenSearchPlugins(unittest.TestCase):
             ],
         )
     @patch("os.chdir")
+    @patch('test_workflow.perf_test.perf_test_runner_opensearch_plugins.subprocess')
     @patch("test_workflow.perf_test.perf_test_runner_opensearch_plugins.TemporaryDirectory")
     @patch("test_workflow.perf_test.perf_test_runner_opensearch_plugins.GitRepository")
     def test_run(self, mock_git, mock_temp_directory, *mocks):
         mock_temp_directory.return_value.__enter__.return_value.name = tempfile.gettempdir()
-        mock_cluster.return_value.__enter__.return_value = mock_cluster
 
         perf_args = PerfArgs()
         test_manifest = BundleManifest.from_file(perf_args.bundle_manifest)
@@ -48,8 +50,8 @@ class PerfTestRunnerOpenSearchPlugins(unittest.TestCase):
 
 
         mock_git.assert_called_with("https://github.com/opensearch-project/plugin-name.git", "main",
-            os.path.join(tempfile.gettempdir(), "infra"))
+            os.path.join(tempfile.gettempdir(), "plugin"))
 
         self.assertEqual(mock_git.call_count, 1)
-        self.assertEqual(mock_temp_directory.call_count, 1)
+        self.assertEqual(mock_temp_directory.call_count, 1)\
 

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_runner_opensearch_plugins.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_runner_opensearch_plugins.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import unittest
+from unittest.mock import patch
+
+from test_workflow.perf_test.perf_args import PerfArgs
+
+
+class PerfTestRunnerOpenSearchPlugins(unittest.TestCase):
+
+
+    @patch(
+            "argparse._sys.argv",
+            [
+                "run_perf_test.py",
+                "--bundle-manifest",
+                os.path.join(os.path.dirname(__file__), "data", "bundle_manifest.yml"),
+                "--config",
+                os.path.join(os.path.dirname(__file__), "data", "cluster_config.yml"),
+                "--workload",
+                "nyc_taxis",
+                "--workload-options",
+                "{\"workload-params\":\"number_of_shards:5,number_of_replicas:0,bulk_size:2500\"}",
+                "--warmup-iters",
+                "2",
+                "--test-iters",
+                "3",
+                "--component",
+                "plugin-name"
+            ],
+        )
+    @patch("os.chdir")
+    @patch("test_workflow.perf_test.perf_test_runner_opensearch_plugins.TemporaryDirectory")
+    @patch("test_workflow.perf_test.perf_test_runner_opensearch_plugins.GitRepository")
+    def test_run(self, mock_git, mock_temp_directory, *mocks):
+        mock_temp_directory.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        mock_cluster.return_value.__enter__.return_value = mock_cluster
+
+        perf_args = PerfArgs()
+        test_manifest = BundleManifest.from_file(perf_args.bundle_manifest)
+        runner = PerfTestRunners.from_args(perf_args, test_manifest)
+        runner.run()
+
+
+        mock_git.assert_called_with("https://github.com/opensearch-project/plugin-name.git", "main",
+            os.path.join(tempfile.gettempdir(), "infra"))
+
+        self.assertEqual(mock_git.call_count, 1)
+        self.assertEqual(mock_temp_directory.call_count, 1)
+

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_suite.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_suite.py
@@ -22,14 +22,48 @@ class TestPerfTestSuite(unittest.TestCase):
         self.data_path = os.path.realpath(os.path.join(os.path.dirname(__file__), "data"))
         self.manifest_filename = os.path.join(self.data_path, "bundle_manifest.yml")
         self.manifest = BundleManifest.from_path(self.manifest_filename)
-        self.endpoint = None
+        self.endpoint = "abc.com"
 
-        self.perf_test_suite = PerfTestSuite(bundle_manifest=self.manifest, endpoint=None, security=False,
+        self.perf_test_suite = PerfTestSuite(bundle_manifest=self.manifest, endpoint=self.endpoint, security=False,
                                              current_workspace="current_workspace", test_results_path="test/results/",
                                              args=self.args)
 
-    def test_execute(self):
+    def test_execute_default(self):
+        perf_test_suite = PerfTestSuite(bundle_manifest=self.manifest, endpoint=self.endpoint, security=False,
+                            current_workspace="current_workspace", test_results_path="test/results/", args=self.args)
         with patch("test_workflow.perf_test.perf_test_suite.os.chdir"):
             with patch("subprocess.check_call") as mock_check_call:
-                self.perf_test_suite.execute()
+                perf_test_suite.execute()
                 self.assertEqual(mock_check_call.call_count, 2)
+                self.assertEqual(perf_test_suite.command, "pipenv run python test_config.py -e abc.com" \
+                " -b 41d5ae25183d4e699e92debfbe3f83bd -a x64 -p test/results/ --workload nyc_taxis" \
+                " --workload-options '{}' --warmup-iters 0 --test-iters 1 --scenario-type DEFAULT --owner opensearch-devops")
+
+    def test_execute_different_owner_and_scenario(self):
+        perf_test_suite = PerfTestSuite(bundle_manifest=self.manifest, endpoint=self.endpoint, security=False,
+                            current_workspace="current_workspace", test_results_path="test/results/", args=self.args,
+                            owner="test-owner", scenario="CROSS_CLUSTER_REPLICATION")
+        with patch("test_workflow.perf_test.perf_test_suite.os.chdir"):
+            with patch("subprocess.check_call") as mock_check_call:
+                perf_test_suite.execute()
+                self.assertEqual(mock_check_call.call_count, 2)
+                self.assertEqual(perf_test_suite.command, "pipenv run python test_config.py -e abc.com" \
+                " -b 41d5ae25183d4e699e92debfbe3f83bd -a x64 -p test/results/ --workload nyc_taxis" \
+                " --workload-options '{}' --warmup-iters 0 --test-iters 1 --scenario-type CROSS_CLUSTER_REPLICATION" \
+                " --owner test-owner")
+
+    def test_execute_with_dict_endpoint(self):
+        endpoint = {
+            "default": ["cluster-1"],
+            "second_cluster": ["cluster-2"]
+        }
+        perf_test_suite = PerfTestSuite(bundle_manifest=self.manifest, endpoint=endpoint, security=False,
+                            current_workspace="current_workspace", test_results_path="test/results/", args=self.args)
+        with patch("test_workflow.perf_test.perf_test_suite.os.chdir"):
+            with patch("subprocess.check_call") as mock_check_call:
+                perf_test_suite.execute()
+                self.assertEqual(mock_check_call.call_count, 2)
+                self.assertEqual(perf_test_suite.command, "pipenv run python test_config.py -t '{\"default\": [\"cluster-1\"], \"second_cluster\": [\"cluster-2\"]}'" \
+                " -b 41d5ae25183d4e699e92debfbe3f83bd -a x64 -p test/results/ --workload nyc_taxis" \
+                " --workload-options '{}' --warmup-iters 0 --test-iters 1 --scenario-type DEFAULT --owner opensearch-devops")
+

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_run_perf_test.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_run_perf_test.py
@@ -31,14 +31,36 @@ class TestRunPerfTest(unittest.TestCase):
             "3"
         ],
     )
-    @patch("os.chdir")
-    @patch("run_perf_test.TemporaryDirectory")
-    @patch("run_perf_test.GitRepository")
-    @patch("run_perf_test.PerfTestCluster.create")
-    @patch("run_perf_test.PerfTestSuite")
-    def test_run_perf_test(self, mock_perf_suite, mock_perf_test_cluster, mock_git_repo, mock_temp_drectory, *mock):
-        mock_temp_drectory.return_value.__enter__.return_value.name = tempfile.gettempdir()
-        mock_perf_test_cluster.return_value.__enter__.return_value = ["endpoint", 1234]
+    @patch("test_workflow.perf_test.perf_test_runners.PerfTestRunnerOpenSearchPlugins.run_tests")
+    @patch("test_workflow.perf_test.perf_test_runners.PerfTestRunnerOpenSearch.run_tests")
+    def test_run_perf_test(self, os_mock_runner, plugin_mock_runner, *mock):
         main()
-        mock_git_repo.assert_called_with("https://github.com/opensearch-project/opensearch-infra.git", "main", os.path.join(tempfile.gettempdir(), "infra"))
-        self.assertEqual(mock_perf_suite.return_value.execute.call_count, 1)
+        self.assertEqual(1, os_mock_runner.call_count)
+        self.assertEqual(0, plugin_mock_runner.call_count)
+
+    @patch(
+        "argparse._sys.argv",
+        [
+            "run_perf_test.py",
+            "--bundle-manifest",
+            os.path.join(os.path.dirname(__file__), "data", "bundle_manifest.yml"),
+            "--config",
+            os.path.join(os.path.dirname(__file__), "data", "cluster_config.yml"),
+            "--workload",
+            "nyc_taxis",
+            "--workload-options",
+            "{\"workload-params\":\"number_of_shards:5,number_of_replicas:0,bulk_size:2500\"}",
+            "--warmup-iters",
+            "2",
+            "--test-iters",
+            "3",
+            "--component",
+            "abc"
+        ],
+    )
+    @patch("test_workflow.perf_test.perf_test_runners.PerfTestRunnerOpenSearchPlugins.run_tests")
+    @patch("test_workflow.perf_test.perf_test_runners.PerfTestRunnerOpenSearch.run_tests")
+    def test_run_perf_test_plugins(self, os_mock_runner, plugin_mock_runner, *mock):
+        main()
+        self.assertEqual(0, os_mock_runner.call_count)
+        self.assertEqual(1, plugin_mock_runner.call_count)


### PR DESCRIPTION
### Description
This PR contains changes to allow triggering a performance suite for Opensearch plugin . 
The plugin owner is required to have a script `` in their repo which can be invoked by this package. Using this, we can invoke Jenkin CI for periodic perf runs for different plugins.This approach also allows plugin owners to reuse the existing infra to initialise the test clusters and test suite while ensuring that the plugin specific logic resides with the plugin owners.  

### Changes which are not included in this PR: 
- Jenkin file to trigger the test run.
- Support for publishing test results.
- Support for multi cluster in `PerfTestCluster`
 
### Related change
[155](https://github.com/opensearch-project/opensearch-infra/pull/155)

### Issues Resolved
[1498](https://github.com/opensearch-project/opensearch-build/issues/1498)
[146](https://github.com/opensearch-project/opensearch-infra/issues/146)

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
