### PR TITLE
Change AD and AD-Dashboards to use 2.0 branch for 2.0 release

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -70,7 +70,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: main
+    ref: '2.0'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
@@ -43,7 +43,7 @@ components:
     ref: main
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: main
+    ref: '2.0'
   - name: notificationsDashboards
     repository: https://github.com/opensearch-project/notifications.git
     working_directory: dashboards-notifications


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
update AD and AD Dashboard to refer to 2.0 branch instead of main for 2.0 release 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
