### PR TITLE
Change the docker image for OSD integ test

### DIFF
--- a/manifests/1.3.2/opensearch-dashboards-1.3.2-test.yml
+++ b/manifests/1.3.2/opensearch-dashboards-1.3.2-test.yml
@@ -3,7 +3,7 @@ schema-version: '1.0'
 name: OpenSearch Dashboards
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
+    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
 components:
   - name: OpenSearch-Dashboards
     bwc-test:


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Change the docker image for OSD integ test.
According to @kavilla, v2 has cypress version 9.x when 1.3 branch expects 5.6.
Change it back to v1 for 1.3.2 release.

### Issues Resolved
Part of #1882 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
