### PR TITLE
Add java args to 2.2.0 manifest

### DIFF
--- a/manifests/2.2.0/opensearch-2.2.0.yml
+++ b/manifests/2.2.0/opensearch-2.2.0.yml
@@ -6,6 +6,7 @@ build:
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2
+    args: -e JAVA_HOME=/opt/java/openjdk-17
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
2.2.0 build were failing for opensearch component due to missing java args. Adding it in this PR

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
