### PR TITLE
Fix incorrect path in documentation

### DIFF
--- a/src/build_workflow/README.md
+++ b/src/build_workflow/README.md
@@ -76,7 +76,7 @@ The following options are available in `build.sh`.
 
 ### Custom Build Scripts
 
-Each component build relies on a `build.sh` script that is used to prepare bundle artifacts for a particular bundle version that takes two arguments: version and target architecture. By default the tool will look for a script in [scripts/components](../../scripts/components), then in the checked-out repository in `build/build.sh`, then default to a Gradle build implemented in [scripts/default/opensearch/build.sh](../../scripts/default/opensearch/build.sh).
+Each component build relies on a `build.sh` script that is used to prepare bundle artifacts for a particular bundle version that takes two arguments: version and target architecture. By default the tool will look for a script in [scripts/components](../../scripts/components), then in the checked-out repository in `build.sh`, then default to a Gradle build implemented in [scripts/default/opensearch/build.sh](../../scripts/default/opensearch/build.sh).
 
 ### Avoiding Rebuilds
 

--- a/src/build_workflow/README.md
+++ b/src/build_workflow/README.md
@@ -76,7 +76,7 @@ The following options are available in `build.sh`.
 
 ### Custom Build Scripts
 
-Each component build relies on a `build.sh` script that is used to prepare bundle artifacts for a particular bundle version that takes two arguments: version and target architecture. By default the tool will look for a script in [scripts/components](../../scripts/components), then in the checked-out repository in `build.sh`, then default to a Gradle build implemented in [scripts/default/opensearch/build.sh](../../scripts/default/opensearch/build.sh).
+Each component build relies on a `build.sh` script that is used to prepare bundle artifacts for a particular bundle version that takes two arguments: version and target architecture. By default the tool will look for a script in [scripts/components](../../scripts/components), then in the checked-out repository in `scripts/build.sh`, then default to a Gradle build implemented in [scripts/default/opensearch/build.sh](../../scripts/default/opensearch/build.sh).
 
 ### Avoiding Rebuilds
 


### PR DESCRIPTION
### Description
When I was authoring https://github.com/opensearch-project/security/pull/1811 I had to iterate a couple of extra times and debug the python code because the custom script was not being picked up due to the incorrect path.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
