### PR TITLE
Reduce manifest workflow runtime and separate os/osd runners

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -9,9 +9,7 @@ pipeline {
         parameterizedCron '''
             H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-dashboards-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=1.2.1/opensearch-dashboards-1.2.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H/10 * * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=1.2.5/opensearch-1.2.5.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=2.0.0/opensearch-2.0.0.yml;TEST_MANIFEST=2.0.0/opensearch-2.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=2.0.0/opensearch-dashboards-2.0.0.yml;TEST_MANIFEST=2.0.0/opensearch-dashboards-2.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H 1 * * * %INPUT_MANIFEST=2.1.0/opensearch-2.1.0.yml;TARGET_JOB_NAME=distribution-build-opensearch

--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -8,9 +8,9 @@ pipeline {
     triggers {
         parameterizedCron '''
             H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-dashboards-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
+            H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.2.1/opensearch-dashboards-1.2.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H/10 * * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.2.5/opensearch-1.2.5.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=2.0.0/opensearch-2.0.0.yml;TEST_MANIFEST=2.0.0/opensearch-2.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=2.0.0/opensearch-dashboards-2.0.0.yml;TEST_MANIFEST=2.0.0/opensearch-dashboards-2.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards

--- a/manifests/1.2.1/opensearch-dashboards-1.2.1.yml
+++ b/manifests/1.2.1/opensearch-dashboards-1.2.1.yml
@@ -5,7 +5,7 @@ build:
   version: 1.2.1
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-centos7-v1
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v1
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git

--- a/manifests/1.2.5/opensearch-1.2.5.yml
+++ b/manifests/1.2.5/opensearch-1.2.5.yml
@@ -5,7 +5,7 @@ build:
   version: 1.2.5
 ci:
   image:
-    name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v1
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git

--- a/manifests/1.3.2/opensearch-1.3.2.yml
+++ b/manifests/1.3.2/opensearch-1.3.2.yml
@@ -5,7 +5,7 @@ build:
   version: 1.3.2
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-centos7-v1
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v1
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git

--- a/manifests/1.3.2/opensearch-dashboards-1.3.2.yml
+++ b/manifests/1.3.2/opensearch-dashboards-1.3.2.yml
@@ -5,7 +5,7 @@ build:
   version: 1.3.2
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-centos7-v1
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v1
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git

--- a/manifests/1.4.0/opensearch-1.4.0.yml
+++ b/manifests/1.4.0/opensearch-1.4.0.yml
@@ -5,7 +5,7 @@ build:
   version: 1.4.0
 ci:
   image:
-    name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v1
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git

--- a/src/manifests_workflow/component_opensearch_min.py
+++ b/src/manifests_workflow/component_opensearch_min.py
@@ -32,10 +32,6 @@ class ComponentOpenSearchMin(Component):
             snapshot,
         )
 
-    def publish_to_maven_local(self) -> None:
-        cmd = ComponentOpenSearch.gradle_cmd("publishToMavenLocal", {"build.snapshot": str(self.snapshot).lower()})
-        self.git_repo.execute_silent(cmd)
-
     @property
     def properties(self) -> PropertiesFile:
         cmd = ComponentOpenSearch.gradle_cmd("properties", {"build.snapshot": str(self.snapshot).lower()})
@@ -43,5 +39,4 @@ class ComponentOpenSearchMin(Component):
 
     @property
     def version(self) -> Any:
-        self.publish_to_maven_local()
         return self.properties.get_value("version")

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -106,6 +106,11 @@ class InputManifests(Manifests):
                 self.add_to_cron(release_version)
 
     def create_manifest(self, version: str, components: List = []) -> InputManifest:
