### PR TITLE
Support multiple values in --component.

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     parameters {
         string(
             name: 'COMPONENT_NAME',
-            description: 'If this field contains a component name (e.g. OpenSearch-Dashboards), will build with "--component <COMPONENT_NAME>", else build everything in the INPUT_MANIFEST.',
+            description: 'If this field contains one or more component names (e.g. OpenSearch-Dashboards reportsDashboards ...), will build with "--component <COMPONENT_NAME> ...", else build everything in the INPUT_MANIFEST.',
             trim: true
         )
         string(

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     parameters {
         string(
             name: 'COMPONENT_NAME',
-            description: 'If this field contains a component name (e.g. OpenSearch), will build with "--component <COMPONENT_NAME>", else build everything in the INPUT_MANIFEST.',
+            description: 'If this field contains one or more component names (e.g. OpenSearch common-utils ...), will build with "--component <COMPONENT_NAME> ...", else build everything in the INPUT_MANIFEST.',
             trim: true
         )
         string(

--- a/src/build_workflow/README.md
+++ b/src/build_workflow/README.md
@@ -63,16 +63,16 @@ To build components we rely on a common entry-point in the form of a `build.sh` 
 
 The following options are available in `build.sh`.
 
-| name               | description                                                             |
-|--------------------|-------------------------------------------------------------------------|
-| -s, --snapshot     | Build a snapshot instead of a release artifact, default is `false`.     |
-| -a, --architecture | Specify architecture to build, default is architecture of build system. |
-| -d, --distribution | Specify distribution to build, default is `tar`.                        |
-| -p, --platform     | Specify platform to build, default is platform of build system.         |
-| --component [name] | Rebuild a single component by name, e.g. `--component common-utils`.    |
-| --keep             | Do not delete the temporary working directory on both success or error. |
-| -l, --lock         | Generate a stable reference manifest.                                   |
-| -v, --verbose      | Show more verbose output.                                               |
+| name                    | description                                                                            |
+|-------------------------|----------------------------------------------------------------------------------------|
+| -s, --snapshot          | Build a snapshot instead of a release artifact, default is `false`.                    |
+| -a, --architecture      | Specify architecture to build, default is architecture of build system.                |
+| -d, --distribution      | Specify distribution to build, default is `tar`.                                       |
+| -p, --platform          | Specify platform to build, default is platform of build system.                        |
+| --component [name ...]  | Rebuild a subset of components by name, e.g. `--component common-utils job-scheduler`. |
+| --keep                  | Do not delete the temporary working directory on both success or error.                |
+| -l, --lock              | Generate a stable reference manifest.                                                  |
+| -v, --verbose           | Show more verbose output.                                                              |
 
 ### Custom Build Scripts
 

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -7,7 +7,7 @@
 import argparse
 import logging
 import sys
-from typing import IO
+from typing import IO, List
 
 
 class BuildArgs:
@@ -20,15 +20,19 @@ class BuildArgs:
 
     manifest: IO
     snapshot: bool
-    component: str
+    components: List[str]
     keep: bool
     platform: str
     architecture: str
     distribution: str
 
     def __init__(self) -> None:
-        parser = argparse.ArgumentParser(description="Build an OpenSearch Bundle")
-        parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
+        parser = argparse.ArgumentParser(description="Build an OpenSearch Distribution")
+        parser.add_argument(
+            "manifest",
+            type=argparse.FileType("r"),
+            help="Manifest file."
+        )
         parser.add_argument(
             "-l",
             "--lock",
@@ -44,15 +48,34 @@ class BuildArgs:
             default=False,
             help="Build snapshot.",
         )
-        parser.add_argument("-c", "--component", type=str, help="Rebuild a single component.")
+        parser.add_argument(
+            "-c",
+            "--component",
+            dest="components",
+            nargs='*',
+            type=str,
+            help="Rebuild one or more components."
+        )
         parser.add_argument(
             "--keep",
             dest="keep",
             action="store_true",
             help="Do not delete the working temporary directory.",
         )
-        parser.add_argument("-p", "--platform", type=str, choices=self.SUPPORTED_PLATFORMS, help="Platform to build.")
-        parser.add_argument("-a", "--architecture", type=str, choices=self.SUPPORTED_ARCHITECTURES, help="Architecture to build.")
+        parser.add_argument(
+            "-p",
+            "--platform",
+            type=str,
+            choices=self.SUPPORTED_PLATFORMS,
+            help="Platform to build."
+        )
+        parser.add_argument(
+            "-a",
+            "--architecture",
+            type=str,
+            choices=self.SUPPORTED_ARCHITECTURES,
+            help="Architecture to build."
+        )
         parser.add_argument(
             "-v",
             "--verbose",
@@ -77,7 +100,7 @@ class BuildArgs:
         self.manifest = args.manifest
         self.ref_manifest = args.manifest.name + ".lock" if args.lock else None
         self.snapshot = args.snapshot
-        self.component = args.component
+        self.components = args.components
         self.keep = args.keep
         self.platform = args.platform
         self.architecture = args.architecture

--- a/src/ci_workflow/README.md
+++ b/src/ci_workflow/README.md
@@ -40,8 +40,8 @@ The following example sanity-checks components in the the OpenSearch 1.2.0 manif
 
 The following options are available.
 
-| name               | description                                                             |
-|--------------------|-------------------------------------------------------------------------|
-| --component [name] | Test a single component by name, e.g. `--component common-utils`.       |
-| --keep             | Do not delete the temporary working directory on both success or error. |
-| -v, --verbose      | Show more verbose output.                                               |
+| name                    | description                                                                         |
+|-------------------------|-------------------------------------------------------------------------------------|
+| --component [name ...]  | Test a subset of components by name, e.g. `--component common-utils job-scheduler`. |
+| --keep                  | Do not delete the temporary working directory on both success or error.             |
+| -v, --verbose           | Show more verbose output.                                                           |

--- a/src/ci_workflow/ci_args.py
+++ b/src/ci_workflow/ci_args.py
@@ -8,11 +8,13 @@ import argparse
 import io
 import logging
 import sys
+from typing import List
 
 
 class CiArgs:
     manifest: io.TextIOWrapper
     snapshot: bool
+    components: List[str]
 
     def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="Sanity test the OpenSearch Bundle")
@@ -24,7 +26,14 @@ class CiArgs:
             default=False,
             help="Build snapshot.",
         )
-        parser.add_argument("-c", "--component", type=str, help="Rebuild a single component.")
+        parser.add_argument(
+            "-c",
+            "--component",
+            type=str,
+            dest="components",
+            nargs='*',
+            help="Rebuild one or more components."
+        )
         parser.add_argument(
             "--keep",
             dest="keep",
@@ -43,7 +52,7 @@ class CiArgs:
         args = parser.parse_args()
         self.manifest = args.manifest
         self.snapshot = args.snapshot
-        self.component = args.component
+        self.components = args.components
         self.keep = args.keep
         self.logging_level = args.logging_level
         self.script_path = sys.argv[0].replace("/src/run_ci.py", "/ci.sh")

--- a/src/ci_workflow/ci_input_manifest.py
+++ b/src/ci_workflow/ci_input_manifest.py
@@ -33,7 +33,7 @@ class CiInputManifest(CiManifest):
 
             logging.info(f"Sanity testing {self.manifest.build.name}")
 
-            for component in self.manifest.components.select(focus=self.args.component):
+            for component in self.manifest.components.select(focus=self.args.components):
                 logging.info(f"Sanity testing {component.name}")
 
                 ci_check_list = CiCheckLists.from_component(component, target)

--- a/src/manifests/component_manifest.py
+++ b/src/manifests/component_manifest.py
@@ -51,19 +51,24 @@ class Components(Dict[str, ComponentType], Generic[ComponentType]):
         as_dict: Callable[[ComponentType], dict] = lambda component: component.__to_dict__()
         return list(map(as_dict, self.values()))
 
-    def select(self, focus: str = None) -> Iterator[ComponentType]:
+    def select(self, focus: List[str] = None) -> Iterator[ComponentType]:
         """
         Select components.
 
-        :param str focus: Choose one component.
+        :param List[str] focus: Choose some components.
         :return: Collection of components.
         :raises ValueError: Invalid platform or component name specified.
         """
+        if focus and len(focus) > 0:
+            invalid = [item for item in focus if item not in self]
+            if len(invalid) > 0:
+                raise ValueError(f"Unknown component{'s'[:len(invalid) != 1]}={','.join(invalid)}.")
+
         is_focused: Callable[[ComponentType], bool] = lambda component: component.__matches__(focus)
         selected, it = itertools.tee(filter(is_focused, self.values()))
 
         if not any(it):
-            raise ValueError(f"No components matched focus={focus}.")
+            raise ValueError(f"No components matched focus={','.join(focus)}.")
 
         return selected
 
@@ -79,8 +84,14 @@ class Component:
             "name": self.name
         }
 
-    def __matches__(self, focus: str = None, platform: str = None) -> bool:
-        matches = ((not focus) or (self.name == focus)) and ((not platform) or (not self.platforms) or (platform in self.platforms))
+    def __matches__(self, focus: List[str] = [], platform: str = None) -> bool:
+        matches = True
+
+        if focus and len(focus) > 0:
+            matches = matches and self.name in focus
+
+        if platform and self.platforms:
+            matches = matches and platform in self.platforms
 
         if not matches:
             logging.info(f"Skipping {self.name}")

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -59,7 +59,7 @@ def main():
 
         logging.info(f"Building {manifest.build.name} ({target.architecture}) into {target.output_dir}")
 
-        for component in manifest.components.select(focus=args.component, platform=target.platform):
+        for component in manifest.components.select(focus=args.components, platform=target.platform):
             logging.info(f"Building {component.name}")
 
             builder = Builders.builder_from(component, target)

--- a/src/run_sign.py
+++ b/src/run_sign.py
@@ -6,43 +6,26 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import argparse
-import logging
 import sys
-from pathlib import Path
 
+from sign_workflow.sign_args import SignArgs
 from sign_workflow.sign_artifacts import SignArtifacts
 from sign_workflow.signer import Signer
 from system import console
 
-ACCEPTED_SIGNATURE_FILE_TYPES = [".sig"]
-
 
 def main():
-    parser = argparse.ArgumentParser(description="Sign artifacts")
-    parser.add_argument("target", type=Path, help="Path to local manifest file or artifact directory.")
-    parser.add_argument("--component", nargs="?", help="Component name")
-    parser.add_argument("--type", nargs="?", help="Artifact type")
-    parser.add_argument("--sigtype", choices=ACCEPTED_SIGNATURE_FILE_TYPES, help="Type of Signature file", default=".asc")
-    parser.add_argument("--platform", nargs="?", help="The distribution platform", default="linux")
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        help="Show more verbose output.",
-        action="store_const",
-        default=logging.INFO,
-        const=logging.DEBUG,
-        dest="logging_level",
-    )
-    args = parser.parse_args()
+    args = SignArgs()
 
     console.configure(level=args.logging_level)
 
-    sign = SignArtifacts.from_path(path=args.target,
-                                   component=args.component,
-                                   artifact_type=args.type,
-                                   signature_type=args.sigtype,
-                                   signer=Signer())
+    sign = SignArtifacts.from_path(
+        path=args.target,
+        components=args.components,
+        artifact_type=args.type,
+        signature_type=args.sigtype,
+        signer=Signer()
+    )
 
     sign.sign()
 

--- a/src/sign_workflow/README.md
+++ b/src/sign_workflow/README.md
@@ -15,7 +15,7 @@ The following options are available.
 
 | name          | description                                                                           |
 |---------------|---------------------------------------------------------------------------------------|
-| --component   | The component name of the component whose artifacts will be signed.                   |
+| --component   | The component name(s) of the component(s) whose artifacts will be signed.             |
 | --type        | The artifact type to be signed. Currently one of 3 options: [plugins, maven, bundle]. |
 | -v, --verbose | Show more verbose output.                                                             |
 

--- a/src/sign_workflow/sign_args.py
+++ b/src/sign_workflow/sign_args.py
@@ -22,7 +22,7 @@ class SignArgs:
     def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="Sign artifacts")
         parser.add_argument("target", type=Path, help="Path to local manifest file or artifact directory")
-        parser.add_argument("-c", "--component", type=str, nargs='+', dest="components", help="Component or components to sign")
+        parser.add_argument("-c", "--component", type=str, nargs='*', dest="components", help="Component or components to sign")
         parser.add_argument("--type", help="Artifact type")
         parser.add_argument("--sigtype", choices=self.ACCEPTED_SIGNATURE_FILE_TYPES, help="Type of signature file.", default=".asc")
         parser.add_argument("--platform", nargs="?", help="Distribution platform.", default="linux")

--- a/src/sign_workflow/sign_args.py
+++ b/src/sign_workflow/sign_args.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import argparse
+import logging
+from pathlib import Path
+from typing import List
+
+
+class SignArgs:
+    ACCEPTED_SIGNATURE_FILE_TYPES = [".sig"]
+
+    target: Path
+    components: List[str]
+    type: str
+    sigtype: str
+    platform: str
+
+    def __init__(self) -> None:
+        parser = argparse.ArgumentParser(description="Sign artifacts")
+        parser.add_argument("target", type=Path, help="Path to local manifest file or artifact directory")
+        parser.add_argument("-c", "--component", type=str, nargs='+', dest="components", help="Component or components to sign")
+        parser.add_argument("--type", help="Artifact type")
+        parser.add_argument("--sigtype", choices=self.ACCEPTED_SIGNATURE_FILE_TYPES, help="Type of signature file.", default=".asc")
+        parser.add_argument("--platform", nargs="?", help="Distribution platform.", default="linux")
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Show more verbose output.",
+            action="store_const",
+            default=logging.INFO,
+            const=logging.DEBUG,
+            dest="logging_level",
+        )
+
+        args = parser.parse_args()
+        self.logging_level = args.logging_level
+        self.target = args.target
+        self.type = args.type
+        self.sigtype = args.sigtype
+        self.components = args.components
+        self.platform = args.platform

