### PR TITLE
Update PA directories from plugins to root

### DIFF
--- a/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
@@ -108,7 +108,7 @@ function runOpensearch {
     OPENSEARCH_PID=$!
 
     # Start performance analyzer agent
-    performance-analyzer-agent-cli > $OPENSEARCH_HOME/logs/performance-analyzer.log 2>&1 &
+    $OPENSEARCH_HOME/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli > $OPENSEARCH_HOME/logs/performance-analyzer.log 2>&1 &
     PA_PID=$!
 
     # Wait for the child processes to terminate

--- a/docker/release/dockerfiles/opensearch.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2.dockerfile
@@ -20,7 +20,7 @@ ARG GID=1000
 ARG TEMP_DIR=/tmp/opensearch
 ARG OPENSEARCH_HOME=/usr/share/opensearch
 ARG SECURITY_PLUGIN_DIR=$OPENSEARCH_HOME/plugins/opensearch-security
-ARG PERFORMANCE_ANALYZER_PLUGIN_DIR=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer
+ARG PERFORMANCE_ANALYZER_PLUGIN_CONFIG_DIR=$OPENSEARCH_HOME/config/opensearch-performance-analyzer
 
 # Update packages
 # Install the tools we need: tar and gzip to unpack the OpenSearch tarball, and shadow-utils to give us `groupadd` and `useradd`.
@@ -39,7 +39,7 @@ RUN ls -l $TEMP_DIR && \
     tar -xzpf /tmp/opensearch/opensearch-`uname -p`.tgz -C $OPENSEARCH_HOME --strip-components=1 && \
     mkdir -p $OPENSEARCH_HOME/data && chown -Rv $UID:$GID $OPENSEARCH_HOME/data && \
     if [[ -d $SECURITY_PLUGIN_DIR ]] ; then chmod -v 750 $SECURITY_PLUGIN_DIR/tools/* ; fi && \
-    if [[ -d $PERFORMANCE_ANALYZER_PLUGIN_DIR ]] ; then cp -v $TEMP_DIR/performance-analyzer.properties $PERFORMANCE_ANALYZER_PLUGIN_DIR/config/; fi && \
+    if [[ -d $PERFORMANCE_ANALYZER_PLUGIN_CONFIG_DIR ]] ; then cp -v $TEMP_DIR/performance-analyzer.properties $PERFORMANCE_ANALYZER_PLUGIN_CONFIG_DIR; fi && \
     cp -v $TEMP_DIR/opensearch-docker-entrypoint.sh $TEMP_DIR/opensearch-onetime-setup.sh $OPENSEARCH_HOME/ && \
     cp -v $TEMP_DIR/log4j2.properties $TEMP_DIR/opensearch.yml $OPENSEARCH_HOME/config/ && \
     ls -l $OPENSEARCH_HOME && \

--- a/scripts/components/performance-analyzer/install.sh
+++ b/scripts/components/performance-analyzer/install.sh
@@ -69,5 +69,3 @@ fi
 
 ## Setup Performance Analyzer Agent
 mv $OUTPUT/plugins/opensearch-performance-analyzer/performance-analyzer-rca $OUTPUT/
-mv $OUTPUT/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli $OUTPUT/bin
-rm -rf $OUTPUT/bin/opensearch-performance-analyzer

--- a/scripts/deploy_single_tar_cluster.sh
+++ b/scripts/deploy_single_tar_cluster.sh
@@ -119,7 +119,7 @@ echo "script.context.field.max_compilations_rate: 1000/1m" >> config/opensearch.
 # Required for Security
 echo "plugins.security.unsupported.restapi.allow_securityconfig_modification: true" >> config/opensearch.yml
 # Required for PA
-echo "webservice-bind-host = 0.0.0.0" >> plugins/opensearch-performance-analyzer/config/performance-analyzer.properties
+echo "webservice-bind-host = 0.0.0.0" >> config/opensearch-performance-analyzer/performance-analyzer.properties
 # Security setup
 if [ "$ENABLE_SECURITY" == "false" ]
 then

--- a/scripts/legacy/tar/linux/opensearch-tar-install.sh
+++ b/scripts/legacy/tar/linux/opensearch-tar-install.sh
@@ -8,11 +8,8 @@ KNN_LIB_DIR=$OPENSEARCH_HOME/plugins/opensearch-knn/lib
 ##Security Plugin
 bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s
 
-##Perf Plugin
-chmod 755 $OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/bin/performance-analyzer-agent
-chmod 755 $OPENSEARCH_HOME/bin/performance-analyzer-agent-cli
 echo "done security"
-PA_AGENT_JAVA_OPTS="-Dlog4j.configurationFile=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/config/log4j2.xml \
+PA_AGENT_JAVA_OPTS="-Dlog4j.configurationFile=$OPENSEARCH_HOME/config/opensearch-performance-analyzer/log4j2.xml \
               -Xms64M -Xmx64M -XX:+UseSerialGC -XX:CICompilerCount=1 -XX:-TieredCompilation -XX:InitialCodeCacheSize=4096 \
               -XX:MaxRAM=400m"
 
@@ -26,7 +23,7 @@ if ! grep -q '## OpenSearch Performance Analyzer' $OPENSEARCH_HOME/config/jvm.op
    echo '## OpenSearch Performance Analyzer' >> $OPENSEARCH_HOME/config/jvm.options
    echo "-Dclk.tck=$CLK_TCK" >> $OPENSEARCH_HOME/config/jvm.options
    echo "-Djdk.attach.allowAttachSelf=true" >> $OPENSEARCH_HOME/config/jvm.options
-   echo "-Djava.security.policy=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/config/opensearch_security.policy" >> $OPENSEARCH_HOME/config/jvm.options
+   echo "-Djava.security.policy=$OPENSEARCH_HOME/config/opensearch-performance-analyzer/opensearch_security.policy" >> $OPENSEARCH_HOME/config/jvm.options
    echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> $OPENSEARCH_HOME/config/jvm.options
 fi
 echo "done plugins"

--- a/scripts/opensearch-onetime-setup.sh
+++ b/scripts/opensearch-onetime-setup.sh
@@ -34,18 +34,13 @@ fi
 ##Perf Plugin
 PA_PLUGIN="opensearch-performance-analyzer"
 
-if [ -d $OPENSEARCH_HOME/plugins/$PA_PLUGIN ]; then
-    chmod 755 $OPENSEARCH_HOME/plugins/$PA_PLUGIN/bin/performance-analyzer-agent
-    chmod 755 $OPENSEARCH_HOME/bin/performance-analyzer-agent-cli
-fi
-
 if ! grep -q '## OpenDistro Performance Analyzer' $OPENSEARCH_HOME/config/jvm.options; then
    CLK_TCK=`/usr/bin/getconf CLK_TCK`
    echo >> $OPENSEARCH_HOME/config/jvm.options
    echo '## OpenDistro Performance Analyzer' >> $OPENSEARCH_HOME/config/jvm.options
    echo "-Dclk.tck=$CLK_TCK" >> $OPENSEARCH_HOME/config/jvm.options
    echo "-Djdk.attach.allowAttachSelf=true" >> $OPENSEARCH_HOME/config/jvm.options
-   echo "-Djava.security.policy=$OPENSEARCH_HOME/plugins/$PA_PLUGIN/config/opensearch_security.policy" >> $OPENSEARCH_HOME/config/jvm.options
+   echo "-Djava.security.policy=$OPENSEARCH_HOME/config/$PA_PLUGIN/opensearch_security.policy" >> $OPENSEARCH_HOME/config/jvm.options
    echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> $OPENSEARCH_HOME/config/jvm.options
 fi
 

--- a/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
@@ -93,7 +93,7 @@ if ! grep -q '## OpenSearch Performance Analyzer' %{config_dir}/jvm.options; the
    echo '## OpenSearch Performance Analyzer' >> %{config_dir}/jvm.options
    echo "-Dclk.tck=$CLK_TCK" >> %{config_dir}/jvm.options
    echo "-Djdk.attach.allowAttachSelf=true" >> %{config_dir}/jvm.options
-   echo "-Djava.security.policy=file:///usr/share/opensearch/plugins/opensearch-performance-analyzer/config/opensearch_security.policy" >> %{config_dir}/jvm.options
+   echo "-Djava.security.policy=file:///etc/opensearch/opensearch-performance-analyzer/opensearch_security.policy" >> %{config_dir}/jvm.options
    echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> %{config_dir}/jvm.options
 fi
 # Reload systemctl daemon

--- a/scripts/pkg/service_templates/opensearch/usr/lib/systemd/system/opensearch-performance-analyzer.service
+++ b/scripts/pkg/service_templates/opensearch/usr/lib/systemd/system/opensearch-performance-analyzer.service
@@ -4,7 +4,7 @@ Description=OpenSearch Performance Analyzer
 
 [Service]
 Type=simple
-ExecStart=/usr/share/opensearch/bin/performance-analyzer-agent-cli
+ExecStart=/usr/share/opensearch/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli
 Restart=on-failure
 User=opensearch
 Group=opensearch


### PR DESCRIPTION
Signed-off-by: sruti1312 <srutiparthiban@gmail.com>

### Description
OpenSearch moves the plugins config and bin directories into root bin and config folder. This behaviour is similar with all plugins and the expected behaviour. Modifying all PA locations to new root directory location.
 
### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/2963
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
