### PR TITLE
Temporary fix the manifest workflow

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -107,6 +107,9 @@ class InputManifests(Manifests):
 
             # generate new manifests
             for release_version in sorted(main_versions.keys() - known_versions):
+                legacy_threshold_version = "1.3"
+                if release_version[:3] < legacy_threshold_version:
+                    continue
                 self.write_manifest(release_version, main_versions[release_version])
                 self.add_to_cron(release_version)
 

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
@@ -42,10 +42,10 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
                     mock_add_to_cron: MagicMock, mock_input_manifest_from_file: MagicMock,
                     mock_input_manifest_component: MagicMock, *mocks: MagicMock) -> None:
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
-        mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
-        mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
+        mock_component_opensearch_min.branches.return_value = ["main", "1.9.0"]
+        mock_component_opensearch_min.checkout.return_value = MagicMock(version="1.9.0")
         mock_component_opensearch.return_value = MagicMock(name="common-utils")
-        mock_component_opensearch.checkout.return_value = MagicMock(version="0.10.0")
+        mock_component_opensearch.checkout.return_value = MagicMock(version="1.7.0")
         mock_input_manifest_from_path.return_value.components = {
             "common-utils": Component({"name": "common-utils", "repository": "git", "ref": "ref"})
         }
@@ -56,22 +56,22 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
             call(
                 os.path.join(
                     InputManifestsOpenSearch.manifests_path(),
-                    "0.10.0",
-                    "opensearch-0.10.0.yml",
+                    "1.7.0",
+                    "opensearch-1.7.0.yml",
                 )
             ),
             call(
                 os.path.join(
                     InputManifestsOpenSearch.manifests_path(),
-                    "0.9.0",
-                    "opensearch-0.9.0.yml",
+                    "1.9.0",
+                    "opensearch-1.9.0.yml",
                 )
             ),
         ]
         mock_input_manifest_from_file().to_file.assert_has_calls(calls)
         mock_add_to_cron.assert_has_calls([
-            call('0.10.0'),
-            call('0.9.0')
+            call('1.7.0'),
+            call('1.9.0')
         ])
 
     @patch("os.makedirs")
@@ -85,11 +85,11 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
                                          *mocks: MagicMock) -> None:
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
         mock_component_opensearch_min.branches.return_value = ["main"]
-        mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
+        mock_component_opensearch_min.checkout.return_value = MagicMock(version="1.9.0")
         mock_component_opensearch.return_value = MagicMock(name="common-utils")
-        mock_component_opensearch.checkout.return_value = MagicMock(version="0.10.0")
+        mock_component_opensearch.checkout.return_value = MagicMock(version="1.10.0")
         manifests = InputManifestsOpenSearch()
         manifests.update()
         mock_component_opensearch_min.branches.assert_called()
-        mock_write_manifest.assert_called_with("0.9.0", [mock_component_opensearch_min.checkout.return_value])
-        mock_add_to_cron.assert_called_with("0.9.0")
+        mock_write_manifest.assert_called_with("1.9.0", [mock_component_opensearch_min.checkout.return_value])
+        mock_add_to_cron.assert_called_with("1.9.0")

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
@@ -40,8 +40,8 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
                     mock_input_manifest_from_file: MagicMock, mock_input_manifest_component: MagicMock,
                     *mocks: MagicMock) -> None:
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch-Dashboards")
-        mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
-        mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
+        mock_component_opensearch_min.branches.return_value = ["main", "1.9.0"]
+        mock_component_opensearch_min.checkout.return_value = MagicMock(version="1.9.0")
         mock_input_manifest_from_path.return_value = MagicMock(components=[])
 
         manifests = InputManifestsOpenSearchDashboards()
@@ -51,12 +51,12 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
             call(
                 os.path.join(
                     InputManifestsOpenSearchDashboards.manifests_path(),
-                    "0.9.0",
-                    "opensearch-dashboards-0.9.0.yml",
+                    "1.9.0",
+                    "opensearch-dashboards-1.9.0.yml",
                 )
             )
         ]
         mock_input_manifest_from_file().to_file.assert_has_calls(calls)
         mock_add_to_cron.assert_has_calls([
-            call('0.9.0')
+            call('1.9.0')
         ])


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Temporary fix the manifest workflow to creating new manifests on legacy. Hardcode setting the threshold to be 1.3 and not auto creating new manifests for all version less than that. 

### Issues Resolved
#2420 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
