### PR TITLE
Remove 2.1.0 from cron for building release candidates

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -12,8 +12,6 @@ pipeline {
     triggers {
         parameterizedCron '''
             H 1 * * * %INPUT_MANIFEST=2.2.0/opensearch-2.2.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=2.1.0/opensearch-2.1.0.yml;TEST_MANIFEST=2.1.0/opensearch-2.1.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/10 * * * * %INPUT_MANIFEST=2.1.0/opensearch-dashboards-2.1.0.yml;TEST_MANIFEST=2.1.0/opensearch-dashboards-2.1.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H 1 * * * %INPUT_MANIFEST=2.0.2/opensearch-dashboards-2.0.2.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Before we start building release candidates, removing 2.1.0 from cron job to avoid accidental builds.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
