### PR TITLE
Revert #1990 and remove rpm integ/bwc test, and disable tar bwc test for 2.0.0

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -166,6 +166,13 @@ pipeline {
                                 architecture: 'x64',
                                 distribution: 'rpm'
                             )
+                            String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
+                            String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
+                            env.ARTIFACT_URL_X64_RPM = artifactUrl
+
+                            echo "buildManifestUrl (x64, rpm): ${buildManifestUrl}"
+                            echo "artifactUrl (x64, rpm): ${artifactUrl}"
+
                         }
                     }
                     post {
@@ -336,6 +343,12 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'rpm'
                                     )
+                                    String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
+                                    String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
+                                    env.ARTIFACT_URL_ARM64_RPM = artifactUrl
+                                    echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
+                                    echo "artifactUrl (arm64, rpm): ${artifactUrl}"
+
                                 }
                             }
                             post {

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -88,27 +88,50 @@ pipeline {
                             echo "buildManifestUrl (x64, tar): ${buildManifestUrl}"
                             echo "artifactUrl (x64, tar): ${artifactUrl}"
 
-                            'integ-test': {
-                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                if (!skipIntegTests) {
-                                    def integTestResults =
-                                        build job: INTEG_TEST_JOB_NAME,
-                                        propagate: false,
-                                        wait: true,
-                                        parameters: [
-                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                            string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                        ]
+                            parallel([
+                                'integ-test': {
+                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    if (!skipIntegTests) {
+                                        def integTestResults =
+                                            build job: INTEG_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
 
-                                    env.ARTIFACT_URL_X64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                        testType: "Integ Tests (x64, tar)",
-                                        status: integTestResults.getResult(),
-                                        absoluteUrl: integTestResults.getAbsoluteUrl()
-                                    )
-                                } 
-                            }
+                                        env.ARTIFACT_URL_X64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
+                                            testType: "Integ Tests (x64, tar)",
+                                            status: integTestResults.getResult(),
+                                            absoluteUrl: integTestResults.getAbsoluteUrl()
+                                        )
+                                    } 
+                                },
+                                'bwc-test': {
+                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    if (!skipBwcTests) {
+                                        def bwcTestResults =
+                                            build job: BWC_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
+
+                                        env.ARTIFACT_URL_X64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
+                                            testType: "BWC Tests (x64, tar)",
+                                            status: bwcTestResults.getResult(),
+                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                }
+                            ])
                         }
                     }
                     post {
@@ -150,6 +173,50 @@ pipeline {
                             echo "buildManifestUrl (x64, rpm): ${buildManifestUrl}"
                             echo "artifactUrl (x64, rpm): ${artifactUrl}"
 
+                            parallel([
+                                'integ-test': {
+                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    if (!skipIntegTests) {
+                                        def integTestResults =
+                                            build job: INTEG_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
+
+                                        env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
+                                            testType: "Integ Tests (x64, rpm)",
+                                            status: integTestResults.getResult(),
+                                            absoluteUrl: integTestResults.getAbsoluteUrl()
+                                        )
+                                    } 
+                                },
+                                'bwc-test': {
+                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    if (!skipBwcTests) {
+                                        def bwcTestResults =
+                                            build job: BWC_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
+
+                                        env.ARTIFACT_URL_X64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
+                                            testType: "BWC Tests (x64, rpm)",
+                                            status: bwcTestResults.getResult(),
+                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                }
+                            ])
                         }
                     }
                     post {
@@ -219,27 +286,50 @@ pipeline {
                                     echo "buildManifestUrl (arm64, tar): ${buildManifestUrl}"
                                     echo "artifactUrl (arm64, tar): ${artifactUrl}"
 
-                                    'integ-test': {
-                                        Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                        echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                        if (!skipIntegTests) {
-                                            def integTestResults = 
-                                                build job: INTEG_TEST_JOB_NAME,
-                                                propagate: false,
-                                                wait: true,
-                                                parameters: [
-                                                    string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                    string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                    string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                                ]
+                                    parallel([
+                                        'integ-test': {
+                                            Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                            echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                            if (!skipIntegTests) {
+                                                def integTestResults = 
+                                                    build job: INTEG_TEST_JOB_NAME,
+                                                    propagate: false,
+                                                    wait: true,
+                                                    parameters: [
+                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                                    ]
 
-                                            env.ARTIFACT_URL_ARM64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                                testType: "Integ Tests (arm64, tar)",
-                                                status: integTestResults.getResult(),
-                                                absoluteUrl: integTestResults.getAbsoluteUrl()
-                                            )
+                                                env.ARTIFACT_URL_ARM64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
+                                                    testType: "Integ Tests (arm64, tar)",
+                                                    status: integTestResults.getResult(),
+                                                    absoluteUrl: integTestResults.getAbsoluteUrl()
+                                                )
+                                            }
+                                        },
+                                        'bwc-test': {
+                                            Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                            echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                            if (!skipBwcTests) {
+                                                def bwcTestResults =
+                                                    build job: BWC_TEST_JOB_NAME,
+                                                    propagate: false,
+                                                    wait: true,
+                                                    parameters: [
+                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                                    ]
+
+                                                env.ARTIFACT_URL_ARM64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
+                                                    testType: "BWC Tests (arm64, tar)",
+                                                    status: bwcTestResults.getResult(),
+                                                    absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                                )
+                                            }
                                         }
-                                    }
+                                    ])
                                 }
                             }
                             post {
@@ -311,6 +401,50 @@ pipeline {
                                     echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
                                     echo "artifactUrl (arm64, rpm): ${artifactUrl}"
 
+                                    parallel([
+                                        'integ-test': {
+                                            Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                            echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                            if (!skipIntegTests) {
+                                                def integTestResults = 
+                                                    build job: INTEG_TEST_JOB_NAME,
+                                                    propagate: false,
+                                                    wait: true,
+                                                    parameters: [
+                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                                    ]
+
+                                                env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
+                                                    testType: "Integ Tests (arm64, rpm)",
+                                                    status: integTestResults.getResult(),
+                                                    absoluteUrl: integTestResults.getAbsoluteUrl()
+                                                )
+                                            }
+                                        },
+                                        'bwc-test': {
+                                            Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                            echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                            if (!skipBwcTests) {
+                                                def bwcTestResults =
+                                                    build job: BWC_TEST_JOB_NAME,
+                                                    propagate: false,
+                                                    wait: true,
+                                                    parameters: [
+                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                                    ]
+
+                                                env.ARTIFACT_URL_ARM64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
+                                                    testType: "BWC Tests (arm64, rpm)",
+                                                    status: bwcTestResults.getResult(),
+                                                    absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                                )
+                                            }
+                                        }
+                                    ])
                                 }
                             }
                             post {

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -166,69 +166,11 @@ pipeline {
                                 architecture: 'x64',
                                 distribution: 'rpm'
                             )
-                            String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
-                            String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
-                            env.ARTIFACT_URL_X64_RPM = artifactUrl
-
-                            echo "buildManifestUrl (x64, rpm): ${buildManifestUrl}"
-                            echo "artifactUrl (x64, rpm): ${artifactUrl}"
-
-                            parallel([
-                                'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
-
-                                        env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (x64, rpm)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
-                                    } 
-                                },
-                                'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
-
-                                        env.ARTIFACT_URL_X64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (x64, rpm)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
-                                    }
-                                }
-                            ])
                         }
                     }
                     post {
                         always {
                             script {
-                                lib.jenkins.Messages.new(this).add(
-                                    "${STAGE_NAME}",
-                                    lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                    "\n${env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT}" +
-                                    "\n${env.ARTIFACT_URL_X64_RPM_BWC_TEST_RESULT}"
-                                )
-
                                 postCleanup()
                             }
                         }
@@ -394,69 +336,11 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'rpm'
                                     )
