### PR TITLE
Add zip publishing to Notifications build scripts

### DIFF
--- a/scripts/components/notifications-core/build.sh
+++ b/scripts/components/notifications-core/build.sh
@@ -74,3 +74,7 @@ fi
 mkdir -p ./$OUTPUT/plugins
 notifCoreZipPath=$(ls core/build/distributions/ | grep .zip)
 cp -v core/build/distributions/$notifCoreZipPath ./$OUTPUT/plugins
+
+./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+mkdir -p $OUTPUT/maven/org/opensearch/plugin
+cp -r ./build/local-staging-repo/org/opensearch/plugin/opensearch-notifications-core $OUTPUT/maven/org/opensearch/plugin/

--- a/scripts/components/notifications/build.sh
+++ b/scripts/components/notifications/build.sh
@@ -75,3 +75,6 @@ mkdir -p ./$OUTPUT/plugins
 notifCoreZipPath=$(ls notifications/build/distributions/ | grep .zip)
 cp -v notifications/build/distributions/$notifCoreZipPath ./$OUTPUT/plugins
 
+./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+mkdir -p $OUTPUT/maven/org/opensearch/plugin
+cp -r ./build/local-staging-repo/org/opensearch/plugin/notifications $OUTPUT/maven/org/opensearch/plugin/


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Add publishing of Notification plugins zips to the appropriate build scripts. This change is complimentary to https://github.com/opensearch-project/notifications/pull/484

### Issues Resolved
https://github.com/opensearch-project/notifications/issues/474

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
