### PR TITLE
Add back binding to 0.0.0.0 for the OSD docker images

### DIFF
--- a/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
@@ -34,6 +34,7 @@ COPY * $TEMP_DIR/
 RUN tar -xzpf $TEMP_DIR/opensearch-dashboards-`uname -p`.tgz -C $OPENSEARCH_DASHBOARDS_HOME --strip-components=1 && \
     cp -v $TEMP_DIR/opensearch-dashboards-docker-entrypoint.sh $OPENSEARCH_DASHBOARDS_HOME/ && \
     cp -v $TEMP_DIR/opensearch_dashboards.yml $TEMP_DIR/opensearch.example.org.* $OPENSEARCH_DASHBOARDS_HOME/config/ && \
+    echo "server.host: '0.0.0.0'" >> $OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.yml && \
     ls -l $OPENSEARCH_DASHBOARDS_HOME && \
     rm -rf $TEMP_DIR
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@dev-dsk-zhujiaxi-2a-c8d595b4.us-west-2.amazon.com>

### Description
Add back binding to 0.0.0.0 for the OSD docker images
 
### Issues Resolved

 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
