### PR TITLE
Switch runner of gradle check to c524xlarge for more stable runs

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -18,7 +18,9 @@ pipeline {
     agent {
         node {
             // Must use Ubuntu agent with 1 executor or gradle check will show a lot of java-related errors
-            label 'Jenkins-Agent-Ubuntu2004-X64-c518xlarge-Single-Host'
+            // The c524xlarge is the instance type that has the least amount of errors during gradle check
+            // https://github.com/opensearch-project/OpenSearch/issues/1975
+            label 'Jenkins-Agent-Ubuntu2004-X64-c524xlarge-Single-Host'
         }
     }
     parameters {


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Switch runner of gradle check to c524xlarge for more stable runs

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/851

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
