### PR TITLE
add new data.search.usageTelemetry.enabled to opensearch_dashboards_vars

### DIFF
--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
@@ -29,6 +29,7 @@ opensearch_dashboards_vars=(
     csp.rules
     csp.strict
     csp.warnLegacyBrowsers
+    data.search.usageTelemetry.enabled
     opensearch.customHeaders
     opensearch.hosts
     opensearch.logQueries


### PR DESCRIPTION
Signed-off-by: Tao liu <liutaoaz@amazon.com>

### Description
Adds new data.search.usageTelemetry.enabled to opensearch_dashboards_vars. 
data.search.usageTelemetry.enabled will be used for controlling the search's usageTelemetry.
This is related with PR https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1427. 
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
