### PR TITLE
Create a docker promotion jenkins workflow

### DIFF
--- a/jenkins/promotion/promote-docker-ecr.jenkinsfile
+++ b/jenkins/promotion/promote-docker-ecr.jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
         )
         string(
             name: 'RELEASE_VERSION',
-            description: 'Official release version on production repository. E.g.: 2.0.1, 1.5.0.',
+            description: 'Official release version on production repository. This is uniform for all source images. E.g.: 2.0.1, 1.5.0.',
             trim: true
         )
         booleanParam(

--- a/jenkins/promotion/promote-docker-ecr.jenkinsfile
+++ b/jenkins/promotion/promote-docker-ecr.jenkinsfile
@@ -1,0 +1,92 @@
+lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+
+pipeline {
+    options {
+        timeout(time: 1, unit: 'HOURS')
+    }
+    agent {
+        docker {
+            label 'Jenkins-Agent-al2-x64-c54xlarge-Docker-Host'
+            image 'opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2'
+            args '-u root -v /var/run/docker.sock:/var/run/docker.sock'
+        }
+}
+    parameters {
+        string(
+            name: 'PROMOTE_PRODUCT',
+            description: 'Comma separated list of product that we want to promote from staging to production. E.g.: opensearch, opensearch-dashboards.',
+            trim: true
+        )
+        string(
+            name: 'RELEASE_VERSION',
+            description: 'Official release version on production repository. E.g.: 2.0.1',
+            trim: true
+        )
+        string(
+            name: 'SOURCE_TAG',
+            description: 'Image tag in the staging E.g.: 2.0.1.3910',
+            trim: true
+        )
+        booleanParam(
+            name: 'DOCKER_HUB_PROMOTE',
+            defaultValue: true,
+            description: 'Promote the staging images to Docker Hub with the tag choices.'
+        )
+        booleanParam(
+            name: 'ECR_PROMOTE',
+            defaultValue: true,
+            description: 'Promote the staging images to ECR with the tag choices.'
+        )
+        booleanParam(
+            name: 'TAG_LATEST',
+            defaultValue: true,
+            description: 'Tag the copied image as latest'
+        )
+        booleanParam(
+            name: 'TAG_MAJOR_VERSION',
+            defaultValue: true,
+            description: 'Tag the copied image to be on the latest image for any build within its major version. E.g.: 1.3.2 image will be tagged with 1 in the hub.'
+        )
+    }
+
+    stages {
+        stage('Parameters Check') {
+            steps {
+                script {
+                    currentBuild.description = "Promoting ${PROMOTE_PRODUCT} to production hub."
+                    if(PROMOTE_PRODUCT.isEmpty()) {
+                        currentBuild.result = 'ABORTED'
+                        error('Make sure at lease one product is added to be promoted.')
+                    }
+                }
+            }
+        }
+        stage('image-promote-to-prod') {
+            steps {
+                script {
+                    for (product in PROMOTE_PRODUCT.split(',')) {
+                        def productRepo = product.trim()
+                        println("Promoting \"$productRepo\" from staging to production.")
+//                         promoteContainer(
+//                             imageRepository: productRepo,
+//                             version: RELEASE_VERSION,
+//                             sourceTag: SOURCE_TAG,
+//                             dockerPromote: DOCKER_HUB_PROMOTE,
+//                             ecrPromote: ECR_PROMOTE,
+//                             latestTag: TAG_LATEST,
+//                             majorVersionTag: TAG_MAJOR_VERSION
+//                         )
+                    }
+                }
+            }
+        }
+    }
+    post() {
+        always {
+            script {
+                postCleanup()
+                sh "docker logout"
+            }
+        }
+    }
+}

--- a/jenkins/promotion/promote-docker-ecr.jenkinsfile
+++ b/jenkins/promotion/promote-docker-ecr.jenkinsfile
@@ -14,17 +14,12 @@ pipeline {
     parameters {
         string(
             name: 'PROMOTE_PRODUCT',
-            description: 'Comma separated list of product that we want to promote from staging to production. E.g.: opensearch, opensearch-dashboards, data-prepper.',
+            description: 'Comma separated list of product with its image tag that we want to promote from staging to production. E.g.: opensearch:2.0.1.3910, opensearch-dashboards:2.0.1, data-prepper1.5.0-19.',
             trim: true
         )
         string(
             name: 'RELEASE_VERSION',
             description: 'Official release version on production repository. E.g.: 2.0.1, 1.5.0.',
-            trim: true
-        )
-        string(
-            name: 'SOURCE_TAG',
-            description: 'Image tag in the staging repository. E.g.: 2.0.1.3910, 1.5.0-19',
             trim: true
         )
         booleanParam(
@@ -70,7 +65,6 @@ pipeline {
                         promoteContainer(
                             imageRepository: productRepo,
                             version: RELEASE_VERSION,
-                            sourceTag: SOURCE_TAG,
                             dockerPromote: DOCKER_HUB_PROMOTE,
                             ecrPromote: ECR_PROMOTE,
                             latestTag: TAG_LATEST,

--- a/jenkins/promotion/promote-docker-ecr.jenkinsfile
+++ b/jenkins/promotion/promote-docker-ecr.jenkinsfile
@@ -14,17 +14,17 @@ pipeline {
     parameters {
         string(
             name: 'PROMOTE_PRODUCT',
-            description: 'Comma separated list of product that we want to promote from staging to production. E.g.: opensearch, opensearch-dashboards.',
+            description: 'Comma separated list of product that we want to promote from staging to production. E.g.: opensearch, opensearch-dashboards, data-prepper.',
             trim: true
         )
         string(
             name: 'RELEASE_VERSION',
-            description: 'Official release version on production repository. E.g.: 2.0.1',
+            description: 'Official release version on production repository. E.g.: 2.0.1, 1.5.0.',
             trim: true
         )
         string(
             name: 'SOURCE_TAG',
-            description: 'Image tag in the staging E.g.: 2.0.1.3910',
+            description: 'Image tag in the staging repository. E.g.: 2.0.1.3910, 1.5.0-19',
             trim: true
         )
         booleanParam(
@@ -67,15 +67,15 @@ pipeline {
                     for (product in PROMOTE_PRODUCT.split(',')) {
                         def productRepo = product.trim()
                         println("Promoting \"$productRepo\" from staging to production.")
-//                         promoteContainer(
-//                             imageRepository: productRepo,
-//                             version: RELEASE_VERSION,
-//                             sourceTag: SOURCE_TAG,
-//                             dockerPromote: DOCKER_HUB_PROMOTE,
-//                             ecrPromote: ECR_PROMOTE,
-//                             latestTag: TAG_LATEST,
-//                             majorVersionTag: TAG_MAJOR_VERSION
-//                         )
+                        promoteContainer(
+                            imageRepository: productRepo,
+                            version: RELEASE_VERSION,
+                            sourceTag: SOURCE_TAG,
+                            dockerPromote: DOCKER_HUB_PROMOTE,
+                            ecrPromote: ECR_PROMOTE,
+                            latestTag: TAG_LATEST,
+                            majorVersionTag: TAG_MAJOR_VERSION
+                        )
                     }
                 }
             }

--- a/jenkins/promotion/promote-docker-ecr.jenkinsfile
+++ b/jenkins/promotion/promote-docker-ecr.jenkinsfile
@@ -13,8 +13,8 @@ pipeline {
 }
     parameters {
         string(
-            name: 'PROMOTE_PRODUCT',
-            description: 'Comma separated list of product with its image tag that we want to promote from staging to production. E.g.: opensearch:2.0.1.3910, opensearch-dashboards:2.0.1, data-prepper1.5.0-19.',
+            name: 'SOURCE_IMAGES',
+            description: 'Comma separated list of product with its image tag that we want to promote from staging to production. E.g.: opensearch:2.0.1.3910, opensearch-dashboards:2.0.1, data-prepper:1.5.0-19.',
             trim: true
         )
         string(
@@ -25,12 +25,12 @@ pipeline {
         booleanParam(
             name: 'DOCKER_HUB_PROMOTE',
             defaultValue: true,
-            description: 'Promote the staging images to Docker Hub with the tag choices.'
+            description: 'Promote SOURCE_IMAGES to `opensearchproject` production Docker Hub.'
         )
         booleanParam(
             name: 'ECR_PROMOTE',
             defaultValue: true,
-            description: 'Promote the staging images to ECR with the tag choices.'
+            description: 'Promote SOURCE_IMAGES to `gallery.ecr.aws/opensearchproject` production ECR repository.'
         )
         booleanParam(
             name: 'TAG_LATEST',
@@ -40,7 +40,7 @@ pipeline {
         booleanParam(
             name: 'TAG_MAJOR_VERSION',
             defaultValue: true,
-            description: 'Tag the copied image to be on the latest image for any build within its major version. E.g.: 1.3.2 image will be tagged with 1 in the hub.'
+            description: 'Tag the copied image with its major version. E.g.: 1.3.2 image will be tagged with 1 in the hub.'
         )
     }
 
@@ -48,10 +48,10 @@ pipeline {
         stage('Parameters Check') {
             steps {
                 script {
-                    currentBuild.description = "Promoting ${PROMOTE_PRODUCT} to production hub."
-                    if(PROMOTE_PRODUCT.isEmpty()) {
+                    currentBuild.description = "Promoting ${SOURCE_IMAGES} to production hub."
+                    if(SOURCE_IMAGES.isEmpty() || RELEASE_VERSION.isEmpty()) {
                         currentBuild.result = 'ABORTED'
-                        error('Make sure at lease one product is added to be promoted.')
+                        error('Make sure at lease one product is added to be promoted with proper release version.')
                     }
                 }
             }
@@ -59,7 +59,7 @@ pipeline {
         stage('image-promote-to-prod') {
             steps {
                 script {
-                    for (product in PROMOTE_PRODUCT.split(',')) {
+                    for (product in SOURCE_IMAGES.split(',')) {
                         def productRepo = product.trim()
                         println("Promoting \"$productRepo\" from staging to production.")
                         promoteContainer(

--- a/tests/jenkins/TestCopyContainer.groovy
+++ b/tests/jenkins/TestCopyContainer.groovy
@@ -13,7 +13,7 @@ class TestCopyContainer extends BuildPipelineTest {
         binding.setVariable('ARTIFACT_PROMOTION_ROLE_NAME', 'sample-agent-AssumeRole')
         binding.setVariable('AWS_ACCOUNT_ARTIFACT', '1234567890')
         binding.setVariable('DATA_PREPPER_STAGING_CONTAINER_REPOSITORY', 'sample_dataprepper_ecr_url')
-         helper.registerAllowedMethod('withAWS', [Map, Closure], null)
+        helper.registerAllowedMethod('withAWS', [Map, Closure], null)
         super.setUp()
 
     }

--- a/tests/jenkins/TestPromoteContainer.groovy
+++ b/tests/jenkins/TestPromoteContainer.groovy
@@ -1,0 +1,118 @@
+import jenkins.tests.BuildPipelineTest
+import org.junit.Before
+import org.junit.Test
+
+class TestPromoteContainer extends BuildPipelineTest {
+
+    String PROMOTE_PRODUCT = 'alpine'
+    String RELEASE_VERSION = '3.15.4'
+    String SOURCE_TAG = '3.15.4-1234'
+
+    @Before
+    void setUp() {
+        binding.setVariable('PROMOTE_PRODUCT', PROMOTE_PRODUCT)
+        binding.setVariable('RELEASE_VERSION', RELEASE_VERSION)
+        binding.setVariable('SOURCE_TAG', SOURCE_TAG)
+        binding.setVariable('DOCKER_USERNAME', 'dummy_docker_username')
+        binding.setVariable('DOCKER_PASSWORD', 'dummy_docker_password')
+        binding.setVariable('ARTIFACT_PROMOTION_ROLE_NAME', 'dummy-agent-AssumeRole')
+        binding.setVariable('AWS_ACCOUNT_ARTIFACT', '1234567890')
+        binding.setVariable('DATA_PREPPER_STAGING_CONTAINER_REPOSITORY', 'dummy_dataprepper_ecr_url')
+
+
+        helper.registerAllowedMethod('withAWS', [Map, Closure], null)
+        super.setUp()
+
+    }
+
+    @Test
+    public void testPromoteContainerToDocker() {
+        String dockerPromote = true
+        String ecrPromote = false
+        String latestBoolean = false
+        String majorVersionBoolean = false
+        binding.setVariable('DOCKER_HUB_PROMOTE', dockerPromote)
+        binding.setVariable('ECR_PROMOTE', ecrPromote)
+        binding.setVariable('TAG_LATEST', latestBoolean)
+        binding.setVariable('TAG_MAJOR_VERSION', majorVersionBoolean)
+
+        super.testPipeline("jenkins/promotion/promote-docker-ecr.jenkinsfile",
+                "tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile")
+    }
+
+    @Test
+    public void testPromoteContainerToDockerLatest() {
+        String dockerPromote = true
+        String ecrPromote = false
+        String latestBoolean = true
+        String majorVersionBoolean = false
+        binding.setVariable('DOCKER_HUB_PROMOTE', dockerPromote)
+        binding.setVariable('ECR_PROMOTE', ecrPromote)
+        binding.setVariable('TAG_LATEST', latestBoolean)
+        binding.setVariable('TAG_MAJOR_VERSION', majorVersionBoolean)
+
+        super.testPipeline("jenkins/promotion/promote-docker-ecr.jenkinsfile",
+                "tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile")
+    }
+
+    @Test
+    public void testPromoteContainerToDockerMajor() {
+        String dockerPromote = true
+        String ecrPromote = false
+        String latestBoolean = false
+        String majorVersionBoolean = true
+        binding.setVariable('DOCKER_HUB_PROMOTE', dockerPromote)
+        binding.setVariable('ECR_PROMOTE', ecrPromote)
+        binding.setVariable('TAG_LATEST', latestBoolean)
+        binding.setVariable('TAG_MAJOR_VERSION', majorVersionBoolean)
+
+        super.testPipeline("jenkins/promotion/promote-docker-ecr.jenkinsfile",
+                "tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile")
+    }
+
+    @Test
+    public void testPromoteContainerToDockerLatestMajor() {
+        String dockerPromote = true
+        String ecrPromote = false
+        String latestBoolean = true
+        String majorVersionBoolean = true
+        binding.setVariable('DOCKER_HUB_PROMOTE', dockerPromote)
+        binding.setVariable('ECR_PROMOTE', ecrPromote)
+        binding.setVariable('TAG_LATEST', latestBoolean)
+        binding.setVariable('TAG_MAJOR_VERSION', majorVersionBoolean)
+
+        super.testPipeline("jenkins/promotion/promote-docker-ecr.jenkinsfile",
+                "tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile")
+    }
+
+    @Test
+    public void testPromoteContainerToECRLatestMajor() {
+        String dockerPromote = false
+        String ecrPromote = true
+        String latestBoolean = true
+        String majorVersionBoolean = true
+        binding.setVariable('DOCKER_HUB_PROMOTE', dockerPromote)
+        binding.setVariable('ECR_PROMOTE', ecrPromote)
+        binding.setVariable('TAG_LATEST', latestBoolean)
+        binding.setVariable('TAG_MAJOR_VERSION', majorVersionBoolean)
+
+        super.testPipeline("jenkins/promotion/promote-docker-ecr.jenkinsfile",
+                "tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile")
+    }
+
+    @Test
+    public void testPromoteContainerToDockerECRLatestMajor() {
+        String dockerPromote = true
+        String ecrPromote = true
+        String latestBoolean = true
+        String majorVersionBoolean = true
+        binding.setVariable('DOCKER_HUB_PROMOTE', dockerPromote)
+        binding.setVariable('ECR_PROMOTE', ecrPromote)
+        binding.setVariable('TAG_LATEST', latestBoolean)
+        binding.setVariable('TAG_MAJOR_VERSION', majorVersionBoolean)
+
+        super.testPipeline("jenkins/promotion/promote-docker-ecr.jenkinsfile",
+                "tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile")
+    }
+
+}

--- a/tests/jenkins/TestPromoteContainer.groovy
+++ b/tests/jenkins/TestPromoteContainer.groovy
@@ -4,7 +4,7 @@ import org.junit.Test
 
 class TestPromoteContainer extends BuildPipelineTest {
 
-    String PROMOTE_PRODUCT = 'opensearch:2.0.1-2901, opensearch-dashboards:2.0.1-2345'
+    String PROMOTE_PRODUCT = 'opensearch:2.0.1.2901, opensearch-dashboards:2.0.1-2345, data-prepper:2.0.1.123'
     String RELEASE_VERSION = '2.0.1'
 
     @Before

--- a/tests/jenkins/TestPromoteContainer.groovy
+++ b/tests/jenkins/TestPromoteContainer.groovy
@@ -4,15 +4,13 @@ import org.junit.Test
 
 class TestPromoteContainer extends BuildPipelineTest {
 
-    String PROMOTE_PRODUCT = 'alpine'
-    String RELEASE_VERSION = '3.15.4'
-    String SOURCE_TAG = '3.15.4-1234'
+    String PROMOTE_PRODUCT = 'opensearch:2.0.1-2901, opensearch-dashboards:2.0.1-2345'
+    String RELEASE_VERSION = '2.0.1'
 
     @Before
     void setUp() {
         binding.setVariable('PROMOTE_PRODUCT', PROMOTE_PRODUCT)
         binding.setVariable('RELEASE_VERSION', RELEASE_VERSION)
-        binding.setVariable('SOURCE_TAG', SOURCE_TAG)
         binding.setVariable('DOCKER_USERNAME', 'dummy_docker_username')
         binding.setVariable('DOCKER_PASSWORD', 'dummy_docker_password')
         binding.setVariable('ARTIFACT_PROMOTION_ROLE_NAME', 'dummy-agent-AssumeRole')

--- a/tests/jenkins/TestPromoteContainer.groovy
+++ b/tests/jenkins/TestPromoteContainer.groovy
@@ -9,7 +9,7 @@ class TestPromoteContainer extends BuildPipelineTest {
 
     @Before
     void setUp() {
-        binding.setVariable('PROMOTE_PRODUCT', PROMOTE_PRODUCT)
+        binding.setVariable('SOURCE_IMAGES', PROMOTE_PRODUCT)
         binding.setVariable('RELEASE_VERSION', RELEASE_VERSION)
         binding.setVariable('DOCKER_USERNAME', 'dummy_docker_username')
         binding.setVariable('DOCKER_PASSWORD', 'dummy_docker_password')

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile.txt
@@ -1,0 +1,23 @@
+   promote-docker-ecr.run()
+      promote-docker-ecr.legacySCM(groovy.lang.Closure)
+      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.pipeline(groovy.lang.Closure)
+         promote-docker-ecr.timeout({time=1, unit=HOURS})
+         promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
+         promote-docker-ecr.stage(Parameters Check, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+         promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3.15.4
+                docker logout
+            )
+         promote-docker-ecr.script(groovy.lang.Closure)
+            promote-docker-ecr.postCleanup()
+               postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})
+            promote-docker-ecr.sh(docker logout)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile.txt
@@ -9,32 +9,23 @@
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
                promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2.0.1
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2.0.1
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
          promote-docker-ecr.script(groovy.lang.Closure)
             promote-docker-ecr.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile.txt
@@ -8,13 +8,22 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3.15.4
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2.0.1
+                docker logout
+            )
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
                 docker logout
             )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile.txt
@@ -8,13 +8,13 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2.0.1
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2.0.1
                 docker logout
             )
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
@@ -24,6 +24,15 @@
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
                 gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
+                docker logout
+            )
+               promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=false})
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2.0.1
                 docker logout
             )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile.txt
@@ -9,170 +9,98 @@
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
                promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:latest
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:2.0.1
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:2
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:latest
-                        docker logout public.ecr.aws/opensearchproject
-                    )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:latest, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:latest
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:2.0.1
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:2
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:latest, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:latest
-                        docker logout public.ecr.aws/opensearchproject
-                    )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:latest, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:latest
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:2.0.1
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:2
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:latest, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:latest
-                        docker logout public.ecr.aws/opensearchproject
-                    )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
          promote-docker-ecr.script(groovy.lang.Closure)
             promote-docker-ecr.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile.txt
@@ -8,59 +8,114 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3.15.4
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2.0.1
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:latest, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:latest
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:latest
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=public.ecr.aws/opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:3.15.4
+                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:2.0.1
                         docker logout public.ecr.aws/opensearchproject
                     )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3, destinationRegistry=public.ecr.aws/opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:3
+                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:2
                         docker logout public.ecr.aws/opensearchproject
                     )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:latest, destinationRegistry=public.ecr.aws/opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:latest
+                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:latest
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:latest, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:latest
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:2.0.1
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:2
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:latest, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:latest
                         docker logout public.ecr.aws/opensearchproject
                     )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile.txt
@@ -8,59 +8,59 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2.0.1
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2.0.1
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:latest
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:latest
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:2.0.1
+                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:2.0.1
                         docker logout public.ecr.aws/opensearchproject
                     )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=public.ecr.aws/opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:2
+                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:2
                         docker logout public.ecr.aws/opensearchproject
                     )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=public.ecr.aws/opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:latest
+                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:latest
                         docker logout public.ecr.aws/opensearchproject
                     )
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
@@ -116,6 +116,61 @@
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
                         gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:latest
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+               promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2.0.1
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:latest, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:latest
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:2.0.1
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:2
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:latest, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:latest
                         docker logout public.ecr.aws/opensearchproject
                     )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile.txt
@@ -1,0 +1,69 @@
+   promote-docker-ecr.run()
+      promote-docker-ecr.legacySCM(groovy.lang.Closure)
+      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.pipeline(groovy.lang.Closure)
+         promote-docker-ecr.timeout({time=1, unit=HOURS})
+         promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
+         promote-docker-ecr.stage(Parameters Check, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+         promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=true, ecrPromote=true, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3.15.4
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:latest, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:latest
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:3.15.4
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:3
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:latest, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:latest
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+         promote-docker-ecr.script(groovy.lang.Closure)
+            promote-docker-ecr.postCleanup()
+               postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})
+            promote-docker-ecr.sh(docker logout)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile.txt
@@ -8,21 +8,21 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2.0.1
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2.0.1
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:latest
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:latest
                 docker logout
             )
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
@@ -40,6 +40,23 @@
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
                 gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:latest
+                docker logout
+            )
+               promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2.0.1
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:latest, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:latest
                 docker logout
             )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile.txt
@@ -1,0 +1,31 @@
+   promote-docker-ecr.run()
+      promote-docker-ecr.legacySCM(groovy.lang.Closure)
+      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.pipeline(groovy.lang.Closure)
+         promote-docker-ecr.timeout({time=1, unit=HOURS})
+         promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
+         promote-docker-ecr.stage(Parameters Check, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+         promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3.15.4
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:latest, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:latest
+                docker logout
+            )
+         promote-docker-ecr.script(groovy.lang.Closure)
+            promote-docker-ecr.postCleanup()
+               postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})
+            promote-docker-ecr.sh(docker logout)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile.txt
@@ -9,56 +9,38 @@
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
                promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:latest
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:latest, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:latest
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:latest, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:latest
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
          promote-docker-ecr.script(groovy.lang.Closure)
             promote-docker-ecr.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile.txt
@@ -8,21 +8,38 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3.15.4
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2.0.1
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:latest, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:latest
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:latest
+                docker logout
+            )
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=false})
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:latest, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:latest
                 docker logout
             )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile.txt
