### PR TITLE
Update jenkins core version to resolve CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ sourceSets {
 }
 
 sharedLibrary {
-    coreVersion = '2.337' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-core?repo=jenkins-releases
+    coreVersion = '2.355' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-core?repo=jenkins-releases
     testHarnessVersion = '1736.vc72c458c5103' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-test-harness?repo=jenkins-releases
     pluginDependencies {
         workflowCpsGlobalLibraryPluginVersion = '2.21.3' // https://mvnrepository.com/artifact/org.jenkins-ci.plugins.workflow/workflow-cps-global-lib?repo=jenkins-releases
@@ -77,7 +77,7 @@ sharedLibrary {
         dependency('org.jenkins-ci.plugins.workflow', 'workflow-cps', '2.94.1')
         dependency('org.jenkins-ci.plugins.workflow', 'workflow-multibranch', '2.26.1')
         dependency('org.jenkins-ci.plugins', 'pipeline-input-step', '2.12')
-        dependency('org.jenkins-ci.plugins', 'script-security', '1.78')
+        dependency('org.jenkins-ci.plugins', 'script-security', '1172.v35f6a_0b_8207e')
         dependency('org.jenkins-ci.plugins', 'credentials', '1112.vc87b_7a_3597f6')
         dependency('org.jenkins-ci.plugins', 'git-client', '3.10.1')
         dependency('org.jenkins-ci.plugins', 'junit', '1.55')

--- a/tests/jenkins/TestUploadMinSnapshotsToS3.groovy
+++ b/tests/jenkins/TestUploadMinSnapshotsToS3.groovy
@@ -8,7 +8,6 @@
 
 package jenkins.tests
 
-import com.kenai.jffi.Closure
 import jenkins.tests.BuildPipelineTest
 import org.junit.*
 


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Update jenkins core version to resolve CVEs

Also found that new Jenkins core version starting from [2.338](https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-core/2.338) won't support `import com.kenai.jffi.Closure` which will cause fail to startup Jenkins test
log: 
```
The input changes require a full rebuild for incremental task ':compileTestGroovy'.
startup failed:
/tmp/opensearch-build/tests/jenkins/TestUploadMinSnapshotsToS3.groovy: 11: unable to resolve class com.kenai.jffi.Closure
 @ line 11, column 1.
   import com.kenai.jffi.Closure
   ^

1 error

:compileTestGroovy (Thread[Execution worker for ':',5,main]) completed. Took 1.612 secs.
```
Remove it since it won't affect the jenkins test. 

We will see how Mend pick up the CVEs support from CI checks.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
