### PR TITLE
[OSD][2.0.0] use rc1 qualifier

### DIFF
--- a/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
@@ -3,7 +3,7 @@ schema-version: '1.0'
 build:
   name: OpenSearch Dashboards
   version: 2.0.0
-  qualifier: alpha1
+  qualifier: rc1
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v1


### PR DESCRIPTION
### Description
Plugins need to specifically update their version to `2.0.0.0-rc1` in the `opensearch_dashboards.json` for the build to succeed.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
