### PR TITLE
Fix test manifest 2.0.0 having wrong docker repo

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0-test.yml
+++ b/manifests/2.0.0/opensearch-2.0.0-test.yml
@@ -3,7 +3,7 @@ schema-version: '1.0'
 name: OpenSearch
 ci:
   image:
-    name: opensearchstaging/ci-runner-centos7-opensearch-build-v1
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v1
     args: -e JAVA_HOME=/opt/java/openjdk-17
 components:
   - name: index-management


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Fix test manifest 2.0.0 having wrong docker repo
 
### Issues Resolved
Part of #1624
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