-
-                                    String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
-                                    String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
-                                    env.ARTIFACT_URL_ARM64_RPM = artifactUrl
-                                    echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
-                                    echo "artifactUrl (arm64, rpm): ${artifactUrl}"
-
-                                    parallel([
-                                        'integ-test': {
-                                            Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                            echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                            if (!skipIntegTests) {
-                                                def integTestResults = 
-                                                    build job: INTEG_TEST_JOB_NAME,
-                                                    propagate: false,
-                                                    wait: true,
-                                                    parameters: [
-                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                                    ]
-
-                                                env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                                    testType: "Integ Tests (arm64, rpm)",
-                                                    status: integTestResults.getResult(),
-                                                    absoluteUrl: integTestResults.getAbsoluteUrl()
-                                                )
-                                            }
-                                        },
-                                        'bwc-test': {
-                                            Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                            echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                            if (!skipBwcTests) {
-                                                def bwcTestResults =
-                                                    build job: BWC_TEST_JOB_NAME,
-                                                    propagate: false,
-                                                    wait: true,
-                                                    parameters: [
-                                                        string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                        string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                        string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                                    ]
-
-                                                env.ARTIFACT_URL_ARM64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
-                                                    testType: "BWC Tests (arm64, rpm)",
-                                                    status: bwcTestResults.getResult(),
-                                                    absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                                )
-                                            }
-                                        }
-                                    ])
                                 }
                             }
                             post {
                                 always {
                                     script {
-                                        lib.jenkins.Messages.new(this).add(
-                                            "${STAGE_NAME}",
-                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                            "\n${env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT}" +
-                                            "\n${env.ARTIFACT_URL_ARM64_RPM_BWC_TEST_RESULT}"
-                                        )
-
                                         postCleanup()
                                     }
                                 }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -154,27 +154,50 @@ pipeline {
                             echo "buildManifestUrl (x64, tar): ${buildManifestUrl}"
                             echo "artifactUrl (x64, tar): ${artifactUrl}"
 
-                            'integ-test': {
-                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                if (!skipIntegTests) {
-                                    def integTestResults =
-                                        build job: INTEG_TEST_JOB_NAME,
-                                        propagate: false,
-                                        wait: true,
-                                        parameters: [
-                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                            string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                        ]
+                            parallel([
+                                'integ-test': {
+                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    if (!skipIntegTests) {
+                                        def integTestResults =
+                                            build job: INTEG_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
 
-                                    env.ARTIFACT_URL_X64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                        testType: "Integ Tests (x64, tar)",
-                                        status: integTestResults.getResult(),
-                                        absoluteUrl: integTestResults.getAbsoluteUrl()
-                                    )
+                                        env.ARTIFACT_URL_X64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
+                                            testType: "Integ Tests (x64, tar)",
+                                            status: integTestResults.getResult(),
+                                            absoluteUrl: integTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                },
+                                'bwc-test': {
+                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    if (!skipBwcTests) {
+                                        def bwcTestResults =
+                                            build job: BWC_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
+
+                                        env.ARTIFACT_URL_X64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
+                                            testType: "BWC Tests (x64, tar)",
+                                            status: bwcTestResults.getResult(),
+                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                        )
+                                    }
                                 }
-                            }
+                            ])
                         }
                     }
                     post {
@@ -214,6 +237,50 @@ pipeline {
                             echo "buildManifestUrl (x64, rpm): ${buildManifestUrl}"
                             echo "artifactUrl (x64, rpm): ${artifactUrl}"
                             
+                            parallel([
+                                'integ-test': {
+                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    if (!skipIntegTests) {
+                                        def integTestResults =
+                                            build job: INTEG_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
+
+                                        env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
+                                            testType: "Integ Tests (x64, rpm)",
+                                            status: integTestResults.getResult(),
+                                            absoluteUrl: integTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                },                            
+                                'bwc-test': {
+                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    if (!skipBwcTests) {
+                                        def bwcTestResults =
+                                            build job: BWC_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
+                                            ]
+
+                                        env.ARTIFACT_URL_X64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
+                                            testType: "BWC Tests (x64, rpm)",
+                                            status: bwcTestResults.getResult(),
+                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                }
+                            ])
                         }
                     }
                     post {
@@ -253,27 +320,50 @@ pipeline {
                             echo "buildManifestUrl (arm64, tar): ${buildManifestUrl}"
                             echo "artifactUrl (arm64, tar): ${artifactUrl}"
 
-                            'integ-test': {
-                                Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                if (!skipIntegTests) {
-                                    def integTestResults =
-                                        build job: INTEG_TEST_JOB_NAME,
-                                        propagate: false,
-                                        wait: true,
-                                        parameters: [
-                                            string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                            string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                            string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                        ]
+                            parallel([
+                                'integ-test': {
+                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    if (!skipIntegTests) {
+                                        def integTestResults =
+                                            build job: INTEG_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                            ]
 
-                                    env.ARTIFACT_URL_ARM64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                        testType: "Integ Tests (arm64, tar)",
-                                        status: integTestResults.getResult(),
-                                        absoluteUrl: integTestResults.getAbsoluteUrl()
-                                    )
+                                        env.ARTIFACT_URL_ARM64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
+                                            testType: "Integ Tests (arm64, tar)",
+                                            status: integTestResults.getResult(),
+                                            absoluteUrl: integTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                },
+                                'bwc-test': {
+                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    if (!skipBwcTests) {
+                                        def bwcTestResults =
+                                            build job: BWC_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                            ]
+
+                                        env.ARTIFACT_URL_ARM64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
+                                            testType: "BWC Tests (arm64, tar)",
+                                            status: bwcTestResults.getResult(),
+                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                        )
+                                    }
                                 }
-                            }
+                            ])
                         }
                     }
                     post {
@@ -313,6 +403,51 @@ pipeline {
                             echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
                             echo "artifactUrl (arm64, rpm): ${artifactUrl}"
 
+                            parallel([
+                                'integ-test': {
+                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
+                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    if (!skipIntegTests) {
+                                        def integTestResults =
+                                            build job: INTEG_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                            ]
+
+                                        env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
+                                            testType: "Integ Tests (arm64, rpm)",
+                                            status: integTestResults.getResult(),
+                                            absoluteUrl: integTestResults.getAbsoluteUrl()
+                                        )
+                                    }
+                                },
+                                'bwc-test': {
+                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
+                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    if (!skipBwcTests) {
+                                        def bwcTestResults =
+                                            build job: BWC_TEST_JOB_NAME,
+                                            propagate: false,
+                                            wait: true,
+                                            parameters: [
+                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
+                                            ]
+
+                                        env.ARTIFACT_URL_ARM64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
+                                            testType: "BWC Tests (arm64, rpm)",
+                                            status: bwcTestResults.getResult(),
+                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
+                                        )
+
+                                    }
+                                }
+                            ])
                         }
                     }
                     post {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -230,6 +230,13 @@ pipeline {
                                 inputManifest: "manifests/${INPUT_MANIFEST}",
                                 distribution: "rpm"
                             )
+                            String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
+                            String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
+                            env.ARTIFACT_URL_X64_RPM = artifactUrl
+
+                            echo "buildManifestUrl (x64, rpm): ${buildManifestUrl}"
+                            echo "artifactUrl (x64, rpm): ${artifactUrl}"
+
                         }
                     }
                     post {
@@ -338,6 +345,13 @@ pipeline {
                                 inputManifest: "manifests/${INPUT_MANIFEST}",
                                 distribution: "rpm"
                             )
+                            String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
+                            String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
+                            env.ARTIFACT_URL_ARM64_RPM = artifactUrl
+
+                            echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
+                            echo "artifactUrl (arm64, rpm): ${artifactUrl}"
+
                         }
                     }
                     post {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -230,69 +230,11 @@ pipeline {
                                 inputManifest: "manifests/${INPUT_MANIFEST}",
                                 distribution: "rpm"
                             )
-                            String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
-                            String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
-                            env.ARTIFACT_URL_X64_RPM = artifactUrl
-
-                            echo "buildManifestUrl (x64, rpm): ${buildManifestUrl}"
-                            echo "artifactUrl (x64, rpm): ${artifactUrl}"
-                            
-                            parallel([
-                                'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
-
-                                        env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (x64, rpm)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
-                                    }
-                                },                            
-                                'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_X64)
-                                            ]
-
-                                        env.ARTIFACT_URL_X64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (x64, rpm)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
-                                    }
-                                }
-                            ])
                         }
                     }
                     post {
                         always {
                             script {
-                                lib.jenkins.Messages.new(this).add(
-                                    "${STAGE_NAME}",
-                                    lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                    "\n${env.ARTIFACT_URL_X64_RPM_INTEG_TEST_RESULT}" +
-                                    "\n${env.ARTIFACT_URL_X64_RPM_BWC_TEST_RESULT}"
-                                )
-
                                 postCleanup()
                             }
                         }
@@ -396,70 +338,10 @@ pipeline {
                                 inputManifest: "manifests/${INPUT_MANIFEST}",
                                 distribution: "rpm"
                             )
-                            String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
-                            String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
-                            env.ARTIFACT_URL_ARM64_RPM = artifactUrl
-
-                            echo "buildManifestUrl (arm64, rpm): ${buildManifestUrl}"
-                            echo "artifactUrl (arm64, rpm): ${artifactUrl}"
-
-                            parallel([
-                                'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                            ]
-
-                                        env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (arm64, rpm)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
-                                    }
-                                },
-                                'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: true,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_ARM64)
-                                            ]
-
-                                        env.ARTIFACT_URL_ARM64_RPM_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (arm64, rpm)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
-
-                                    }
-                                }
-                            ])
                         }
                     }
                     post {
                         always {
-                            script {
-                                lib.jenkins.Messages.new(this).add(
-                                    "${STAGE_NAME}",
-                                    lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) + 
-                                    "\n${env.ARTIFACT_URL_ARM64_RPM_INTEG_TEST_RESULT}" +
-                                    "\n${env.ARTIFACT_URL_ARM64_RPM_BWC_TEST_RESULT}"
-                                )
-
                                 postCleanup()
                             }
                         }

