### PR TITLE
Add sample component as we continue to move component specific scripts out of build repo

### DIFF
--- a/scripts/components/sample_component/build.sh
+++ b/scripts/components/sample_component/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This is a sample build.sh which will override the build.sh in ../../default

--- a/tests/tests_build_workflow/test_builder_from_source.py
+++ b/tests/tests_build_workflow/test_builder_from_source.py
@@ -18,7 +18,7 @@ from paths.script_finder import ScriptFinder
 class TestBuilderFromSource(unittest.TestCase):
     def setUp(self) -> None:
         self.builder = BuilderFromSource(
-            InputComponentFromSource({"name": "security", "repository": "url", "ref": "ref"}),
+            InputComponentFromSource({"name": "sample_component", "repository": "url", "ref": "ref"}),
             BuildTarget(
                 name="OpenSearch",
                 version="1.1.0",
@@ -41,7 +41,7 @@ class TestBuilderFromSource(unittest.TestCase):
         )
 
         self.builder_distribution_support = BuilderFromSource(
-            InputComponentFromSource({"name": "security", "repository": "url", "ref": "ref"}),
+            InputComponentFromSource({"name": "sample_component", "repository": "url", "ref": "ref"}),
             BuildTarget(
                 name="OpenSearch",
                 version="1.3.0",
@@ -53,7 +53,7 @@ class TestBuilderFromSource(unittest.TestCase):
         )
 
     def test_builder(self) -> None:
-        self.assertEqual(self.builder.component.name, "security")
+        self.assertEqual(self.builder.component.name, "sample_component")
 
     @patch("build_workflow.builder_from_source.GitRepository")
     def test_build(self, mock_git_repo: Mock) -> None:
@@ -65,7 +65,7 @@ class TestBuilderFromSource(unittest.TestCase):
             " ".join(
                 [
                     "bash",
-                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "security", "build.sh")),
+                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "sample_component", "build.sh")),
                     "-v 1.1.0",
                     "-p linux",
                     "-a x64",
@@ -74,7 +74,7 @@ class TestBuilderFromSource(unittest.TestCase):
                 ]
             )
         )
-        build_recorder.record_component.assert_called_with("security", mock_git_repo.return_value)
+        build_recorder.record_component.assert_called_with("sample_component", mock_git_repo.return_value)
 
     @patch("build_workflow.builder_from_source.GitRepository")
     def test_build_distribution(self, mock_git_repo: Mock) -> None:
@@ -108,7 +108,7 @@ class TestBuilderFromSource(unittest.TestCase):
             " ".join(
                 [
                     "bash",
-                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "security", "build.sh")),
+                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "sample_component", "build.sh")),
                     "-v 1.3.0",
                     "-p linux",
                     "-a x64",
@@ -117,7 +117,7 @@ class TestBuilderFromSource(unittest.TestCase):
                 ]
             )
         )
-        build_recorder.record_component.assert_called_with("security", mock_git_repo.return_value)
+        build_recorder.record_component.assert_called_with("sample_component", mock_git_repo.return_value)
 
     @patch("build_workflow.builder_from_source.GitRepository")
     def test_build_snapshot(self, mock_git_repo: Mock) -> None:
@@ -130,7 +130,7 @@ class TestBuilderFromSource(unittest.TestCase):
             " ".join(
                 [
                     "bash",
-                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "security", "build.sh")),
+                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "sample_component", "build.sh")),
                     "-v 1.1.0",
                     "-p linux",
                     "-a x64",
@@ -139,7 +139,7 @@ class TestBuilderFromSource(unittest.TestCase):
                 ]
             )
         )
-        build_recorder.record_component.assert_called_with("security", self.builder.git_repo)
+        build_recorder.record_component.assert_called_with("sample_component", self.builder.git_repo)
 
     @patch("build_workflow.builder_from_source.GitRepository")
     def test_build_snapshot_qualiier(self, mock_git_repo: Mock) -> None:
@@ -153,7 +153,7 @@ class TestBuilderFromSource(unittest.TestCase):
             " ".join(
                 [
                     "bash",
-                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "security", "build.sh")),
+                    os.path.realpath(os.path.join(ScriptFinder.component_scripts_path, "sample_component", "build.sh")),
                     "-v 1.1.0",
                     "-q alpha1",
                     "-p linux",
