### PR TITLE
Fix the path for maven sign and staging job

### DIFF
--- a/jenkins/opensearch-maven-release/maven-sign-release.jenkinsfile
+++ b/jenkins/opensearch-maven-release/maven-sign-release.jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
                 script {
                     // stage artifacts for release with Sonatype
                     withCredentials([usernamePassword(credentialsId: 'Sonatype', usernameVariable: 'SONATYPE_USERNAME', passwordVariable: 'SONATYPE_PASSWORD')]) {
-                        sh('$WORKSPACE/publish/stage-maven-release.sh $WORKSPACE/artifacts/$ARTIFACT_PATH/maven-signed')
+                        sh('$WORKSPACE/publish/stage-maven-release.sh $WORKSPACE/artifacts/$ARTIFACT_PATH/opensearch/maven')
                     }
                 }
             }

--- a/jenkins/opensearch-maven-release/maven-sign-release.jenkinsfile
+++ b/jenkins/opensearch-maven-release/maven-sign-release.jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
         )
     }
     environment {
-        ARTIFACT_PATH = "distribution-build-opensearch/${VERSION}/${BUILD_ID}/linux/x64/builds"
+        ARTIFACT_PATH = "distribution-build-opensearch/${VERSION}/${BUILD_ID}/linux/x64/tar/builds"
     }
     stages {
         stage('sign') {

--- a/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
@@ -30,7 +30,7 @@
             maven-sign-release.script(groovy.lang.Closure)
                maven-sign-release.usernamePassword({credentialsId=Sonatype, usernameVariable=SONATYPE_USERNAME, passwordVariable=SONATYPE_PASSWORD})
                maven-sign-release.withCredentials([[SONATYPE_USERNAME, SONATYPE_PASSWORD]], groovy.lang.Closure)
-                  maven-sign-release.sh($WORKSPACE/publish/stage-maven-release.sh $WORKSPACE/artifacts/$ARTIFACT_PATH/maven-signed)
+                  maven-sign-release.sh($WORKSPACE/publish/stage-maven-release.sh $WORKSPACE/artifacts/$ARTIFACT_PATH/opensearch/maven)
          maven-sign-release.script(groovy.lang.Closure)
             maven-sign-release.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
The old jenkins job used to upload the signed maven artifacts from `builds/opensearch/maven` to a new folder called `maven-signed` and downloaded it again before staging. I skipped that step in this workflow because the entire process is within the same workspace. 
This PR changed the path for signed maven artifacts used for staging. 
 
### Issues Resolved
#1893
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
