### PR TITLE
Updating Opensearch ref to 2.2 branch for 2.2.0 release

### DIFF
--- a/manifests/2.2.0/opensearch-2.2.0.yml
+++ b/manifests/2.2.0/opensearch-2.2.0.yml
@@ -10,7 +10,7 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: 2.x
+    ref: '2.2'
     checks:
       - gradle:publish
       - gradle:properties:version


### PR DESCRIPTION
Signed-off-by: Kartik Ganesh <gkart@amazon.com>

### Description
Updates the Opensearch ref in the `2.2.0` manifest to point to the `2.2` branch, now that it is created.

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/4017

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
