### PR TITLE
Remove AGENT_RPM args on docker so bundled java takes over

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -189,7 +189,6 @@ pipeline {
                                 docker {
                                     label AGENT_X64
                                     image IMAGE_RPM
-                                    args dockerAgent.args
                                     alwaysPull true
                                 }
                             }
@@ -399,7 +398,6 @@ pipeline {
                                 docker {
                                     label AGENT_ARM64
                                     image IMAGE_RPM
-                                    args dockerAgent.args
                                     alwaysPull true
                                 }
                             }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -260,7 +260,6 @@ pipeline {
                                 docker {
                                     label AGENT_X64
                                     image IMAGE_RPM
-                                    args dockerAgent.args
                                     alwaysPull true
                                 }
                             }
@@ -435,7 +434,6 @@ pipeline {
                                 docker {
                                     label AGENT_ARM64
                                     image IMAGE_RPM
-                                    args dockerAgent.args
                                     alwaysPull true
                                 }
                             }


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove AGENT_RPM args on docker so bundled java takes over.
Rockylinux8 image does not include an extra JDK installation.
So just let the bundled one take over during assemble.

### Issues Resolved
#2120

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
