### PR TITLE
Add rpm digest generation so FIPS enabled host can install rpm

### DIFF
--- a/scripts/pkg/build_templates/opensearch-dashboards/opensearch-dashboards.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch-dashboards/opensearch-dashboards.rpm.spec
@@ -4,6 +4,10 @@
 # Disable brp-java-repack-jars, so jars will not be decompressed and repackaged
 %define __jar_repack 0
 
+# Generate digests
+%define _source_filedigest_algorithm 8
+%define _binary_filedigest_algorithm 8
+
 # User Define Variables
 %define product_dir %{_datadir}/%{name}
 %define config_dir %{_sysconfdir}/%{name}

--- a/scripts/pkg/build_templates/opensearch-dashboards/opensearch-dashboards.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch-dashboards/opensearch-dashboards.rpm.spec
@@ -4,7 +4,9 @@
 # Disable brp-java-repack-jars, so jars will not be decompressed and repackaged
 %define __jar_repack 0
 
-# Generate digests
+# Generate digests, 8 means algorithm of sha256
+# This is different from rpm sig algorithm
+# Requires rpm version 4.12 + to generate but b/c run on older versions
 %define _source_filedigest_algorithm 8
 %define _binary_filedigest_algorithm 8
 

--- a/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
@@ -4,6 +4,10 @@
 # Disable brp-java-repack-jars, so jars will not be decompressed and repackaged
 %define __jar_repack 0
 
+# Generate digests
+%define _source_filedigest_algorithm 8
+%define _binary_filedigest_algorithm 8
+
 # User Define Variables
 %define product_dir %{_datadir}/%{name}
 %define config_dir %{_sysconfdir}/%{name}

--- a/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/opensearch.rpm.spec
@@ -4,7 +4,9 @@
 # Disable brp-java-repack-jars, so jars will not be decompressed and repackaged
 %define __jar_repack 0
 
-# Generate digests
+# Generate digests, 8 means algorithm of sha256
+# This is different from rpm sig algorithm
+# Requires rpm version 4.12 + to generate but b/c run on older versions
 %define _source_filedigest_algorithm 8
 %define _binary_filedigest_algorithm 8
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add rpm digest generation so FIPS enabled host can install rpm

### Issues Resolved
#2099

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
