### PR TITLE
Make sure gradle check is using c518xlarge runner

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     agent {
         node {
             // Must use Ubuntu agent with 1 executor or gradle check will show a lot of java-related errors
-            label 'Jenkins-Agent-Ubuntu2004-X64-c54xlarge-Single-Host'
+            label 'Jenkins-Agent-Ubuntu2004-X64-c518xlarge-Single-Host'
         }
     }
     parameters {


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Make sure gradle check is using c518xlarge runner

### Issues Resolved
#851

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
