### PR TITLE
upload test result to upstream job if exists

### DIFF
--- a/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
@@ -99,9 +99,11 @@ pipeline {
             post {
                 always {
                     script {
+                        String jobNameToUploadResult = currentBuild.upstreamBuilds ? currentBuild.upstreamBuilds[0].fullProjectName : JOB_NAME
+
                         uploadTestResults(
                             buildManifestFileName: BUILD_MANIFEST,
-                            jobName: JOB_NAME,
+                            jobName: jobNameToUploadResult,
                             buildNumber: BUILD_ID
                         )
                     }

--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -99,9 +99,11 @@ pipeline {
             post {
                 always {
                     script {
+                        String jobNameToUploadResult = currentBuild.upstreamBuilds ? currentBuild.upstreamBuilds[0].fullProjectName : JOB_NAME
+
                         uploadTestResults(
                             buildManifestFileName: BUILD_MANIFEST,
-                            jobName: JOB_NAME,
+                            jobName: jobNameToUploadResult,
                             buildNumber: BUILD_ID
                         )
                     }

--- a/jenkins/opensearch/bwc-test.jenkinsfile
+++ b/jenkins/opensearch/bwc-test.jenkinsfile
@@ -102,9 +102,11 @@ pipeline {
             post {
                 always {
                     script {
+                        String jobNameToUploadResult = currentBuild.upstreamBuilds ? currentBuild.upstreamBuilds[0].fullProjectName : JOB_NAME
+
                         uploadTestResults(
                             buildManifestFileName: BUILD_MANIFEST,
-                            jobName: JOB_NAME,
+                            jobName: jobNameToUploadResult,
                             buildNumber: BUILD_ID
                         )
                     }

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -102,9 +102,11 @@ pipeline {
             post {
                 always {
                     script {
+                        String jobNameToUploadResult = currentBuild.upstreamBuilds ? currentBuild.upstreamBuilds[0].fullProjectName : JOB_NAME
+
                         uploadTestResults(
                             buildManifestFileName: BUILD_MANIFEST,
-                            jobName: JOB_NAME,
+                            jobName: jobNameToUploadResult,
                             buildNumber: BUILD_ID
                         )
                     }


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
Follow up on https://github.com/opensearch-project/opensearch-build/pull/2024#issuecomment-1106743524
When non-prod build job triggers the integ test, it will override the result from prod build job if the build number happens to be same. Thus add the logic to upload the test result to its upstream job if it exists. This can avoid such conflict and also allow us to use `latest` url to access the test result.
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
