### PR TITLE
Add observability BE integTest and remove 2.0.0 builds trigger

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -7,12 +7,10 @@ pipeline {
     agent none
     triggers {
         parameterizedCron '''
-            H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-dashboards-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
-            H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=2.0.0/opensearch-2.0.0.yml;TEST_MANIFEST=2.0.0/opensearch-2.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=2.0.0/opensearch-dashboards-2.0.0.yml;TEST_MANIFEST=2.0.0/opensearch-dashboards-2.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H 1 * * * %INPUT_MANIFEST=2.1.0/opensearch-2.1.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
+            H 1 * * * %INPUT_MANIFEST=1.3.2/opensearch-dashboards-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
+            H 1 * * * %INPUT_MANIFEST=1.3.2/opensearch-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
+            H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
         '''
     }
     parameters {

--- a/manifests/2.0.0/opensearch-2.0.0-test.yml
+++ b/manifests/2.0.0/opensearch-2.0.0-test.yml
@@ -65,7 +65,7 @@ components:
       test-configs:
         - without-security
 
-  - name: observability
+  - name: opensearch-observability
     working-directory: opensearch-observability
     integ-test:
       test-configs:


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add observability BE integTest and remove 2.0.0 builds trigger
 
### Issues Resolved
Part of #1624
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
