### PR TITLE
add i18nPluin to 2.1 manifests

### DIFF
--- a/manifests/2.1.0/opensearch-dashboards-2.1.0.yml
+++ b/manifests/2.1.0/opensearch-dashboards-2.1.0.yml
@@ -10,3 +10,6 @@ components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     ref: 2.x
+  - name: i18nPlugin
+    repository: https://github.com/opensearch-project/i18n-plugin.git
+    ref: 2.x


### PR DESCRIPTION
i18nPlugin is a new external plugin which lets you build localized OpenSearch Dashboards platform and plugins.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
