### PR TITLE
Add check for test manifest and update error message

### DIFF
--- a/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
@@ -40,9 +40,9 @@ pipeline {
                         currentBuild.result = 'ABORTED'
                         error("BWC Tests failed to start. Missing parameter: AGENT_LABEL.")
                     }
-                    if (!fileExists("manifests/${TEST_MANIFEST}")) {
+                    if (TEST_MANIFEST == '' || !fileExists("manifests/${TEST_MANIFEST}")) {
                         currentBuild.result = 'ABORTED'
-                        error("BWC Tests failed to start. Test manifest not found in manifests/${TEST_MANIFEST}.")
+                        error("BWC Tests failed to start. Test manifest was not provided or not found in manifests/${TEST_MANIFEST}.")
                     }
                     /*
                     Rebuilding of this job will result in considering the upstream build as self($JOB_NAME) See https://issues.jenkins.io/browse/JENKINS-61590 for bug

--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -36,9 +36,9 @@ pipeline {
                         currentBuild.result = 'ABORTED'
                         error("Integration Tests failed to start. Missing parameter: AGENT_LABEL.")
                     }
-                    if (!fileExists("manifests/${TEST_MANIFEST}")) {
+                    if (TEST_MANIFEST == '' || !fileExists("manifests/${TEST_MANIFEST}")) {
                         currentBuild.result = 'ABORTED'
-                        error("Integration Tests failed to start. Test manifest not found in manifests/${TEST_MANIFEST}.")
+                        error("Integration Tests failed to start. Test manifest was not provided or not found in manifests/${TEST_MANIFEST}.")
                     }
                     /*
                     Rebuilding of this job will result in considering upstream build as self($JOB_NAME) See https://issues.jenkins.io/browse/JENKINS-61590 for bug

--- a/jenkins/opensearch/bwc-test.jenkinsfile
+++ b/jenkins/opensearch/bwc-test.jenkinsfile
@@ -43,9 +43,9 @@ pipeline {
                         currentBuild.result = 'ABORTED'
                         error("BWC Tests failed to start. Missing parameter: AGENT_LABEL.")
                     }
-                    if (!fileExists("manifests/${TEST_MANIFEST}")) {
+                    if (TEST_MANIFEST == '' || !fileExists("manifests/${TEST_MANIFEST}")) {
                         currentBuild.result = 'ABORTED'
-                        error("BWC Tests failed to start. Test manifest not found in manifests/${TEST_MANIFEST}.")
+                        error("BWC Tests failed to start. Test manifest not was provided or not found in manifests/${TEST_MANIFEST}.")
                     }
                     /*
                     Rebuilding of this job will result in considering upstream build as self($JOB_NAME) See https://issues.jenkins.io/browse/JENKINS-61590 for bug

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -39,9 +39,9 @@ pipeline {
                         currentBuild.result = 'ABORTED'
                         error("Integration Tests failed to start. Missing parameter: AGENT_LABEL.")
                     }
-                    if (!fileExists("manifests/${TEST_MANIFEST}")) {
+                    if (TEST_MANIFEST == '' || !fileExists("manifests/${TEST_MANIFEST}")) {
                         currentBuild.result = 'ABORTED'
-                        error("Integration Tests failed to start. Test manifest not found in manifests/${TEST_MANIFEST}.")
+                        error("Integration Tests failed to start. Test manifest was not provided or not found in manifests/${TEST_MANIFEST}.")
                     }
                     /*
                     Rebuilding of this job will result in considering upstream build as self($JOB_NAME) See https://issues.jenkins.io/browse/JENKINS-61590 for bug


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Integration tests workflow did not check if test manifest was provided or not and hence the error message was not clear. This fixes that.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