--- a/src/sign_workflow/sign_artifacts.py
+++ b/src/sign_workflow/sign_artifacts.py
@@ -10,14 +10,15 @@ import logging
 import os
 from abc import abstractmethod
 from pathlib import Path
+from typing import List
 
 from manifests.build_manifest import BuildManifest
 
 
 class SignArtifacts:
-    def __init__(self, target: Path, component, artifact_type, signature_type, signer):
+    def __init__(self, target: Path, components: List[str], artifact_type, signature_type, signer):
         self.target = target
-        self.component = component
+        self.components = components
         self.artifact_type = artifact_type
         self.signature_type = signature_type
         self.signer = signer
@@ -46,9 +47,9 @@ class SignArtifacts:
             return SignArtifactsExistingArtifactFile
 
     @classmethod
-    def from_path(self, path: Path, component, artifact_type, signature_type, signer):
+    def from_path(self, path: Path, components: List[str], artifact_type, signature_type, signer):
         klass = self.__signer_class__(path)
-        return klass(path, component, artifact_type, signature_type, signer)
+        return klass(path, components, artifact_type, signature_type, signer)
 
 
 class SignWithBuildManifest(SignArtifacts):
@@ -56,7 +57,7 @@ class SignWithBuildManifest(SignArtifacts):
     def __sign__(self):
         manifest = BuildManifest.from_file(self.target.open("r"))
         basepath = self.target.parent
