### PR TITLE
Move artifact bucket name from env to creds

### DIFF
--- a/jenkins/opensearch-maven-release/maven-sign-release.jenkinsfile
+++ b/jenkins/opensearch-maven-release/maven-sign-release.jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
     }
     environment {
         ARTIFACT_PATH = "distribution-build-opensearch/${VERSION}/${BUILD_ID}/linux/x64/tar/builds"
+        ARTIFACT_BUCKET_NAME = credentials('jenkins-artifact-bucket-name')
     }
     stages {
         stage('sign') {

--- a/jenkins/opensearch-ruby/Jenkinsfile
+++ b/jenkins/opensearch-ruby/Jenkinsfile
@@ -12,6 +12,9 @@ pipeline {
             trim: true
         )
     }
+    environment {
+        ARTIFACT_BUCKET_NAME = credentials('jenkins-artifact-bucket-name')
+    }
     stages {
         stage('ruby-build-sign-upload') {
             agent {

--- a/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
+++ b/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
@@ -30,6 +30,9 @@ pipeline {
                 description: 'What is signature file type? Required only for linux signing.'
         )
     }
+    environment {
+        ARTIFACT_BUCKET_NAME = credentials('jenkins-artifact-bucket-name')
+    }
     stages {
         stage('sign') {
             steps {

--- a/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
@@ -2,6 +2,7 @@
       maven-sign-release.legacySCM(groovy.lang.Closure)
       maven-sign-release.library({identifier=jenkins@20211123, retriever=null})
       maven-sign-release.pipeline(groovy.lang.Closure)
+         maven-sign-release.credentials(jenkins-artifact-bucket-name)
          maven-sign-release.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211130, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
          maven-sign-release.stage(sign, groovy.lang.Closure)
             maven-sign-release.script(groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
@@ -2,6 +2,7 @@
       sign-standalone-artifacts.legacySCM(groovy.lang.Closure)
       sign-standalone-artifacts.library({identifier=jenkins@20211123, retriever=null})
       sign-standalone-artifacts.pipeline(groovy.lang.Closure)
+         sign-standalone-artifacts.credentials(jenkins-artifact-bucket-name)
          sign-standalone-artifacts.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v2, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-al2-x64-c54xlarge-Docker-Host]])
          sign-standalone-artifacts.stage(sign, groovy.lang.Closure)
             sign-standalone-artifacts.script(groovy.lang.Closure)


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Move artifact bucket name from env to creds

### Issues Resolved
resolves #2220 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
