### PR TITLE
[OSD] remove check for build for 1.3.2 and 1.2.1

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -7,8 +7,6 @@ pipeline {
     agent none
     triggers {
         parameterizedCron '''
-            H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-dashboards-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
-            H/10 * * * * %INPUT_MANIFEST=1.2.1/opensearch-dashboards-1.2.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H/10 * * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H/10 * * * * %INPUT_MANIFEST=1.2.5/opensearch-1.2.5.yml;TARGET_JOB_NAME=distribution-build-opensearch


### PR DESCRIPTION
### Description
We have bumped the 1.x branches patch versions but it doesn't have the rpm commands so it's failing. We also don't have plan to release this so for now we can just not build these and add them later if there is a plan.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
