### PR TITLE
Fix tests to run offline.

### DIFF
--- a/tests/tests_sign_workflow/test_signer.py
+++ b/tests/tests_sign_workflow/test_signer.py
@@ -73,15 +73,11 @@ class TestSigner(unittest.TestCase):
         signer.sign_artifacts(artifacts, Path("path"), ".sig")
         self.assertEqual(signer.sign.call_args_list, expected)
 
-    @patch(
-        "sign_workflow.signer.Signer.get_repo_url",
-        return_value="https://github.com/opensearch-project/.github",
-    )
-    @patch("sign_workflow.signer.GitRepository.execute")
-    def test_signer_checks_out_tool(self, mock_execute: Mock, mock_signer: Mock) -> None:
+    @patch("sign_workflow.signer.GitRepository")
+    def test_signer_checks_out_tool(self, mock_repo: Mock) -> None:
         Signer()
-        self.assertEqual(mock_execute.call_count, 2)
-        mock_execute.assert_has_calls([call("./bootstrap"), call("rm config.cfg")])
+        self.assertEqual(mock_repo.return_value.execute.call_count, 2)
+        mock_repo.return_value.execute.assert_has_calls([call("./bootstrap"), call("rm config.cfg")])
 
     @patch("sign_workflow.signer.GitRepository")
     def test_signer_verify_asc(self, mock_repo: Mock) -> None:

--- a/tests/tests_test_workflow/test_test_component.py
+++ b/tests/tests_test_workflow/test_test_component.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.mock import Mock, patch
 
 from system.temporary_directory import TemporaryDirectory
 from test_workflow.test_component import TestComponent
@@ -12,9 +13,14 @@ class TestTestComponent(unittest.TestCase):
             "8ac515431bf24caf92fea9d9b0af3b8f10b88453",
         )
 
-    def test_checkout(self) -> None:
+    @patch("test_workflow.test_component.GitRepository")
+    def test_checkout(self, mock_repo: Mock) -> None:
         with TemporaryDirectory() as tmpdir:
             subdir = os.path.join(tmpdir.name, ".github")
             repo = self.test_component.checkout(subdir)
-            self.assertEqual(repo.url, "https://github.com/opensearch-project/.github")
-            self.assertEqual(repo.ref, "8ac515431bf24caf92fea9d9b0af3b8f10b88453")
+            self.assertEqual(repo, mock_repo.return_value)
+            mock_repo.assert_called_with(
+                "https://github.com/opensearch-project/.github",
+                "8ac515431bf24caf92fea9d9b0af3b8f10b88453",
+                subdir
+            )


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

I was on a 🚌 going through a tunnel. 

Some tests do not work if you are offline, attempting to check out actual repositories and such. This fixes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
