### PR TITLE
Consider legacy manifests for auto versions workflow.

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -30,6 +30,10 @@ class InputManifests(Manifests):
         return os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "manifests"))
 
     @classmethod
+    def legacy_manifests_path(self) -> str:
+        return os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "legacy-manifests"))
+
+    @classmethod
     def jenkins_path(self) -> str:
         return os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "jenkins"))
 
@@ -40,11 +44,12 @@ class InputManifests(Manifests):
     @classmethod
     def files(self, name: str) -> List:
         results = []
-        for filename in glob.glob(os.path.join(self.manifests_path(), f"**/{name}-*.yml")):
-            # avoids the -maven manifest
-            match = re.search(rf"^{name}-([0-9.]*).yml$", os.path.basename(filename))
-            if match:
-                results.append(filename)
+        for path in [self.manifests_path(), self.legacy_manifests_path()]:
+            for filename in glob.glob(os.path.join(path, f"**/{name}-*.yml")):
+                # avoids the -maven manifest
+                match = re.search(rf"^{name}-([0-9.]*).yml$", os.path.basename(filename))
+                if match:
+                    results.append(filename)
         return results
 
     @abstractmethod

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -16,6 +16,24 @@ class TestInputManifests(unittest.TestCase):
         path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "manifests"))
         self.assertEqual(path, InputManifests.manifests_path())
 
+    def test_legacy_manifests_path(self) -> None:
+        path = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "legacy-manifests"))
+        self.assertEqual(path, InputManifests.legacy_manifests_path())
+
+    def test_files(self) -> None:
+        files = InputManifests.files("invalid")
+        self.assertEqual(len(files), 0)
+
+    def test_files_opensearch(self) -> None:
+        files = InputManifests.files("opensearch")
+        self.assertTrue(os.path.join(InputManifests.manifests_path(), os.path.join("1.3.0", "opensearch-1.3.0.yml")) in files)
+        self.assertTrue(os.path.join(InputManifests.legacy_manifests_path(), os.path.join("1.2.1", "opensearch-1.2.1.yml")) in files)
+
+    def test_files_opensearch_dashboards(self) -> None:
+        files = InputManifests.files("opensearch-dashboards")
+        self.assertTrue(os.path.join(InputManifests.manifests_path(), os.path.join("1.3.3", "opensearch-dashboards-1.3.3.yml")) in files)
+        self.assertTrue(os.path.join(InputManifests.legacy_manifests_path(), os.path.join("1.2.1", "opensearch-dashboards-1.2.1.yml")) in files)
+
     def test_create_manifest_opensearch(self) -> None:
         input_manifests = InputManifests("OpenSearch")
         input_manifest = input_manifests.create_manifest("1.2.3", [])


### PR DESCRIPTION
Signed-off-by: Daniel (dB.) Doubrovkine <dblock@amazon.com>

### Description

With the change to move the old input manifests to [legacy-manifests folder](url) in build repo, the [auto generate manifest workflow ](https://github.com/opensearch-project/opensearch-build/blob/main/.github/workflows/versions.yml) [creates](https://github.com/opensearch-project/opensearch-build/pull/2389) even the manifests part of the legacy-manifests folder assuming they does not exist.

The most straightforward way to prevent this is to add `legacy-manifests` to the known manifests.

See https://github.com/dblock/opensearch-build/pull/43 for an example run with this change.

### Issues Resolved

Closes #2420.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
