### PR TITLE
Reduce input manifest build frequency for new upcoming versions

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -146,7 +146,7 @@ class InputManifests(Manifests):
         with open(jenkinsfile, "r") as f:
             data = f.read()
 
-        cron_entry = f"H/10 * * * * %INPUT_MANIFEST={version}/{self.prefix}-{version}.yml;TARGET_JOB_NAME=distribution-build-{self.prefix}\n"
+        cron_entry = f"H 1 * * * %INPUT_MANIFEST={version}/{self.prefix}-{version}.yml;TARGET_JOB_NAME=distribution-build-{self.prefix}\n"
 
         if cron_entry in data:
             raise ValueError(f"{jenkinsfile} already contains an entry for {self.prefix} {version}")

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -75,7 +75,7 @@ class TestInputManifests(unittest.TestCase):
         mock_open.assert_has_calls([call(InputManifests.cron_jenkinsfile(), 'w')])
         mock_open.assert_has_calls([call(InputManifests.cron_jenkinsfile(), 'r')])
         mock_open().write.assert_called_once_with(
-            f"parameterizedCron '''\n{' ' * 12}H/10 * * * * %INPUT_MANIFEST=0.1.2/test-0.1.2.yml;TARGET_JOB_NAME=distribution-build-test\n"
+            f"parameterizedCron '''\n{' ' * 12}H 1 * * * %INPUT_MANIFEST=0.1.2/test-0.1.2.yml;TARGET_JOB_NAME=distribution-build-test\n"
         )
 
     def test_create_manifest_with_components(self) -> None:


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Reduce input manifest build frequency for new upcoming versions.
Every time when a new input manifest getting created, it often doesnt have all the necessary pieces.
Core not ready, plugin not bumping or supporting it, etc.
It is not very useful to build every 10min for these broken builds.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
