### PR TITLE
Resolve docker does not build on dashboards (PR2)

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -391,8 +391,8 @@ pipeline {
                         
                         buildDockerImage(
                             inputManifest: "manifests/${INPUT_MANIFEST}",
-                            artifactUrlX64: env.ARTIFACT_URL_X64,
-                            artifactUrlArm64: env.ARTIFACT_URL_ARM64
+                            artifactUrlX64: env.ARTIFACT_URL_X64_TAR,
+                            artifactUrlArm64: env.ARTIFACT_URL_ARM64_TAR
                         )
                     }
                 }


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Resolve docker does not build on dashboards (PR2)
 
### Issues Resolved
Part of #1624
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