-        for component in manifest.components.select(focus=self.component):
+        for component in manifest.components.select(focus=self.components):
             logging.info(f"Signing {component.name}")
 
             for component_artifact_type in component.artifacts:

--- a/src/test_workflow/README.md
+++ b/src/test_workflow/README.md
@@ -26,15 +26,15 @@ Testing is run via `./test.sh`.
 
 The following options are available.
 
-| name               | description                                                             |
-| ------------------ | ----------------------------------------------------------------------- |
-| test-type          | Run tests of a test suite. [integ-test, bwc-test, perf-test]            |
-| test-manifest-path | Specify a test manifest path.                                           |
-| --paths            | Location of manifest(s).                                                |
-| --test-run-id      | Unique identifier for a test run.                                       |
-| --component        | Test a specific component in a manifest.                                |
-| --keep             | Do not delete the temporary working directory on both success or error. |
-| -v, --verbose      | Show more verbose output.                                               |
+| name                   | description                                                             |
+| ---------------------- | ----------------------------------------------------------------------- |
+| test-type              | Run tests of a test suite. [integ-test, bwc-test, perf-test]            |
+| test-manifest-path     | Specify a test manifest path.                                           |
+| --paths                | Location of manifest(s).                                                |
+| --test-run-id          | Unique identifier for a test run.                                       |
+| --component [name ...] | Test a subset of specific components.                                   |
+| --keep                 | Do not delete the temporary working directory on both success or error. |
+| -v, --verbose          | Show more verbose output.                                               |
 
 ### Integration Tests
 

