### PR TITLE
Add more components to 2.0.1 manifest and test manifests

### DIFF
--- a/manifests/2.0.1/opensearch-2.0.1-test.yml
+++ b/manifests/2.0.1/opensearch-2.0.1-test.yml
@@ -1,0 +1,78 @@
+---
+schema-version: '1.0'
+name: OpenSearch
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2
+    args: -e JAVA_HOME=/opt/java/openjdk-17
+components:
+  - name: index-management
+    integ-test:
+      build-dependencies:
+        - job-scheduler
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        path.repo: [/tmp]
+
+  - name: anomaly-detection
+    integ-test:
+      build-dependencies:
+        - job-scheduler
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: asynchronous-search
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: alerting
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        plugins.destination.host.deny_list: [10.0.0.0/8, 127.0.0.1]
+
+  - name: notifications
+    working-directory: notifications
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: sql
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        script.context.field.max_compilations_rate: 1000/1m
+
+  - name: k-NN
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: dashboards-reports
+    working-directory: reports-scheduler
+    integ-test:
+      test-configs:
+        - without-security
+
+  - name: opensearch-observability
+    working-directory: opensearch-observability
+    integ-test:
+      test-configs:
+        - without-security
+
+  - name: ml-commons
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security

--- a/manifests/2.0.1/opensearch-2.0.1-test.yml
+++ b/manifests/2.0.1/opensearch-2.0.1-test.yml
@@ -30,6 +30,12 @@ components:
         - with-security
         - without-security
 
+  - name: cross-cluster-replication
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
   - name: alerting
     integ-test:
       test-configs:

--- a/manifests/2.0.1/opensearch-2.0.1.yml
+++ b/manifests/2.0.1/opensearch-2.0.1.yml
@@ -105,3 +105,12 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: '2.0'
+  - name: cross-cluster-replication
+    repository: https://github.com/opensearch-project/cross-cluster-replication.git
+    ref: '2.0'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version

--- a/manifests/2.0.1/opensearch-2.0.1.yml
+++ b/manifests/2.0.1/opensearch-2.0.1.yml
@@ -59,7 +59,7 @@ components:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: opensearch-observability
-    repository: https://github.com/opensearch-project/observability
+    repository: https://github.com/opensearch-project/observability.git
     ref: '2.0'
     working_directory: opensearch-observability
     checks:

--- a/manifests/2.0.1/opensearch-2.0.1.yml
+++ b/manifests/2.0.1/opensearch-2.0.1.yml
@@ -52,3 +52,56 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: notifications
+  - name: anomaly-detection
+    repository: https://github.com/opensearch-project/anomaly-detection.git
+    ref: '2.0'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: opensearch-observability
+    repository: https://github.com/opensearch-project/observability
+    ref: '2.0'
+    working_directory: opensearch-observability
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: k-NN
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: '2.0'
+    platforms:
+      - darwin
+      - linux
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: asynchronous-search
+    repository: https://github.com/opensearch-project/asynchronous-search.git
+    ref: '2.0'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: sql
+    repository: https://github.com/opensearch-project/sql.git
+    ref: '2.0'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: plugin
+  - name: dashboards-reports
+    repository: https://github.com/opensearch-project/dashboards-reports.git
+    ref: '2.0'
+    working_directory: reports-scheduler
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: '2.0'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting
+  - name: index-management
+    repository: https://github.com/opensearch-project/index-management.git
+    ref: '2.0'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version

--- a/manifests/2.0.1/opensearch-dashboards-2.0.1-test.yml
+++ b/manifests/2.0.1/opensearch-dashboards-2.0.1-test.yml
@@ -1,0 +1,17 @@
+---
+schema-version: '1.0'
+name: OpenSearch Dashboards
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
+components:
+  - name: OpenSearch-Dashboards
+    bwc-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: functionalTestDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security

--- a/manifests/2.0.1/opensearch-dashboards-2.0.1.yml
+++ b/manifests/2.0.1/opensearch-dashboards-2.0.1.yml
@@ -10,3 +10,29 @@ components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     ref: '2.0'
+  - name: functionalTestDashboards
+    repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
+    ref: main
+  - name: queryWorkbenchDashboards
+    repository: https://github.com/opensearch-project/sql.git
+    working_directory: workbench
+    ref: '2.0'
+  - name: observabilityDashboards
+    repository: https://github.com/opensearch-project/observability.git
+    working_directory: dashboards-observability
+    ref: '2.0'
+  - name: ganttChartDashboards
+    repository: https://github.com/opensearch-project/dashboards-visualizations.git
+    working_directory: gantt-chart
+    ref: '2.0'
+  - name: reportsDashboards
+    repository: https://github.com/opensearch-project/dashboards-reports.git
+    working_directory: dashboards-reports
+    ref: '2.0'
+  - name: anomalyDetectionDashboards
+    repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
+    ref: '2.0'
+  - name: notificationsDashboards
+    repository: https://github.com/opensearch-project/notifications.git
+    working_directory: dashboards-notifications
+    ref: '2.0'


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Add more components to 2.0.1 manifest and test manifests.
After this PR only two OpenSearch plugins (Security, Cross cluster replication) are missing because of https://github.com/opensearch-project/OpenSearch/issues/3554 with Core and security plugin. 

Two dashboards plugins need to be added later as well. 
https://github.com/opensearch-project/index-management-dashboards-plugin/pull/202
https://github.com/opensearch-project/security-dashboards-plugin/pull/1010

### Issues Resolved
Part of #2165 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