--- a/manifests/2.0.0/opensearch-2.0.0-test.yml
+++ b/manifests/2.0.0/opensearch-2.0.0-test.yml
@@ -15,10 +15,6 @@ components:
         - without-security
       additional-cluster-configs:
         path.repo: [/tmp]
-    bwc-test:
-      test-configs:
-        - with-security
-        - without-security
 
   - name: anomaly-detection
     integ-test:
@@ -27,17 +23,9 @@ components:
       test-configs:
         - with-security
         - without-security
-    bwc-test:
-      test-configs:
-        - with-security
-        - without-security
 
   - name: asynchronous-search
     integ-test:
-      test-configs:
-        - with-security
-        - without-security
-    bwc-test:
       test-configs:
         - with-security
         - without-security
@@ -49,18 +37,10 @@ components:
         - without-security
       additional-cluster-configs:
         plugins.destination.host.deny_list: [10.0.0.0/8, 127.0.0.1]
-    bwc-test:
-      test-configs:
-        - with-security
-        - without-security
 
   - name: notifications
     working-directory: notifications
     integ-test:
-      test-configs:
-        - with-security
-        - without-security
-    bwc-test:
       test-configs:
         - with-security
         - without-security
@@ -72,17 +52,9 @@ components:
         - without-security
       additional-cluster-configs:
         script.context.field.max_compilations_rate: 1000/1m
-    bwc-test:
-      test-configs:
-        - with-security
-        - without-security
 
   - name: k-NN
     integ-test:
-      test-configs:
-        - with-security
-        - without-security
-    bwc-test:
       test-configs:
         - with-security
         - without-security
@@ -92,25 +64,15 @@ components:
     integ-test:
       test-configs:
         - without-security
-    bwc-test:
-      test-configs:
-        - without-security
 
   - name: observability
     working-directory: opensearch-observability
     integ-test:
       test-configs:
         - without-security
-    bwc-test:
-      test-configs:
-        - without-security
 
   - name: ml-commons
     integ-test:
-      test-configs:
-        - with-security
-        - without-security
-    bwc-test:
       test-configs:
         - with-security
         - without-security


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Revert #1990 and remove rpm integ/bwc test, and disable tar bwc test for 2.0.0
 
### Issues Resolved
Part of #1624
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