--- a/src/test_workflow/bwc_test/bwc_test_runner.py
+++ b/src/test_workflow/bwc_test/bwc_test_runner.py
@@ -25,7 +25,7 @@ class BwcTestRunner(abc.ABC):
     def run(self):
         with TemporaryDirectory(keep=self.args.keep, chdir=True) as work_dir:
             all_results = TestSuiteResults()
-            for component in self.components.select(focus=self.args.component):
+            for component in self.components.select(focus=self.args.components):
                 if component.name in self.test_manifest.components:
                     test_config = self.test_manifest.components[component.name]
                     if test_config.bwc_test:

--- a/src/test_workflow/integ_test/integ_test_runner.py
+++ b/src/test_workflow/integ_test/integ_test_runner.py
@@ -26,7 +26,7 @@ class IntegTestRunner(abc.ABC):
         with TemporaryDirectory(keep=self.args.keep, chdir=True) as work_dir:
 
             all_results = TestSuiteResults()
-            for component in self.components.select(focus=self.args.component):
+            for component in self.components.select(focus=self.args.components):
                 if component.name in self.test_manifest.components:
                     test_config = self.test_manifest.components[component.name]
                     if test_config.integ_test:

--- a/src/test_workflow/test_args.py
+++ b/src/test_workflow/test_args.py
@@ -10,6 +10,7 @@
 import argparse
 import logging
 import uuid
