### PR TITLE
default build.sh logic add for Gradle custom java zippublish plugin

### DIFF
--- a/scripts/default/opensearch/build.sh
+++ b/scripts/default/opensearch/build.sh
@@ -77,3 +77,14 @@ distributions="$(dirname "${zipPath}")"
 echo "COPY ${distributions}/*.zip"
 mkdir -p $OUTPUT/plugins
 cp ${distributions}/*.zip ./$OUTPUT/plugins
+
+TASK="publishMavenzipPublicationToZipstagingRepository"
+if ./gradlew tasks --all | grep -qw "^$TASK"
+then
+   ./gradlew publishMavenzipPublicationToZipstagingRepository -PzipVersion=$VERSION 
+    echo "Copying the Maven plugin Zips"
+    mkdir -p $OUTPUT/maven/org/opensearch/plugin
+    cp -r ./build/local-staging-repo/org/opensearch/plugin/. $OUTPUT/maven/org/opensearch/plugin
+else
+    echo "Not running publishMavenzipPublicationToZipstagingRepository"
+fi


### PR DESCRIPTION
Signed-off-by: pgodithi <pgodithi@amazon.com>

### Description
This change will add custom zippublish plugin publishMavenzipPublicationToZipstagingRepository logic to default build.sh, this can publish plugin zips to maven repo.
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1916
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
