### PR TITLE
[OSD][2.0] use Cypress 5.x test runner

### DIFF
--- a/manifests/2.0.0/opensearch-dashboards-2.0.0-test.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0-test.yml
@@ -3,7 +3,7 @@ schema-version: '1.0'
 name: OpenSearch Dashboards
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
+    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
 components:
   - name: OpenSearch-Dashboards
     bwc-test:


### PR DESCRIPTION
### Description
For OSD 2.0, we utilize Cypress version 5.x, the current test runner for OSD 2.0 utilizes a Cypress version of 9.x. This points tests to run on a test runner that has a 5.x version of Cypress and OSD will utilize the pre-packaged Node executable so it doesn't matter what node version is on the test runner.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
