### PR TITLE
Add uninstall function for tar integTest between plugins

### DIFF
--- a/src/test_workflow/integ_test/distribution.py
+++ b/src/test_workflow/integ_test/distribution.py
@@ -47,8 +47,9 @@ class Distribution(ABC):
         """
         pass
 
+    @abstractmethod
     def uninstall(self) -> None:
         """
-        Allow distribution that is not 'tar' to do proper cleanup
+        Allow distribution to do proper cleanup
         """
         pass

--- a/src/test_workflow/integ_test/distribution_tar.py
+++ b/src/test_workflow/integ_test/distribution_tar.py
@@ -6,8 +6,8 @@
 
 import logging
 import os
-import tarfile
 import subprocess
+import tarfile
 
 from test_workflow.integ_test.distribution import Distribution
 

--- a/src/test_workflow/integ_test/distribution_tar.py
+++ b/src/test_workflow/integ_test/distribution_tar.py
@@ -7,6 +7,7 @@
 import logging
 import os
 import tarfile
+import subprocess
 
 from test_workflow.integ_test.distribution import Distribution
 
@@ -35,3 +36,7 @@ class DistributionTar(Distribution):
             "opensearch-dashboards": "./opensearch-dashboards",
         }
         return start_cmd_map[self.filename]
+
+    def uninstall(self) -> None:
+        logging.info(f"Cleanup {self.work_dir}/* content after the test")
+        subprocess.check_call(f"rm -rf {self.work_dir}/*", shell=True)

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_tar.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_tar.py
@@ -6,7 +6,7 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from test_workflow.integ_test.distribution_tar import DistributionTar
 
@@ -43,3 +43,11 @@ class TestDistributionTar(unittest.TestCase):
     def test_start_cmd(self) -> None:
         self.assertEqual(self.distribution_tar.start_cmd, "./opensearch-tar-install.sh")
         self.assertEqual(self.distribution_tar_dashboards.start_cmd, "./opensearch-dashboards")
+
+    @patch("subprocess.check_call")
+    def test_uninstall(self, check_call_mock: Mock) -> None:
+        self.distribution_tar.uninstall()
+        args_list = check_call_mock.call_args_list
+
+        self.assertEqual(check_call_mock.call_count, 1)
+        self.assertEqual(f"rm -rf {self.work_dir}/*", args_list[0][0][0])


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add uninstall function for tar integTest between plugins.

Now the cluster is green not yellow between each plugin type run.

```
2022-04-21 22:42:48 INFO     200: {"cluster_name":"opensearch","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"discovered_cluster_manager":true,"active_primary_shards":1,"active_shards":1,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0}

2022-04-21 22:43:33 INFO     200: {"cluster_name":"opensearch","status":"green","timed_out":false,"number_of_nodes":1,"number_of_data_nodes":1,"discovered_master":true,"discovered_cluster_manager":true,"active_primary_shards":1,"active_shards":1,"relocating_shards":0,"initializing_shards":0,"unassigned_shards":0,"delayed_unassigned_shards":0,"number_of_pending_tasks":0,"number_of_in_flight_fetch":0,"task_max_waiting_in_queue_millis":0,"active_shards_percent_as_number":100.0}
```
 
### Issues Resolved
#2018
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