@@ -163,7 +163,7 @@ class TestBuilderFromSource(unittest.TestCase):
                 ]
             )
         )
-        build_recorder.record_component.assert_called_with("security", self.builder.git_repo)
+        build_recorder.record_component.assert_called_with("sample_component", self.builder.git_repo)
 
     def mock_os_walk(self, artifact_path: str) -> List[Any]:
         if artifact_path.endswith(os.path.join("dir", "builds", "core-plugins")):
@@ -185,7 +185,7 @@ class TestBuilderFromSource(unittest.TestCase):
         build_recorder.record_artifact.assert_has_calls(
             [
                 call(
-                    "security",
+                    "sample_component",
                     "maven",
                     os.path.relpath(
                         os.path.join("maven", "artifact1.jar"),
@@ -194,7 +194,7 @@ class TestBuilderFromSource(unittest.TestCase):
                     os.path.join("maven", "artifact1.jar"),
                 ),
                 call(
-                    "security",
+                    "sample_component",
                     "core-plugins",
                     os.path.relpath(
                         os.path.join("core-plugins", "plugin1.zip"),

--- a/tests/tests_build_workflow/test_builder_from_source.py
+++ b/tests/tests_build_workflow/test_builder_from_source.py
@@ -52,6 +52,18 @@ class TestBuilderFromSource(unittest.TestCase):
             ),
         )
 
+        self.builder_distribution_support_component_not_found = BuilderFromSource(
+            InputComponentFromSource({"name": "not_found_component", "repository": "url", "ref": "ref"}),
+            BuildTarget(
+                name="OpenSearch",
+                version="1.3.0",
+                platform="linux",
+                architecture="x64",
+                distribution="rpm",
+                snapshot=False,
+            ),
+        )
+
     def test_builder(self) -> None:
         self.assertEqual(self.builder.component.name, "sample_component")
 
@@ -142,7 +154,7 @@ class TestBuilderFromSource(unittest.TestCase):
         build_recorder.record_component.assert_called_with("sample_component", self.builder.git_repo)
 
     @patch("build_workflow.builder_from_source.GitRepository")
-    def test_build_snapshot_qualiier(self, mock_git_repo: Mock) -> None:
+    def test_build_snapshot_qualifier(self, mock_git_repo: Mock) -> None:
         self.builder.target.snapshot = True
         self.builder.target.qualifier = "alpha1"
         mock_git_repo.return_value = MagicMock(working_directory="dir")
@@ -164,6 +176,30 @@ class TestBuilderFromSource(unittest.TestCase):
             )
         )
         build_recorder.record_component.assert_called_with("sample_component", self.builder.git_repo)
+
+    @patch("build_workflow.builder_from_source.GitRepository")
+    def test_build_snapshot_qualifier_component_not_found(self, mock_git_repo: Mock) -> None:
+        self.builder_distribution_support_component_not_found.target.snapshot = True
+        self.builder_distribution_support_component_not_found.target.qualifier = "alpha1"
+        mock_git_repo.return_value = MagicMock(working_directory="dir")
+        build_recorder = MagicMock()
+        self.builder_distribution_support_component_not_found.checkout("dir")
+        self.builder_distribution_support_component_not_found.build(build_recorder)
+        mock_git_repo.return_value.execute.assert_called_with(
+            " ".join(
+                [
+                    "bash",
+                    os.path.realpath(os.path.join(ScriptFinder.default_scripts_path, "opensearch", "build.sh")),
+                    "-v 1.3.0",
+                    "-q alpha1",
+                    "-p linux",
+                    "-a x64",
+                    "-s true",
+                    "-o builds",
+                ]
+            )
+        )
+        build_recorder.record_component.assert_called_with("not_found_component", mock_git_repo.return_value)
 
     def mock_os_walk(self, artifact_path: str) -> List[Any]:
         if artifact_path.endswith(os.path.join("dir", "builds", "core-plugins")):


### PR DESCRIPTION


Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add sample component as we continue to move component specific scripts out of build repo
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
