### PR TITLE
Add jenkins prefix to signer credentials

### DIFF
--- a/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
@@ -22,7 +22,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(
@@ -98,7 +98,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(

--- a/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
@@ -22,7 +22,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(
@@ -98,7 +98,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(

--- a/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
@@ -19,7 +19,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(

--- a/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
@@ -19,7 +19,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(

--- a/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
@@ -15,7 +15,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(

--- a/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
@@ -15,7 +15,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(

--- a/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_Jenkinsfile.txt
@@ -38,7 +38,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(
@@ -76,7 +76,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(

--- a/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_Jenkinsfile.txt
@@ -38,7 +38,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(
@@ -76,7 +76,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(

--- a/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_OpenSearch_Dashboards_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_OpenSearch_Dashboards_Jenkinsfile.txt
@@ -38,7 +38,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(
@@ -76,7 +76,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(

--- a/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_OpenSearch_Dashboards_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifactsQualifier_actions_OpenSearch_Dashboards_Jenkinsfile.txt
@@ -38,7 +38,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(
@@ -76,7 +76,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(

--- a/tests/jenkins/jobs/PromoteArtifacts_actions_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifacts_actions_Jenkinsfile.txt
@@ -41,7 +41,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(
@@ -70,7 +70,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(
@@ -128,7 +128,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(

--- a/tests/jenkins/jobs/PromoteArtifacts_actions_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifacts_actions_Jenkinsfile.txt
@@ -41,7 +41,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(
@@ -70,7 +70,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(
@@ -128,7 +128,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(

--- a/tests/jenkins/jobs/PromoteArtifacts_actions_OpenSearch_Dashboards_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifacts_actions_OpenSearch_Dashboards_Jenkinsfile.txt
@@ -38,7 +38,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(
@@ -76,7 +76,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(

--- a/tests/jenkins/jobs/PromoteArtifacts_actions_OpenSearch_Dashboards_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteArtifacts_actions_OpenSearch_Dashboards_Jenkinsfile.txt
@@ -38,7 +38,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(
@@ -76,7 +76,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(

--- a/tests/jenkins/jobs/PromoteYumRepos_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteYumRepos_Jenkinsfile.txt
@@ -49,7 +49,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(

--- a/tests/jenkins/jobs/PromoteYumRepos_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/PromoteYumRepos_Jenkinsfile.txt
@@ -49,7 +49,7 @@
                         signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                         signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                         signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                        signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                        signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                         signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                            signArtifacts.readJSON({text=configs})
                            signArtifacts.sh(

--- a/tests/jenkins/jobs/SignArtifacts_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/SignArtifacts_Jenkinsfile.txt
@@ -9,7 +9,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(
@@ -108,7 +108,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(

--- a/tests/jenkins/jobs/SignArtifacts_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/SignArtifacts_Jenkinsfile.txt
@@ -9,7 +9,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(
@@ -108,7 +108,7 @@
                   signArtifacts.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   signArtifacts.sh(curl -sSL https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -)
                   signArtifacts.usernamePassword({credentialsId=github_bot_token_name, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
-                  signArtifacts.string({credentialsId=jenkins-signer-pgp-config, variable=configs})
+                  signArtifacts.string({credentialsId=jenkins-signer-client-creds, variable=configs})
                   signArtifacts.withCredentials([[GITHUB_USER, GITHUB_TOKEN], configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.sh(

--- a/vars/signArtifacts.groovy
+++ b/vars/signArtifacts.groovy
@@ -111,7 +111,7 @@ void call(Map args = [:]) {
         String arguments = generateArguments(args)
 
         // Sign artifacts
-        def configSecret = args.platform == "windows" ? "signer-windows-config" : "signer-pgp-config"
+        def configSecret = args.platform == "windows" ? "jenkins-signer-windows-config" : "jenkins-signer-pgp-config"
         withCredentials([usernamePassword(credentialsId: "${GITHUB_BOT_TOKEN_NAME}", usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN'),
                         string(credentialsId: configSecret, variable: 'configs')]) {
             def creds = readJSON(text: configs)

--- a/vars/signArtifacts.groovy
+++ b/vars/signArtifacts.groovy
@@ -111,7 +111,7 @@ void call(Map args = [:]) {
         String arguments = generateArguments(args)
 
         // Sign artifacts
-        def configSecret = args.platform == "windows" ? "jenkins-signer-windows-config" : "jenkins-signer-pgp-config"
+        def configSecret = args.platform == "windows" ? "jenkins-signer-windows-config" : "jenkins-signer-client-creds"
         withCredentials([usernamePassword(credentialsId: "${GITHUB_BOT_TOKEN_NAME}", usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN'),
                         string(credentialsId: configSecret, variable: 'configs')]) {
             def creds = readJSON(text: configs)


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Add jenkins prefix to signer credentials

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
