### PR TITLE
Add RPM Temporary Signing Through Shell Scripts

### DIFF
--- a/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
+++ b/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     agent {
         docker {
             label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
-            image 'opensearchstaging/ci-runner:ci-runner-centos7-v1'
+            image 'opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v2'
             alwaysPull true
         }
     }
@@ -25,7 +25,7 @@ pipeline {
                 description: 'What platform is this distribution build for?'
         )
         choice(
-                choices: ['.sig'],
+                choices: ['.sig', '.rpm'],
                 name: 'SIGNATURE_TYPE',
                 description: 'What is signature file type?'
         )
@@ -46,14 +46,20 @@ pipeline {
                             sigtype: SIGNATURE_TYPE,
                             platform: DISTRIBUTION_PLATFORM
                     )
+                    echo "out now"
 
                     filenamesForUrls = []
 
                     println("Note: only supported file types will be signed")
 
                     for(filename in downloadedFiles){
-                        filenamesForUrls.add(filename)
-                        filenamesForUrls.add(filename + SIGNATURE_TYPE)
+                        if (SIGNATURE_TYPE.equals('.sig')) {
+                            filenamesForUrls.add(filename)
+                            filenamesForUrls.add(filename + SIGNATURE_TYPE)
+                        }
+                        else {
+                            filenamesForUrls.add(filename)
+                        }
                     }
 
                     finalUploadPath = ([

--- a/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
+++ b/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
@@ -46,7 +46,6 @@ pipeline {
                             sigtype: SIGNATURE_TYPE,
                             platform: DISTRIBUTION_PLATFORM
                     )
-                    echo "out now"
 
                     filenamesForUrls = []
 

--- a/scripts/pkg/sign_templates/rpmmacros
+++ b/scripts/pkg/sign_templates/rpmmacros
@@ -1,0 +1,10 @@
+%_signature gpg
+%_gpg_path ~/.gnupg
+%_gpg_name ##key_name##
+%_gpg /usr/bin/gpg
+%__gpg_sign_cmd %{__gpg} \
+    gpg --no-verbose --no-armor --batch --yes --pinentry-mode loopback \
+    --passphrase-file ##passphrase_name## \
+    %{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \
+    --no-secmem-warning \
+    -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha512 %{__plaintext_filename}

--- a/tests/jenkins/TestAssembleManifest.groovy
+++ b/tests/jenkins/TestAssembleManifest.groovy
@@ -15,6 +15,8 @@ class TestAssembleManifest extends BuildPipelineTest {
     void testAssembleManifest_rpm() {
         this.registerLibTester(new AssembleManifestLibTester('tests/data/opensearch-build-1.3.0-rpm.yml'))
 
+        this.registerLibTester(new SignArtifactsLibTester('.rpm', 'linux', "rpm/dist/opensearch", null, null))
+
         this.registerLibTester(new BuildYumRepoTester(
             'tests/data/opensearch-build-1.3.0-rpm.yml',
             'https://ci.opensearch.org/dbc/vars-build/1.3.0/123/linux/x64'

--- a/tests/jenkins/TestSignArtifacts.groovy
+++ b/tests/jenkins/TestSignArtifacts.groovy
@@ -17,6 +17,7 @@ class TestSignArtifacts extends BuildPipelineTest {
     void setUp() {
 
         this.registerLibTester(new SignArtifactsLibTester('.sig', 'linux', "${this.workspace}/artifacts", null, null))
+        this.registerLibTester(new SignArtifactsLibTester('.rpm', 'linux', "${this.workspace}/artifacts", 'null', null))
         this.registerLibTester(new SignArtifactsLibTester(null, 'linux', "${this.workspace}/file.yml", 'maven', null))
         super.setUp()
     }

--- a/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
@@ -12,21 +12,22 @@
          release-data-prepper-all-artifacts.stage(Sign Archives, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
                release-data-prepper-all-artifacts.signArtifacts({artifactPath=/tmp/workspace/archive, sigtype=.sig, platform=linux})
+                  signArtifacts.echo(PGP Signature Signing)
                   signArtifacts.fileExists(/tmp/workspace/sign.sh)
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                      signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            /tmp/workspace/sign.sh /tmp/workspace/archive --sigtype=.sig --platform=linux
-        )
+                /tmp/workspace/sign.sh /tmp/workspace/archive --sigtype=.sig --platform=linux
+            )
          release-data-prepper-all-artifacts.stage(Release Archives to Production Distribution Bucket, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
                release-data-prepper-all-artifacts.withAWS({role=production-role-name, roleAccount=aws-account-artifact, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
@@ -77,21 +78,22 @@
          release-data-prepper-all-artifacts.stage(Sign Maven Artifacts, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
                release-data-prepper-all-artifacts.signArtifacts({artifactPath=/tmp/workspace/maven, type=maven, platform=linux})
+                  signArtifacts.echo(PGP Signature Signing)
                   signArtifacts.fileExists(/tmp/workspace/sign.sh)
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                      signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            /tmp/workspace/sign.sh /tmp/workspace/maven --type=maven --platform=linux
-        )
+                /tmp/workspace/sign.sh /tmp/workspace/maven --type=maven --platform=linux
+            )
          release-data-prepper-all-artifacts.stage(Upload Artifacts to Sonatype, groovy.lang.Closure)
             release-data-prepper-all-artifacts.script(groovy.lang.Closure)
                release-data-prepper-all-artifacts.usernamePassword({credentialsId=Sonatype, usernameVariable=SONATYPE_USERNAME, passwordVariable=SONATYPE_PASSWORD})

--- a/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
@@ -11,21 +11,22 @@
                      downloadFromS3.s3Download({file=/tmp/workspace/artifacts, bucket=job-s3-bucket-name, path=distribution-build-opensearch/1.0.0/123/linux/x64/builds/, force=true})
                maven-sign-release.echo(Signing Maven artifacts.)
                maven-sign-release.signArtifacts({artifactPath=/tmp/workspace/artifacts/distribution-build-opensearch/1.0.0/123/linux/x64/builds/opensearch/manifest.yml, type=maven, platform=linux})
+                  signArtifacts.echo(PGP Signature Signing)
                   signArtifacts.fileExists(/tmp/workspace/sign.sh)
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                      signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            /tmp/workspace/sign.sh /tmp/workspace/artifacts/distribution-build-opensearch/1.0.0/123/linux/x64/builds/opensearch/manifest.yml --type=maven --platform=linux
-        )
+                /tmp/workspace/sign.sh /tmp/workspace/artifacts/distribution-build-opensearch/1.0.0/123/linux/x64/builds/opensearch/manifest.yml --type=maven --platform=linux
+            )
          maven-sign-release.stage(stage maven artifacts, groovy.lang.Closure)
             maven-sign-release.script(groovy.lang.Closure)
                maven-sign-release.usernamePassword({credentialsId=Sonatype, usernameVariable=SONATYPE_USERNAME, passwordVariable=SONATYPE_PASSWORD})

--- a/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
@@ -2,28 +2,29 @@
       sign-standalone-artifacts.legacySCM(groovy.lang.Closure)
       sign-standalone-artifacts.library({identifier=jenkins@20211123, retriever=null})
       sign-standalone-artifacts.pipeline(groovy.lang.Closure)
-         sign-standalone-artifacts.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-centos7-v1, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
+         sign-standalone-artifacts.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v2, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
          sign-standalone-artifacts.stage(sign, groovy.lang.Closure)
             sign-standalone-artifacts.script(groovy.lang.Closure)
                sign-standalone-artifacts.sh(mkdir /tmp/workspace/artifacts)
                sign-standalone-artifacts.sh(curl -SL https://www.dummy.com/dummy_1_artifact.tar.gz -o /tmp/workspace/artifacts/dummy_1_artifact.tar.gz)
                sign-standalone-artifacts.sh(curl -SL https://www.dummy.com/dummy_2_artifact.tar.gz -o /tmp/workspace/artifacts/dummy_2_artifact.tar.gz)
                sign-standalone-artifacts.signArtifacts({artifactPath=/tmp/workspace/artifacts, sigtype=.sig, platform=linux})
+                  signArtifacts.echo(PGP Signature Signing)
                   signArtifacts.fileExists(/tmp/workspace/sign.sh)
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                      signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            /tmp/workspace/sign.sh /tmp/workspace/artifacts --sigtype=.sig --platform=linux
-        )
+                /tmp/workspace/sign.sh /tmp/workspace/artifacts --sigtype=.sig --platform=linux
+            )
                sign-standalone-artifacts.uploadToS3({sourcePath=/tmp/workspace/artifacts, bucket=dummy_bucket_name, path=sign_artifacts_job/dummy/upload/path/20/dist/signed})
                   uploadToS3.withAWS({role=Dummy_Upload_Role, roleAccount=dummy_account, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      uploadToS3.s3Upload({file=/tmp/workspace/artifacts, bucket=dummy_bucket_name, path=sign_artifacts_job/dummy/upload/path/20/dist/signed})

--- a/tests/jenkins/jobs/AssembleManifest_rpm_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/AssembleManifest_rpm_Jenkinsfile.txt
@@ -12,6 +12,84 @@
                   BuildManifest.asBoolean()
                   BuildManifest.getArtifactRootUrlWithoutDistribution(https://ci.opensearch.org/dbc, vars-build, 123)
                   assembleManifest.sh(./assemble.sh "tests/data/opensearch-build-1.3.0-rpm.yml" --base-url https://ci.opensearch.org/dbc/vars-build/1.3.0/123/linux/x64)
+                  assembleManifest.signArtifacts({artifactPath=rpm/dist/opensearch, sigtype=.rpm, platform=linux})
+                     signArtifacts.echo(RPM Add Sign)
+                     signArtifacts.withAWS({role=sign_asm_role, roleAccount=sign_asm_account, duration=900, roleSessionName=jenkins-signing-session}, groovy.lang.Closure)
+                        signArtifacts.string({credentialsId=jenkins-rpm-signing-asm-pass-id, variable=SIGNING_PASS_ID})
+                        signArtifacts.string({credentialsId=jenkins-rpm-signing-asm-secret-id, variable=SIGNING_SECRET_ID})
+                        signArtifacts.withCredentials([SIGNING_PASS_ID, SIGNING_SECRET_ID], groovy.lang.Closure)
+                           signArtifacts.sh(
+                        set -e
+                        set +x
+
+                        ARTIFACT_PATH="rpm/dist/opensearch"
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Check Utility Versions"
+                        gpg_version_limit="2.2.0"
+                        rpm_version_limit="4.13.0" # https://bugzilla.redhat.com/show_bug.cgi?id=227632
+
+                        gpg_version_check=`gpg --version | head -n 1 | grep -oE '[0-9.]+'`
+                        gpg_version_check_final=`echo $gpg_version_check $gpg_version_limit | tr ' ' '
+' | sort -V | head -n 1`
+                        rpm_version_check=`rpm --version | head -n 1 | grep -oE '[0-9.]+'`
+                        rpm_version_check_final=`echo $rpm_version_check $rpm_version_limit | tr ' ' '
+' | sort -V | head -n 1`
+
+                        echo -e "gpg_version_limit gpg_version_check"
+                        echo -e "$gpg_version_limit $gpg_version_check_final"
+                        echo -e "rpm_version_limit rpm_version_check"
+                        echo -e "$rpm_version_limit $rpm_version_check_final"
+
+                        if [[ $gpg_version_limit = $gpg_version_check_final ]] && [[ $rpm_version_limit = $rpm_version_check_final ]]; then
+                            echo "Utility version is equal or greater than set limit, continue."
+                        else
+                            echo "Utility version is lower than set limit, exit 1"
+                            exit 1
+                        fi
+
+                        export GPG_TTY=`tty`
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Setup RPM Macros"
+                        cp -v scripts/pkg/sign_templates/rpmmacros ~/.rpmmacros
+                        sed -i "s/##key_name##/OpenSearch project/g;s/##passphrase_name##/passphrase/g" ~/.rpmmacros
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Import OpenSearch keys"
+                        aws secretsmanager get-secret-value --region "sign_asm_region" --secret-id "SIGNING_PASS_ID" | jq -r .SecretBinary | base64 --decode > passphrase
+                        aws secretsmanager get-secret-value --region "sign_asm_region" --secret-id "SIGNING_SECRET_ID" | jq -r .SecretBinary | base64 --decode | gpg --quiet --import --pinentry-mode loopback --passphrase-file passphrase -
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Start Signing Rpm"
+
+                        if file $ARTIFACT_PATH | grep -q directory; then
+
+                            echo "Sign directory"
+                            for rpm_file in `ls $ARTIFACT_PATH`; do
+                                if file $ARTIFACT_PATH/$rpm_file | grep -q RPM; then
+                                    rpm --addsign $ARTIFACT_PATH/$rpm_file
+                                    rpm -qip $ARTIFACT_PATH/$rpm_file | grep Signature
+                                fi
+                            done
+
+                        elif file $ARTIFACT_PATH | grep -q RPM; then
+                            echo "Sign single rpm"
+                            rpm --addsign $ARTIFACT_PATH
+                            rpm -qip $ARTIFACT_PATH | grep Signature
+
+                        else
+                            echo "This is neither a directory nor a RPM pkg, exit 1"
+                            exit 1
+                        fi
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Clean up gpg"
+                        gpg --batch --yes --delete-secret-keys sign_asm_keyid
+                        gpg --batch --yes --delete-keys sign_asm_keyid
+                        rm -v passphrase
+
+                    )
                   assembleManifest.buildYumRepo({baseUrl=https://ci.opensearch.org/dbc/vars-build/1.3.0/123/linux/x64, buildManifest=tests/data/opensearch-build-1.3.0-rpm.yml})
                      buildYumRepo.legacySCM(groovy.lang.Closure)
                      buildYumRepo.library({identifier=jenkins@20211123, retriever=null})

--- a/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_Jenkinsfile.txt
@@ -24,21 +24,22 @@
                   promoteArtifacts.findFiles({glob=**/opensearch-min-2.0.0-rc1*.tar*,**/opensearch-2.0.0-rc1*.tar*})
                   promoteArtifacts.getPath()
                   createSignatureFiles.signArtifacts({sigtype=.sig, artifactPath=tests/jenkins/tests/jenkins/file/found.zip})
+                     signArtifacts.echo(PGP Signature Signing)
                      signArtifacts.fileExists(tests/jenkins/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                      signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                      signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                      signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
-        )
+                tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
+            )
                   promoteArtifacts.withAWS({role=artifactPromotionRole, roleAccount=artifactsAccount, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/core/opensearch/2.0.0-rc1/, workingDir=tests/jenkins/artifacts/tar/vars-build/2.0.0-rc1/33/linux/x64/tar/builds/opensearch/dist/, includePathPattern=**/opensearch-min-2.0.0-rc1-linux-x64*})
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch/2.0.0-rc1/, workingDir=tests/jenkins/artifacts/tar/vars-build/2.0.0-rc1/33/linux/x64/tar/dist/opensearch/, includePathPattern=**/opensearch-2.0.0-rc1-linux-x64*})
@@ -54,20 +55,21 @@
                   promoteArtifacts.findFiles({glob=**/opensearch-min-2.0.0-rc1*.rpm*,**/opensearch-2.0.0-rc1*.rpm*})
                   promoteArtifacts.getPath()
                   createSignatureFiles.signArtifacts({sigtype=.sig, artifactPath=tests/jenkins/tests/jenkins/file/found.zip})
+                     signArtifacts.echo(PGP Signature Signing)
                      signArtifacts.fileExists(tests/jenkins/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                      signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                      signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                      signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
-        )
+                tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
+            )
                   promoteArtifacts.withAWS({role=artifactPromotionRole, roleAccount=artifactsAccount, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch/2.0.0-rc1/, workingDir=tests/jenkins/artifacts/rpm/vars-build/2.0.0-rc1/33/linux/x64/rpm/dist/opensearch/, includePathPattern=**/opensearch-2.0.0-rc1-linux-x64*})

--- a/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_OpenSearch_Dashboards_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_OpenSearch_Dashboards_Jenkinsfile.txt
@@ -24,21 +24,22 @@
                   promoteArtifacts.findFiles({glob=**/opensearch-dashboards-min-2.0.0-rc1*.tar*,**/opensearch-dashboards-2.0.0-rc1*.tar*})
                   promoteArtifacts.getPath()
                   createSignatureFiles.signArtifacts({sigtype=.sig, artifactPath=tests/jenkins/tests/jenkins/file/found.zip})
+                     signArtifacts.echo(PGP Signature Signing)
                      signArtifacts.fileExists(tests/jenkins/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                      signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                      signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                      signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
-        )
+                tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
+            )
                   promoteArtifacts.withAWS({role=artifactPromotionRole, roleAccount=artifactsAccount, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/core/opensearch-dashboards/2.0.0-rc1/, workingDir=tests/jenkins/artifacts/tar/vars-build/2.0.0-rc1/33/linux/x64/tar/builds/opensearch-dashboards/dist/, includePathPattern=**/opensearch-dashboards-min-2.0.0-rc1-linux-x64*})
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch-dashboards/2.0.0-rc1/, workingDir=tests/jenkins/artifacts/tar/vars-build/2.0.0-rc1/33/linux/x64/tar/dist/opensearch-dashboards/, includePathPattern=**/opensearch-dashboards-2.0.0-rc1-linux-x64*})
@@ -54,20 +55,21 @@
                   promoteArtifacts.findFiles({glob=**/opensearch-dashboards-min-2.0.0-rc1*.rpm*,**/opensearch-dashboards-2.0.0-rc1*.rpm*})
                   promoteArtifacts.getPath()
                   createSignatureFiles.signArtifacts({sigtype=.sig, artifactPath=tests/jenkins/tests/jenkins/file/found.zip})
+                     signArtifacts.echo(PGP Signature Signing)
                      signArtifacts.fileExists(tests/jenkins/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                      signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                      signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                      signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
-        )
+                tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
+            )
                   promoteArtifacts.withAWS({role=artifactPromotionRole, roleAccount=artifactsAccount, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch-dashboards/2.0.0-rc1/, workingDir=tests/jenkins/artifacts/rpm/vars-build/2.0.0-rc1/33/linux/x64/rpm/dist/opensearch-dashboards/, includePathPattern=**/opensearch-dashboards-2.0.0-rc1-linux-x64*})

--- a/tests/jenkins/jobs/PromoteArtifacts_actions_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifacts_actions_Jenkinsfile.txt
@@ -27,21 +27,22 @@
                   createSha512Checksums.writeFile({file=zip_dummy_artifact_1.3.0.zip.sha512, text=shaHashDummy_zip_dummy_artifact_1.3.0.zip  zip_dummy_artifact_1.3.0.zip})
                   createSha512Checksums.echo(Not generating sha for dummy_artifact_1.3.0.dummy in tests/jenkins/artifacts/tar/vars-build/1.3.0/33/linux/x64/tar/builds/opensearch/core-plugins, doesn't match allowed types [.tar.gz, .zip, .rpm])
                   createSignatureFiles.signArtifacts({sigtype=.sig, artifactPath=tests/jenkins/artifacts/tar/vars-build/1.3.0/33/linux/x64/tar/builds/opensearch/core-plugins})
+                     signArtifacts.echo(PGP Signature Signing)
                      signArtifacts.fileExists(tests/jenkins/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                      signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                      signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                      signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            tests/jenkins/sign.sh tests/jenkins/artifacts/tar/vars-build/1.3.0/33/linux/x64/tar/builds/opensearch/core-plugins --sigtype=.sig
-        )
+                tests/jenkins/sign.sh tests/jenkins/artifacts/tar/vars-build/1.3.0/33/linux/x64/tar/builds/opensearch/core-plugins --sigtype=.sig
+            )
                   promoteArtifacts.findFiles({glob=**/opensearch-min-1.3.0*.tar*,**/opensearch-1.3.0*.tar*})
                   promoteArtifacts.getPath()
                   createSha512Checksums.sh({script=find tests/jenkins/tests/jenkins/file/found.zip -type f, returnStdout=true})
@@ -50,21 +51,22 @@
                   promoteArtifacts.findFiles({glob=**/opensearch-min-1.3.0*.tar*,**/opensearch-1.3.0*.tar*})
                   promoteArtifacts.getPath()
                   createSignatureFiles.signArtifacts({sigtype=.sig, artifactPath=tests/jenkins/tests/jenkins/file/found.zip})
+                     signArtifacts.echo(PGP Signature Signing)
                      signArtifacts.fileExists(tests/jenkins/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                      signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                      signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                      signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
-        )
+                tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
+            )
                   promoteArtifacts.withAWS({role=artifactPromotionRole, roleAccount=artifactsAccount, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/plugins/discovery-ec2/1.3.0/, workingDir=tests/jenkins/artifacts/tar/vars-build/1.3.0/33/linux/x64/tar/builds/opensearch/core-plugins/, includePathPattern=**/discovery-ec2*})
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/plugins/transport-nio/1.3.0/, workingDir=tests/jenkins/artifacts/tar/vars-build/1.3.0/33/linux/x64/tar/builds/opensearch/core-plugins/, includePathPattern=**/transport-nio*})
@@ -100,20 +102,21 @@
                   promoteArtifacts.findFiles({glob=**/opensearch-min-1.3.0*.rpm*,**/opensearch-1.3.0*.rpm*})
                   promoteArtifacts.getPath()
                   createSignatureFiles.signArtifacts({sigtype=.sig, artifactPath=tests/jenkins/tests/jenkins/file/found.zip})
+                     signArtifacts.echo(PGP Signature Signing)
                      signArtifacts.fileExists(tests/jenkins/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                      signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                      signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                      signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
-        )
+                tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
+            )
                   promoteArtifacts.withAWS({role=artifactPromotionRole, roleAccount=artifactsAccount, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch/1.3.0/, workingDir=tests/jenkins/artifacts/rpm/vars-build/1.3.0/33/linux/x64/rpm/dist/opensearch/, includePathPattern=**/opensearch-1.3.0-linux-x64*})

--- a/tests/jenkins/jobs/PromoteArtifacts_actions_OpenSearch_Dashboards_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifacts_actions_OpenSearch_Dashboards_Jenkinsfile.txt
@@ -24,21 +24,22 @@
                   promoteArtifacts.findFiles({glob=**/opensearch-dashboards-min-1.3.0*.tar*,**/opensearch-dashboards-1.3.0*.tar*})
                   promoteArtifacts.getPath()
                   createSignatureFiles.signArtifacts({sigtype=.sig, artifactPath=tests/jenkins/tests/jenkins/file/found.zip})
+                     signArtifacts.echo(PGP Signature Signing)
                      signArtifacts.fileExists(tests/jenkins/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                      signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                      signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                      signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
-        )
+                tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
+            )
                   promoteArtifacts.withAWS({role=artifactPromotionRole, roleAccount=artifactsAccount, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/core/opensearch-dashboards/1.3.0/, workingDir=tests/jenkins/artifacts/tar/vars-build/1.3.0/33/linux/x64/tar/builds/opensearch-dashboards/dist/, includePathPattern=**/opensearch-dashboards-min-1.3.0-linux-x64*})
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch-dashboards/1.3.0/, workingDir=tests/jenkins/artifacts/tar/vars-build/1.3.0/33/linux/x64/tar/dist/opensearch-dashboards/, includePathPattern=**/opensearch-dashboards-1.3.0-linux-x64*})
@@ -54,20 +55,21 @@
                   promoteArtifacts.findFiles({glob=**/opensearch-dashboards-min-1.3.0*.rpm*,**/opensearch-dashboards-1.3.0*.rpm*})
                   promoteArtifacts.getPath()
                   createSignatureFiles.signArtifacts({sigtype=.sig, artifactPath=tests/jenkins/tests/jenkins/file/found.zip})
