### PR TITLE
Rename webhooks for notifications

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
                     publishNotification(
                         icon: ':warning:',
                         message: 'Failed checking for build to trigger',
-                        credentialsId: 'BUILD_NOTICE_WEBHOOK',
+                        credentialsId: 'jenkins-build-notice-webhook',
                         manifest: "${INPUT_MANIFEST}",
                         target_job_name: "${TARGET_JOB_NAME}"
                     )

--- a/jenkins/cross-cluster-replication/perf-test.jenkinsfile
+++ b/jenkins/cross-cluster-replication/perf-test.jenkinsfile
@@ -116,7 +116,7 @@ pipeline {
                         icon: ':white_check_mark:',
                         message: 'CCR Performance Tests Successful',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                     )
                     postCleanup()
                 }
@@ -130,7 +130,7 @@ pipeline {
                         icon: ':warning:',
                         message: 'Failed CCR Performance Tests',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                     )
                     postCleanup()
                 }

--- a/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
@@ -120,7 +120,7 @@ pipeline {
                         icon: ':white_check_mark:',
                         message: 'BWC Tests Successful',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                         manifest: TEST_MANIFEST,
                     )
 
@@ -136,7 +136,7 @@ pipeline {
                         icon: ':warning:',
                         message: 'Failed BWC Tests',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                         manifest: TEST_MANIFEST,
                     )
 

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -518,7 +518,7 @@ pipeline {
                             icon: ':white_check_mark:',
                             message: 'Successful Build',
                             extra: stashed,
-                            credentialsId: 'BUILD_NOTICE_WEBHOOK',
+                            credentialsId: 'jenkins-build-notice-webhook',
                             manifest: "${INPUT_MANIFEST}"
                         )
                     }
@@ -534,7 +534,7 @@ pipeline {
                         publishNotification(
                             icon: ':warning:',
                             message: 'Failed Build',
-                            credentialsId: 'BUILD_NOTICE_WEBHOOK',
+                            credentialsId: 'jenkins-build-notice-webhook',
                             manifest: "${INPUT_MANIFEST}"
                         )
                     }

--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -115,7 +115,7 @@ pipeline {
                         icon: ':white_check_mark:',
                         message: 'Integration Tests Successful',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                         manifest: TEST_MANIFEST,
                     )
 
@@ -131,7 +131,7 @@ pipeline {
                         icon: ':warning:',
                         message: 'Failed Integration Tests',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                         manifest: TEST_MANIFEST,
                     )
 

--- a/jenkins/opensearch/bwc-test.jenkinsfile
+++ b/jenkins/opensearch/bwc-test.jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
                         icon: ':white_check_mark:',
                         message: 'BWC Tests Successful',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                         manifest: TEST_MANIFEST,
                     )
 
@@ -139,7 +139,7 @@ pipeline {
                         icon: ':warning:',
                         message: 'Failed BWC Tests',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                         manifest: TEST_MANIFEST,
                     )
 

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -555,7 +555,7 @@ pipeline {
                             icon: ':white_check_mark:',
                             message: 'Successful Build',
                             extra: stashed,
-                            credentialsId: 'BUILD_NOTICE_WEBHOOK',
+                            credentialsId: 'jenkins-build-notice-webhook',
                             manifest: "${INPUT_MANIFEST}"
                         )
                     }
@@ -571,7 +571,7 @@ pipeline {
                         publishNotification(
                             icon: ':warning:',
                             message: buildFailureMessage(),
-                            credentialsId: 'BUILD_NOTICE_WEBHOOK',
+                            credentialsId: 'jenkins-build-notice-webhook',
                             manifest: "${INPUT_MANIFEST}"
                         )
                     }

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -152,7 +152,7 @@ pipeline {
                         icon: ':white_check_mark:',
                         message: 'Integration Tests Successful',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                         manifest: TEST_MANIFEST,
                     )
 
@@ -168,7 +168,7 @@ pipeline {
                         icon: ':warning:',
                         message: 'Failed Integration Tests',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                         manifest: TEST_MANIFEST,
                     )
 

