### PR TITLE
[OSD] do not enforce auth on api/status

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -184,3 +184,4 @@ opensearch_security.multitenancy.tenants.preferred: [Private, Global]
 opensearch_security.readonly_mode.roles: [kibana_read_only]
 # Use this setting if you are running kibana without https
 opensearch_security.cookie.secure: false
+opensearch_security.auth.unauthenticated_routes: ['/api/reporting/stats', '/api/status']

--- a/docker/release/config/opensearch-dashboards/opensearch_dashboards.yml
+++ b/docker/release/config/opensearch-dashboards/opensearch_dashboards.yml
@@ -17,3 +17,4 @@ opensearch_security.multitenancy.tenants.preferred: [Private, Global]
 opensearch_security.readonly_mode.roles: [kibana_read_only]
 # Use this setting if you are running opensearch-dashboards without https
 opensearch_security.cookie.secure: false
+opensearch_security.auth.unauthenticated_routes: ['/api/reporting/stats', '/api/status']


### PR DESCRIPTION
### Description
Allow for the API status for OSD not to enforce auth.

https://github.com/opensearch-project/security-dashboards-plugin/pull/943

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
