### PR TITLE
Add dataprepper as a part of the source image param

### DIFF
--- a/jenkins/docker/docker-copy.jenkinsfile
+++ b/jenkins/docker/docker-copy.jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     parameters {
         choice(
             name: 'SOURCE_IMAGE_REGISTRY', 
-            choices: ['opensearchstaging', 'public.ecr.aws/opensearchstaging', 'opensearchproject', 'public.ecr.aws/opensearchproject'],
+            choices: ['opensearchstaging', 'public.ecr.aws/opensearchstaging', 'opensearchproject', 'public.ecr.aws/opensearchproject', "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"],
             description: 'Choose the source image registry'
         )
         string(

--- a/tests/jenkins/TestCopyContainer.groovy
+++ b/tests/jenkins/TestCopyContainer.groovy
@@ -12,6 +12,7 @@ class TestCopyContainer extends BuildPipelineTest {
         binding.setVariable('DOCKER_PASSWORD', 'dummy_docker_password')
         binding.setVariable('ARTIFACT_PROMOTION_ROLE_NAME', 'sample-agent-AssumeRole')
         binding.setVariable('AWS_ACCOUNT_ARTIFACT', '1234567890')
+        binding.setVariable('DATA_PREPPER_STAGING_CONTAINER_REPOSITORY', 'sample_dataprepper_ecr_url')
          helper.registerAllowedMethod('withAWS', [Map, Closure], null)
         super.setUp()
 


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add dataprepper as a part of the source image param

### Issues Resolved
#2157

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
