### PR TITLE
Switch gradle check to 15 max parallel runs

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -61,6 +61,7 @@ __REPLACE with OpenSearch wide initiatives to improve quality and consistency.__
 
 ### Release testing - _Ends __REPLACE_RELEASE-minus-6-days___
 
+- [ ] All components should have cut branch 2.2 for the release.
 - [ ] Declare a release candidate build, and provide the instructions with the release candidates for teams on testing (__REPLACE_RELEASE-minus-8-days__).
 - [ ] Stop builds for this version of OpenSearch and/or OpenSearch Dashboards in order to avoid accidental commits going in unknowingly. Restart only if necessary else manually run the build workflow and declare new release candidate.
 - [ ] Sanity Testing (__REPLACE_RELEASE-minus-8-days__ - __REPLACE_RELEASE-minus-6-days__): Sanity testing and fixing of critical issues found by teams. Teams test their components within the distribution, ensuring integration, backwards compatibility, and perf tests pass.

--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -47,7 +47,7 @@ To aid in understanding the state of the release there is a table with status in
 - [ ] Increment each component version to {{ env.VERSION }} and ensure working CI in component repositories.
 - [ ] Make pull requests to add each component to [manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml) and [manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml) with the corresponding checks.
 - [ ] OpenSearch / OpenSearch-Dashboards core and components teams finalize their features
-- [ ] OpenSearch / OpenSearch-Dashboards core cut branch early.
+- [ ] OpenSearch / OpenSearch-Dashboards core cut branch `<MajorVersion>.<MinorVersion>` early.
 
 ### Campaigns
 
@@ -61,7 +61,7 @@ __REPLACE with OpenSearch wide initiatives to improve quality and consistency.__
 
 ### Release testing - _Ends __REPLACE_RELEASE-minus-6-days___
 
-- [ ] All components should have cut branch for the release.
+- [ ] All components should have cut branch `<MajorVersion>.<MinorVersion>` for the release.
 - [ ] Declare a release candidate build, and provide the instructions with the release candidates for teams on testing (__REPLACE_RELEASE-minus-8-days__).
 - [ ] Stop builds for this version of OpenSearch and/or OpenSearch Dashboards in order to avoid accidental commits going in unknowingly. Restart only if necessary else manually run the build workflow and declare new release candidate.
 - [ ] Sanity Testing (__REPLACE_RELEASE-minus-8-days__ - __REPLACE_RELEASE-minus-6-days__): Sanity testing and fixing of critical issues found by teams. Teams test their components within the distribution, ensuring integration, backwards compatibility, and perf tests pass.

--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -47,6 +47,7 @@ To aid in understanding the state of the release there is a table with status in
 - [ ] Increment each component version to {{ env.VERSION }} and ensure working CI in component repositories.
 - [ ] Make pull requests to add each component to [manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml) and [manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml) with the corresponding checks.
 - [ ] OpenSearch / OpenSearch-Dashboards core and components teams finalize their features
+- [ ] OpenSearch / OpenSearch-Dashboards core cut branch early.
 
 ### Campaigns
 

--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -61,7 +61,7 @@ __REPLACE with OpenSearch wide initiatives to improve quality and consistency.__
 
 ### Release testing - _Ends __REPLACE_RELEASE-minus-6-days___
 
-- [ ] All components should have cut branch 2.2 for the release.
+- [ ] All components should have cut branch for the release.
 - [ ] Declare a release candidate build, and provide the instructions with the release candidates for teams on testing (__REPLACE_RELEASE-minus-8-days__).
 - [ ] Stop builds for this version of OpenSearch and/or OpenSearch Dashboards in order to avoid accidental commits going in unknowingly. Restart only if necessary else manually run the build workflow and declare new release candidate.
 - [ ] Sanity Testing (__REPLACE_RELEASE-minus-8-days__ - __REPLACE_RELEASE-minus-6-days__): Sanity testing and fixing of critical issues found by teams. Teams test their components within the distribution, ensuring integration, backwards compatibility, and perf tests pass.

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
             categories: [],
             limitOneJobWithMatchingParams: false,
             maxConcurrentPerNode: 0,
-            maxConcurrentTotal: 50,
+            maxConcurrentTotal: 15,
             paramsToUseForLimit: '',
             throttleEnabled: true,
             throttleOption: 'project',


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Switch gradle check to 15 max parallel runs

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
