### PR TITLE
Add gcc-gfortran in default installation for future reference

### DIFF
--- a/docker/ci/dockerfiles/build.centos7.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/build.centos7.opensearch.x64.arm64.dockerfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: Apache-3.0
 #
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
@@ -91,7 +91,7 @@ RUN ln -sfn /usr/local/bin/python3.7 /usr/bin/python3 && \
     pip3 install pipenv && pipenv --version
 
 # Add k-NN Library dependencies
-RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack -y
+RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack gcc-gfortran -y
 RUN pip3 install pip==21.3.1
 RUN pip3 install cmake==3.21.3
 RUN pip3 install awscli==1.22.12

--- a/docker/ci/dockerfiles/build.centos7.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/build.centos7.opensearch.x64.arm64.dockerfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-3.0
+# SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Hi,

Add gcc-gfortran in default installation for future reference.

As of now, gcc-gfortran automatically installed as part of `Development Tools` group package in centos7.
However, upon testing in centos8/rockylinux8 this behavior is not there anymore, and requires specific installation to get the pkg.

Since this pkg is required to compile k-NN lib with openblas, I would like to include this pkg in the centos dockerfile, in case it get missed later.

Thanks.



### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
