### PR TITLE
Correct the RPM artifact link so docker can trigger correctly

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -397,7 +397,7 @@ pipeline {
 
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
                                     String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
-                                    env.ARTIFACT_URL_ARM64_TAR = artifactUrl
+                                    env.ARTIFACT_URL_ARM64_RPM = artifactUrl
                                     echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
                                     echo "artifactUrl (arm64, rpm): ${artifactUrl}"
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Correct the RPM artifact link so docker can trigger correctly
RPM override TAR:

![image](https://user-images.githubusercontent.com/65193828/164306335-3b3a6906-7573-456a-b963-6212988b2f1f.png)

 
### Issues Resolved
Part of #1624
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
