### PR TITLE
Use 2.6.0 Ruby and tweak jdk tool naming to be consistent with docker images

### DIFF
--- a/docker/ci/config/jdk-setup.sh
+++ b/docker/ci/config/jdk-setup.sh
@@ -19,15 +19,17 @@ JDKS=""
 case "${ARCH}" in
    aarch64|arm64)
        # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
-       JDKS+="f287cdc2a688c2df247ea0d8bfe2863645b73848e4e5c35b02a8a3d2d6b69551@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u302b08.tar.gz "
-       JDKS+="0ba188a2a739733163cd0049344429d2284867e04ca452879be24f3b54320c9a@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14%2B9/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.14_9.tar.gz "
-       JDKS+="302caf29f73481b2b914ba2b89705036010c65eb9bc8d7712b27d6e9bedf6200@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.2_8.tar.gz "
+       JDKS+="d10efb2afad3ed3d7bac9d3249cea77928aca6acb973cac0f90a2dd3606a3533@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u332b09.tar.gz "
+       JDKS+="999fbd90b070f9896142f0eb28354abbeb367cbe49fd86885c626e2999189e0a@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15%2B10/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.15_10.tar.gz "
+       JDKS+="ee87e9f03b1fbe6f328429b78fe1a9f44900026d220c90dfd747fe0bcd62d904@https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.2_12.tar.gz "
+       JDKS+="2e3c19c1707205c6b90cc04b416e8d83078ed98417d5a69dce3cf7dc0d7cfbca@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.3_7.tar.gz "
        ;;
    amd64|x86_64)
        # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
-       JDKS+="cc13f274becf9dd5517b6be583632819dfd4dd81e524b5c1b4f406bdaf0e063a@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz "
-       JDKS+="1189bee178d11402a690edf3fbba0c9f2ada1d3a36ff78929d81935842ef24a9@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.14%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.14_9.tar.gz "
-       JDKS+="288f34e3ba8a4838605636485d0365ce23e57d5f2f68997ac4c2e4c01967cd48@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.2%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.2_8.tar.gz "
+       JDKS+="adc13a0a0540d77f0a3481b48f10d61eb203e5ad4914507d489c2de3bd3d83da@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u332b09.tar.gz "
+       JDKS+="5fdb4d5a1662f0cca73fec30f99e67662350b1fa61460fa72e91eb9f66b54d0b@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.15_10.tar.gz "
+       JDKS+="7d5ee7e06909b8a99c0d029f512f67b092597aa5b0e78c109bd59405bbfa74fe@https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz "
+       JDKS+="81f5bed21077f9fbb04909b50391620c78b9a3c376593c0992934719c0de6b73@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.3_7.tar.gz "
        ;;
    *)
        echo "Unsupported arch: ${ARCH}"

--- a/docker/ci/config/jdk-setup.sh
+++ b/docker/ci/config/jdk-setup.sh
@@ -21,14 +21,12 @@ case "${ARCH}" in
        # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
        JDKS+="d10efb2afad3ed3d7bac9d3249cea77928aca6acb973cac0f90a2dd3606a3533@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u332b09.tar.gz "
        JDKS+="999fbd90b070f9896142f0eb28354abbeb367cbe49fd86885c626e2999189e0a@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15%2B10/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.15_10.tar.gz "
-       JDKS+="ee87e9f03b1fbe6f328429b78fe1a9f44900026d220c90dfd747fe0bcd62d904@https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.2_12.tar.gz "
        JDKS+="2e3c19c1707205c6b90cc04b416e8d83078ed98417d5a69dce3cf7dc0d7cfbca@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.3_7.tar.gz "
        ;;
    amd64|x86_64)
        # Use "<checksum>@<URL>" format to collect all JDK platform specific distributions
        JDKS+="adc13a0a0540d77f0a3481b48f10d61eb203e5ad4914507d489c2de3bd3d83da@https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u332b09.tar.gz "
        JDKS+="5fdb4d5a1662f0cca73fec30f99e67662350b1fa61460fa72e91eb9f66b54d0b@https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.15_10.tar.gz "
-       JDKS+="7d5ee7e06909b8a99c0d029f512f67b092597aa5b0e78c109bd59405bbfa74fe@https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz "
        JDKS+="81f5bed21077f9fbb04909b50391620c78b9a3c376593c0992934719c0de6b73@https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.3_7.tar.gz "
        ;;
    *)

--- a/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
@@ -57,9 +57,9 @@ SHELL ["/bin/bash", "-lc"]
 CMD ["/bin/bash", "-l"]
 
 # Install ruby / rpm / fpm related dependencies
-RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 && yum install -y rpm-build createrepo && yum clean all
+RUN . /etc/profile.d/rvm.sh && rvm install 2.6.0 && rvm --default use 2.6.0 && yum install -y rpm-build createrepo && yum clean all
 
-ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.4.0/bin
+ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.6.0/bin
 ENV RVM_HOME=/usr/local/rvm/bin
 ENV GEM_HOME=/usr/share/opensearch/.gem
 ENV GEM_PATH=$GEM_HOME

--- a/docker/ci/dockerfiles/current/build.centos7.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch.x64.arm64.dockerfile
@@ -69,9 +69,9 @@ SHELL ["/bin/bash", "-lc"]
 CMD ["/bin/bash", "-l"]
 
 # Install ruby / rpm / fpm related dependencies
-RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 && yum install -y rpm-build createrepo && yum clean all
+RUN . /etc/profile.d/rvm.sh && rvm install 2.6.0 && rvm --default use 2.6.0 && yum install -y rpm-build createrepo && yum clean all
 
-ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.4.0/bin
+ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.6.0/bin
 ENV RVM_HOME=/usr/local/rvm/bin
 ENV GEM_HOME=/usr/share/opensearch/.gem
 ENV GEM_PATH=$GEM_HOME

--- a/docker/ci/dockerfiles/current/build.rockylinux8.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.rockylinux8.opensearch.x64.arm64.dockerfile
@@ -69,9 +69,9 @@ SHELL ["/bin/bash", "-lc"]
 CMD ["/bin/bash", "-l"]
 
 # Install ruby / rpm / fpm related dependencies
-RUN . /etc/profile.d/rvm.sh && rvm install 2.4.0 && rvm --default use 2.4.0 && dnf install -y rpm-build rpm-sign createrepo pinentry && dnf clean all
+RUN . /etc/profile.d/rvm.sh && rvm install 2.6.0 && rvm --default use 2.6.0 && dnf install -y rpm-build rpm-sign createrepo pinentry && dnf clean all
 
-ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.4.0/bin
+ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.6.0/bin
 ENV RVM_HOME=/usr/local/rvm/bin
 ENV GEM_HOME=/usr/share/opensearch/.gem
 ENV GEM_PATH=$GEM_HOME

--- a/jenkins/docker/docker-copy.jenkinsfile
+++ b/jenkins/docker/docker-copy.jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     parameters {
         choice(
             name: 'SOURCE_IMAGE_REGISTRY', 
-            choices: ['opensearchstaging', 'public.ecr.aws/opensearchstaging', 'opensearchproject', 'public.ecr.aws/opensearchproject', "${DATA_PREPPER_STAGING_CONTAINER_REPOSITORY}"],
+            choices: ['opensearchstaging', 'public.ecr.aws/opensearchstaging', 'opensearchproject', 'public.ecr.aws/opensearchproject', 'public.ecr.aws/t2m2d0w1'],
             description: 'Choose the source image registry'
         )
         string(

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -53,48 +53,48 @@ pipeline {
         )
     }
     environment {
-        JAVA8_HOME="/var/jenkins/tools/hudson.model.JDK/jdk-8"
-        JAVA11_HOME="/var/jenkins/tools/hudson.model.JDK/jdk-11"
-        JAVA14_HOME="/var/jenkins/tools/hudson.model.JDK/jdk-14"
-        JAVA17_HOME="/var/jenkins/tools/hudson.model.JDK/jdk-17"
+        JAVA8_HOME="/var/jenkins/tools/hudson.model.JDK/openjdk-8"
+        JAVA11_HOME="/var/jenkins/tools/hudson.model.JDK/openjdk-11"
+        JAVA14_HOME="/var/jenkins/tools/hudson.model.JDK/openjdk-14"
+        JAVA17_HOME="/var/jenkins/tools/hudson.model.JDK/openjdk-17"
         USER_BUILD_CAUSE = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')
         TIMER_BUILD_CAUSE = currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause')
     }
     stages {
-        stage('Install jdk-8') {
+        stage('Install openjdk-8') {
             tools {
-                jdk 'jdk-8'
+                jdk 'openjdk-8'
             }
             steps {
-                echo "Install jdk-8"
-                sh("ls ${JAVA8_HOME}/.. | grep jdk-8")
-            }
-        }
-        stage('Install jdk-11') {
-           tools {
-               jdk 'jdk-11'
-           }
-            steps {
-                echo "Install jdk-11"
-                sh("ls ${JAVA11_HOME}/.. | grep jdk-11")
+                echo "Install openjdk-8"
+                sh("ls ${JAVA8_HOME}/.. | grep openjdk-8")
             }
         }
-        stage('Install jdk-14') {
+        stage('Install openjdk-11') {
            tools {
-               jdk 'jdk-14'
+               jdk 'openjdk-11'
            }
             steps {
-                echo "Install jdk-14"
-                sh("ls ${JAVA14_HOME}/.. | grep jdk-14")
+                echo "Install openjdk-11"
+                sh("ls ${JAVA11_HOME}/.. | grep openjdk-11")
             }
         }
-        stage('Install jdk-17') {
+        stage('Install openjdk-14') {
            tools {
-               jdk 'jdk-17'
+               jdk 'openjdk-14'
            }
             steps {
-                echo "Install jdk-17"
-                sh("ls ${JAVA17_HOME}/.. | grep jdk-17")
+                echo "Install openjdk-14"
+                sh("ls ${JAVA14_HOME}/.. | grep openjdk-14")
+            }
+        }
+        stage('Install openjdk-17') {
+           tools {
+               jdk 'openjdk-17'
+           }
+            steps {
+                echo "Install openjdk-17"
+                sh("ls ${JAVA17_HOME}/.. | grep openjdk-17")
             }
         }
         stage('Run Gradle Check') {


### PR DESCRIPTION

Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Use 2.6.0 Ruby and tweak jdk tool naming to be consistent with docker images

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/pull/2365, #2364

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