+from typing import List
 
 from test_workflow.test_args_path_validator import TestArgsPathValidator
 from test_workflow.test_kwargs import TestKwargs
@@ -17,7 +18,7 @@ from test_workflow.test_kwargs import TestKwargs
 
 class TestArgs:
     test_run_id: int
-    component: str
+    components: List[str]
     keep: bool
     logging_level: int
     test_manifest_path: str
@@ -28,14 +29,14 @@ class TestArgs:
         parser.add_argument("test_manifest_path", type=TestArgsPathValidator.validate, help="Specify a test manifest path.")
         parser.add_argument("-p", "--paths", nargs='*', action=TestKwargs, default={}, help="Specify paths for OpenSearch and OpenSearch Dashboards.")
         parser.add_argument("--test-run-id", type=int, help="The unique execution id for the test")
-        parser.add_argument("--component", type=str, help="Test a specific component instead of the entire distribution.")
+        parser.add_argument("--component", type=str, dest="components", nargs='*', help="Test a specific component or components instead of the entire distribution.")
         parser.add_argument("--keep", dest="keep", action="store_true", help="Do not delete the working temporary directory.")
         parser.add_argument(
             "-v", "--verbose", help="Show more verbose output.", action="store_const", default=logging.INFO, const=logging.DEBUG, dest="logging_level"
         )
         args = parser.parse_args()
         self.test_run_id = args.test_run_id or uuid.uuid4().hex
-        self.component = args.component
+        self.components = args.components
         self.keep = args.keep
         self.logging_level = args.logging_level
         self.test_manifest_path = args.test_manifest_path

--- a/tests/tests_build_workflow/test_build_args.py
+++ b/tests/tests_build_workflow/test_build_args.py
@@ -59,11 +59,15 @@ class TestBuildArgs(unittest.TestCase):
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
     def test_component_default(self) -> None:
-        self.assertIsNone(BuildArgs().component)
+        self.assertIsNone(BuildArgs().components)
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
     def test_component(self) -> None:
-        self.assertEqual(BuildArgs().component, "xyz")
+        self.assertEqual(BuildArgs().components, ["xyz"])
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--component", "foo", "bar"])
+    def test_components(self) -> None:
+        self.assertEqual(BuildArgs().components, ["foo", "bar"])
 
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
     def test_platform_default(self) -> None:

--- a/tests/tests_ci_workflow/test_ci_args.py
+++ b/tests/tests_ci_workflow/test_ci_args.py
@@ -50,13 +50,17 @@ class TestCiArgs(unittest.TestCase):
 
     @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST])
     def test_component_default(self) -> None:
-        self.assertIsNone(CiArgs().component)
+        self.assertIsNone(CiArgs().components)
 
     @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
     def test_component(self) -> None:
-        self.assertEqual(CiArgs().component, "xyz")
+        self.assertEqual(CiArgs().components, ["xyz"])
 
-    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST, "--component", "foo", "bar"])
+    def test_components(self) -> None:
+        self.assertEqual(CiArgs().components, ["foo", "bar"])
+
+    @patch("argparse._sys.argv", [CI_PY, OPENSEARCH_MANIFEST])
     def test_script_path(self) -> None:
         self.assertEqual(CiArgs().script_path, self.CI_SH)
 

--- a/tests/tests_manifests/test_component_manifest.py
+++ b/tests/tests_manifests/test_component_manifest.py
@@ -32,5 +32,11 @@ class TestComponentManifest(unittest.TestCase):
         })
 
         self.assertEqual(len(list(manifest.components.select(focus=None))), 2)
