### PR TITLE
Exclude manifest checks for 3.0.0 for now

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -5,7 +5,8 @@ on:
   push:
   pull_request:
     paths:
-      - manifests/**/*.yml
+      - 'manifests/**/*.yml'
+      - '!manifests/3.**/**'
   schedule:
     - cron: 0 0 * * *
 


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Exclude manifest checks for 3.0.0 manifest for now since it requires JDK 17.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
