### PR TITLE
Support release iteration value for assemble workflow rpm

### DIFF
--- a/scripts/pkg/build_templates/opensearch-dashboards/opensearch-dashboards.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch-dashboards/opensearch-dashboards.rpm.spec
@@ -11,6 +11,7 @@
 %define log_dir %{_localstatedir}/log/%{name}
 %define pid_dir %{_localstatedir}/run/%{name}
 %{!?_version: %define _version 0.0.0 }
+%{!?_release: %define _release 1 }
 %{!?_architecture: %define _architecture x86_64 }
 
 Name: opensearch-dashboards

--- a/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
@@ -11,11 +11,12 @@
 %define log_dir %{_localstatedir}/log/%{name}
 %define pid_dir %{_localstatedir}/run/%{name}
 %{!?_version: %define _version 0.0.0 }
+%{!?_release: %define _release 1 }
 %{!?_architecture: %define _architecture x86_64 }
 
 Name: opensearch
 Version: %{_version}
-Release: 1
+Release: %{_release}
 License: Apache-2.0
 Summary: An open source distributed and RESTful search engine
 URL: https://opensearch.org/

--- a/src/assemble_workflow/assemble_args.py
+++ b/src/assemble_workflow/assemble_args.py
@@ -8,15 +8,29 @@ import argparse
 import logging
 from typing import IO
 
-
 class AssembleArgs:
     manifest: IO
     keep: bool
 
     def __init__(self) -> None:
+
+        def check_positive(value) -> int:
+            int_value = int(value)
+            if int_value <= 0:
+                raise argparse.ArgumentTypeError(f"{value} is invalid, you must enter a positive integer")
+            return str(int_value)
+
         parser = argparse.ArgumentParser(description="Assemble an OpenSearch Distribution")
         parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
         parser.add_argument("-b", "--base-url", dest="base_url", help="The base url to download the artifacts.")
+        parser.add_argument(
+            "-r",
+            "--release-iteration",
+            dest="release_iteration",
+            type=check_positive,
+            default="1",
+            help="The release/iteration number of deb/rpm packages, allow multiple revision of same package version (e.g. 2.0.0-1, 2.0.0-2, 2.0.0-3)"
+        )
         parser.add_argument(
             "--keep",
             dest="keep",
@@ -38,3 +52,4 @@ class AssembleArgs:
         self.manifest = args.manifest
         self.keep = args.keep
         self.base_url = args.base_url
+        self.release_iteration = args.release_iteration

--- a/src/assemble_workflow/bundle.py
+++ b/src/assemble_workflow/bundle.py
@@ -99,7 +99,7 @@ class Bundle(ABC):
         self._execute(install_command)
 
     def package(self, dest: str) -> None:
-        self.min_dist.build(self.bundle_recorder.package_name, dest)
+        self.min_dist.build(self.bundle_recorder.package_name, self.bundle_recorder.release_iteration, dest)
 
     def _execute(self, command: str) -> None:
         logging.info(f'Executing "{command}" in {self.min_dist.archive_path}')

--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -16,11 +16,12 @@ from manifests.manifest import Manifest
 
 class BundleRecorder:
 
-    def __init__(self, build: BuildManifest.Build, output_dir: str, artifacts_dir: str, bundle_location: BundleLocation) -> None:
+    def __init__(self, build: BuildManifest.Build, release_iteration: str, output_dir: str, artifacts_dir: str, bundle_location: BundleLocation) -> None:
         self.output_dir = output_dir
         self.build_id = build.id
         self.bundle_location = bundle_location
         self.version = build.version
+        self.release_iteration = release_iteration
         self.distribution = build.distribution
         self.package_name = self.__get_package_name(build)
         self.artifacts_dir = artifacts_dir

--- a/src/assemble_workflow/bundle_rpm.py
+++ b/src/assemble_workflow/bundle_rpm.py
@@ -75,7 +75,7 @@ class BundleRpm:
             with open(min_bin_env_path, 'wb') as fp:
                 fp.write(min_bin_env_lines.replace('source', '#source').encode('ascii'))
 
-    def build(self, name: str, dest: str, archive_path: str, build_cls: BuildManifest.Build) -> None:
+    def build(self, name: str, dest: str, archive_path: str, build_cls: BuildManifest.Build, release_iteration: str) -> None:
         # extract dest and build dest are not the same, this is restoring the extract dest
         # mainly due to rpm requires several different setups compares to tarball and zip
         ext_dest = os.path.dirname(archive_path)
@@ -102,11 +102,13 @@ class BundleRpm:
                 '-bb',
                 f"--define '_topdir {ext_dest}'",
                 f"--define '_version {build_cls.version}'",
+                f"--define '_release {release_iteration}'",
                 f"--define '_architecture {rpm_architecture(build_cls.architecture)}'",
                 f"{self.filename}.rpm.spec",
             ]
         )
 
