### PR TITLE
Change rpm signing role with new one

### DIFF
--- a/tests/jenkins/jobs/AssembleManifest_rpm_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/AssembleManifest_rpm_Jenkinsfile.txt
@@ -17,7 +17,7 @@
                      signArtifacts.withCredentials([configs], groovy.lang.Closure)
                         signArtifacts.readJSON({text=configs})
                         signArtifacts.echo(RPM Add Sign)
-                        signArtifacts.withAWS({role=jenki-jenki-asm-assume-role, roleAccount=1234, duration=900, roleSessionName=jenkins-signing-session}, groovy.lang.Closure)
+                        signArtifacts.withAWS({role=jenkins-prod-rpm-signing-assume-role, roleAccount=1234, duration=900, roleSessionName=jenkins-signing-session}, groovy.lang.Closure)
                            signArtifacts.sh(
                         set -e
                         set +x

--- a/tests/jenkins/jobs/SignArtifacts_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/SignArtifacts_Jenkinsfile.txt
@@ -29,7 +29,7 @@
                   signArtifacts.withCredentials([configs], groovy.lang.Closure)
                      signArtifacts.readJSON({text=configs})
                      signArtifacts.echo(RPM Add Sign)
-                     signArtifacts.withAWS({role=jenki-jenki-asm-assume-role, roleAccount=null, duration=900, roleSessionName=jenkins-signing-session}, groovy.lang.Closure)
+                     signArtifacts.withAWS({role=jenkins-prod-rpm-signing-assume-role, roleAccount=null, duration=900, roleSessionName=jenkins-signing-session}, groovy.lang.Closure)
                         signArtifacts.sh(
                         set -e
                         set +x

--- a/vars/signArtifacts.groovy
+++ b/vars/signArtifacts.groovy
@@ -25,7 +25,7 @@ void call(Map args = [:]) {
 
             echo 'RPM Add Sign'
 
-            withAWS(role: 'jenki-jenki-asm-assume-role', roleAccount: "${signingAccount}", duration: 900, roleSessionName: 'jenkins-signing-session') {
+            withAWS(role: 'jenkins-prod-rpm-signing-assume-role', roleAccount: "${signingAccount}", duration: 900, roleSessionName: 'jenkins-signing-session') {
                     sh """
                         set -e
                         set +x


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
With jenkins going public we had to change the permissions from old account to new account, hence created a new role and replaced it in this PR.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-ci/issues/122

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
