### PR TITLE
Temporary solution to unblock notifications 2.2.0 to publishtomavenlocal / publishzips

### DIFF
--- a/scripts/components/notifications-core/build.sh
+++ b/scripts/components/notifications-core/build.sh
@@ -67,9 +67,11 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
-
+# Temp solution, see this issue for more details: https://github.com/opensearch-project/notifications/issues/501
+sed -i 's/apply plugin.*opensearch.pluginzip/\/\/&/g' core/build.gradle
 ./gradlew publishToMavenLocal -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+sed -i "s/\/\/.*apply plugin.*opensearch.pluginzip.*/apply plugin: 'opensearch.pluginzip'/g" core/build.gradle
 
 mkdir -p ./$OUTPUT/plugins
 notifCoreZipPath=$(ls core/build/distributions/ | grep .zip)

--- a/scripts/components/notifications/build.sh
+++ b/scripts/components/notifications/build.sh
@@ -67,8 +67,11 @@ fi
 [[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 
+# Temp solution, see this issue for more details: https://github.com/opensearch-project/notifications/issues/501
+sed -i 's/apply plugin.*opensearch.pluginzip/\/\/&/g' notifications/build.gradle
 ./gradlew publishToMavenLocal -PexcludeTests="**/SesChannelIT*" -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+sed -i "s/\/\/.*apply plugin.*opensearch.pluginzip.*/apply plugin: 'opensearch.pluginzip'/g" notifications/build.gradle
 
 mkdir -p ./$OUTPUT/plugins
 


### PR DESCRIPTION


Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Temporary solution to unblock notifications 2.2.0 to publishtomavenlocal / publishzips
See this issue for more details: https://github.com/opensearch-project/notifications/issues/501

### Issues Resolved
Part of https://github.com/opensearch-project/notifications/issues/501

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