+        logging.info(f"Generate {self.filename}-{build_cls.version}-{release_iteration}.{rpm_architecture(build_cls.architecture)}.rpm")
         logging.info(f"Execute {bundle_cmd} in {ext_dest}")
         subprocess.check_call(bundle_cmd, cwd=ext_dest, shell=True)
 

--- a/src/assemble_workflow/dist.py
+++ b/src/assemble_workflow/dist.py
@@ -78,8 +78,8 @@ class Dist(ABC):
         )
         return self.archive_path
 
-    def build(self, name: str, dest: str) -> None:
-        self.__build__(name, dest)
+    def build(self, name: str, release_iteration: str, dest: str) -> None:
+        self.__build__(name, release_iteration, dest)
         path = os.path.join(dest, name)
         shutil.copyfile(name, path)
         logging.info(f"Published {path}.")
@@ -114,5 +114,5 @@ class DistRpm(Dist):
     def __extract__(self, dest: str) -> None:
         BundleRpm(self.filename, self.path, self.min_path).extract(dest)
 
-    def __build__(self, name: str, dest: str) -> None:
-        BundleRpm(self.filename, self.path, self.min_path).build(name, dest, self.archive_path, self.build_cls)
+    def __build__(self, name: str, release_iteration: str, dest: str) -> None:
+        BundleRpm(self.filename, self.path, self.min_path).build(name, dest, self.archive_path, self.build_cls, release_iteration)

--- a/src/run_assemble.py
+++ b/src/run_assemble.py
@@ -27,6 +27,7 @@ def main() -> int:
     build_manifest = BuildManifest.from_file(args.manifest)
     build = build_manifest.build
     artifacts_dir = os.path.dirname(os.path.realpath(args.manifest.name))
+    release_iteration = args.release_iteration
 
     output_dir = AssembleOutputDir(build.filename).dir
 
@@ -34,6 +35,7 @@ def main() -> int:
 
     bundle_recorder = BundleRecorder(
         build,
+        release_iteration,
         output_dir,
         artifacts_dir,
         BundleLocations.from_path(args.base_url, os.getcwd(), build.filename)


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Support release iteration value for assemble workflow rpm.

This PR add support for release/iteration value in rpm/deb packages.

It allows us to build packages with the same version without overriding existing packages.
It also allow users to upgrade the package to the same version but latest release/iteration.

```
-rw-r--r-- 1 <> 390033760 Apr  7 02:09 opensearch-1.3.0-1-linux-x64.rpm
-rw-r--r-- 1 <> 390033852 Apr  7 01:59 opensearch-1.3.0-2-linux-x64.rpm
-rw-r--r-- 1 <> 386532844 Apr  7 02:04 opensearch-1.3.1-1-linux-x64.rpm
```
```
opensearch-1.3.0-1.x86_64.rpm
Name        : opensearch
Version     : 1.3.0
Release     : 1
Architecture: x86_64

opensearch-1.3.0-2.x86_64.rpm
Name        : opensearch
Version     : 1.3.0
Release     : 2
Architecture: x86_64
```

It also allows us to assign the $BUILD_NUMBER to release/iteration in Jenkins so we can separate then when pushing to staging yum repo for testing.

Thanks.

 
### Issues Resolved
#1545
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