+        runner_map = {
+            "opensearch": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v1",
+            "opensearch-dashboards": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v1"
+        }
+
         data: Dict = {
             "schema-version": "1.0",
             "build": {
@@ -114,7 +119,7 @@ class InputManifests(Manifests):
             },
             "ci": {
                 "image": {
-                    "name": "opensearchstaging/ci-runner:ci-runner-centos7-v1"
+                    "name": runner_map[self.prefix]
                 }
             },
             "components": [],

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -106,7 +106,7 @@ class InputManifests(Manifests):
                 self.add_to_cron(release_version)
 
     def create_manifest(self, version: str, components: List = []) -> InputManifest:
-        runner_map = {
+        image_map = {
             "opensearch": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v1",
             "opensearch-dashboards": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v1"
         }
@@ -119,7 +119,7 @@ class InputManifests(Manifests):
             },
             "ci": {
                 "image": {
-                    "name": runner_map[self.prefix]
+                    "name": image_map[self.prefix]
                 }
             },
             "components": [],

--- a/tests/tests_manifests_workflow/test_component_opensearch_min.py
+++ b/tests/tests_manifests_workflow/test_component_opensearch_min.py
@@ -28,12 +28,6 @@ class TestComponentOpenSearchMin(unittest.TestCase):
         self.assertEqual(component.name, "OpenSearch")
         self.assertFalse(component.snapshot)
 
-    def test_publish_to_maven_local(self) -> None:
-        component = ComponentOpenSearchMin(MagicMock())
-        component.publish_to_maven_local()
-        execute_silent = unittest.mock.create_autospec(component.git_repo.execute_silent)
-        execute_silent.assert_called_with("./gradlew publishToMavenLocal -Dbuild.snapshot=false")
-
     def test_version(self) -> None:
         repo = MagicMock()
         repo.output.return_value = "version=2.1"

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# The OpenSearch Contributors require contributions made to
+# The opensearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
@@ -16,27 +16,39 @@ class TestInputManifests(unittest.TestCase):
         path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "manifests"))
         self.assertEqual(path, InputManifests.manifests_path())
 
-    def test_create_manifest(self) -> None:
-        input_manifests = InputManifests("test")
+    def test_create_manifest_opensearch(self) -> None:
+        input_manifests = InputManifests("opensearch")
         input_manifest = input_manifests.create_manifest("1.2.3", [])
         self.assertEqual(
             input_manifest.to_dict(),
             {
                 "schema-version": "1.0",
-                "build": {"name": "test", "version": "1.2.3"},
-                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-v1"}},
+                "build": {"name": "opensearch", "version": "1.2.3"},
+                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v1"}},
+            },
+        )
+
+    def test_create_manifest_opensearch_dashboards(self) -> None:
+        input_manifests = InputManifests("opensearch-dashboards")
+        input_manifest = input_manifests.create_manifest("1.2.3", [])
+        self.assertEqual(
+            input_manifest.to_dict(),
+            {
+                "schema-version": "1.0",
+                "build": {"name": "opensearch-dashboards", "version": "1.2.3"},
+                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v1"}},
             },
         )
 
     @patch("os.makedirs")
     @patch("manifests_workflow.input_manifests.InputManifests.create_manifest")
     def test_write_manifest(self, mock_create_manifest: MagicMock, mock_makedirs: MagicMock) -> None:
-        input_manifests = InputManifests("test")
+        input_manifests = InputManifests("opensearch")
         input_manifests.write_manifest('0.1.2', [])
         mock_create_manifest.assert_called_with('0.1.2', [])
         mock_makedirs.assert_called_with(os.path.join(InputManifests.manifests_path(), '0.1.2'), exist_ok=True)
         mock_create_manifest.return_value.to_file.assert_called_with(
-            os.path.join(InputManifests.manifests_path(), '0.1.2', 'test-0.1.2.yml')
+            os.path.join(InputManifests.manifests_path(), '0.1.2', 'opensearch-0.1.2.yml')
         )
 
     def test_jenkins_path(self) -> None:

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
-# The opensearch Contributors require contributions made to
+# The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Reduce manifest workflow runtime and separate os/osd runners
 
### Issues Resolved
#1978
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
