### PR TITLE
Remove maven tool

### DIFF
--- a/jenkins/opensearch-maven-release/maven-sign-release.jenkinsfile
+++ b/jenkins/opensearch-maven-release/maven-sign-release.jenkinsfile
@@ -45,9 +45,6 @@ pipeline {
             }
         }
         stage('stage maven artifacts') {
-            tools {
-                maven "maven-3.8.2"
-            }
             environment {
                 REPO_URL = "https://aws.oss.sonatype.org/"
                 STAGING_PROFILE_ID = "${SONATYPE_STAGING_PROFILE_ID}"

--- a/jenkins/opensearch/bwc-test.jenkinsfile
+++ b/jenkins/opensearch/bwc-test.jenkinsfile
@@ -9,9 +9,6 @@ pipeline {
         BUILD_MANIFEST = "build-manifest.yml"
         DEFAULT_BUILD_JOB_NAME = "distribution-build-opensearch"
     }
-    tools {
-        maven "maven-3.8.2"
-    }
     parameters {
         string(
             name: 'TEST_MANIFEST',

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -9,9 +9,6 @@ pipeline {
         BUILD_MANIFEST = "build-manifest.yml"
         DEFAULT_BUILD_JOB_NAME = "distribution-build-opensearch"
     }
-    tools {
-        maven "maven-3.8.2"
-    }
     parameters {
         string(
             name: 'TEST_MANIFEST',


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Coming from https://github.com/opensearch-project/opensearch-ci/pull/166#pullrequestreview-1047219557
Removing maven here as it is already installed on docker images. 
https://github.com/opensearch-project/opensearch-build/blob/main/docker/ci/dockerfiles/current/build.centos7.opensearch.x64.arm64.dockerfile#L52-L57

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
