### PR TITLE
Add the jenkinsfile for rpm validation

### DIFF
--- a/jenkins/rpm-validation/rpm-validation.jenkinsfile
+++ b/jenkins/rpm-validation/rpm-validation.jenkinsfile
@@ -1,0 +1,55 @@
+lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+
+pipeline {
+    agent none
+    options {
+        timeout(time: 30, unit: 'MINUTES')
+    }
+    parameters {
+            string(
+                name: 'BUNDLE_MANIFEST_URL',
+                description: 'The bundle manifest url. (e.g. https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.0.0-rc1/2493/linux/x64/rpm/dist/opensearch/manifest.yml)',
+                trim: true
+            )
+            string(
+                name: 'AGENT_LABEL',
+                description: 'The agent label where the tests should be executed, e.g. Jenkins-Agent-al2-x64-c54xlarge-Docker-Host.',
+                trim: true
+            )
+
+        }
+
+    stages {
+        stage('RPM distribution validation starts:') {
+            agent {
+                docker {
+                    label AGENT_LABEL
+                    image 'opensearchstaging/ci-runner:ci-runner-centos7-systemd-base-integtest-v1'
+                    args '--entrypoint=/usr/sbin/init -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro'
+                    alwaysPull true
+                }
+            }
+            steps {
+                script {
+                    rpmDistValidation(
+                        bundleManifestURL: "$BUNDLE_MANIFEST_URL"
+                    )
+                }
+            }
+            post {
+                always {
+                    sh "rm -rf $WORKSPACE/*"
+                    postCleanup()
+                }
+            }
+        }
+    }
+    post() {
+        success {
+            echo "Validation for the RPM distribution has been completed successfully."
+        }
+        failure {
+            echo "Validation for RPM distribution failed."
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Add the jenkinsfile for job to call the RPM distribution validation. 
 
### Issues Resolved
#1555
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
