### PR TITLE
Change back the WhiteSource unified agent version

### DIFF
--- a/tools/vulnerability-scan/wss-scan.sh
+++ b/tools/vulnerability-scan/wss-scan.sh
@@ -33,7 +33,7 @@ java -version; gradle -v; mvn -v; node -v; npm -v; yarn -v
 if [ ! -f "wss-unified-agent.jar" ]
 then
   # Download the WhiteSource Agent 
-  curl https://unified-agent.s3.amazonaws.com/wss-unified-agent-22.3.3.jar --output wss-unified-agent.jar
+  curl https://unified-agent.s3.amazonaws.com/wss-unified-agent-21.11.2.1.jar --output wss-unified-agent.jar
 fi
 
 # scan the config file for the user configurations


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
There was an issue with our WhiteSource offline scan on OpenSearch Dashboards 1.3 branch after we changed the unified agent to the latest one and this is currently blocking the entire offline scan. 
The error context: 
```
[INFO] [2022-05-09 03:28:56,980 +0000] - Process finished with exit code SERVER_FAILURE (Failed to send request to WhiteSource server: Illegal arguments: Invalid NPM dependency info, DependencyInfo@73080e73[groupId= rxjs/fetch,artifactId= rxjs/fetch-.tgz,version= ,filename= rxjs/fetch-.tgz,dependencyType= NPM ]
Support token: 3d03f98a901074d0b9ba1ca96f2dbf1421652066936695)
```
This issue was reproduced locally with unified agent `v22.3.3`. However this haven't seen before with older version `v21.11.2.1`. Therefore this PR is to switch back to the older stable version of WhiteSource unified agent for our offline scan. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