@@ -1,0 +1,39 @@
+   promote-docker-ecr.run()
+      promote-docker-ecr.legacySCM(groovy.lang.Closure)
+      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.pipeline(groovy.lang.Closure)
+         promote-docker-ecr.timeout({time=1, unit=HOURS})
+         promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
+         promote-docker-ecr.stage(Parameters Check, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+         promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3.15.4
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:latest, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:latest
+                docker logout
+            )
+         promote-docker-ecr.script(groovy.lang.Closure)
+            promote-docker-ecr.postCleanup()
+               postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})
+            promote-docker-ecr.sh(docker logout)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile.txt
@@ -8,29 +8,54 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3.15.4
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2.0.1
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:latest, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:latest
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:latest
+                docker logout
+            )
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:latest, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:latest
                 docker logout
             )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile.txt
@@ -9,80 +9,53 @@
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
                promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:latest
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:latest, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:latest
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:latest, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:latest
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
          promote-docker-ecr.script(groovy.lang.Closure)
             promote-docker-ecr.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile.txt
@@ -8,29 +8,29 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2.0.1
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2.0.1
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:latest
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:latest
                 docker logout
             )
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
@@ -56,6 +56,31 @@
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
                 gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:latest
+                docker logout
+            )
+               promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2.0.1
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:latest, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:latest
                 docker logout
             )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile.txt