--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -194,7 +194,7 @@ pipeline {
                         icon: ':white_check_mark:',
                         message: 'Performance Tests Successful',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                     )
                     postCleanup()
                 }
@@ -208,7 +208,7 @@ pipeline {
                         icon: ':warning:',
                         message: 'Failed Performance Tests',
                         extra: stashed,
-                        credentialsId: 'INTEG_TEST_WEBHOOK',
+                        credentialsId: 'jenkins-integ-test-webhook',
                     )
                     postCleanup()
                 }

--- a/tests/jenkins/TestOpenSearchBwcTest.groovy
+++ b/tests/jenkins/TestOpenSearchBwcTest.groovy
@@ -29,7 +29,7 @@ class TestOpenSearchBwcTest extends BuildPipelineTest {
                 'BWC Tests Successful',
                 '',
                 testManifest,
-                'INTEG_TEST_WEBHOOK'))
+                'jenkins-integ-test-webhook'))
         super.setUp()
 
         // Variables

--- a/tests/jenkins/TestOpenSearchDashboardsBwcTest.groovy
+++ b/tests/jenkins/TestOpenSearchDashboardsBwcTest.groovy
@@ -29,7 +29,7 @@ class TestOpenSearchDashboardsBwcTest extends BuildPipelineTest {
                 'BWC Tests Successful',
                 '',
                 testManifest,
-                'INTEG_TEST_WEBHOOK'))
+                'jenkins-integ-test-webhook'))
         super.setUp()
 
         // Variables

--- a/tests/jenkins/TestOpenSearchDashboardsIntegTest.groovy
+++ b/tests/jenkins/TestOpenSearchDashboardsIntegTest.groovy
@@ -29,7 +29,7 @@ class TestOpenSearchDashboardsIntegTest extends BuildPipelineTest {
                 'Integration Tests Successful',
                 '',
                 testManifest,
-                'INTEG_TEST_WEBHOOK'))
+                'jenkins-integ-test-webhook'))
         super.setUp()
 
         // Variables

--- a/tests/jenkins/TestOpenSearchIntegTest.groovy
+++ b/tests/jenkins/TestOpenSearchIntegTest.groovy
@@ -29,7 +29,7 @@ class TestOpenSearchIntegTest extends BuildPipelineTest {
                 'Integration Tests Successful',
                 '',
                 testManifest,
-                'INTEG_TEST_WEBHOOK'))
+                'jenkins-integ-test-webhook'))
         super.setUp()
 
         // Variables

--- a/tests/jenkins/TestPublishNotification.groovy
+++ b/tests/jenkins/TestPublishNotification.groovy
@@ -17,7 +17,7 @@ class TestPublishNotification extends BuildPipelineTest {
     void setUp() {
 
         this.registerLibTester(new PublishNotificationLibTester(
-                ':white_check_mark:', 'Successful Build' , 'extra', '1.2.0/opensearch-1.2.0.yml', 'BUILD_NOTICE_WEBHOOK'))
+                ':white_check_mark:', 'Successful Build' , 'extra', '1.2.0/opensearch-1.2.0.yml', 'jenkins-build-notice-webhook'))
 
         super.setUp()
     }

