### PR TITLE
updated 3.0.0 manifest with JAVA_HOME arguement

### DIFF
--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -6,6 +6,7 @@ build:
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2
+    args: -e JAVA_HOME=/opt/java/openjdk-17
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git


### PR DESCRIPTION
Signed-off-by: Joshua Palis <jpalis@amazon.com>

### Description
Distribution build pipelines using the OpenSearch 3.0.0 manifest fail since JAVA_HOME is not set within the node. I've added this argument to the 3.0.0 manifest, mirroring the 2.0.0 manifest

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