@@ -9,56 +9,38 @@
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
                promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2.0.1
-                docker logout
-            )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2, destinationRegistry=opensearchproject})
-                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
-                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
-                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                        copyContainer.sh(
-                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2
-                docker logout
-            )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
          promote-docker-ecr.script(groovy.lang.Closure)
             promote-docker-ecr.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile.txt
@@ -1,0 +1,31 @@
+   promote-docker-ecr.run()
+      promote-docker-ecr.legacySCM(groovy.lang.Closure)
+      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.pipeline(groovy.lang.Closure)
+         promote-docker-ecr.timeout({time=1, unit=HOURS})
+         promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
+         promote-docker-ecr.stage(Parameters Check, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+         promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3.15.4
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3
+                docker logout
+            )
+         promote-docker-ecr.script(groovy.lang.Closure)
+            promote-docker-ecr.postCleanup()
+               postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})
+            promote-docker-ecr.sh(docker logout)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile.txt
@@ -8,21 +8,38 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3.15.4
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2.0.1
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4-1234 opensearchproject/alpine:3
+                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2
+                docker logout
+            )
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2.0.1
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2
                 docker logout
             )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile.txt
@@ -8,21 +8,21 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2.0.1
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2.0.1
                 docker logout
             )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=opensearchproject})
                      copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                      copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