-        self.assertEqual(len(list(manifest.components.select(focus="one"))), 1)
-        self.assertEqual(next(manifest.components.select(focus="two")).name, "two")
+        self.assertEqual(len(list(manifest.components.select(focus=[]))), 2)
+        self.assertEqual(len(list(manifest.components.select(focus=["one"]))), 1)
+        self.assertEqual(len(list(manifest.components.select(focus=["one", "two"]))), 2)
+        self.assertEqual(next(manifest.components.select(focus=["two"])).name, "two")
+
+        with self.assertRaises(ValueError) as ctx:
+            self.assertEqual(len(list(manifest.components.select(focus=["one", "invalid"]))), 0)
+        self.assertEqual(str(ctx.exception), "Unknown component=invalid.")

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -28,7 +28,7 @@ class TestInputManifest(unittest.TestCase):
         self.assertEqual(manifest.build.name, "OpenSearch Dashboards")
         self.assertEqual(manifest.build.filename, "opensearch-dashboards")
         self.assertEqual(manifest.build.version, "1.1.1")
-        self.assertEqual(len(list(manifest.components.select(focus="alertingDashboards"))), 1)
+        self.assertEqual(len(list(manifest.components.select(focus=["alertingDashboards"]))), 1)
         opensearch_component: InputComponentFromDist = manifest.components["OpenSearch-Dashboards"]  # type: ignore[assignment]
         self.assertIsInstance(opensearch_component, InputComponentFromDist)
         self.assertEqual(opensearch_component.name, "OpenSearch-Dashboards")
@@ -49,7 +49,7 @@ class TestInputManifest(unittest.TestCase):
         self.assertEqual(manifest.build.name, "OpenSearch")
         self.assertEqual(manifest.build.filename, "opensearch")
         self.assertEqual(manifest.build.version, "1.0.0")
-        self.assertEqual(len(list(manifest.components.select(focus="common-utils"))), 1)
+        self.assertEqual(len(list(manifest.components.select(focus=["common-utils"]))), 1)
         opensearch_component: InputComponentFromSource = manifest.components["OpenSearch"]  # type: ignore[assignment]
         self.assertIsInstance(opensearch_component, InputComponentFromSource)
         self.assertEqual(opensearch_component.name, "OpenSearch")
@@ -68,7 +68,7 @@ class TestInputManifest(unittest.TestCase):
         self.assertEqual(manifest.build.name, "OpenSearch")
         self.assertEqual(manifest.build.filename, "opensearch")
         self.assertEqual(manifest.build.version, "1.1.0")
-        self.assertEqual(len(list(manifest.components.select(focus="common-utils"))), 1)
+        self.assertEqual(len(list(manifest.components.select(focus=["common-utils"]))), 1)
         # opensearch component
         opensearch_component: InputComponentFromSource = manifest.components["OpenSearch"]  # type: ignore[assignment]
         self.assertEqual(opensearch_component.name, "OpenSearch")
@@ -100,7 +100,7 @@ class TestInputManifest(unittest.TestCase):
         self.assertEqual(manifest.ci.image.name, "opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028")
         self.assertEqual(manifest.ci.image.args, "-e JAVA_HOME=/usr/lib/jvm/adoptopenjdk-14-hotspot")
         self.assertNotEqual(len(manifest.components), 0)
-        self.assertEqual(len(list(manifest.components.select(focus="common-utils"))), 1)
+        self.assertEqual(len(list(manifest.components.select(focus=["common-utils"]))), 1)
         # opensearch component
         opensearch_component: InputComponentFromSource = manifest.components["OpenSearch"]  # type: ignore[assignment]
         self.assertEqual(opensearch_component.name, "OpenSearch")
@@ -139,15 +139,15 @@ class TestInputManifest(unittest.TestCase):
     def test_select(self) -> None:
         path = os.path.join(self.manifests_path, "1.1.0", "opensearch-1.1.0.yml")
         manifest = InputManifest.from_path(path)
-        self.assertEqual(len(list(manifest.components.select(focus="common-utils"))), 1)
+        self.assertEqual(len(list(manifest.components.select(focus=["common-utils"]))), 1)
         self.assertNotEqual(len(list(manifest.components.select(platform="windows"))), 0)
-        self.assertEqual(len(list(manifest.components.select(focus="k-NN", platform="linux"))), 1)
+        self.assertEqual(len(list(manifest.components.select(focus=["k-NN"], platform="linux"))), 1)
 
     def test_select_none(self) -> None:
         path = os.path.join(self.manifests_path, "1.1.0", "opensearch-1.1.0.yml")
         manifest = InputManifest.from_path(path)
         with self.assertRaises(ValueError) as ctx:
-            self.assertEqual(len(list(manifest.components.select(focus="k-NN", platform="windows"))), 0)
+            self.assertEqual(len(list(manifest.components.select(focus=["k-NN"], platform="windows"))), 0)
         self.assertEqual(str(ctx.exception), "No components matched focus=k-NN, platform=windows.")
 
     def test_component___matches__(self) -> None:
