### PR TITLE
Disable security to unblock the RC1 build

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -100,9 +100,9 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
-  - name: security
-    repository: https://github.com/opensearch-project/security.git
-    ref: main
+  # - name: security
+  #   repository: https://github.com/opensearch-project/security.git
+  #   ref: main
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
     ref: main


### PR DESCRIPTION
### Description
Disable security to unblock the RC1 build

> This is a chicken v. egg build problem. The security plugin uses the OpenSearch min tar to make sure it can be installed. Until we've got a rc1 version of OpenSearch min our CI check won't pass.
> 
> Option 1) remove security plugin from the manifest. Cleanest approach for build safety with the tradeoff of consuming a lot of time during this transition phase.
> 
> Option 2) bypass the CI check and cross fingers that the new build doesn't have any unexpected issues.
> 
> My preference is towards option 1 with the understanding it will slow down the whole rollout. This will ensure only correctly building plugins are included in the build, avoiding an utterly broken build.
> 
> Note; These problems are magnified in security-dashboards-plugin as it depends on a full distribution build for its CI checks.
_From https://github.com/opensearch-project/security/pull/1764_
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
