### PR TITLE
Make check for build longer before timeout

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -2,7 +2,7 @@ lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
 
 pipeline {
     options {
-        timeout(time: 1, unit: 'HOURS')
+        timeout(time: 5, unit: 'HOURS')
         buildDiscarder(logRotator(daysToKeepStr: '7'))
     }
     agent none


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Make check for build longer before timeout.

Not sure why this issue never show up before, now we have


1. check trigger build, build have 4HRs max.
2. build trigger test, test have 3HRs max.
3. test trigger component integTest on each plugin, parallel 2HRs each.

This means check must have at least 4HRs max to not cancel / abort child workflows.

Therefore, set check to have 5HRs max.

Thanks.


### Issues Resolved
Part of #2086

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