-                gcrane cp opensearchstaging/opensearch:2.0.1-2901 opensearchproject/opensearch:2
+                gcrane cp opensearchstaging/opensearch:2.0.1.2901 opensearchproject/opensearch:2
                 docker logout
             )
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
@@ -40,6 +40,23 @@
                         copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
                         copyContainer.sh(
                 gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 opensearchproject/opensearch-dashboards:2
+                docker logout
+            )
+               promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=true, ecrPromote=false, latestTag=false, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2.0.1
+                docker logout
+            )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2, destinationRegistry=opensearchproject})
+                     copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
+                     copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
+                        copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
+                        copyContainer.sh(
+                gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 opensearchproject/data-prepper:2
                 docker logout
             )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile.txt
@@ -1,0 +1,45 @@
+   promote-docker-ecr.run()
+      promote-docker-ecr.legacySCM(groovy.lang.Closure)
+      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.pipeline(groovy.lang.Closure)
+         promote-docker-ecr.timeout({time=1, unit=HOURS})
+         promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
+         promote-docker-ecr.stage(Parameters Check, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+         promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
+            promote-docker-ecr.script(groovy.lang.Closure)
+               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:3.15.4
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:3
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:latest, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:latest
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+         promote-docker-ecr.script(groovy.lang.Closure)
+            promote-docker-ecr.postCleanup()
+               postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})
+            promote-docker-ecr.sh(docker logout)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile.txt
@@ -8,35 +8,66 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=alpine, version=3.15.4, sourceTag=3.15.4-1234, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=public.ecr.aws/opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:3.15.4
+                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:2.0.1
                         docker logout public.ecr.aws/opensearchproject
                     )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:3, destinationRegistry=public.ecr.aws/opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:3
