### PR TITLE
Fix component release template and add improvements

### DIFF
--- a/meta/README.md
+++ b/meta/README.md
@@ -58,7 +58,7 @@ When creating a version label for the ongoing release, always create the next ve
 We create release issues in all component repos that link back to a parent release issue in this repository. 
 
 1. Locate the parent release issue, e.g. [opensearch-build#567](https://github.com/opensearch-project/opensearch-build/issues/567) for version 1.2.
-2. Clone the [release template](templates/releases/release-1.2.0.md) into a new `release-X.Y.Z.md`, e.g. [release-1.2.0.md](templates/releases/release-1.2.0.md). Update all `REPLACE` tags with actual versions and dates and commit and PR the file.
+2. Clone the [release template](templates/releases/release_template.md) into a new `release-X.Y.Z.md`, e.g. [release-1.2.0.md](templates/releases/release-1.2.0.md). Update all `REPLACE` tags with actual versions and dates and commit and PR the file.
 3. From [components](components), run `meta exec "gh issue create --label v1.2.0 --title 'Release version 1.2' --body-file ../../templates/releases/release-1.2.0.md"`.
 
 ### Check for Release Tags

--- a/meta/README.md
+++ b/meta/README.md
@@ -58,7 +58,7 @@ When creating a version label for the ongoing release, always create the next ve
 We create release issues in all component repos that link back to a parent release issue in this repository. 
 
 1. Locate the parent release issue, e.g. [opensearch-build#567](https://github.com/opensearch-project/opensearch-build/issues/567) for version 1.2.
-2. Clone the [release template](templates/releases/release_template.md) into a new `release-X.Y.Z.md`, e.g. [release-1.2.0.md](templates/releases/release-1.2.0.md). Update all `REPLACE` tags with actual versions and dates and commit and PR the file.
+2. Clone the [release template](templates/releases/release-1.2.0.md) into a new `release-X.Y.Z.md`, e.g. [release-1.2.0.md](templates/releases/release-1.2.0.md). Update all `REPLACE` tags with actual versions and dates and commit and PR the file.
 3. From [components](components), run `meta exec "gh issue create --label v1.2.0 --title 'Release version 1.2' --body-file ../../templates/releases/release-1.2.0.md"`.
 
 ### Check for Release Tags

--- a/meta/templates/releases/release-1.2.0.md
+++ b/meta/templates/releases/release-1.2.0.md
@@ -31,7 +31,7 @@ Coming from [opensearch-build#567](https://github.com/opensearch-project/opensea
 
 ### Post Release
 
-- [ ] Ensure you have a release tag for `v2.1.0` in your repo. If not [create one](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging) and open an issue in [build repo](https://github.com/opensearch-project/opensearch-build/issues)
+- [ ] Ensure you have a release tag for `v1.2.0` in your repo. If not [create one](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging) and open an issue in [build repo](https://github.com/opensearch-project/opensearch-build/issues)
 - [ ] Create a [GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) release in your repo.
 - [ ] [Suggest improvements](https://github.com/opensearch-project/opensearch-build/issues/new) to [this template](https://github.com/opensearch-project/opensearch-build/meta/templates/releases/release-1.2.0.md).
 - [ ] Conduct a postmortem, and publish its results.

--- a/meta/templates/releases/release-1.2.0.md
+++ b/meta/templates/releases/release-1.2.0.md
@@ -31,7 +31,7 @@ Coming from [opensearch-build#567](https://github.com/opensearch-project/opensea
 
 ### Post Release
 
-- [ ] Ensure you have a release tag for `v2.1.0` in your repo. If not [create one](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging) and open issue in [build repo](https://github.com/opensearch-project/opensearch-build/issues)
+- [ ] Ensure you have a release tag for `v2.1.0` in your repo. If not [create one](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging) and open an issue in [build repo](https://github.com/opensearch-project/opensearch-build/issues)
 - [ ] Create a [GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) release in your repo.
 - [ ] [Suggest improvements](https://github.com/opensearch-project/opensearch-build/issues/new) to [this template](https://github.com/opensearch-project/opensearch-build/meta/templates/releases/release-1.2.0.md).
 - [ ] Conduct a postmortem, and publish its results.

--- a/meta/templates/releases/release-1.2.0.md
+++ b/meta/templates/releases/release-1.2.0.md
@@ -31,7 +31,7 @@ Coming from [opensearch-build#567](https://github.com/opensearch-project/opensea
 
 ### Post Release
 
-- [ ] Ensure you have a [a release tag](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging) for your repo. If not create one and open issue in [build repo](https://github.com/opensearch-project/opensearch-build/issues)
+- [ ] Ensure you have a release tag for `v2.1.0` in your repo. If not [create one](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging) and open issue in [build repo](https://github.com/opensearch-project/opensearch-build/issues)
 - [ ] Create a [GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) release in your repo.
 - [ ] [Suggest improvements](https://github.com/opensearch-project/opensearch-build/issues/new) to [this template](https://github.com/opensearch-project/opensearch-build/meta/templates/releases/release-1.2.0.md).
 - [ ] Conduct a postmortem, and publish its results.

--- a/meta/templates/releases/release-1.2.0.md
+++ b/meta/templates/releases/release-1.2.0.md
@@ -31,6 +31,7 @@ Coming from [opensearch-build#567](https://github.com/opensearch-project/opensea
 
 ### Post Release
 
-- [ ] Create [a release tag](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging).
+- [ ] Ensure you have a [a release tag](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#tagging) for your repo. If not create one and open issue in [build repo](https://github.com/opensearch-project/opensearch-build/issues)
+- [ ] Create a [GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) release in your repo.
 - [ ] [Suggest improvements](https://github.com/opensearch-project/opensearch-build/issues/new) to [this template](https://github.com/opensearch-project/opensearch-build/meta/templates/releases/release-1.2.0.md).
 - [ ] Conduct a postmortem, and publish its results.


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
1. Fixes the hyperlink to component release template
2. Since creating tags for all repos is automated now (see https://github.com/opensearch-project/opensearch-build/pull/1666), components teams just need to take care of github releases.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
