### PR TITLE
Add Notifications and Notifications Dashboards to 2.2 manifest

### DIFF
--- a/manifests/2.2.0/opensearch-2.2.0.yml
+++ b/manifests/2.2.0/opensearch-2.2.0.yml
@@ -55,3 +55,17 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: notifications-core
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: '2.2'
+    working_directory: notifications
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: opensearch-notifications-core
+  - name: notifications
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: '2.2'
+    working_directory: notifications
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: notifications

--- a/manifests/2.2.0/opensearch-dashboards-2.2.0.yml
+++ b/manifests/2.2.0/opensearch-dashboards-2.2.0.yml
@@ -20,3 +20,7 @@ components:
     repository: https://github.com/opensearch-project/dashboards-maps.git
     working_directory: src/plugins/custom_import_map
     ref: '2.2'
+  - name: notificationsDashboards
+    repository: https://github.com/opensearch-project/notifications.git
+    working_directory: dashboards-notifications
+    ref: '2.2'


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Add Notifications and Notifications Dashboards to 2.2.0 manifest. Required to unblock dependent plugins (`Alerting and Index Management`).

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
