### PR TITLE
Set concurrent build limit for gradle check to 50

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -2,7 +2,16 @@ lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
 
 pipeline {
     options {
-            timeout(time: 2, unit: 'HOURS')
+        timeout(time: 2, unit: 'HOURS')
+        throttleJobProperty(
+            categories: [],
+            limitOneJobWithMatchingParams: false,
+            maxConcurrentPerNode: 0,
+            maxConcurrentTotal: 50,
+            paramsToUseForLimit: '',
+            throttleEnabled: true,
+            throttleOption: 'project',
+        )
     }
     // gradle check have a lot of issues running on containers
     // Therefore, we directly run it on the agent node


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Set concurrent build limit for gradle check to 50
![image](https://user-images.githubusercontent.com/65193828/176260651-59ef79eb-d89e-4918-9c46-e8a34a8e9a00.png)


### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/851

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
