### PR TITLE
pass test run id when running tests from Jenkins

### DIFF
--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/bwc-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/bwc-test.jenkinsfile.txt
@@ -37,7 +37,7 @@
                   BuildManifest.getArtifactRootUrl(dummy_job, 215)
                   runBwcTestScript.echo(Artifact root URL: https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
                   runBwcTestScript.echo(Paths: opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
-                  runBwcTestScript.sh(./test.sh bwc-test manifests/tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml --paths opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
+                  runBwcTestScript.sh(./test.sh bwc-test manifests/tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml --test-run-id 1 --paths opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
          bwc-test.script(groovy.lang.Closure)
             bwc-test.uploadTestResults({buildManifestFileName=tests/jenkins/data/opensearch-dashboards-1.2.0-build.yml, jobName=dummy_job, buildNumber=215})
                uploadTestResults.legacySCM(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
@@ -37,7 +37,7 @@
                   BuildManifest.getArtifactRootUrl(dummy_job, 215)
                   runIntegTestScript.echo(Artifact root URL: https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
                   runIntegTestScript.echo(Paths: opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.2.0/latest/linux/x64/tar opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
-                  runIntegTestScript.sh(./test.sh integ-test manifests/tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.2.0/latest/linux/x64/tar opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
+                  runIntegTestScript.sh(./test.sh integ-test manifests/tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml --test-run-id 1 --paths opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.2.0/latest/linux/x64/tar opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
          integ-test.script(groovy.lang.Closure)
             integ-test.uploadTestResults({buildManifestFileName=tests/jenkins/data/opensearch-dashboards-1.2.0-build.yml, jobName=dummy_job, buildNumber=215})
                uploadTestResults.legacySCM(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/bwc-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/bwc-test.jenkinsfile.txt
@@ -37,7 +37,7 @@
                   BuildManifest.getArtifactRootUrl(dummy_job, 717)
                   runBwcTestScript.echo(Artifact root URL: https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
                   runBwcTestScript.echo(Paths: opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
-                  runBwcTestScript.sh(./test.sh bwc-test manifests/tests/jenkins/data/opensearch-1.3.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
+                  runBwcTestScript.sh(./test.sh bwc-test manifests/tests/jenkins/data/opensearch-1.3.0-test.yml --test-run-id 1 --paths opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
          bwc-test.script(groovy.lang.Closure)
             bwc-test.uploadTestResults({buildManifestFileName=tests/jenkins/data/opensearch-1.3.0-build.yml, jobName=dummy_job, buildNumber=717})
                uploadTestResults.legacySCM(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
@@ -37,7 +37,7 @@
                   BuildManifest.getArtifactRootUrl(dummy_job, 717)
                   runIntegTestScript.echo(Artifact root URL: https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
                   runIntegTestScript.echo(Paths: opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
-                  runIntegTestScript.sh(./test.sh integ-test manifests/tests/jenkins/data/opensearch-1.3.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
+                  runIntegTestScript.sh(./test.sh integ-test manifests/tests/jenkins/data/opensearch-1.3.0-test.yml --test-run-id 1 --paths opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
          integ-test.script(groovy.lang.Closure)
             integ-test.uploadTestResults({buildManifestFileName=tests/jenkins/data/opensearch-1.3.0-build.yml, jobName=dummy_job, buildNumber=717})
                uploadTestResults.legacySCM(groovy.lang.Closure)

--- a/tests/jenkins/jobs/RunBwcTestScript_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RunBwcTestScript_Jenkinsfile.txt
@@ -11,4 +11,4 @@
                   BuildManifest.getArtifactRootUrl(dummy_job, 717)
                   runBwcTestScript.echo(Artifact root URL: https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
                   runBwcTestScript.echo(Paths: opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
-                  runBwcTestScript.sh(./test.sh bwc-test tests/jenkins/data/opensearch-1.3.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
+                  runBwcTestScript.sh(./test.sh bwc-test tests/jenkins/data/opensearch-1.3.0-test.yml --test-run-id 1 --paths opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)

--- a/tests/jenkins/jobs/RunBwcTestScript_OpenSearch_Dashboards_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RunBwcTestScript_OpenSearch_Dashboards_Jenkinsfile.txt
@@ -11,4 +11,4 @@
                   BuildManifest.getArtifactRootUrl(dummy_job, 215)
                   runBwcTestScript.echo(Artifact root URL: https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
                   runBwcTestScript.echo(Paths: opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
-                  runBwcTestScript.sh(./test.sh bwc-test tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml --paths opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
+                  runBwcTestScript.sh(./test.sh bwc-test tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml --test-run-id 1 --paths opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)

--- a/tests/jenkins/jobs/RunIntegTestScript_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RunIntegTestScript_Jenkinsfile.txt
@@ -11,4 +11,4 @@
                   BuildManifest.getArtifactRootUrl(dummy_job, 717)
                   runIntegTestScript.echo(Artifact root URL: https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
                   runIntegTestScript.echo(Paths: opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
-                  runIntegTestScript.sh(./test.sh integ-test tests/jenkins/data/opensearch-1.3.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)
+                  runIntegTestScript.sh(./test.sh integ-test tests/jenkins/data/opensearch-1.3.0-test.yml --test-run-id 1 --paths opensearch=https://ci.opensearch.org/ci/dbc/dummy_job/1.3.0/717/linux/x64/tar)

--- a/tests/jenkins/jobs/RunIntegTestScript_OpenSearch_Dashboards_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RunIntegTestScript_OpenSearch_Dashboards_Jenkinsfile.txt
@@ -11,4 +11,4 @@
                   BuildManifest.getArtifactRootUrl(dummy_job, 215)
                   runIntegTestScript.echo(Artifact root URL: https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
                   runIntegTestScript.echo(Paths: opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.2.0/latest/linux/x64/tar opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
-                  runIntegTestScript.sh(./test.sh integ-test tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml --paths opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.2.0/latest/linux/x64/tar opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)
+                  runIntegTestScript.sh(./test.sh integ-test tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml --test-run-id 1 --paths opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.2.0/latest/linux/x64/tar opensearch-dashboards=https://ci.opensearch.org/ci/dbc/dummy_job/1.2.0/215/linux/x64/tar)

--- a/vars/runBwcTestScript.groovy
+++ b/vars/runBwcTestScript.groovy
@@ -12,6 +12,7 @@ void call(Map args = [:]) {
         './test.sh',
         'bwc-test',
         "${args.testManifest}",
+        '--test-run-id 1',
         "--paths ${paths}",
     ].join(' '))
 }

--- a/vars/runIntegTestScript.groovy
+++ b/vars/runIntegTestScript.groovy
@@ -12,6 +12,7 @@ void call(Map args = [:]) {
         './test.sh',
         'integ-test',
         "${args.testManifest}",
+        '--test-run-id 1',
         "--paths ${paths}",
     ].join(' '))
 }

--- a/vars/runPerfTestScript.groovy
+++ b/vars/runPerfTestScript.groovy
@@ -15,6 +15,7 @@ void call(Map args = [:]) {
         "--stack test-single-security-${args.buildId}-${args.architecture}",
         "--bundle-manifest ${args.bundleManifest}",
         "--config config.yml",
+        '--test-run-id 1',
         args.insecure ? "--without-security" : "",
         isNullOrEmpty(args.workload) ? "" : "--workload ${args.workload}",
         isNullOrEmpty(args.testIterations) ? "" : "--test-iters ${args.testIterations}",

--- a/vars/runPerfTestScript.groovy
+++ b/vars/runPerfTestScript.groovy
@@ -15,7 +15,6 @@ void call(Map args = [:]) {
         "--stack test-single-security-${args.buildId}-${args.architecture}",
         "--bundle-manifest ${args.bundleManifest}",
         "--config config.yml",
-        '--test-run-id 1',
         args.insecure ? "--without-security" : "",
         isNullOrEmpty(args.workload) ? "" : "--workload ${args.workload}",
         isNullOrEmpty(args.testIterations) ? "" : "--test-iters ${args.testIterations}",


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
Currently the test result can be accessed by a url with a random value https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/1.3.0/1493/linux/arm64/test-results/e4fe62b882294caabd99701b6d0b612f/integ-test/functionalTestDashboards/without-security/test-results/stdout.txt
 
This will require us to check the S3 to get the full url which is very inconvenient. Thus set a value to the id so that we can use `latest` url to check the results.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
