### PR TITLE
Remove opensearch-env backup as core has fixed the source in rpm

### DIFF
--- a/src/assemble_workflow/bundle_rpm.py
+++ b/src/assemble_workflow/bundle_rpm.py
@@ -63,18 +63,6 @@ class BundleRpm:
         # https://github.com/opensearch-project/OpenSearch/issues/2092
         os.environ[f"{self.filename.upper()}_PATH_CONF"] = min_config_path
 
-        if os.path.exists(min_bin_env_path):
-            # Backup original file
-            shutil.copy2(min_bin_env_path, f"{min_bin_env_path}.backup")
-            # Prevent sourcing as file is only in place after rpm installation
-            # So that min can install plugin zips
-            # Have to decode then encode back to ascii due to mypy complains TextIO not equals to BinaryIO
-            with open(min_bin_env_path, 'rb') as fp:
-                min_bin_env_lines = fp.read().decode('ascii')
-
-            with open(min_bin_env_path, 'wb') as fp:
-                fp.write(min_bin_env_lines.replace('source', '#source').encode('ascii'))
-
     def build(self, name: str, dest: str, archive_path: str, build_cls: BuildManifest.Build) -> None:
         # extract dest and build dest are not the same, this is restoring the extract dest
         # mainly due to rpm requires several different setups compares to tarball and zip
@@ -87,11 +75,6 @@ class BundleRpm:
         # Remove env var
         logging.info('Organize folder structure before generating rpm')
         os.environ.pop('OPENSEARCH_PATH_CONF', None)
-
-        # Restore config file and core folder to original location
-        if os.path.exists(f"{min_bin_env_path}.backup"):
-            logging.info(f"Restore {min_bin_env_path}.backup to {min_bin_env_path}")
-            shutil.move(f"{min_bin_env_path}.backup", min_bin_env_path)
 
         shutil.move(min_dest_path, min_source_path)
 

--- a/src/assemble_workflow/bundle_rpm.py
+++ b/src/assemble_workflow/bundle_rpm.py
@@ -26,7 +26,6 @@ class BundleRpm:
         min_source_path = os.path.join(dest, 'usr', 'share', self.filename)
         min_dest_path = os.path.join(dest, self.min_path)
         min_config_path = os.path.join(dest, 'etc', self.filename)
-        min_bin_env_path = os.path.join(min_dest_path, 'bin', f"{self.filename}-env")
 
         # Convert rpm to cpio so we can extract the content
         logging.info(f"Convert rpm to cpio for extraction: {self.package_path} to {cpio_path}")
@@ -69,7 +68,6 @@ class BundleRpm:
         ext_dest = os.path.dirname(archive_path)
         min_source_path = os.path.join(ext_dest, 'usr', 'share', self.filename)
         min_dest_path = os.path.join(ext_dest, self.min_path)
-        min_bin_env_path = os.path.join(min_dest_path, 'bin', f"{self.filename}-env")
         bundle_artifact_path: str = None
 
         # Remove env var

--- a/tests/tests_assemble_workflow/test_bundle_rpm.py
+++ b/tests/tests_assemble_workflow/test_bundle_rpm.py
@@ -27,11 +27,10 @@ class TestBundleRpm(unittest.TestCase):
         self.manifest_rpm_qualifier = BuildManifest.from_path(os.path.join(os.path.dirname(__file__), "data/opensearch-build-rpm-2.0.0-alpha1.yml"))
 
     @patch("builtins.open")
-    @patch("os.path.exists", return_value=False)
     @patch("shutil.move")
     @patch("shutil.copy2")
     @patch("subprocess.check_call")
-    def test_extract_rpm(self, check_call_mock: Mock, shutil_copy2_mock: Mock, shutil_move_mock: Mock, os_path_exists_mock: Mock, builtins_open: Mock) -> None:
+    def test_extract_rpm(self, check_call_mock: Mock, shutil_copy2_mock: Mock, shutil_move_mock: Mock, builtins_open: Mock) -> None:
 
         self.bundle_rpm.extract(self.artifacts_path)
         args_list = check_call_mock.call_args_list
@@ -41,7 +40,6 @@ class TestBundleRpm(unittest.TestCase):
         self.assertEqual(['cpio', '-imdv'], args_list[1][0][0])
         self.assertEqual(shutil_copy2_mock.call_count, 0)
         self.assertEqual(shutil_move_mock.call_count, 1)
-        self.assertEqual(os_path_exists_mock.call_count, 1)
         self.assertEqual(os.environ['OPENSEARCH_PATH_CONF'], os.path.join(self.artifacts_path, 'etc', 'opensearch'))
 
     @patch("os.path.exists", return_value=True)
@@ -57,7 +55,7 @@ class TestBundleRpm(unittest.TestCase):
         self.assertRaises(KeyError, lambda: os.environ['OPENSEARCH_PATH_CONF'])
         self.assertEqual(check_call_mock.call_count, 1)
         self.assertEqual(f"rpmbuild -bb --define '_topdir {self.artifacts_path}' --define '_version 1.3.0' --define '_architecture x86_64' opensearch.rpm.spec", args_list_rpm[0][0][0])
-        self.assertEqual(shutil_move_mock.call_count, 3)
+        self.assertEqual(shutil_move_mock.call_count, 2)
 
     @patch("os.path.exists", return_value=True)
     @patch("os.walk")
@@ -73,4 +71,4 @@ class TestBundleRpm(unittest.TestCase):
         self.assertEqual(check_call_mock.call_count, 1)
         self.assertEqual(f"rpmbuild -bb --define '_topdir {self.artifacts_path}' --define '_version 2.0.0.alpha1' --define '_architecture x86_64' opensearch.rpm.spec",
                          args_list_rpm_qualifier[0][0][0])
-        self.assertEqual(shutil_move_mock.call_count, 3)
+        self.assertEqual(shutil_move_mock.call_count, 2)


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove opensearch-env backup as core has fixed the source
 
### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/1545#issuecomment-1099632988
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
