### PR TITLE
Remove security component from 2.1.0

### DIFF
--- a/manifests/2.1.0/opensearch-2.1.0.yml
+++ b/manifests/2.1.0/opensearch-2.1.0.yml
@@ -14,6 +14,3 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
-  - name: security
-    repository: https://github.com/opensearch-project/security.git
-    ref: main


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Currently build is failing for 2.1.0 due to security. Removing it to let the build pass

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
