### PR TITLE
Adds OpenSearch Dashboards circuit breaker vars

### DIFF
--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
@@ -33,6 +33,8 @@ opensearch_dashboards_vars=(
     opensearch.customHeaders
     opensearch.hosts
     opensearch.logQueries
+    opensearch.memoryCircuitBreaker.enabled
+    opensearch.memoryCircuitBreaker.maxPercentage
     opensearch.password
     opensearch.pingTimeout
     opensearch.requestHeadersWhitelist


### PR DESCRIPTION
### Description
* Adds new `opensearch.memoryCircuitBreaker.enabled` and `opensearch.memoryCircuitBreaker.maxPercentage` variables for the memory circuit breaker limits.
* Issue: https://github.com/opensearch-project/opensearch-js/issues/202
* OpenSearch Dashboards PR: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/1347

We're targeting v2.0 for this change.
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