@@ -164,8 +164,10 @@ class TestInputManifest(unittest.TestCase):
     def test_component___matches_focus__(self) -> None:
         component = InputComponent({"name": "x", "repository": "", "ref": ""})
         self.assertTrue(component.__matches__(focus=None))
-        self.assertTrue(component.__matches__(focus="x"))
-        self.assertFalse(component.__matches__(focus="y"))
+        self.assertTrue(component.__matches__(focus=[]))
+        self.assertTrue(component.__matches__(focus=["x"]))
+        self.assertTrue(component.__matches__(focus=["x", "y"]))
+        self.assertFalse(component.__matches__(focus=["y"]))
 
     @patch("subprocess.check_output")
     def test_stable(self, mock_output: Mock) -> None:

--- a/tests/tests_sign_workflow/test_sign_args.py
+++ b/tests/tests_sign_workflow/test_sign_args.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import logging
+import os
+import unittest
+from unittest.mock import patch
+
+from sign_workflow.sign_args import SignArgs
+
+
+class TestSignArgs(unittest.TestCase):
+
+    SIGN_PY = "./src/run_sign.py"
+
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "manifests",
+            "1.1.0",
+            "opensearch-1.1.0.yml",
+        )
+    )
+
+    @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST])
+    def test_verbose_default(self) -> None:
+        self.assertEqual(SignArgs().logging_level, logging.INFO)
+
+    @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST])
+    def test_sigtype_default(self) -> None:
+        self.assertEqual(SignArgs().sigtype, ".asc")
+
+    @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST, "--verbose"])
+    def test_verbose_true(self) -> None:
+        self.assertTrue(SignArgs().logging_level, logging.DEBUG)
+
+    @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST])
+    def test_component_default(self) -> None:
+        self.assertIsNone(SignArgs().components)
+
+    @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST, "--component", "xyz"])
+    def test_component(self) -> None:
+        self.assertEqual(SignArgs().components, ["xyz"])
+
+    @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST, "--component", "foo", "bar"])
+    def test_components(self) -> None:
+        self.assertEqual(SignArgs().components, ["foo", "bar"])
+
+    @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST])
+    def test_platform_default(self) -> None:
+        self.assertEqual(SignArgs().platform, "linux")
+
+    @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST, "--platform", "windows"])
+    def test_platform_windows(self) -> None:
+        self.assertEqual(SignArgs().platform, "windows")

--- a/tests/tests_sign_workflow/test_sign_artifacts.py
+++ b/tests/tests_sign_workflow/test_sign_artifacts.py
@@ -11,17 +11,17 @@ class TestSignArtifacts(unittest.TestCase):
     @patch("sign_workflow.signer.GitRepository")
     @patch("sign_workflow.signer.Signer", return_value=MagicMock())
     def test_from_path_method(self, mock_signer, *mocks):
-        component = 'maven'
+        components = ['maven']
         artifact_type = 'dummy'
         sigtype = '.asc'
 
-        klass = SignArtifacts.from_path(Path(r"/dummy/path/manifest.yml"), component, artifact_type, sigtype, mock_signer)
+        klass = SignArtifacts.from_path(Path(r"/dummy/path/manifest.yml"), components, artifact_type, sigtype, mock_signer)
         self.assertEqual(type(SignWithBuildManifest), type(klass.__class__))
 
-        klass = SignArtifacts.from_path(Path(os.path.dirname(__file__)), component, artifact_type, sigtype, mock_signer)
+        klass = SignArtifacts.from_path(Path(os.path.dirname(__file__)), components, artifact_type, sigtype, mock_signer)
         self.assertEqual(type(SignExistingArtifactsDir), type(klass.__class__))
 
-        klass = SignArtifacts.from_path(Path(r"/dummy/path/artifact.tar.gz"), component, artifact_type, sigtype, mock_signer)
+        klass = SignArtifacts.from_path(Path(r"/dummy/path/artifact.tar.gz"), components, artifact_type, sigtype, mock_signer)
         self.assertEqual(type(SignArtifactsExistingArtifactFile), type(klass.__class__))
 
     def test_signer_class(self):