+                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:2
                         docker logout public.ecr.aws/opensearchproject
                     )
-                  promoteContainer.copyContainer({sourceImage=alpine:3.15.4-1234, sourceRegistry=opensearchstaging, destinationImage=alpine:latest, destinationRegistry=public.ecr.aws/opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/alpine:3.15.4-1234 public.ecr.aws/opensearchproject/alpine:latest
+                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:latest
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:2.0.1
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:2
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:latest, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:latest
                         docker logout public.ecr.aws/opensearchproject
                     )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile.txt
@@ -9,98 +9,53 @@
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
                promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:2.0.1
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:2
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:latest
-                        docker logout public.ecr.aws/opensearchproject
-                    )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch:2.0.1.2901})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:2.0.1
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:2, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:2
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=opensearch-dashboards:2.0.1-2345, sourceRegistry=opensearchstaging, destinationImage=opensearch-dashboards:latest, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:latest
-                        docker logout public.ecr.aws/opensearchproject
-                    )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=opensearchstaging})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=opensearch-dashboards:2.0.1-2345})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=opensearch-dashboards:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
                promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:2.0.1
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:2
-                        docker logout public.ecr.aws/opensearchproject
-                    )
-                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:latest, destinationRegistry=public.ecr.aws/opensearchproject})
-                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
-                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
-                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
-                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
-                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                           copyContainer.sh(
-                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:latest
-                        docker logout public.ecr.aws/opensearchproject
-                    )
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2.0.1})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:2})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
+                  promoteContainer.string({name=SOURCE_IMAGE_REGISTRY, value=dummy_dataprepper_ecr_url})
+                  promoteContainer.string({name=SOURCE_IMAGE, value=data-prepper:2.0.1.123})
+                  promoteContainer.string({name=DESTINATION_IMAGE_REGISTRY, value=public.ecr.aws/opensearchproject})
+                  promoteContainer.string({name=DESTINATION_IMAGE, value=data-prepper:latest})
+                  promoteContainer.build({job=docker-copy, parameters=[null, null, null, null]})
          promote-docker-ecr.script(groovy.lang.Closure)
             promote-docker-ecr.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile.txt
@@ -8,35 +8,35 @@
             promote-docker-ecr.script(groovy.lang.Closure)
          promote-docker-ecr.stage(image-promote-to-prod, groovy.lang.Closure)
             promote-docker-ecr.script(groovy.lang.Closure)
-               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1-2901, version=2.0.1, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
+               promote-docker-ecr.promoteContainer({imageRepository=opensearch:2.0.1.2901, version=2.0.1, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:2.0.1
+                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:2.0.1
                         docker logout public.ecr.aws/opensearchproject
                     )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=public.ecr.aws/opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:2, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:2
+                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:2
                         docker logout public.ecr.aws/opensearchproject
                     )
-                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1-2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=public.ecr.aws/opensearchproject})
+                  promoteContainer.copyContainer({sourceImage=opensearch:2.0.1.2901, sourceRegistry=opensearchstaging, destinationImage=opensearch:latest, destinationRegistry=public.ecr.aws/opensearchproject})
                      copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
                      copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
                      copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                         copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
-                        gcrane cp opensearchstaging/opensearch:2.0.1-2901 public.ecr.aws/opensearchproject/opensearch:latest
+                        gcrane cp opensearchstaging/opensearch:2.0.1.2901 public.ecr.aws/opensearchproject/opensearch:latest
                         docker logout public.ecr.aws/opensearchproject
                     )
                promote-docker-ecr.promoteContainer({imageRepository=opensearch-dashboards:2.0.1-2345, version=2.0.1, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
@@ -68,6 +68,37 @@
                            copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
                            copyContainer.sh(
                         gcrane cp opensearchstaging/opensearch-dashboards:2.0.1-2345 public.ecr.aws/opensearchproject/opensearch-dashboards:latest
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+               promote-docker-ecr.promoteContainer({imageRepository=data-prepper:2.0.1.123, version=2.0.1, dockerPromote=false, ecrPromote=true, latestTag=true, majorVersionTag=true})
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2.0.1, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:2.0.1
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:2, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:2
+                        docker logout public.ecr.aws/opensearchproject
+                    )
+                  promoteContainer.copyContainer({sourceImage=data-prepper:2.0.1.123, sourceRegistry=dummy_dataprepper_ecr_url, destinationImage=data-prepper:latest, destinationRegistry=public.ecr.aws/opensearchproject})
+                     copyContainer.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})
+                     copyContainer.string({credentialsId=jenkins-aws-production-account, variable=AWS_ACCOUNT_ARTIFACT})
+                     copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
+                        copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
+                           copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
+                           copyContainer.sh(
+                        gcrane cp dummy_dataprepper_ecr_url/data-prepper:2.0.1.123 public.ecr.aws/opensearchproject/data-prepper:latest
                         docker logout public.ecr.aws/opensearchproject
                     )
          promote-docker-ecr.script(groovy.lang.Closure)

