### PR TITLE
Use tags for 2.0.1 manifest

### DIFF
--- a/manifests/2.0.1/opensearch-2.0.1.yml
+++ b/manifests/2.0.1/opensearch-2.0.1.yml
@@ -10,64 +10,64 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: '2.0'
+    ref: tags/2.0.1
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: notifications-core
     repository: https://github.com/opensearch-project/notifications.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     working_directory: notifications
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-notifications-core
   - name: notifications
     repository: https://github.com/opensearch-project/notifications.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     working_directory: notifications
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: notifications
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     working_directory: opensearch-observability
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     platforms:
       - darwin
       - linux
@@ -76,41 +76,41 @@ components:
       - gradle:dependencies:opensearch.version
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     working_directory: reports-scheduler
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/2.0.1/opensearch-dashboards-2.0.1.yml
+++ b/manifests/2.0.1/opensearch-dashboards-2.0.1.yml
@@ -9,39 +9,39 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: '2.0'
+    ref: tags/2.0.1
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: main
+    ref: tags/2.0.1
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/sql.git
     working_directory: workbench
-    ref: '2.0'
+    ref: tags/2.0.1.0
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/observability.git
     working_directory: dashboards-observability
-    ref: '2.0'
+    ref: tags/2.0.1.0
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
     working_directory: gantt-chart
-    ref: '2.0'
+    ref: tags/2.0.1.0
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reports.git
     working_directory: dashboards-reports
-    ref: '2.0'
+    ref: tags/2.0.1.0
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: '2.0'
+    ref: tags/2.0.1.0
   - name: notificationsDashboards
     repository: https://github.com/opensearch-project/notifications.git
     working_directory: dashboards-notifications
-    ref: '2.0'
+    ref: tags/2.0.1.0
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
-    ref: '2.0'
+    ref: tags/2.0.1.0
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: '2.0'
+    ref: tags/2.0.1.0


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Update the refs with tags for 2.0.1 manifest after release.

The CI checks for this PR are expected to fail since we haven't cut the tags yet. We will re-run the checks once 2.0.1 is released.

### Issues Resolved
Part of #2165 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
