### PR TITLE
Remove the period at the end of RPM metadata description.

### DIFF
--- a/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
@@ -25,7 +25,7 @@ ExclusiveArch: %{_architecture}
 AutoReqProv: no
 
 %description
-OpenSearch makes it easy to ingest, search, visualize, and analyze your data.
+OpenSearch makes it easy to ingest, search, visualize, and analyze your data
 For more information, see: https://opensearch.org/
 
 %prep

--- a/tests/jenkins/TestRpmMetaValidation.groovy
+++ b/tests/jenkins/TestRpmMetaValidation.groovy
@@ -20,7 +20,7 @@ class TestRpmMetaValidation extends BuildPipelineTest {
         def refMap = [Name:"opensearch", Version: "1.3.1", Architecture: "x64", Group: "Application/Internet",
                 License: "Apache-2.0", Relocations: "(not relocatable)", URL: "https://opensearch.org/",
                 Summary: "An open source distributed and RESTful search engine",
-                Description: "OpenSearch makes it easy to ingest, search, visualize, and analyze your data.\n" +
+                Description: "OpenSearch makes it easy to ingest, search, visualize, and analyze your data\n" +
                         "For more information, see: https://opensearch.org/"
         ]
         this.registerLibTester(new RpmMetaValidationLibTester(rpmDistribution, refMap))
@@ -41,7 +41,7 @@ class TestRpmMetaValidation extends BuildPipelineTest {
                 "URL         : https://opensearch.org/\n" +
                 "Summary     : An open source distributed and RESTful search engine\n" +
                 "Description :\n" +
-                "OpenSearch makes it easy to ingest, search, visualize, and analyze your data.\n" +
+                "OpenSearch makes it easy to ingest, search, visualize, and analyze your data\n" +
                 "For more information, see: https://opensearch.org/"
         helper.addShMock("rpm -qip $workspace/opensearch-1.3.1-linux-x64.rpm") { script ->
             return [stdout: out, exitValue: 0]

--- a/tests/jenkins/TestRpmOpenSearchDistValidation.groovy
+++ b/tests/jenkins/TestRpmOpenSearchDistValidation.groovy
@@ -36,7 +36,7 @@ class TestRpmOpenSearchDistValidation extends BuildPipelineTest {
                 "URL         : https://opensearch.org/\n" +
                 "Summary     : An open source distributed and RESTful search engine\n" +
                 "Description :\n" +
-                "OpenSearch makes it easy to ingest, search, visualize, and analyze your data.\n" +
+                "OpenSearch makes it easy to ingest, search, visualize, and analyze your data\n" +
                 "For more information, see: https://opensearch.org/"
         helper.addShMock("rpm -qip $workspace/opensearch-1.3.1-linux-x64.rpm") { script ->
             return [stdout: out, exitValue: 0]

--- a/tests/jenkins/jobs/RpmMetaValidation_Jenkinsfile
+++ b/tests/jenkins/jobs/RpmMetaValidation_Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
                         refMap: [Name:"opensearch", Version: "1.3.1", Architecture: "x64", Group: "Application/Internet",
                                                 License: "Apache-2.0", Relocations: "(not relocatable)", URL: "https://opensearch.org/",
                                                 Summary: "An open source distributed and RESTful search engine",
-                                                Description: "OpenSearch makes it easy to ingest, search, visualize, and analyze your data.\n" +
+                                                Description: "OpenSearch makes it easy to ingest, search, visualize, and analyze your data\n" +
                                                         "For more information, see: https://opensearch.org/"
                                         ],
                         rpmDistribution: "/tmp/workspace/opensearch-1.3.1-linux-x64.rpm"

--- a/tests/jenkins/jobs/RpmMetaValidation_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RpmMetaValidation_Jenkinsfile.txt
@@ -3,7 +3,7 @@
          RpmMetaValidation_Jenkinsfile.echo(Executing on agent [label:none])
          RpmMetaValidation_Jenkinsfile.stage(validate RPM meta, groovy.lang.Closure)
             RpmMetaValidation_Jenkinsfile.script(groovy.lang.Closure)
-               RpmMetaValidation_Jenkinsfile.rpmMetaValidation({refMap={Name=opensearch, Version=1.3.1, Architecture=x64, Group=Application/Internet, License=Apache-2.0, Relocations=(not relocatable), URL=https://opensearch.org/, Summary=An open source distributed and RESTful search engine, Description=OpenSearch makes it easy to ingest, search, visualize, and analyze your data.
+               RpmMetaValidation_Jenkinsfile.rpmMetaValidation({refMap={Name=opensearch, Version=1.3.1, Architecture=x64, Group=Application/Internet, License=Apache-2.0, Relocations=(not relocatable), URL=https://opensearch.org/, Summary=An open source distributed and RESTful search engine, Description=OpenSearch makes it easy to ingest, search, visualize, and analyze your data
 For more information, see: https://opensearch.org/}, rpmDistribution=/tmp/workspace/opensearch-1.3.1-linux-x64.rpm})
                   rpmMetaValidation.sh({script=rpm -qip /tmp/workspace/opensearch-1.3.1-linux-x64.rpm, returnStdout=true})
                   rpmMetaValidation.println(Meta data for Name is validated)

--- a/tests/jenkins/jobs/RpmOpenSearchDistValidation_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RpmOpenSearchDistValidation_Jenkinsfile.txt
@@ -9,7 +9,7 @@
                   rpmOpenSearchDistValidation.readYaml({file=tests/jenkins/data/opensearch-1.3.1-x64-rpm.yml})
                   BundleManifest.asBoolean()
                   BundleManifest.getNames()
-                  rpmOpenSearchDistValidation.rpmMetaValidation({rpmDistribution=/tmp/workspace/opensearch-1.3.1-linux-x64.rpm, refMap={Name=opensearch, Version=1.3.1, Architecture=x64, Group=Application/Internet, License=Apache-2.0, Relocations=(not relocatable), URL=https://opensearch.org/, Summary=An open source distributed and RESTful search engine, Description=OpenSearch makes it easy to ingest, search, visualize, and analyze your data.
+                  rpmOpenSearchDistValidation.rpmMetaValidation({rpmDistribution=/tmp/workspace/opensearch-1.3.1-linux-x64.rpm, refMap={Name=opensearch, Version=1.3.1, Architecture=x64, Group=Application/Internet, License=Apache-2.0, Relocations=(not relocatable), URL=https://opensearch.org/, Summary=An open source distributed and RESTful search engine, Description=OpenSearch makes it easy to ingest, search, visualize, and analyze your data
 For more information, see: https://opensearch.org/}})
                      rpmMetaValidation.sh({script=rpm -qip /tmp/workspace/opensearch-1.3.1-linux-x64.rpm, returnStdout=true})
                      rpmMetaValidation.println(Meta data for Name is validated)

--- a/vars/rpmOpenSearchDistValidation.groovy
+++ b/vars/rpmOpenSearchDistValidation.groovy
@@ -26,7 +26,7 @@ def call(Map args = [:]) {
     refMap['URL'] = "https://opensearch.org/"
     // The context the meta data should be for OpenSearch
     refMap['Summary'] = "An open source distributed and RESTful search engine"
-    refMap['Description'] = "OpenSearch makes it easy to ingest, search, visualize, and analyze your data.\n" +
+    refMap['Description'] = "OpenSearch makes it easy to ingest, search, visualize, and analyze your data\n" +
             "For more information, see: https://opensearch.org/"
 
     rpmMetaValidation(


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Remove the period at the end of RPM metadata description for OS to be consistent with the description of OSD. 
https://github.com/opensearch-project/opensearch-build/blob/cbe0f12ba5b57675e8cf2ad464cd7e0184d86117/scripts/pkg/build_templates/opensearch-dashboards/opensearch-dashboards.rpm.spec#L27-L28

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
