### PR TITLE
Temporarily takes out security plugin from manifest to allow CI build to pass successfully

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -100,9 +100,9 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
-  - name: security
-    repository: https://github.com/opensearch-project/security.git
-    ref: main
+  # - name: security
+  #   repository: https://github.com/opensearch-project/security.git
+  #   ref: main
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
     ref: main

--- a/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
@@ -38,9 +38,9 @@ components:
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
     ref: main
-  - name: securityDashboards
-    repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: main
+  # - name: securityDashboards
+  #   repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+  #   ref: main
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     ref: main


### PR DESCRIPTION
### Description
This PR os to temporarily remove security from manifests to allow OpenSearch 2.0-rc1 to be built which will then be used by security plugin for its version change to 2.0-rc1 and then security plugin will later be added back to the 2.0 manifest.
 
See https://github.com/opensearch-project/security/pull/1764 for more details.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
