### PR TITLE
add common-utils to 2.1.0 manifest and remove security plugin

### DIFF
--- a/manifests/2.1.0/opensearch-2.1.0.yml
+++ b/manifests/2.1.0/opensearch-2.1.0.yml
@@ -17,3 +17,9 @@ components:
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: main
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: main
+    checks:
+      - gradle:publish
+      - gradle:properties:version

--- a/manifests/2.1.0/opensearch-2.1.0.yml
+++ b/manifests/2.1.0/opensearch-2.1.0.yml
@@ -14,9 +14,6 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
-  - name: security
-    repository: https://github.com/opensearch-project/security.git
-    ref: main
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
     ref: main


### PR DESCRIPTION
Signed-off-by: Subhobrata Dey <sbcd90@gmail.com>

### Description
add common-utils to 2.1.0 manifest and remove security plugin

### Issues Resolved
[Release version 2.1.0](https://github.com/opensearch-project/common-utils/issues/189)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