+                     signArtifacts.echo(PGP Signature Signing)
                      signArtifacts.fileExists(tests/jenkins/sign.sh)
                      signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                      signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                      signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                      signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                         signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
-        )
+                tests/jenkins/sign.sh tests/jenkins/tests/jenkins/file/found.zip --sigtype=.sig
+            )
                   promoteArtifacts.withAWS({role=artifactPromotionRole, roleAccount=artifactsAccount, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                      promoteArtifacts.s3Upload({bucket=prod-bucket-name, path=releases/bundle/opensearch-dashboards/1.3.0/, workingDir=tests/jenkins/artifacts/rpm/vars-build/1.3.0/33/linux/x64/rpm/dist/opensearch-dashboards/, includePathPattern=**/opensearch-dashboards-1.3.0-linux-x64*})

--- a/tests/jenkins/jobs/SignArtifacts_Jenkinsfile
+++ b/tests/jenkins/jobs/SignArtifacts_Jenkinsfile
@@ -11,6 +11,12 @@ pipeline {
                     )
 
                     signArtifacts(
+                            artifactPath: "${WORKSPACE}/artifacts",
+                            sigtype: '.rpm',
+                            platform: 'linux'
+                    )
+
+                    signArtifacts(
                             artifactPath: "${WORKSPACE}/file.yml",
                             platform: 'linux',
                             type: 'maven'

--- a/tests/jenkins/jobs/SignArtifacts_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/SignArtifacts_Jenkinsfile.txt
@@ -4,34 +4,114 @@
          SignArtifacts_Jenkinsfile.stage(sign, groovy.lang.Closure)
             SignArtifacts_Jenkinsfile.script(groovy.lang.Closure)
                SignArtifacts_Jenkinsfile.signArtifacts({artifactPath=/tmp/workspace/artifacts, sigtype=.sig, platform=linux})
+                  signArtifacts.echo(PGP Signature Signing)
                   signArtifacts.fileExists(/tmp/workspace/sign.sh)
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                      signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            /tmp/workspace/sign.sh /tmp/workspace/artifacts --sigtype=.sig --platform=linux
-        )
+                /tmp/workspace/sign.sh /tmp/workspace/artifacts --sigtype=.sig --platform=linux
+            )
+               SignArtifacts_Jenkinsfile.signArtifacts({artifactPath=/tmp/workspace/artifacts, sigtype=.rpm, platform=linux})
+                  signArtifacts.echo(RPM Add Sign)
+                  signArtifacts.withAWS({role=sign_asm_role, roleAccount=sign_asm_account, duration=900, roleSessionName=jenkins-signing-session}, groovy.lang.Closure)
+                     signArtifacts.string({credentialsId=jenkins-rpm-signing-asm-pass-id, variable=SIGNING_PASS_ID})
+                     signArtifacts.string({credentialsId=jenkins-rpm-signing-asm-secret-id, variable=SIGNING_SECRET_ID})
+                     signArtifacts.withCredentials([SIGNING_PASS_ID, SIGNING_SECRET_ID], groovy.lang.Closure)
+                        signArtifacts.sh(
+                        set -e
+                        set +x
+
+                        ARTIFACT_PATH="/tmp/workspace/artifacts"
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Check Utility Versions"
+                        gpg_version_limit="2.2.0"
+                        rpm_version_limit="4.13.0" # https://bugzilla.redhat.com/show_bug.cgi?id=227632
+
+                        gpg_version_check=`gpg --version | head -n 1 | grep -oE '[0-9.]+'`
+                        gpg_version_check_final=`echo $gpg_version_check $gpg_version_limit | tr ' ' '
+' | sort -V | head -n 1`
+                        rpm_version_check=`rpm --version | head -n 1 | grep -oE '[0-9.]+'`
+                        rpm_version_check_final=`echo $rpm_version_check $rpm_version_limit | tr ' ' '
+' | sort -V | head -n 1`
+
+                        echo -e "gpg_version_limit gpg_version_check"
+                        echo -e "$gpg_version_limit $gpg_version_check_final"
+                        echo -e "rpm_version_limit rpm_version_check"
+                        echo -e "$rpm_version_limit $rpm_version_check_final"
+
+                        if [[ $gpg_version_limit = $gpg_version_check_final ]] && [[ $rpm_version_limit = $rpm_version_check_final ]]; then
+                            echo "Utility version is equal or greater than set limit, continue."
+                        else
+                            echo "Utility version is lower than set limit, exit 1"
+                            exit 1
+                        fi
+
+                        export GPG_TTY=`tty`
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Setup RPM Macros"
+                        cp -v scripts/pkg/sign_templates/rpmmacros ~/.rpmmacros
+                        sed -i "s/##key_name##/OpenSearch project/g;s/##passphrase_name##/passphrase/g" ~/.rpmmacros
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Import OpenSearch keys"
+                        aws secretsmanager get-secret-value --region "sign_asm_region" --secret-id "SIGNING_PASS_ID" | jq -r .SecretBinary | base64 --decode > passphrase
+                        aws secretsmanager get-secret-value --region "sign_asm_region" --secret-id "SIGNING_SECRET_ID" | jq -r .SecretBinary | base64 --decode | gpg --quiet --import --pinentry-mode loopback --passphrase-file passphrase -
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Start Signing Rpm"
+
+                        if file $ARTIFACT_PATH | grep -q directory; then
+
+                            echo "Sign directory"
+                            for rpm_file in `ls $ARTIFACT_PATH`; do
+                                if file $ARTIFACT_PATH/$rpm_file | grep -q RPM; then
+                                    rpm --addsign $ARTIFACT_PATH/$rpm_file
+                                    rpm -qip $ARTIFACT_PATH/$rpm_file | grep Signature
+                                fi
+                            done
+
+                        elif file $ARTIFACT_PATH | grep -q RPM; then
+                            echo "Sign single rpm"
+                            rpm --addsign $ARTIFACT_PATH
+                            rpm -qip $ARTIFACT_PATH | grep Signature
+
+                        else
+                            echo "This is neither a directory nor a RPM pkg, exit 1"
+                            exit 1
+                        fi
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Clean up gpg"
+                        gpg --batch --yes --delete-secret-keys sign_asm_keyid
+                        gpg --batch --yes --delete-keys sign_asm_keyid
+                        rm -v passphrase
+
+                    )
                SignArtifacts_Jenkinsfile.signArtifacts({artifactPath=/tmp/workspace/file.yml, platform=linux, type=maven})
+                  signArtifacts.echo(PGP Signature Signing)
                   signArtifacts.fileExists(/tmp/workspace/sign.sh)
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
                      signArtifacts.sh(
-            #!/bin/bash
-            set +x
-            export ROLE=dummy_signer_client_role
-            export EXTERNAL_ID=signer_client_external_id
-            export UNSIGNED_BUCKET=signer_client_unsigned_bucket
-            export SIGNED_BUCKET=signer_client_signed_bucket
+                #!/bin/bash
+                set +x
+                export ROLE=dummy_signer_client_role
+                export EXTERNAL_ID=signer_client_external_id
+                export UNSIGNED_BUCKET=signer_client_unsigned_bucket
+                export SIGNED_BUCKET=signer_client_signed_bucket
 
-            /tmp/workspace/sign.sh /tmp/workspace/file.yml --platform=linux --type=maven
-        )
+                /tmp/workspace/sign.sh /tmp/workspace/file.yml --platform=linux --type=maven
+            )

