### PR TITLE
Add Common Utils to 3.0.0 manifest

### DIFF
--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -14,3 +14,9 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: main
+    checks:
+      - gradle:publish
+      - gradle:properties:version


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Adding Common Utils to 3.0.0 manifest so it's available for dependent components to bump their `main` branches to 3.0

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
