### PR TITLE
Make sure notifications is built correctly while passing ci checks

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -45,11 +45,17 @@ components:
   - name: notifications-core
     repository: https://github.com/opensearch-project/notifications.git
     ref: main
-    working_directory: notifications/core
+    working_directory: notifications
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: opensearch-notifications-core
   - name: notifications
     repository: https://github.com/opensearch-project/notifications.git
     ref: main
-    working_directory: notifications/notifications
+    working_directory: notifications
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: notifications
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
     ref: main

--- a/scripts/components/notifications-core/build.sh
+++ b/scripts/components/notifications-core/build.sh
@@ -68,11 +68,9 @@ fi
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
 
-# Go to the first notifications folder, which holds the core folder and the second notifications folder
-cd ../
 ./gradlew publishToMavenLocal -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
-mkdir -p core/$OUTPUT/plugins
+mkdir -p ./$OUTPUT/plugins
 notifCoreZipPath=$(ls core/build/distributions/ | grep .zip)
-cp -v core/build/distributions/$notifCoreZipPath core/$OUTPUT/plugins
+cp -v core/build/distributions/$notifCoreZipPath ./$OUTPUT/plugins

--- a/scripts/components/notifications/build.sh
+++ b/scripts/components/notifications/build.sh
@@ -67,13 +67,11 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-# Go to the first notifications folder, which holds the core folder and the second notifications folder
-cd ../
 ./gradlew publishToMavenLocal -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
-mkdir -p notifications/$OUTPUT/plugins
+mkdir -p ./$OUTPUT/plugins
 
 notifCoreZipPath=$(ls notifications/build/distributions/ | grep .zip)
-cp -v notifications/build/distributions/$notifCoreZipPath notifications/$OUTPUT/plugins
+cp -v notifications/build/distributions/$notifCoreZipPath ./$OUTPUT/plugins
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Make sure notifications is built correctly while passing ci checks
 
### Issues Resolved
#1950
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
