### PR TITLE
Add geospatial plugin to meta

### DIFF
--- a/meta/.gitignore
+++ b/meta/.gitignore
@@ -22,3 +22,4 @@
 /common-utils/
 /opensearch-build/
 /ml-commons/
+/geospatial/

--- a/meta/.meta
+++ b/meta/.meta
@@ -22,6 +22,7 @@
     "cross-cluster-replication": "git@github.com:opensearch-project/cross-cluster-replication.git",
     "common-utils": "git@github.com:opensearch-project/common-utils.git",
     "opensearch-build": "git@github.com:opensearch-project/opensearch-build.git",
-    "ml-commons": "git@github.com:opensearch-project/ml-commons.git"
+    "ml-commons": "git@github.com:opensearch-project/ml-commons.git",
+    "geospatial": "git@github.com:opensearch-project/geospatial.git"
   }
 }


### PR DESCRIPTION
Signed-off-by: Vijayan Balasubramanian <balasvij@amazon.com>

### Description
Include [geospatial plugin](https://github.com/opensearch-project/geospatial) to meta
 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
