### PR TITLE
Use dedicated jenkins host for CCR Perf tests

### DIFF
--- a/jenkins/cross-cluster-replication/perf-test.jenkinsfile
+++ b/jenkins/cross-cluster-replication/perf-test.jenkinsfile
@@ -6,8 +6,8 @@ pipeline {
         timeout(time: 10, unit: 'HOURS')
     }
     environment {
-        AGENT_LABEL = 'Jenkins-Agent-al2-x64-m5xlarge-Perf-Test'
-        AGENT_IMAGE = 'opensearchstaging/ci-runner:ci-runner-centos7-v1'
+        AGENT_LABEL = 'Jenkins-Agent-al2-x64-m52xlarge-Docker-Host-Perf-Test'
+        AGENT_IMAGE = 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2'
         BUNDLE_MANIFEST = 'bundle-manifest.yml'
         JOB_NAME = 'ccr-perf-test'
     }


### PR DESCRIPTION
Signed-off-by: Ankit Kala <ankikala@amazon.com>

### Description
Use dedicated jenkins host for CCR Perf tests

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1500

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
