### PR TITLE
Switch 2.0.0 release to tags

### DIFF
--- a/manifests/2.0.0/opensearch-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-2.0.0.yml
@@ -9,32 +9,32 @@ build:
   version: 2.0.0
 components:
   - name: OpenSearch
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     repository: https://github.com/opensearch-project/OpenSearch.git
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     platforms:
       - darwin
       - linux
@@ -43,74 +43,74 @@ components:
       - gradle:dependencies:opensearch.version
   - name: notifications-core
     repository: https://github.com/opensearch-project/notifications.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     working_directory: notifications
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-notifications-core
   - name: notifications
     repository: https://github.com/opensearch-project/notifications.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     working_directory: notifications
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: notifications
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     working_directory: opensearch-observability
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     working_directory: reports-scheduler
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+++ b/manifests/2.0.0/opensearch-dashboards-2.0.0.yml
@@ -8,7 +8,7 @@ ci:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2
 components:
   - name: OpenSearch-Dashboards
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     checks:
       - npm:package:version
@@ -18,32 +18,32 @@ components:
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/sql.git
     working_directory: workbench
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/observability.git
     working_directory: dashboards-observability
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
     working_directory: gantt-chart
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reports.git
     working_directory: dashboards-reports
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1
   - name: notificationsDashboards
     repository: https://github.com/opensearch-project/notifications.git
     working_directory: dashboards-notifications
-    ref: '2.0'
+    ref: tags/2.0.0.0-rc1


### PR DESCRIPTION
### Description
Switching the manifest over to tags

Note; I figured I would update all projects, when this passes CI it indicates that all repositories have cut release tags.

### Issues Resolved
Completes finalize the release of https://github.com/opensearch-project/opensearch-build/issues/1624

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
