### PR TITLE
Make sure the build repo is pulled in docker-build stage

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -433,18 +433,24 @@ pipeline {
                     return params.BUILD_DOCKER
                 }
             }
+            agent {
+                docker {
+                    label AGENT_X64
+                    image dockerAgent.image
+                    args dockerAgent.args
+                    alwaysPull true
+                }
+            }
             steps {
-                node(AGENT_X64) {
-                    script {
-                        echo "env.ARTIFACT_URL_X64_TAR: ${env.ARTIFACT_URL_X64_TAR}"
-                        echo "env.ARTIFACT_URL_ARM64_TAR: ${env.ARTIFACT_URL_ARM64_TAR}"
-                        
-                        buildDockerImage(
-                            inputManifest: "manifests/${INPUT_MANIFEST}",
-                            artifactUrlX64: env.ARTIFACT_URL_X64_TAR,
-                            artifactUrlArm64: env.ARTIFACT_URL_ARM64_TAR
-                        )
-                    }
+                script {
+                    echo "env.ARTIFACT_URL_X64_TAR: ${env.ARTIFACT_URL_X64_TAR}"
+                    echo "env.ARTIFACT_URL_ARM64_TAR: ${env.ARTIFACT_URL_ARM64_TAR}"
+                    
+                    buildDockerImage(
+                        inputManifest: "manifests/${INPUT_MANIFEST}",
+                        artifactUrlX64: env.ARTIFACT_URL_X64_TAR,
+                        artifactUrlArm64: env.ARTIFACT_URL_ARM64_TAR
+                    )
                 }
             }
         }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -432,19 +432,24 @@ pipeline {
                     return params.BUILD_DOCKER
                 }
             }
+            agent {
+                docker {
+                    label AGENT_X64
+                    image dockerAgent.image
+                    args dockerAgent.args
+                    alwaysPull true
+                }
+            }
             steps {
-                node('Jenkins-Agent-al2-x64-c54xlarge-Docker-Host') {
-                    script {
-
-                        echo "env.ARTIFACT_URL_X64_TAR: ${env.ARTIFACT_URL_X64_TAR}"
-                        echo "env.ARTIFACT_URL_ARM64_TAR: ${env.ARTIFACT_URL_ARM64_TAR}"
-                        
-                        buildDockerImage(
-                            inputManifest: "manifests/${INPUT_MANIFEST}",
-                            artifactUrlX64: env.ARTIFACT_URL_X64_TAR,
-                            artifactUrlArm64: env.ARTIFACT_URL_ARM64_TAR
-                        )
-                    }
+                script {
+                    echo "env.ARTIFACT_URL_X64_TAR: ${env.ARTIFACT_URL_X64_TAR}"
+                    echo "env.ARTIFACT_URL_ARM64_TAR: ${env.ARTIFACT_URL_ARM64_TAR}"
+                    
+                    buildDockerImage(
+                        inputManifest: "manifests/${INPUT_MANIFEST}",
+                        artifactUrlX64: env.ARTIFACT_URL_X64_TAR,
+                        artifactUrlArm64: env.ARTIFACT_URL_ARM64_TAR
+                    )
                 }
             }
         }


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Make sure the build repo is pulled in docker-build stage.
Directly use agent node will have consequences where git repo is not pulled.
Running on docker container will force the pull every time.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
