### PR TITLE
Add Java home argument to the manifest workflow

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -126,7 +126,7 @@ class InputManifests(Manifests):
             "ci": {
                 "image": {
                     "name": image_map[self.prefix],
-                    "args": jdk_map[version.split(".")[0]]
+                    "args": jdk_map.get(version.split(".")[0], jdk_map["3"])
                 }
             },
             "components": [],

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -111,6 +111,12 @@ class InputManifests(Manifests):
             "opensearch-dashboards": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2"
         }
 
+        jdk_map = {
+            "1": "-e JAVA_HOME=/opt/java/openjdk-11",
+            "2": "-e JAVA_HOME=/opt/java/openjdk-17",
+            "3": "-e JAVA_HOME=/opt/java/openjdk-17"
+        }
+
         data: Dict = {
             "schema-version": "1.0",
             "build": {
@@ -119,7 +125,8 @@ class InputManifests(Manifests):
             },
             "ci": {
                 "image": {
-                    "name": image_map[self.prefix]
+                    "name": image_map[self.prefix],
+                    "args": jdk_map[version.split(".")[0]]
                 }
             },
             "components": [],

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -24,7 +24,8 @@ class TestInputManifests(unittest.TestCase):
             {
                 "schema-version": "1.0",
                 "build": {"name": "opensearch", "version": "1.2.3"},
-                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2"}},
+                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2",
+                                 "args": "-e JAVA_HOME=/opt/java/openjdk-11"}},
             },
         )
 
@@ -36,7 +37,8 @@ class TestInputManifests(unittest.TestCase):
             {
                 "schema-version": "1.0",
                 "build": {"name": "opensearch-dashboards", "version": "1.2.3"},
-                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2"}},
+                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2",
+                                 "args": "-e JAVA_HOME=/opt/java/openjdk-11"}},
             },
         )
 


### PR DESCRIPTION
### Description
Add Java home argument to the manifest workflow based on the manifest version. If it's 1.x (in our case 1.3.x primarily), it will add jdk 11 argument. If it's 2.x or 3.x, it will add jdk 17 for now. Otherwise, it will set to jdk17 by default. 

### Issues Resolved
#2044 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
