### PR TITLE
Adding open access for a module to fix pa plugin jdk 17 issue

### DIFF
--- a/scripts/legacy/tar/linux/opensearch-tar-install.sh
+++ b/scripts/legacy/tar/linux/opensearch-tar-install.sh
@@ -27,6 +27,7 @@ if ! grep -q '## OpenSearch Performance Analyzer' $OPENSEARCH_HOME/config/jvm.op
    echo "-Dclk.tck=$CLK_TCK" >> $OPENSEARCH_HOME/config/jvm.options
    echo "-Djdk.attach.allowAttachSelf=true" >> $OPENSEARCH_HOME/config/jvm.options
    echo "-Djava.security.policy=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/pa_config/opensearch_security.policy" >> $OPENSEARCH_HOME/config/jvm.options
+   echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> $OPENSEARCH_HOME/config/jvm.options
 fi
 echo "done plugins"
 

--- a/scripts/opensearch-onetime-setup.sh
+++ b/scripts/opensearch-onetime-setup.sh
@@ -46,5 +46,6 @@ if ! grep -q '## OpenDistro Performance Analyzer' $OPENSEARCH_HOME/config/jvm.op
    echo "-Dclk.tck=$CLK_TCK" >> $OPENSEARCH_HOME/config/jvm.options
    echo "-Djdk.attach.allowAttachSelf=true" >> $OPENSEARCH_HOME/config/jvm.options
    echo "-Djava.security.policy=$OPENSEARCH_HOME/plugins/$PA_PLUGIN/pa_config/opensearch_security.policy" >> $OPENSEARCH_HOME/config/jvm.options
+   echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> $OPENSEARCH_HOME/config/jvm.options
 fi
 

--- a/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
@@ -94,6 +94,7 @@ if ! grep -q '## OpenSearch Performance Analyzer' %{config_dir}/jvm.options; the
    echo "-Dclk.tck=$CLK_TCK" >> %{config_dir}/jvm.options
    echo "-Djdk.attach.allowAttachSelf=true" >> %{config_dir}/jvm.options
    echo "-Djava.security.policy=file:///usr/share/opensearch/plugins/opensearch-performance-analyzer/pa_config/opensearch_security.policy" >> %{config_dir}/jvm.options
+   echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> %{config_dir}/jvm.options
 fi
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then


### PR DESCRIPTION
Signed-off-by: Sagar Upadhyaya <sagar.upadhyaya.121@gmail.com>

### Description
This change adds open access(via 'add-opens') to jdk.attach module as PA plugin fails to start otherwise in jdk 17 (which had breaking changes and not allowing illegal runtime access to jdk internal classes)

We have opened an internal in RCA to exploring changing logic of taking thread dumps and avoid using "add-open" access.
https://github.com/opensearch-project/performance-analyzer-rca/issues/161
 
### Issues Resolved
https://github.com/opensearch-project/performance-analyzer/issues/144 -  Though this states 1.3 as we had earlier planned JDK 17 for 1.3 release. 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