--- a/tests/jenkins/jenkinsjob-regression-files/cross-cluster-replication/perf-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/cross-cluster-replication/perf-test.jenkinsfile.txt
@@ -91,8 +91,8 @@ CCR Performance tests for 1236 completed})
                   perf-test.findFiles({excludes=, glob=messages/*})
                   perf-test.dir(messages, groovy.lang.Closure)
                      perf-test.deleteDir()
-               perf-test.publishNotification({icon=:white_check_mark:, message=CCR Performance Tests Successful, extra=, credentialsId=INTEG_TEST_WEBHOOK})
-                  publishNotification.string({credentialsId=INTEG_TEST_WEBHOOK, variable=WEBHOOK_URL})
+               perf-test.publishNotification({icon=:white_check_mark:, message=CCR Performance Tests Successful, extra=, credentialsId=jenkins-integ-test-webhook})
+                  publishNotification.string({credentialsId=jenkins-integ-test-webhook, variable=WEBHOOK_URL})
                   publishNotification.withCredentials([WEBHOOK_URL], groovy.lang.Closure)
                      publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
 JOB_NAME=perf-test

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/bwc-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/bwc-test.jenkinsfile.txt
@@ -67,8 +67,8 @@
                   bwc-test.findFiles({excludes=, glob=messages/*})
                   bwc-test.dir(messages, groovy.lang.Closure)
                      bwc-test.deleteDir()
-               bwc-test.publishNotification({icon=:white_check_mark:, message=BWC Tests Successful, extra=, credentialsId=INTEG_TEST_WEBHOOK, manifest=tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml})
-                  publishNotification.string({credentialsId=INTEG_TEST_WEBHOOK, variable=WEBHOOK_URL})
+               bwc-test.publishNotification({icon=:white_check_mark:, message=BWC Tests Successful, extra=, credentialsId=jenkins-integ-test-webhook, manifest=tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml})
+                  publishNotification.string({credentialsId=jenkins-integ-test-webhook, variable=WEBHOOK_URL})
                   publishNotification.withCredentials([WEBHOOK_URL], groovy.lang.Closure)
                      publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
 JOB_NAME=dummy_job

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
@@ -69,8 +69,8 @@
                   integ-test.findFiles({excludes=, glob=messages/*})
                   integ-test.dir(messages, groovy.lang.Closure)
                      integ-test.deleteDir()
-               integ-test.publishNotification({icon=:white_check_mark:, message=Integration Tests Successful, extra=, credentialsId=INTEG_TEST_WEBHOOK, manifest=tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml})
-                  publishNotification.string({credentialsId=INTEG_TEST_WEBHOOK, variable=WEBHOOK_URL})
+               integ-test.publishNotification({icon=:white_check_mark:, message=Integration Tests Successful, extra=, credentialsId=jenkins-integ-test-webhook, manifest=tests/jenkins/data/opensearch-dashboards-1.2.0-test.yml})
+                  publishNotification.string({credentialsId=jenkins-integ-test-webhook, variable=WEBHOOK_URL})
                   publishNotification.withCredentials([WEBHOOK_URL], groovy.lang.Closure)
                      publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
 JOB_NAME=dummy_job

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/bwc-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/bwc-test.jenkinsfile.txt
@@ -67,8 +67,8 @@
                   bwc-test.findFiles({excludes=, glob=messages/*})
                   bwc-test.dir(messages, groovy.lang.Closure)
                      bwc-test.deleteDir()
-               bwc-test.publishNotification({icon=:white_check_mark:, message=BWC Tests Successful, extra=, credentialsId=INTEG_TEST_WEBHOOK, manifest=tests/jenkins/data/opensearch-1.3.0-test.yml})
-                  publishNotification.string({credentialsId=INTEG_TEST_WEBHOOK, variable=WEBHOOK_URL})
+               bwc-test.publishNotification({icon=:white_check_mark:, message=BWC Tests Successful, extra=, credentialsId=jenkins-integ-test-webhook, manifest=tests/jenkins/data/opensearch-1.3.0-test.yml})
+                  publishNotification.string({credentialsId=jenkins-integ-test-webhook, variable=WEBHOOK_URL})
                   publishNotification.withCredentials([WEBHOOK_URL], groovy.lang.Closure)
                      publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
 JOB_NAME=dummy_job

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
@@ -79,8 +79,8 @@
                   integ-test.findFiles({excludes=, glob=messages/*})
                   integ-test.dir(messages, groovy.lang.Closure)
                      integ-test.deleteDir()
-               integ-test.publishNotification({icon=:white_check_mark:, message=Integration Tests Successful, extra=, credentialsId=INTEG_TEST_WEBHOOK, manifest=tests/jenkins/data/opensearch-1.3.0-test.yml})
-                  publishNotification.string({credentialsId=INTEG_TEST_WEBHOOK, variable=WEBHOOK_URL})
+               integ-test.publishNotification({icon=:white_check_mark:, message=Integration Tests Successful, extra=, credentialsId=jenkins-integ-test-webhook, manifest=tests/jenkins/data/opensearch-1.3.0-test.yml})
+                  publishNotification.string({credentialsId=jenkins-integ-test-webhook, variable=WEBHOOK_URL})
                   publishNotification.withCredentials([WEBHOOK_URL], groovy.lang.Closure)
                      publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
 JOB_NAME=dummy_job

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test-with-security.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test-with-security.jenkinsfile.txt
@@ -154,8 +154,8 @@ Performance tests without security for 1236 completed})
                   perf-test.findFiles({excludes=, glob=messages/*})
                   perf-test.dir(messages, groovy.lang.Closure)
                      perf-test.deleteDir()
-               perf-test.publishNotification({icon=:white_check_mark:, message=Performance Tests Successful, extra=, credentialsId=INTEG_TEST_WEBHOOK})
-                  publishNotification.string({credentialsId=INTEG_TEST_WEBHOOK, variable=WEBHOOK_URL})
+               perf-test.publishNotification({icon=:white_check_mark:, message=Performance Tests Successful, extra=, credentialsId=jenkins-integ-test-webhook})
+                  publishNotification.string({credentialsId=jenkins-integ-test-webhook, variable=WEBHOOK_URL})
                   publishNotification.withCredentials([WEBHOOK_URL], groovy.lang.Closure)
                      publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
 JOB_NAME=perf-test

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test.jenkinsfile.txt
@@ -92,8 +92,8 @@ Performance tests without security for 1236 completed})
                   perf-test.findFiles({excludes=, glob=messages/*})
                   perf-test.dir(messages, groovy.lang.Closure)
                      perf-test.deleteDir()
-               perf-test.publishNotification({icon=:white_check_mark:, message=Performance Tests Successful, extra=, credentialsId=INTEG_TEST_WEBHOOK})
-                  publishNotification.string({credentialsId=INTEG_TEST_WEBHOOK, variable=WEBHOOK_URL})
+               perf-test.publishNotification({icon=:white_check_mark:, message=Performance Tests Successful, extra=, credentialsId=jenkins-integ-test-webhook})
+                  publishNotification.string({credentialsId=jenkins-integ-test-webhook, variable=WEBHOOK_URL})
                   publishNotification.withCredentials([WEBHOOK_URL], groovy.lang.Closure)
                      publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
 JOB_NAME=perf-test

--- a/tests/jenkins/jobs/PublishNotification_Jenkinsfile
+++ b/tests/jenkins/jobs/PublishNotification_Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
                             message: 'Successful Build',
                             extra: 'extra',
                             manifest: '1.2.0/opensearch-1.2.0.yml',
-                            credentialsId: 'BUILD_NOTICE_WEBHOOK'
+                            credentialsId: 'jenkins-build-notice-webhook'
                         )
                     }catch (Exception e) {
                         echo 'Exception occurred: ' + e.toString()

--- a/tests/jenkins/jobs/PublishNotification_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PublishNotification_Jenkinsfile.txt
@@ -3,8 +3,8 @@
          PublishNotification_Jenkinsfile.echo(Executing on agent [label:none])
          PublishNotification_Jenkinsfile.stage(notify, groovy.lang.Closure)
             PublishNotification_Jenkinsfile.script(groovy.lang.Closure)
-               PublishNotification_Jenkinsfile.publishNotification({icon=:white_check_mark:, message=Successful Build, extra=extra, manifest=1.2.0/opensearch-1.2.0.yml, credentialsId=BUILD_NOTICE_WEBHOOK})
-                  publishNotification.string({credentialsId=BUILD_NOTICE_WEBHOOK, variable=WEBHOOK_URL})
+               PublishNotification_Jenkinsfile.publishNotification({icon=:white_check_mark:, message=Successful Build, extra=extra, manifest=1.2.0/opensearch-1.2.0.yml, credentialsId=jenkins-build-notice-webhook})
+                  publishNotification.string({credentialsId=jenkins-build-notice-webhook, variable=WEBHOOK_URL})
                   publishNotification.withCredentials([WEBHOOK_URL], groovy.lang.Closure)
                      publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
 JOB_NAME=dummy_job


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
These webhooks credentials were stored on jenkins server directly which is not the best practice. Hence moving them to AWS secrets manager and renaming them with `jenkins-*` prefix

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