@@ -43,7 +43,7 @@ class TestSignArtifacts(unittest.TestCase):
         signer = MagicMock()
         signer_with_manifest = SignWithBuildManifest(
             target=manifest,
-            component="",
+            components=[],
             artifact_type="maven",
             signature_type=sigtype,
             signer=signer
@@ -65,7 +65,7 @@ class TestSignArtifacts(unittest.TestCase):
         signer = MagicMock()
         signer_with_manifest = SignArtifactsExistingArtifactFile(
             target=path,
-            component='maven',
+            components=['maven'],
             artifact_type='dummy',
             signature_type=sigtype,
             signer=signer
@@ -83,7 +83,7 @@ class TestSignArtifacts(unittest.TestCase):
         signer = MagicMock()
         signer_with_manifest = SignExistingArtifactsDir(
             target=path,
-            component='maven',
+            components=['maven'],
             artifact_type='dummy',
             signature_type=sigtype,
             signer=signer

--- a/tests/tests_test_workflow/test_test_args.py
+++ b/tests/tests_test_workflow/test_test_args.py
@@ -33,10 +33,15 @@ class TestTestArgs(unittest.TestCase):
         self.assertFalse(hasattr(test_args, "opensearch-dashboards"))
 
         self.assertIsNotNone(test_args.test_run_id)
-        self.assertIsNone(test_args.component)
+        self.assertIsNone(test_args.components)
         self.assertFalse(test_args.keep)
         self.assertEqual(test_args.logging_level, logging.INFO)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
+
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--component", "foo", "bar"])
+    def test_components(self):
+        test_args = TestArgs()
+        self.assertEqual(test_args.components, ["foo", "bar"])
 
     @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--paths", "opensearch=" + TEST_MANIFEST_PATH])
     def test_opensearch_file_with_opensearch_test_manifest(self):
@@ -45,7 +50,7 @@ class TestTestArgs(unittest.TestCase):
         self.assertFalse(hasattr(test_args.paths, "opensearch-dashboards"))
 
         self.assertIsNotNone(test_args.test_run_id)
-        self.assertIsNone(test_args.component)
+        self.assertIsNone(test_args.components)
         self.assertFalse(test_args.keep)
         self.assertEqual(test_args.logging_level, logging.INFO)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
@@ -57,7 +62,7 @@ class TestTestArgs(unittest.TestCase):
         self.assertFalse(hasattr(test_args.paths, "opensearch-dashboards"))
 
         self.assertIsNotNone(test_args.test_run_id)
-        self.assertIsNone(test_args.component)
+        self.assertIsNone(test_args.components)
         self.assertFalse(test_args.keep)
         self.assertEqual(test_args.logging_level, logging.DEBUG)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_PATH)
@@ -69,7 +74,7 @@ class TestTestArgs(unittest.TestCase):
         self.assertEqual(test_args.paths.get("opensearch"), self.TEST_MANIFEST_PATH)
 
         self.assertIsNotNone(test_args.test_run_id)
-        self.assertIsNone(test_args.component)
+        self.assertIsNone(test_args.components)
         self.assertFalse(test_args.keep)
         self.assertEqual(test_args.logging_level, logging.INFO)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH)
@@ -90,7 +95,7 @@ class TestTestArgs(unittest.TestCase):
         self.assertEqual(test_args.paths.get("opensearch"), self.TEST_MANIFEST_PATH)
 
         self.assertIsNotNone(test_args.test_run_id)
-        self.assertIsNone(test_args.component)
+        self.assertIsNone(test_args.components)
         self.assertFalse(test_args.keep)
         self.assertEqual(test_args.logging_level, logging.INFO)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH)
@@ -102,7 +107,7 @@ class TestTestArgs(unittest.TestCase):
         self.assertEqual(test_args.paths.get("opensearch"), self.TEST_MANIFEST_PATH)
 
         self.assertIsNotNone(test_args.test_run_id)
-        self.assertIsNone(test_args.component)
+        self.assertIsNone(test_args.components)
         self.assertFalse(test_args.keep)
         self.assertEqual(test_args.logging_level, logging.INFO)
         self.assertEqual(test_args.test_manifest_path, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH)


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description
Added support for multiple values in `--component` in various build, test and sign workflows. 

I chose to support `--component x y` vs. `--component x --component y` to make it easier to specify from Jenkins. In code that's done with `nargs='+'` vs. `action='append'`, see https://stackoverflow.com/questions/15753701/how-can-i-pass-a-list-as-a-command-line-argument-with-argparse.

Together with https://github.com/opensearch-project/opensearch-build/pull/2100 this change allows on-demand rebuilding of a subset of components in a manifest when it contains a subsequent component that has a broken build. This is useful when wanting to increment versions and needing a new -SNAPSHOT build of OpenSearch or common-utils for dependencies that are already in a manifest. Avoids having to pull out a component from the manifest and then reverting that change every time.

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/2091

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