--- a/vars/promoteContainer.groovy
+++ b/vars/promoteContainer.groovy
@@ -29,7 +29,7 @@ void call(Map args = [:]) {
     if (dockerPromote.toBoolean()) {
         println("Promoting $imageProduct to production docker hub with with $version tag.")
         dockerCopy: {
-            build job: 'fake-docker-copy',
+            build job: 'docker-copy',
                 parameters: [
                     string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
                     string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
@@ -40,7 +40,7 @@ void call(Map args = [:]) {
         if (majorVersionBoolean.toBoolean()) {
             println("Promoting to production docker hub with with $majorVersion tag.")
             dockerCopy: {
-                build job: 'fake-docker-copy',
+                build job: 'docker-copy',
                     parameters: [
                         string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
                         string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
@@ -52,7 +52,7 @@ void call(Map args = [:]) {
         if (latestBoolean.toBoolean()) {
             println("Promoting to production docker hub with with latest tag.")
             dockerCopy: {
-                build job: 'fake-docker-copy',
+                build job: 'docker-copy',
                     parameters: [
                         string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
                         string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
@@ -66,7 +66,7 @@ void call(Map args = [:]) {
     if (ecrPromote.toBoolean()) {
         println("Promoting to production ECR with with $version tag.")
         dockerCopy: {
-            build job: 'fake-docker-copy',
+            build job: 'docker-copy',
                 parameters: [
                     string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
                     string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
@@ -77,7 +77,7 @@ void call(Map args = [:]) {
         if (majorVersionBoolean.toBoolean()) {
             println("Promoting to production ECR with with $majorVersion tag.")
             dockerCopy: {
-                build job: 'fake-docker-copy',
+                build job: 'docker-copy',
                     parameters: [
                         string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
                         string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
@@ -89,7 +89,7 @@ void call(Map args = [:]) {
         if (latestBoolean.toBoolean()) {
             println("Promoting to production ECR with with latest tag.")
             dockerCopy: {
-                build job: 'fake-docker-copy',
+                build job: 'docker-copy',
                     parameters: [
                         string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
                         string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),

--- a/vars/promoteContainer.groovy
+++ b/vars/promoteContainer.groovy
@@ -1,0 +1,80 @@
+/**@
+ * Copies a container from one docker registry to another
+ *
+ * @param args A map of the following parameters
+ * @param args.imageRepository The repository of staging image. E.g.: opensearch, opensearch-dashboards, data-prepper
+ * @param args.version The official version for release. E.g.: 2.0.1
+ * @param args.sourceTag The image tag from the staging repo. E.g.: 2.0.1.3910
+ * @param args.dockerPromote
+ * @param args.ecrPromote
+ * @param args.latestTag
+ * @param args.majorVersionTag
+ */
+void call(Map args = [:]) {
+
+    def imageRepo = args.imageRepository
+    def version = args.version
+    def sourceTag = args.sourceTag
+    def dockerPromote = args.dockerPromote
+    def ecrPromote = args.ecrPromote
+    def latestBoolean = args.latestTag
+    def majorVersionBoolean = args.majorVersionTag
+    def majorVersion = version.split("\\.").first()
+
+    //Promoting docker images
+    if (dockerPromote) {
+        println("Promoting to production docker hub with with $version tag.")
+        copyContainer(
+                sourceImage: "$imageRepo:$sourceTag",
+                sourceRegistry: "opensearchstaging",
+                destinationImage: "$imageRepo:$version",
+                destinationRegistry: "opensearchproject"
+        )
+        if (majorVersionBoolean) {
+            println("Promoting to production docker hub with with $majorVersion tag.")
+            copyContainer(
+                    sourceImage: "$imageRepo:$sourceTag",
+                    sourceRegistry: "opensearchstaging",
+                    destinationImage: "$imageRepo:$majorVersion",
+                    destinationRegistry: "opensearchproject"
+            )
+        }
+        if (latestBoolean) {
+            println("Promoting to production docker hub with with latest tag.")
+            copyContainer(
+                    sourceImage: "$imageRepo:$sourceTag",
+                    sourceRegistry: "opensearchstaging",
+                    destinationImage: "$imageRepo:latest",
+                    destinationRegistry: "opensearchproject"
+            )
+        }
+    }
+    if (ecrPromote) {
+        println("Promoting to production ECR with with $version tag.")
+        copyContainer(
+                sourceImage: "$imageRepo:$sourceTag",
+                sourceRegistry: "opensearchstaging",
+                destinationImage: "$imageRepo:$version",
+                destinationRegistry: "public.ecr.aws/opensearchproject"
+        )
+        if (majorVersionBoolean) {
+            println("Promoting to production ECR with with $majorVersion tag.")
+            copyContainer(
+                    sourceImage: "$imageRepo:$sourceTag",
+                    sourceRegistry: "opensearchstaging",
+                    destinationImage: "$imageRepo:$majorVersion",
+                    destinationRegistry: "public.ecr.aws/opensearchproject"
+            )
+        }
+        if (latestBoolean) {
+            println("Promoting to production ECR with with latest tag.")
+            copyContainer(
+                    sourceImage: "$imageRepo:$sourceTag",
+                    sourceRegistry: "opensearchstaging",
+                    destinationImage: "$imageRepo:latest",
+                    destinationRegistry: "public.ecr.aws/opensearchproject"
+            )
+        }
+    }
+
+}

--- a/vars/promoteContainer.groovy
+++ b/vars/promoteContainer.groovy
@@ -2,9 +2,8 @@
  * Promote image from staging docker to production docker hub or ECR repository.
  *
  * @param args A map of the following parameters
- * @param args.imageRepository The repository of staging image. E.g.: opensearch, opensearch-dashboards, data-prepper
+ * @param args.imageRepository The repository of staging image. E.g.: opensearch:2.0.1.3910, opensearch-dashboards:2.0.1, data-prepper
  * @param args.version The official version for release. E.g.: 2.0.1
- * @param args.sourceTag The image tag from the staging repo. E.g.: 2.0.1.3910
  * @param args.dockerPromote The boolean argument if promote containers from staging to production docker repo.
  * @param args.ecrPromote The boolean argument if promote containers from staging to production ECR repo.
  * @param args.latestTag The boolean argument if promote containers from staging to production with latest tag.
@@ -14,7 +13,8 @@ void call(Map args = [:]) {
 
     def imageRepo = args.imageRepository
     def version = args.version
-    def sourceTag = args.sourceTag
+    def imageProduct = imageRepo.split(':').first()
+    def sourceTag = imageRepo.split(':').last()
     def dockerPromote = args.dockerPromote
     def ecrPromote = args.ecrPromote
     def latestBoolean = args.latestTag
@@ -27,55 +27,56 @@ void call(Map args = [:]) {
 
     //Promoting docker images
     if (dockerPromote.toBoolean()) {
-        println("Promoting to production docker hub with with $version tag.")
+        println("Promoting $imageProduct to production docker hub with with $version tag.")
         copyContainer(
-                sourceImage: "$imageRepo:$sourceTag",
+                sourceImage: "$imageProduct:$sourceTag",
                 sourceRegistry: sourceReg,
-                destinationImage: "$imageRepo:$version",
+                destinationImage: "$imageProduct:$version",
                 destinationRegistry: dockerProduction
         )
         if (majorVersionBoolean.toBoolean()) {
             println("Promoting to production docker hub with with $majorVersion tag.")
             copyContainer(
-                    sourceImage: "$imageRepo:$sourceTag",
+                    sourceImage: "$imageProduct:$sourceTag",
                     sourceRegistry: sourceReg,
-                    destinationImage: "$imageRepo:$majorVersion",
+                    destinationImage: "$imageProduct:$majorVersion",
                     destinationRegistry: dockerProduction
             )
         }
         if (latestBoolean.toBoolean()) {
             println("Promoting to production docker hub with with latest tag.")
             copyContainer(
-                    sourceImage: "$imageRepo:$sourceTag",
+                    sourceImage: "$imageProduct:$sourceTag",
                     sourceRegistry: sourceReg,
-                    destinationImage: "$imageRepo:latest",
+                    destinationImage: "$imageProduct:latest",
                     destinationRegistry: dockerProduction
             )
         }
     }
+    //Promoting image to ECR
     if (ecrPromote.toBoolean()) {
         println("Promoting to production ECR with with $version tag.")
         copyContainer(
-                sourceImage: "$imageRepo:$sourceTag",
+                sourceImage: "$imageProduct:$sourceTag",
                 sourceRegistry: sourceReg,
-                destinationImage: "$imageRepo:$version",
+                destinationImage: "$imageProduct:$version",
                 destinationRegistry: ecrProduction
         )
         if (majorVersionBoolean.toBoolean()) {
             println("Promoting to production ECR with with $majorVersion tag.")
             copyContainer(
-                    sourceImage: "$imageRepo:$sourceTag",
+                    sourceImage: "$imageProduct:$sourceTag",
                     sourceRegistry: sourceReg,
-                    destinationImage: "$imageRepo:$majorVersion",
+                    destinationImage: "$imageProduct:$majorVersion",
                     destinationRegistry: ecrProduction
             )
         }
         if (latestBoolean.toBoolean()) {
             println("Promoting to production ECR with with latest tag.")
             copyContainer(
-                    sourceImage: "$imageRepo:$sourceTag",
+                    sourceImage: "$imageProduct:$sourceTag",
                     sourceRegistry: sourceReg,
-                    destinationImage: "$imageRepo:latest",
+                    destinationImage: "$imageProduct:latest",
                     destinationRegistry: ecrProduction
             )
         }

--- a/vars/promoteContainer.groovy
+++ b/vars/promoteContainer.groovy
@@ -2,7 +2,7 @@
  * Promote image from staging docker to production docker hub or ECR repository.
  *
  * @param args A map of the following parameters
- * @param args.imageRepository The repository of staging image. E.g.: opensearch:2.0.1.3910, opensearch-dashboards:2.0.1, data-prepper
+ * @param args.imageRepository The repository of staging image. E.g.: opensearch:2.0.1.3910, opensearch-dashboards:2.0.1, data-prepper:2.0.1-1234
  * @param args.version The official version for release. E.g.: 2.0.1
  * @param args.dockerPromote The boolean argument if promote containers from staging to production docker repo.
  * @param args.ecrPromote The boolean argument if promote containers from staging to production ECR repo.
@@ -21,7 +21,7 @@ void call(Map args = [:]) {
     def majorVersionBoolean = args.majorVersionTag
     def majorVersion = version.split("\\.").first()
 
-    def sourceReg = (imageRepo == 'data-prepper') ? ${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY} : "opensearchstaging"
+    def sourceReg = (imageProduct == 'data-prepper') ? "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}" : "opensearchstaging"
     def dockerProduction = "opensearchproject"
     def ecrProduction = "public.ecr.aws/opensearchproject"
 

--- a/vars/promoteContainer.groovy
+++ b/vars/promoteContainer.groovy
@@ -28,57 +28,75 @@ void call(Map args = [:]) {
     //Promoting docker images
     if (dockerPromote.toBoolean()) {
         println("Promoting $imageProduct to production docker hub with with $version tag.")
-        copyContainer(
-                sourceImage: "$imageProduct:$sourceTag",
-                sourceRegistry: sourceReg,
-                destinationImage: "$imageProduct:$version",
-                destinationRegistry: dockerProduction
-        )
+        dockerCopy: {
+            build job: 'fake-docker-copy',
+                parameters: [
+                    string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
+                    string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
+                    string(name: 'DESTINATION_IMAGE_REGISTRY', value: dockerProduction),
+                    string(name: 'DESTINATION_IMAGE', value: "${imageProduct}:${version}")
+                ]
+        }
         if (majorVersionBoolean.toBoolean()) {
             println("Promoting to production docker hub with with $majorVersion tag.")
-            copyContainer(
-                    sourceImage: "$imageProduct:$sourceTag",
-                    sourceRegistry: sourceReg,
-                    destinationImage: "$imageProduct:$majorVersion",
-                    destinationRegistry: dockerProduction
-            )
+            dockerCopy: {
+                build job: 'fake-docker-copy',
+                    parameters: [
+                        string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
+                        string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
+                        string(name: 'DESTINATION_IMAGE_REGISTRY', value: dockerProduction),
+                        string(name: 'DESTINATION_IMAGE', value: "${imageProduct}:${majorVersion}")
+                    ]
+            }
         }
         if (latestBoolean.toBoolean()) {
             println("Promoting to production docker hub with with latest tag.")
-            copyContainer(
-                    sourceImage: "$imageProduct:$sourceTag",
-                    sourceRegistry: sourceReg,
-                    destinationImage: "$imageProduct:latest",
-                    destinationRegistry: dockerProduction
-            )
+            dockerCopy: {
+                build job: 'fake-docker-copy',
+                    parameters: [
+                        string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
+                        string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
+                        string(name: 'DESTINATION_IMAGE_REGISTRY', value: dockerProduction),
+                        string(name: 'DESTINATION_IMAGE', value: "${imageProduct}:latest")
+                    ]
+            }
         }
     }
     //Promoting image to ECR
     if (ecrPromote.toBoolean()) {
         println("Promoting to production ECR with with $version tag.")
-        copyContainer(
-                sourceImage: "$imageProduct:$sourceTag",
-                sourceRegistry: sourceReg,
-                destinationImage: "$imageProduct:$version",
-                destinationRegistry: ecrProduction
-        )
+        dockerCopy: {
+            build job: 'fake-docker-copy',
+                parameters: [
+                    string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
+                    string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
+                    string(name: 'DESTINATION_IMAGE_REGISTRY', value: ecrProduction),
+                    string(name: 'DESTINATION_IMAGE', value: "${imageProduct}:${version}")
+                ]
+        }
         if (majorVersionBoolean.toBoolean()) {
             println("Promoting to production ECR with with $majorVersion tag.")
-            copyContainer(
-                    sourceImage: "$imageProduct:$sourceTag",
-                    sourceRegistry: sourceReg,
-                    destinationImage: "$imageProduct:$majorVersion",
-                    destinationRegistry: ecrProduction
-            )
+            dockerCopy: {
+                build job: 'fake-docker-copy',
+                    parameters: [
+                        string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
+                        string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
+                        string(name: 'DESTINATION_IMAGE_REGISTRY', value: ecrProduction),
+                        string(name: 'DESTINATION_IMAGE', value: "${imageProduct}:${majorVersion}")
+                    ]
+            }
         }
         if (latestBoolean.toBoolean()) {
             println("Promoting to production ECR with with latest tag.")
-            copyContainer(
-                    sourceImage: "$imageProduct:$sourceTag",
-                    sourceRegistry: sourceReg,
-                    destinationImage: "$imageProduct:latest",
-                    destinationRegistry: ecrProduction
-            )
+            dockerCopy: {
+                build job: 'fake-docker-copy',
+                    parameters: [
+                        string(name: 'SOURCE_IMAGE_REGISTRY', value: sourceReg),
+                        string(name: 'SOURCE_IMAGE', value: "${imageProduct}:${sourceTag}"),
+                        string(name: 'DESTINATION_IMAGE_REGISTRY', value: ecrProduction),
+                        string(name: 'DESTINATION_IMAGE', value: "${imageProduct}:latest")
+                    ]
+            }
         }
     }
 }

--- a/vars/promoteContainer.groovy
+++ b/vars/promoteContainer.groovy
@@ -1,14 +1,14 @@
 /**@
- * Copies a container from one docker registry to another
+ * Promote image from staging docker to production docker hub or ECR repository.
  *
  * @param args A map of the following parameters
  * @param args.imageRepository The repository of staging image. E.g.: opensearch, opensearch-dashboards, data-prepper
  * @param args.version The official version for release. E.g.: 2.0.1
  * @param args.sourceTag The image tag from the staging repo. E.g.: 2.0.1.3910
- * @param args.dockerPromote
- * @param args.ecrPromote
- * @param args.latestTag
- * @param args.majorVersionTag
+ * @param args.dockerPromote The boolean argument if promote containers from staging to production docker repo.
+ * @param args.ecrPromote The boolean argument if promote containers from staging to production ECR repo.
+ * @param args.latestTag The boolean argument if promote containers from staging to production with latest tag.
+ * @param args.majorVersionTag The boolean argument if promote containers from staging to production with its major version tag.
  */
 void call(Map args = [:]) {
 
@@ -21,60 +21,63 @@ void call(Map args = [:]) {
     def majorVersionBoolean = args.majorVersionTag
     def majorVersion = version.split("\\.").first()
 
+    def sourceReg = (imageRepo == 'data-prepper') ? ${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY} : "opensearchstaging"
+    def dockerProduction = "opensearchproject"
+    def ecrProduction = "public.ecr.aws/opensearchproject"
+
     //Promoting docker images
-    if (dockerPromote) {
+    if (dockerPromote.toBoolean()) {
         println("Promoting to production docker hub with with $version tag.")
         copyContainer(
                 sourceImage: "$imageRepo:$sourceTag",
-                sourceRegistry: "opensearchstaging",
+                sourceRegistry: sourceReg,
                 destinationImage: "$imageRepo:$version",
-                destinationRegistry: "opensearchproject"
+                destinationRegistry: dockerProduction
         )
-        if (majorVersionBoolean) {
+        if (majorVersionBoolean.toBoolean()) {
             println("Promoting to production docker hub with with $majorVersion tag.")
             copyContainer(
                     sourceImage: "$imageRepo:$sourceTag",
-                    sourceRegistry: "opensearchstaging",
+                    sourceRegistry: sourceReg,
                     destinationImage: "$imageRepo:$majorVersion",
-                    destinationRegistry: "opensearchproject"
+                    destinationRegistry: dockerProduction
             )
         }
-        if (latestBoolean) {
+        if (latestBoolean.toBoolean()) {
             println("Promoting to production docker hub with with latest tag.")
             copyContainer(
                     sourceImage: "$imageRepo:$sourceTag",
-                    sourceRegistry: "opensearchstaging",
+                    sourceRegistry: sourceReg,
                     destinationImage: "$imageRepo:latest",
-                    destinationRegistry: "opensearchproject"
+                    destinationRegistry: dockerProduction
             )
         }
     }
-    if (ecrPromote) {
+    if (ecrPromote.toBoolean()) {
         println("Promoting to production ECR with with $version tag.")
         copyContainer(
                 sourceImage: "$imageRepo:$sourceTag",
-                sourceRegistry: "opensearchstaging",
+                sourceRegistry: sourceReg,
                 destinationImage: "$imageRepo:$version",
-                destinationRegistry: "public.ecr.aws/opensearchproject"
+                destinationRegistry: ecrProduction
         )
-        if (majorVersionBoolean) {
+        if (majorVersionBoolean.toBoolean()) {
             println("Promoting to production ECR with with $majorVersion tag.")
             copyContainer(
                     sourceImage: "$imageRepo:$sourceTag",
-                    sourceRegistry: "opensearchstaging",
+                    sourceRegistry: sourceReg,
                     destinationImage: "$imageRepo:$majorVersion",
-                    destinationRegistry: "public.ecr.aws/opensearchproject"
+                    destinationRegistry: ecrProduction
             )
         }
-        if (latestBoolean) {
+        if (latestBoolean.toBoolean()) {
             println("Promoting to production ECR with with latest tag.")
             copyContainer(
                     sourceImage: "$imageRepo:$sourceTag",
-                    sourceRegistry: "opensearchstaging",
+                    sourceRegistry: sourceReg,
                     destinationImage: "$imageRepo:latest",
-                    destinationRegistry: "public.ecr.aws/opensearchproject"
+                    destinationRegistry: ecrProduction
             )
         }
     }
-
 }


### PR DESCRIPTION
### Description
Create a docker promotion jenkins workflow.
User is able to select several options: 
- If promoting the staging docker image to production docker hub.
- If promoting to production ECR repository.
- If promoting with its major version tag.
- If promoting with `latest` tag.

### Issues Resolved
#1621 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
