### PR TITLE
Reduce the frequency to build 1.3.2 once a day

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -7,8 +7,8 @@ pipeline {
     agent none
     triggers {
         parameterizedCron '''
-            H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-dashboards-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
-            H/10 * * * * %INPUT_MANIFEST=1.3.2/opensearch-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
+            H 1 * * * %INPUT_MANIFEST=1.3.2/opensearch-dashboards-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
+            H 1 * * * %INPUT_MANIFEST=1.3.2/opensearch-1.3.2.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=2.1.0/opensearch-2.1.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
         '''


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Currently 1.3.2 build is failing every five minutes and overwhelmed the build for 2.0.0 rc1.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
