### PR TITLE
Change ref to 2.1 for opensearch

### DIFF
--- a/manifests/2.1.0/opensearch-2.1.0.yml
+++ b/manifests/2.1.0/opensearch-2.1.0.yml
@@ -16,19 +16,19 @@ components:
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: main
+    ref: '2.1'
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: main
+    ref: '2.1'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: main
+    ref: '2.1'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
@@ -40,49 +40,49 @@ components:
       - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: main
+    ref: '2.1'
   - name: notifications-core
     repository: https://github.com/opensearch-project/notifications.git
-    ref: main
+    ref: '2.1'
     working_directory: notifications
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-notifications-core
   - name: notifications
     repository: https://github.com/opensearch-project/notifications.git
-    ref: main
+    ref: '2.1'
     working_directory: notifications
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: notifications
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: main
+    ref: '2.1'
     checks:
       - gradle:properties:version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: main
+    ref: '2.1'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability
-    ref: main
+    ref: '2.1'
     working_directory: opensearch-observability
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: main
+    ref: '2.1'
     working_directory: reports-scheduler
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: main
+    ref: '2.1'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
@@ -97,13 +97,13 @@ components:
       - gradle:dependencies:opensearch.version
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: main
+    ref: '2.1'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: main
+    ref: '2.1'
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Change the branch references to 2.1 for 2.1.0 manifest opensearch component

### Issues Resolved
Related to #2218 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
