### PR TITLE
Remove BWC test for now as BWC framework does not run correctly as well as rpm integTest as it requires root

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -173,50 +173,27 @@ pipeline {
                             echo "buildManifestUrl (x64, rpm): ${buildManifestUrl}"
                             echo "artifactUrl (x64, rpm): ${artifactUrl}"
 
-                            parallel([
-                                'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
+                            'integ-test': {
+                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                if (!skipIntegTests) {
+                                    def integTestResults =
+                                        build job: INTEG_TEST_JOB_NAME,
+                                        propagate: false,
+                                        wait: true,
+                                        parameters: [
+                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                            string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                        ]
 
-                                        env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (x64, rpm)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
-                                    } 
-                                },
-                                'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
-
-                                        env.ARTIFACT_URL_X64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (x64, rpm)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
-                                    }
-                                }
-                            ])
+                                    env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
+                                        testType: "Integ Tests (x64, rpm)",
+                                        status: integTestResults.getResult(),
+                                        absoluteUrl: integTestResults.getAbsoluteUrl()
+                                    )
+                                } 
+                            }
                         }
                     }
                     post {
@@ -401,50 +378,27 @@ pipeline {
                                     echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
                                     echo "artifactUrl (arm64, rpm): ${artifactUrl}"
 
-                                    parallel([
-                                        'integ-test': {
-                                            Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                            echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                            if (!skipIntegTests) {
-                                                def integTestResults = 
-                                                    build job: INTEG_TEST_JOB_NAME,
-                                                    propagate: false,
-                                                    wait: true,
-                                                    parameters: [
-                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                                    ]
+                                    'integ-test': {
+                                        Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                        echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                        if (!skipIntegTests) {
+                                            def integTestResults = 
+                                                build job: INTEG_TEST_JOB_NAME,
+                                                propagate: false,
+                                                wait: true,
+                                                parameters: [
+                                                    string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                    string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                    string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                                ]
 
-                                                env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                                    testType: "Integ Tests (arm64, rpm)",
-                                                    status: integTestResults.getResult(),
-                                                    absoluteUrl: integTestResults.getAbsoluteUrl()
-                                                )
-                                            }
-                                        },
-                                        'bwc-test': {
-                                            Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                            echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                            if (!skipBwcTests) {
-                                                def bwcTestResults =
-                                                    build job: BWC_TEST_JOB_NAME,
-                                                    propagate: false,
-                                                    wait: true,
-                                                    parameters: [
-                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                                    ]
-
-                                                env.ARTIFACT_URL_ARM64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
-                                                    testType: "BWC Tests (arm64, rpm)",
-                                                    status: bwcTestResults.getResult(),
-                                                    absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                                )
-                                            }
+                                            env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
+                                                testType: "Integ Tests (arm64, rpm)",
+                                                status: integTestResults.getResult(),
+                                                absoluteUrl: integTestResults.getAbsoluteUrl()
+                                            )
                                         }
-                                    ])
+                                    }
                                 }
                             }
                             post {

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -150,27 +150,6 @@ pipeline {
                             echo "buildManifestUrl (x64, rpm): ${buildManifestUrl}"
                             echo "artifactUrl (x64, rpm): ${artifactUrl}"
 
-                            'integ-test': {
-                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                if (!skipIntegTests) {
-                                    def integTestResults =
-                                        build job: INTEG_TEST_JOB_NAME,
-                                        propagate: false,
-                                        wait: true,
-                                        parameters: [
-                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                            string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                        ]
-
-                                    env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                        testType: "Integ Tests (x64, rpm)",
-                                        status: integTestResults.getResult(),
-                                        absoluteUrl: integTestResults.getAbsoluteUrl()
-                                    )
-                                } 
-                            }
                         }
                     }
                     post {
@@ -332,27 +311,6 @@ pipeline {
                                     echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
                                     echo "artifactUrl (arm64, rpm): ${artifactUrl}"
 
-                                    'integ-test': {
-                                        Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                        echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                        if (!skipIntegTests) {
-                                            def integTestResults = 
-                                                build job: INTEG_TEST_JOB_NAME,
-                                                propagate: false,
-                                                wait: true,
-                                                parameters: [
-                                                    string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                    string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                    string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                                ]
-
-                                            env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                                testType: "Integ Tests (arm64, rpm)",
-                                                status: integTestResults.getResult(),
-                                                absoluteUrl: integTestResults.getAbsoluteUrl()
-                                            )
-                                        }
-                                    }
                                 }
                             }
                             post {

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -88,50 +88,27 @@ pipeline {
                             echo "buildManifestUrl (x64, tar): ${buildManifestUrl}"
                             echo "artifactUrl (x64, tar): ${artifactUrl}"
 
-                            parallel([
-                                'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
+                            'integ-test': {
+                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                if (!skipIntegTests) {
+                                    def integTestResults =
+                                        build job: INTEG_TEST_JOB_NAME,
+                                        propagate: false,
+                                        wait: true,
+                                        parameters: [
+                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                            string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                        ]
 
-                                        env.ARTIFACT_URL_X64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (x64, tar)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
-                                    } 
-                                },
-                                'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
-
-                                        env.ARTIFACT_URL_X64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (x64, tar)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
-                                    }
-                                }
-                            ])
+                                    env.ARTIFACT_URL_X64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
+                                        testType: "Integ Tests (x64, tar)",
+                                        status: integTestResults.getResult(),
+                                        absoluteUrl: integTestResults.getAbsoluteUrl()
+                                    )
+                                } 
+                            }
                         }
                     }
                     post {
@@ -263,50 +240,27 @@ pipeline {
                                     echo "buildManifestUrl (arm64, tar): ${buildManifestUrl}"
                                     echo "artifactUrl (arm64, tar): ${artifactUrl}"
 
-                                    parallel([
-                                        'integ-test': {
-                                            Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                            echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                            if (!skipIntegTests) {
-                                                def integTestResults = 
-                                                    build job: INTEG_TEST_JOB_NAME,
-                                                    propagate: false,
-                                                    wait: true,
-                                                    parameters: [
-                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                                    ]
+                                    'integ-test': {
+                                        Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                        echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                        if (!skipIntegTests) {
+                                            def integTestResults = 
+                                                build job: INTEG_TEST_JOB_NAME,
+                                                propagate: false,
+                                                wait: true,
+                                                parameters: [
+                                                    string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                    string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                    string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                                ]
 
-                                                env.ARTIFACT_URL_ARM64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                                    testType: "Integ Tests (arm64, tar)",
-                                                    status: integTestResults.getResult(),
-                                                    absoluteUrl: integTestResults.getAbsoluteUrl()
-                                                )
-                                            }
-                                        },
-                                        'bwc-test': {
-                                            Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                            echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                            if (!skipBwcTests) {
-                                                def bwcTestResults =
-                                                    build job: BWC_TEST_JOB_NAME,
-                                                    propagate: false,
-                                                    wait: true,
-                                                    parameters: [
-                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                                    ]
-
-                                                env.ARTIFACT_URL_ARM64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
-                                                    testType: "BWC Tests (arm64, tar)",
-                                                    status: bwcTestResults.getResult(),
-                                                    absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                                )
-                                            }
+                                            env.ARTIFACT_URL_ARM64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
+                                                testType: "Integ Tests (arm64, tar)",
+                                                status: integTestResults.getResult(),
+                                                absoluteUrl: integTestResults.getAbsoluteUrl()
+                                            )
                                         }
-                                    ])
+                                    }
                                 }
                             }
                             post {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -237,50 +237,27 @@ pipeline {
                             echo "buildManifestUrl (x64, rpm): ${buildManifestUrl}"
                             echo "artifactUrl (x64, rpm): ${artifactUrl}"
                             
-                            parallel([
-                                'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
+                            'integ-test': {
+                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                if (!skipIntegTests) {
+                                    def integTestResults =
+                                        build job: INTEG_TEST_JOB_NAME,
+                                        propagate: false,
+                                        wait: true,
+                                        parameters: [
+                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                            string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                        ]
 
-                                        env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (x64, rpm)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
-                                    }
-                                },                            
-                                'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
-
-                                        env.ARTIFACT_URL_X64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (x64, rpm)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
-                                    }
+                                    env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
+                                        testType: "Integ Tests (x64, rpm)",
+                                        status: integTestResults.getResult(),
+                                        absoluteUrl: integTestResults.getAbsoluteUrl()
+                                    )
                                 }
-                            ])
+                            }
                         }
                     }
                     post {
@@ -403,51 +380,27 @@ pipeline {
                             echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
                             echo "artifactUrl (arm64, rpm): ${artifactUrl}"
 
-                            parallel([
-                                'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                            ]
+                            'integ-test': {
+                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                if (!skipIntegTests) {
+                                    def integTestResults =
+                                        build job: INTEG_TEST_JOB_NAME,
+                                        propagate: false,
+                                        wait: true,
+                                        parameters: [
+                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                            string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                        ]
 
-                                        env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (arm64, rpm)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
-                                    }
-                                },
-                                'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                            ]
-
-                                        env.ARTIFACT_URL_ARM64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (arm64, rpm)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
-
-                                    }
+                                    env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
+                                        testType: "Integ Tests (arm64, rpm)",
+                                        status: integTestResults.getResult(),
+                                        absoluteUrl: integTestResults.getAbsoluteUrl()
+                                    )
                                 }
-                            ])
+                            }
                         }
                     }
                     post {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -214,27 +214,6 @@ pipeline {
                             echo "buildManifestUrl (x64, rpm): ${buildManifestUrl}"
                             echo "artifactUrl (x64, rpm): ${artifactUrl}"
                             
-                            'integ-test': {
-                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                if (!skipIntegTests) {
-                                    def integTestResults =
-                                        build job: INTEG_TEST_JOB_NAME,
-                                        propagate: false,
-                                        wait: true,
-                                        parameters: [
-                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                            string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                        ]
-
-                                    env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                        testType: "Integ Tests (x64, rpm)",
-                                        status: integTestResults.getResult(),
-                                        absoluteUrl: integTestResults.getAbsoluteUrl()
-                                    )
-                                }
-                            }
                         }
                     }
                     post {
@@ -334,27 +313,6 @@ pipeline {
                             echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
                             echo "artifactUrl (arm64, rpm): ${artifactUrl}"
 
-                            'integ-test': {
-                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                if (!skipIntegTests) {
-                                    def integTestResults =
-                                        build job: INTEG_TEST_JOB_NAME,
-                                        propagate: false,
-                                        wait: true,
-                                        parameters: [
-                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                            string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                        ]
-
-                                    env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                        testType: "Integ Tests (arm64, rpm)",
-                                        status: integTestResults.getResult(),
-                                        absoluteUrl: integTestResults.getAbsoluteUrl()
-                                    )
-                                }
-                            }
                         }
                     }
                     post {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -154,50 +154,27 @@ pipeline {
                             echo "buildManifestUrl (x64, tar): ${buildManifestUrl}"
                             echo "artifactUrl (x64, tar): ${artifactUrl}"
 
-                            parallel([
-                                'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
+                            'integ-test': {
+                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                if (!skipIntegTests) {
+                                    def integTestResults =
+                                        build job: INTEG_TEST_JOB_NAME,
+                                        propagate: false,
+                                        wait: true,
+                                        parameters: [
+                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                            string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                        ]
 
-                                        env.ARTIFACT_URL_X64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (x64, tar)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
-                                    }
-                                },
-                                'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
-
-                                        env.ARTIFACT_URL_X64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (x64, tar)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
-                                    }
+                                    env.ARTIFACT_URL_X64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
+                                        testType: "Integ Tests (x64, tar)",
+                                        status: integTestResults.getResult(),
+                                        absoluteUrl: integTestResults.getAbsoluteUrl()
+                                    )
                                 }
-                            ])
+                            }
                         }
                     }
                     post {
@@ -297,50 +274,27 @@ pipeline {
                             echo "buildManifestUrl (arm64, tar): ${buildManifestUrl}"
                             echo "artifactUrl (arm64, tar): ${artifactUrl}"
 
-                            parallel([
-                                'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                            ]
+                            'integ-test': {
+                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                if (!skipIntegTests) {
+                                    def integTestResults =
+                                        build job: INTEG_TEST_JOB_NAME,
+                                        propagate: false,
+                                        wait: true,
+                                        parameters: [
+                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                            string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                        ]
 
-                                        env.ARTIFACT_URL_ARM64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (arm64, tar)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
-                                    }
-                                },
-                                'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                            ]
-
-                                        env.ARTIFACT_URL_ARM64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (arm64, tar)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
-                                    }
+                                    env.ARTIFACT_URL_ARM64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
+                                        testType: "Integ Tests (arm64, tar)",
+                                        status: integTestResults.getResult(),
+                                        absoluteUrl: integTestResults.getAbsoluteUrl()
+                                    )
                                 }
-                            ])
+                            }
                         }
                     }
                     post {


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove BWC test for now as BWC framework does not run correctly as well as rpm integTest as it requires root

 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
