### PR TITLE
Fix cdk version issues for performance tests

### DIFF
--- a/jenkins/cross-cluster-replication/perf-test.jenkinsfile
+++ b/jenkins/cross-cluster-replication/perf-test.jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     }
     environment {
         AGENT_LABEL = 'Jenkins-Agent-al2-x64-m52xlarge-Docker-Host-Perf-Test'
-        AGENT_IMAGE = 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2'
+        AGENT_IMAGE = 'opensearchstaging/ci-runner:ci-runner-centos7-performance-test-v1'
         BUNDLE_MANIFEST = 'bundle-manifest.yml'
         JOB_NAME = 'ccr-perf-test'
     }

--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -3,11 +3,11 @@ lib = library(identifier: "jenkins@20211118", retriever: legacySCM(scm))
 pipeline {
     agent none
     options {
-        timeout(time: 10, unit: 'HOURS')
+        timeout(time: 15, unit: 'HOURS')
     }
     environment {
         AGENT_LABEL = 'Jenkins-Agent-al2-x64-m52xlarge-Docker-Host-Perf-Test'
-        AGENT_IMAGE = 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2'
+        AGENT_IMAGE = 'opensearchstaging/ci-runner:ci-runner-centos7-performance-test-v1'
         BUNDLE_MANIFEST = 'bundle-manifest.yml'
         JOB_NAME = 'perf-test'
     }

--- a/tests/jenkins/TestCCRPerfTest.groovy
+++ b/tests/jenkins/TestCCRPerfTest.groovy
@@ -61,12 +61,6 @@ class TestCCRPerfTest extends BuildPipelineTest {
     void testCCRPerfTestScript_verifyPackageInstallation() {
         runScript("jenkins/cross-cluster-replication/perf-test.jenkinsfile")
 
-        def npmCommands = getCommandExecutions('sh', 'npm').findAll {
-            shCommand -> shCommand.contains('npm')
-        }
-
-        assertThat(npmCommands.size(), equalTo(1))
-
         def pipenvCommands = getCommandExecutions('sh', 'pipenv').findAll {
             shCommand -> shCommand.contains('pipenv')
         }

--- a/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
+++ b/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
@@ -64,12 +64,6 @@ class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
     void testRunNonSecurityPerfTestScript_verifyPackageInstallation() {
         runScript("jenkins/opensearch/perf-test.jenkinsfile")
 
-        def npmCommands = getCommandExecutions('sh', 'npm').findAll {
-            shCommand -> shCommand.contains('npm')
-        }
-
-        assertThat(npmCommands.size(), equalTo(1))
-
         def pipenvCommands = getCommandExecutions('sh', 'pipenv').findAll {
             shCommand -> shCommand.contains('pipenv')
         }

--- a/tests/jenkins/TestRunPerfTestScript.groovy
+++ b/tests/jenkins/TestRunPerfTestScript.groovy
@@ -64,12 +64,6 @@ class TestRunPerfTestScript extends BuildPipelineTest {
     void testRunPerfTestScript_verifyPackageInstallation() {
         runScript("jenkins/opensearch/perf-test.jenkinsfile")
 
-        def npmCommands = getCommandExecutions('sh', 'npm').findAll {
-            shCommand -> shCommand.contains('npm')
-        }
-
-        assertThat(npmCommands.size(), equalTo(2))
-
         def pipenvCommands = getCommandExecutions('sh', 'pipenv').findAll {
             shCommand -> shCommand.contains('pipenv')
         }

--- a/tests/jenkins/jenkinsjob-regression-files/cross-cluster-replication/perf-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/cross-cluster-replication/perf-test.jenkinsfile.txt
@@ -38,13 +38,6 @@
                   runPerfTestScript.readYaml({file=tests/jenkins/data/opensearch-1.3.0-bundle.yml})
                   BuildManifest.asBoolean()
                   runPerfTestScript.sh(
-        npm install -g fs-extra
-        npm install -g chalk@4.1.2
-        npm install -g @aws-cdk/cloudformation-diff
-        npm install -g aws-cdk
-        npm install -g cdk-assume-role-credential-plugin@1.4.0
-    )
-                  runPerfTestScript.sh(
         pipenv install "dataclasses_json~=0.5" "aws_requests_auth~=0.4" "json2html~=1.3.0"
         pipenv install "aws-cdk.core~=1.143.0" "aws_cdk.aws_ec2~=1.143.0" "aws_cdk.aws_iam~=1.143.0"
         pipenv install "boto3~=1.18" "setuptools~=57.4" "retry~=0.9"

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test-with-security.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test-with-security.jenkinsfile.txt
@@ -2,7 +2,7 @@
       perf-test.legacySCM(groovy.lang.Closure)
       perf-test.library({identifier=jenkins@20211118, retriever=null})
       perf-test.pipeline(groovy.lang.Closure)
-         perf-test.timeout({time=10, unit=HOURS})
+         perf-test.timeout({time=15, unit=HOURS})
          perf-test.echo(Executing on agent [label:none])
          perf-test.stage(validate-and-set-parameters, groovy.lang.Closure)
             perf-test.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-centos7-v1, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
@@ -37,13 +37,6 @@
                   runPerfTestScript.library({identifier=jenkins@20211123, retriever=null})
                   runPerfTestScript.readYaml({file=tests/jenkins/data/opensearch-1.3.0-bundle.yml})
                   BuildManifest.asBoolean()
-                  runPerfTestScript.sh(
-        npm install -g fs-extra
-        npm install -g chalk@4.1.2
-        npm install -g @aws-cdk/cloudformation-diff
-        npm install -g aws-cdk
-        npm install -g cdk-assume-role-credential-plugin@1.4.0
-    )
                   runPerfTestScript.sh(
         pipenv install "dataclasses_json~=0.5" "aws_requests_auth~=0.4" "json2html~=1.3.0"
         pipenv install "aws-cdk.core~=1.143.0" "aws_cdk.aws_ec2~=1.143.0" "aws_cdk.aws_iam~=1.143.0"
@@ -101,13 +94,6 @@ Performance tests with security for 1236 completed})
                   runPerfTestScript.library({identifier=jenkins@20211123, retriever=null})
                   runPerfTestScript.readYaml({file=tests/jenkins/data/opensearch-1.3.0-bundle.yml})
                   BuildManifest.asBoolean()
-                  runPerfTestScript.sh(
-        npm install -g fs-extra
-        npm install -g chalk@4.1.2
-        npm install -g @aws-cdk/cloudformation-diff
-        npm install -g aws-cdk
-        npm install -g cdk-assume-role-credential-plugin@1.4.0
-    )
                   runPerfTestScript.sh(
         pipenv install "dataclasses_json~=0.5" "aws_requests_auth~=0.4" "json2html~=1.3.0"
         pipenv install "aws-cdk.core~=1.143.0" "aws_cdk.aws_ec2~=1.143.0" "aws_cdk.aws_iam~=1.143.0"

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test.jenkinsfile.txt
@@ -2,7 +2,7 @@
       perf-test.legacySCM(groovy.lang.Closure)
       perf-test.library({identifier=jenkins@20211118, retriever=null})
       perf-test.pipeline(groovy.lang.Closure)
-         perf-test.timeout({time=10, unit=HOURS})
+         perf-test.timeout({time=15, unit=HOURS})
          perf-test.echo(Executing on agent [label:none])
          perf-test.stage(validate-and-set-parameters, groovy.lang.Closure)
             perf-test.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-centos7-v1, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
@@ -38,13 +38,6 @@
                   runPerfTestScript.library({identifier=jenkins@20211123, retriever=null})
                   runPerfTestScript.readYaml({file=tests/jenkins/data/opensearch-1.3.0-non-security-bundle.yml})
                   BuildManifest.asBoolean()
-                  runPerfTestScript.sh(
-        npm install -g fs-extra
-        npm install -g chalk@4.1.2
-        npm install -g @aws-cdk/cloudformation-diff
-        npm install -g aws-cdk
-        npm install -g cdk-assume-role-credential-plugin@1.4.0
-    )
                   runPerfTestScript.sh(
         pipenv install "dataclasses_json~=0.5" "aws_requests_auth~=0.4" "json2html~=1.3.0"
         pipenv install "aws-cdk.core~=1.143.0" "aws_cdk.aws_ec2~=1.143.0" "aws_cdk.aws_iam~=1.143.0"

--- a/vars/runPerfTestScript.groovy
+++ b/vars/runPerfTestScript.groovy
@@ -2,7 +2,6 @@ void call(Map args = [:]) {
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
     def buildManifest = lib.jenkins.BuildManifest.new(readYaml(file: args.bundleManifest))
 
-    install_dependencies()
     install_opensearch_infra_dependencies()
     config_name = isNullOrEmpty(args.config) ? "config.yml" : args.config
     withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
@@ -35,15 +34,5 @@ void install_opensearch_infra_dependencies() {
         pipenv install "dataclasses_json~=0.5" "aws_requests_auth~=0.4" "json2html~=1.3.0"
         pipenv install "aws-cdk.core~=1.143.0" "aws_cdk.aws_ec2~=1.143.0" "aws_cdk.aws_iam~=1.143.0"
         pipenv install "boto3~=1.18" "setuptools~=57.4" "retry~=0.9"
-    '''
-}
-
-void install_dependencies() {
-    sh '''
-        npm install -g fs-extra
-        npm install -g chalk@4.1.2
-        npm install -g @aws-cdk/cloudformation-diff
-        npm install -g aws-cdk
-        npm install -g cdk-assume-role-credential-plugin@1.4.0
     '''
 }


### PR DESCRIPTION
Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

### Description
- Version mismatches between node and cdk are causing failures with performance tests
- A new docker image was created to resolve these issues
- Change the pipeline logic to utilize new image as well as increase timeouts based on recent trends

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/3628

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