--- a/tests/jenkins/lib-testers/SignArtifactsLibTester.groovy
+++ b/tests/jenkins/lib-testers/SignArtifactsLibTester.groovy
@@ -24,9 +24,17 @@ class SignArtifactsLibTester extends LibFunctionTester {
         binding.setVariable('SIGNER_CLIENT_EXTERNAL_ID', 'signer_client_external_id')
         binding.setVariable('SIGNER_CLIENT_UNSIGNED_BUCKET', 'signer_client_unsigned_bucket')
         binding.setVariable('SIGNER_CLIENT_SIGNED_BUCKET', 'signer_client_signed_bucket')
+        binding.setVariable('SIGN_ASM_ROLE', 'sign_asm_role')
+        binding.setVariable('SIGN_ASM_ACCOUNT', 'sign_asm_account')
+        binding.setVariable('SIGN_ASM_REGION', 'sign_asm_region')
+        binding.setVariable('SIGN_ASM_KEYID', 'sign_asm_keyid')
 
         helper.registerAllowedMethod("git", [Map])
         helper.registerAllowedMethod("withCredentials", [Map])
+        helper.registerAllowedMethod("withAWS", [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
     }
 
     void parameterInvariantsAssertions(call) {

--- a/vars/assembleManifest.groovy
+++ b/vars/assembleManifest.groovy
@@ -1,6 +1,7 @@
 void call(Map args = [:]) {
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
     def buildManifest = lib.jenkins.BuildManifest.new(readYaml(file: args.buildManifest))
+    def filename = buildManifest.build.getFilename()
     def baseUrl = buildManifest.getArtifactRootUrlWithoutDistribution("${PUBLIC_ARTIFACT_URL}", "${JOB_NAME}", "${BUILD_NUMBER}")
     sh([
         './assemble.sh',
@@ -9,6 +10,13 @@ void call(Map args = [:]) {
     ].join(' '))
 
     if (buildManifest.build.distribution == 'rpm') {
+
+        signArtifacts(
+            artifactPath: "rpm/dist/${filename}",
+            sigtype: '.rpm',
+            platform: 'linux'
+        )
+
         buildYumRepo(
             baseUrl: baseUrl,
             buildManifest: args.buildManifest

--- a/vars/signArtifacts.groovy
+++ b/vars/signArtifacts.groovy
@@ -33,7 +33,7 @@ void call(Map args = [:]) {
                         echo "------------------------------------------------------------------------"
                         echo "Check Utility Versions"
                         gpg_version_limit="2.2.0"
-                        rpm_version_limit="4.12.0"
+                        rpm_version_limit="4.13.0" # https://bugzilla.redhat.com/show_bug.cgi?id=227632
 
                         gpg_version_check=`gpg --version | head -n 1 | grep -oE '[0-9.]+'`
                         gpg_version_check_final=`echo \$gpg_version_check \$gpg_version_limit | tr ' ' '\n' | sort -V | head -n 1`

--- a/vars/signArtifacts.groovy
+++ b/vars/signArtifacts.groovy
@@ -20,7 +20,6 @@ void call(Map args = [:]) {
         echo "RPM Add Sign"
 
         withAWS(role: "${SIGN_ASM_ROLE}", roleAccount: "${SIGN_ASM_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-signing-session') {
-            //s3Download(bucket: "${ARTIFACT_BUCKET_NAME}", file: "${prefixPath}", path: "${artifactPath}/",  force: true)
             withCredentials([
                 string(credentialsId: 'jenkins-rpm-signing-asm-pass-id', variable: 'SIGNING_PASS_ID'),
                 string(credentialsId: 'jenkins-rpm-signing-asm-secret-id', variable: 'SIGNING_SECRET_ID')])

--- a/vars/signArtifacts.groovy
+++ b/vars/signArtifacts.groovy
@@ -16,26 +16,119 @@ SignArtifacts signs the given artifacts and saves the signature in the same dire
 */
 void call(Map args = [:]) {
 
-    if( !fileExists("$WORKSPACE/sign.sh")) {
-        git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
+    if (args.sigtype.equals('.rpm')) {
+        echo "RPM Add Sign"
+
+        withAWS(role: "${SIGN_ASM_ROLE}", roleAccount: "${SIGN_ASM_ACCOUNT}", duration: 900, roleSessionName: 'jenkins-signing-session') {
+            //s3Download(bucket: "${ARTIFACT_BUCKET_NAME}", file: "${prefixPath}", path: "${artifactPath}/",  force: true)
+            withCredentials([
+                string(credentialsId: 'jenkins-rpm-signing-asm-pass-id', variable: 'SIGNING_PASS_ID'),
+                string(credentialsId: 'jenkins-rpm-signing-asm-secret-id', variable: 'SIGNING_SECRET_ID')])
+                {
+                    sh """
+                        set -e
+                        set +x
+
+                        ARTIFACT_PATH="${args.artifactPath}"
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Check Utility Versions"
+                        gpg_version_limit="2.2.0"
+                        rpm_version_limit="4.12.0"
+
+                        gpg_version_check=`gpg --version | head -n 1 | grep -oE '[0-9.]+'`
+                        gpg_version_check_final=`echo \$gpg_version_check \$gpg_version_limit | tr ' ' '\n' | sort -V | head -n 1`
+                        rpm_version_check=`rpm --version | head -n 1 | grep -oE '[0-9.]+'`
+                        rpm_version_check_final=`echo \$rpm_version_check \$rpm_version_limit | tr ' ' '\n' | sort -V | head -n 1`
+
+                        echo -e "gpg_version_limit gpg_version_check"
+                        echo -e "\$gpg_version_limit \$gpg_version_check_final"
+                        echo -e "rpm_version_limit rpm_version_check"
+                        echo -e "\$rpm_version_limit \$rpm_version_check_final"
+
+                        if [[ \$gpg_version_limit = \$gpg_version_check_final ]] && [[ \$rpm_version_limit = \$rpm_version_check_final ]]; then
+                            echo "Utility version is equal or greater than set limit, continue."
+                        else
+                            echo "Utility version is lower than set limit, exit 1"
+                            exit 1
+                        fi
+
+                        export GPG_TTY=`tty`
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Setup RPM Macros"
+                        cp -v scripts/pkg/sign_templates/rpmmacros ~/.rpmmacros
+                        sed -i "s/##key_name##/OpenSearch project/g;s/##passphrase_name##/passphrase/g" ~/.rpmmacros
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Import OpenSearch keys"
+                        aws secretsmanager get-secret-value --region "${SIGN_ASM_REGION}" --secret-id "${SIGNING_PASS_ID}" | jq -r .SecretBinary | base64 --decode > passphrase
+                        aws secretsmanager get-secret-value --region "${SIGN_ASM_REGION}" --secret-id "${SIGNING_SECRET_ID}" | jq -r .SecretBinary | base64 --decode | gpg --quiet --import --pinentry-mode loopback --passphrase-file passphrase -
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Start Signing Rpm"
+
+                        if file \$ARTIFACT_PATH | grep -q directory; then
+
+                            echo "Sign directory"
+                            for rpm_file in `ls \$ARTIFACT_PATH`; do
+                                if file \$ARTIFACT_PATH/\$rpm_file | grep -q RPM; then
+                                    rpm --addsign \$ARTIFACT_PATH/\$rpm_file
+                                    rpm -qip \$ARTIFACT_PATH/\$rpm_file | grep Signature
+                                fi
+                            done
+
+                        elif file \$ARTIFACT_PATH | grep -q RPM; then
+                            echo "Sign single rpm"
+                            rpm --addsign \$ARTIFACT_PATH
+                            rpm -qip \$ARTIFACT_PATH | grep Signature
+
+                        else
+                            echo "This is neither a directory nor a RPM pkg, exit 1"
+                            exit 1
+                        fi
+
+                        echo "------------------------------------------------------------------------"
+                        echo "Clean up gpg"
+                        gpg --batch --yes --delete-secret-keys $SIGN_ASM_KEYID
+                        gpg --batch --yes --delete-keys $SIGN_ASM_KEYID
+                        rm -v passphrase
+
+                    """
+
+                }
+        }
+
     }
+    else if (args.sigtype.equals('.sig')) {
+        echo "PGP Signature Signing"
 
-    importPGPKey()
-    
-    String arguments = generateArguments(args)
+        if( !fileExists("$WORKSPACE/sign.sh")) {
+            git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
+        }
 
-    // Sign artifacts
-    withCredentials([usernamePassword(credentialsId: "${GITHUB_BOT_TOKEN_NAME}", usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
-        sh """
-            #!/bin/bash
-            set +x
-            export ROLE=${SIGNER_CLIENT_ROLE}
-            export EXTERNAL_ID=${SIGNER_CLIENT_EXTERNAL_ID}
-            export UNSIGNED_BUCKET=${SIGNER_CLIENT_UNSIGNED_BUCKET}
-            export SIGNED_BUCKET=${SIGNER_CLIENT_SIGNED_BUCKET}
+        importPGPKey()
+        
+        String arguments = generateArguments(args)
 
-            $WORKSPACE/sign.sh ${arguments}
-        """
+        // Sign artifacts
+        withCredentials([usernamePassword(credentialsId: "${GITHUB_BOT_TOKEN_NAME}", usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
+            sh """
+                #!/bin/bash
+                set +x
+                export ROLE=${SIGNER_CLIENT_ROLE}
+                export EXTERNAL_ID=${SIGNER_CLIENT_EXTERNAL_ID}
+                export UNSIGNED_BUCKET=${SIGNER_CLIENT_UNSIGNED_BUCKET}
+                export SIGNED_BUCKET=${SIGNER_CLIENT_SIGNED_BUCKET}
+
+                $WORKSPACE/sign.sh ${arguments}
+            """
+        }
+
+    }
+    else {
+        echo "Wrong sigtype, exit"
+        System.exit(1)
     }
 }
 
@@ -53,3 +146,4 @@ void importPGPKey(){
     sh "curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -"
 
 }
+

--- a/vars/signArtifacts.groovy
+++ b/vars/signArtifacts.groovy
@@ -99,7 +99,7 @@ void call(Map args = [:]) {
         }
 
     }
-    else if (args.sigtype.equals('.sig')) {
+    else {
         echo "PGP Signature Signing"
 
         if( !fileExists("$WORKSPACE/sign.sh")) {
@@ -124,10 +124,6 @@ void call(Map args = [:]) {
             """
         }
 
-    }
-    else {
-        echo "Wrong sigtype, exit"
-        System.exit(1)
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add RPM Temporary Signing Through Shell Scripts

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/2190

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
