### PR TITLE
Release Notes tracker for component repos

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,10 @@ atomicwrites = "*"
 validators = "*"
 yamlfix = "*"
 yamllint = "*"
+pytablewriter = "*"
+typed-ast = "*"
+zipp = "*"
+importlib-metadata = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3da3cb40cf6d9fb381ad4499ae93f01db922e93f1bed2fd233bb880b2ad422cd"
+            "sha256": "5113bcbe0eef2135817e49ecadae8b4336ab2ca1d9877ed3e8781369b197bf45"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,11 +25,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
-                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.4.0"
+            "markers": "python_version >= '3.5'",
+            "version": "==22.1.0"
         },
         "cerberus": {
             "hashes": [
@@ -53,6 +53,14 @@
             ],
             "markers": "python_full_version >= '3.6.1'",
             "version": "==3.3.1"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:0368df2bfd78b5fc20572bb4e9bb7fb53e2c094f60ae9993339e8671d0afb8aa",
+                "sha256:d3e64f022d254183001eccc5db4040520c0f23b1a3f33d6413e099eb7f126557"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.0.0"
         },
         "charset-normalizer": {
             "hashes": [
@@ -108,6 +116,14 @@
             "index": "pypi",
             "version": "==4.5.4"
         },
+        "dataproperty": {
+            "hashes": [
+                "sha256:73ccf10f8b123968210438a1a1aa859ea6d5a16b4e1f4d307da7a81b838e79fa",
+                "sha256:a8f29175950f4b2c33a387aa3809130d87b9a8d3b92a916c906c49efdb566b32"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.55.0"
+        },
         "decorator": {
             "hashes": [
                 "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
@@ -118,10 +134,10 @@
         },
         "distlib": {
             "hashes": [
-                "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b",
-                "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"
+                "sha256:a7f75737c70be3b25e2bee06288cec4e4c221de18455b2dd037fe2a795cab2fe",
+                "sha256:b710088c59f06338ca514800ad795a132da19fda270e3ce4affc74abf955a26c"
             ],
-            "version": "==0.3.4"
+            "version": "==0.3.5"
         },
         "distro": {
             "hashes": [
@@ -133,11 +149,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404",
-                "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"
+                "sha256:55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc",
+                "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.7.1"
+            "version": "==3.8.0"
         },
         "flake8": {
             "hashes": [
@@ -149,11 +165,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:0dca2ea3e4381c435ef9c33ba100a78a9b40c0bab11189c7cf121f75815efeaa",
-                "sha256:3d11b16f3fe19f52039fb7e39c9c884b21cb1b586988114fbe42671f03de3e82"
+                "sha256:25851c8c1370effb22aaa3c987b30449e9ff0cece408f810ae6ce408fdd20893",
+                "sha256:887e7b91a1be152b0d46bbf072130235a8117392b9f1828446079a816a05ef44"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.1"
+            "version": "==2.5.3"
         },
         "idna": {
             "hashes": [
@@ -168,7 +184,7 @@
                 "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
                 "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
             ],
-            "markers": "python_version < '3.8'",
+            "index": "pypi",
             "version": "==4.12.0"
         },
         "iniconfig": {
@@ -194,41 +210,50 @@
             "index": "pypi",
             "version": "==2.1.1"
         },
+        "mbstrdecoder": {
+            "hashes": [
+                "sha256:0a99413b92bbaddda89d376f496d710dc7131417e98414a756ebcd41374e068d",
+                "sha256:37a7739a365f1bf8aa5ff2de2d66b1a84e96dcb41868cc97c480c20b40c3670b"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.1.1"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==0.6.1"
         },
         "mypy": {
             "hashes": [
-                "sha256:006be38474216b833eca29ff6b73e143386f352e10e9c2fbe76aa8549e5554f5",
-                "sha256:03c6cc893e7563e7b2949b969e63f02c000b32502a1b4d1314cabe391aa87d66",
-                "sha256:0e9f70df36405c25cc530a86eeda1e0867863d9471fe76d1273c783df3d35c2e",
-                "sha256:1ece702f29270ec6af25db8cf6185c04c02311c6bb21a69f423d40e527b75c56",
-                "sha256:3e09f1f983a71d0672bbc97ae33ee3709d10c779beb613febc36805a6e28bb4e",
-                "sha256:439c726a3b3da7ca84a0199a8ab444cd8896d95012c4a6c4a0d808e3147abf5d",
-                "sha256:5a0b53747f713f490affdceef835d8f0cb7285187a6a44c33821b6d1f46ed813",
-                "sha256:5f1332964963d4832a94bebc10f13d3279be3ce8f6c64da563d6ee6e2eeda932",
-                "sha256:63e85a03770ebf403291ec50097954cc5caf2a9205c888ce3a61bd3f82e17569",
-                "sha256:64759a273d590040a592e0f4186539858c948302c653c2eac840c7a3cd29e51b",
-                "sha256:697540876638ce349b01b6786bc6094ccdaba88af446a9abb967293ce6eaa2b0",
-                "sha256:9940e6916ed9371809b35b2154baf1f684acba935cd09928952310fbddaba648",
-                "sha256:9f5f5a74085d9a81a1f9c78081d60a0040c3efb3f28e5c9912b900adf59a16e6",
-                "sha256:a5ea0875a049de1b63b972456542f04643daf320d27dc592d7c3d9cd5d9bf950",
-                "sha256:b117650592e1782819829605a193360a08aa99f1fc23d1d71e1a75a142dc7e15",
-                "sha256:b24be97351084b11582fef18d79004b3e4db572219deee0212078f7cf6352723",
-                "sha256:b88f784e9e35dcaa075519096dc947a388319cb86811b6af621e3523980f1c8a",
-                "sha256:bdd5ca340beffb8c44cb9dc26697628d1b88c6bddf5c2f6eb308c46f269bb6f3",
-                "sha256:d5aaf1edaa7692490f72bdb9fbd941fbf2e201713523bdb3f4038be0af8846c6",
-                "sha256:e999229b9f3198c0c880d5e269f9f8129c8862451ce53a011326cad38b9ccd24",
-                "sha256:f4a21d01fc0ba4e31d82f0fff195682e29f9401a8bdb7173891070eb260aeb3b",
-                "sha256:f4b794db44168a4fc886e3450201365c9526a522c46ba089b55e1f11c163750d",
-                "sha256:f730d56cb924d371c26b8eaddeea3cc07d78ff51c521c6d04899ac6904b75492"
+                "sha256:02ef476f6dcb86e6f502ae39a16b93285fef97e7f1ff22932b657d1ef1f28655",
+                "sha256:0d054ef16b071149917085f51f89555a576e2618d5d9dd70bd6eea6410af3ac9",
+                "sha256:19830b7dba7d5356d3e26e2427a2ec91c994cd92d983142cbd025ebe81d69cf3",
+                "sha256:1f7656b69974a6933e987ee8ffb951d836272d6c0f81d727f1d0e2696074d9e6",
+                "sha256:23488a14a83bca6e54402c2e6435467a4138785df93ec85aeff64c6170077fb0",
+                "sha256:23c7ff43fff4b0df93a186581885c8512bc50fc4d4910e0f838e35d6bb6b5e58",
+                "sha256:25c5750ba5609a0c7550b73a33deb314ecfb559c350bb050b655505e8aed4103",
+                "sha256:2ad53cf9c3adc43cf3bea0a7d01a2f2e86db9fe7596dfecb4496a5dda63cbb09",
+                "sha256:3fa7a477b9900be9b7dd4bab30a12759e5abe9586574ceb944bc29cddf8f0417",
+                "sha256:40b0f21484238269ae6a57200c807d80debc6459d444c0489a102d7c6a75fa56",
+                "sha256:4b21e5b1a70dfb972490035128f305c39bc4bc253f34e96a4adf9127cf943eb2",
+                "sha256:5a361d92635ad4ada1b1b2d3630fc2f53f2127d51cf2def9db83cba32e47c856",
+                "sha256:77a514ea15d3007d33a9e2157b0ba9c267496acf12a7f2b9b9f8446337aac5b0",
+                "sha256:855048b6feb6dfe09d3353466004490b1872887150c5bb5caad7838b57328cc8",
+                "sha256:9796a2ba7b4b538649caa5cecd398d873f4022ed2333ffde58eaf604c4d2cb27",
+                "sha256:98e02d56ebe93981c41211c05adb630d1d26c14195d04d95e49cd97dbc046dc5",
+                "sha256:b793b899f7cf563b1e7044a5c97361196b938e92f0a4343a5d27966a53d2ec71",
+                "sha256:d1ea5d12c8e2d266b5fb8c7a5d2e9c0219fedfeb493b7ed60cd350322384ac27",
+                "sha256:d2022bfadb7a5c2ef410d6a7c9763188afdb7f3533f22a0a32be10d571ee4bbe",
+                "sha256:d3348e7eb2eea2472db611486846742d5d52d1290576de99d59edeb7cd4a42ca",
+                "sha256:d744f72eb39f69312bc6c2abf8ff6656973120e2eb3f3ec4f758ed47e414a4bf",
+                "sha256:ef943c72a786b0f8d90fd76e9b39ce81fb7171172daf84bf43eaf937e9f220a9",
+                "sha256:f2899a3cbd394da157194f913a931edfd4be5f274a88041c9dc2d9cdcb1c315c"
             ],
             "index": "pypi",
-            "version": "==0.961"
+            "version": "==0.971"
         },
         "mypy-extensions": {
             "hashes": [
@@ -259,6 +284,14 @@
                 "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
             ],
             "version": "==0.9.0"
+        },
+        "pathvalidate": {
+            "hashes": [
+                "sha256:8dbbc64e78e874ddff049ac187499d8bf34f890adb8b7f657e134a842832d3b9",
+                "sha256:bbc27e653335aba7935a2ade2299622e76a9487bc9004cdcf1441ce8d2ff4a54"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.5.1"
         },
         "platformdirs": {
             "hashes": [
@@ -354,6 +387,14 @@
             "markers": "python_full_version >= '3.6.8'",
             "version": "==3.0.9"
         },
+        "pytablewriter": {
+            "hashes": [
+                "sha256:99409d401d6ef5f06d1bc40f265a8e3053afe4cbfbaf709f71124076afb40dbb",
+                "sha256:c46d1ddc40ef4d084213a86f8626cee33b3aa0119535aa8555da64cb5b65e382"
+            ],
+            "index": "pypi",
+            "version": "==0.64.2"
+        },
         "pytest": {
             "hashes": [
                 "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c",
@@ -369,6 +410,20 @@
             ],
             "index": "pypi",
             "version": "==2.10.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "version": "==2.8.2"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197",
+                "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"
+            ],
+            "version": "==2022.2.1"
         },
         "pyyaml": {
             "hashes": [
@@ -431,11 +486,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793",
-                "sha256:db3b8e2f922b2a910a29804776c643ea609badb6a32c4bcc226fd4fd902cce65"
+                "sha256:194b74f2c2d1800268fe2d857d99981e7c04d010de3099f04ee45ebec535e560",
+                "sha256:3bcaf6e27ad3b0f643ba0a48c5ab9eca930c3eb51df0e068f4826ab880c394ea"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==63.1.0"
+            "version": "==64.0.3"
         },
         "six": {
             "hashes": [
@@ -453,6 +508,22 @@
             "index": "pypi",
             "version": "==2.4.0"
         },
+        "tabledata": {
+            "hashes": [
+                "sha256:2016fa561552bbf2266682fe328e9161359e605620084bac4754e91c238880f1",
+                "sha256:54541b0c9e58f8fa38251ea0a60965dbaf95737027fa80e6ab56f98d7e4d61e9"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.3.0"
+        },
+        "tcolorpy": {
+            "hashes": [
+                "sha256:88b1a5c1f4d14fa0a3c9fb97d93f84f0540c7a0e3f3957b1967b1b8ea93dbdbc",
+                "sha256:8a669c29aada6e6715048ae04116e6b620f0864541fecb8722ede568f403b76e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.1.2"
+        },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
@@ -466,7 +537,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.11'",
             "version": "==2.0.1"
         },
         "typed-ast": {
@@ -496,8 +567,19 @@
                 "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3",
                 "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"
             ],
-            "markers": "python_version < '3.8'",
+            "index": "pypi",
             "version": "==1.5.4"
+        },
+        "typepy": {
+            "extras": [
+                "datetime"
+            ],
+            "hashes": [
+                "sha256:96788530614083164993d1443959f6c58e6bb8e2da839812ddf462c203e4b84c",
+                "sha256:cf1913982969cf6348152c4a5feec08e324addd99670999e57cdb3ad87a61e9a"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.3.0"
         },
         "types-pyyaml": {
             "hashes": [
@@ -509,18 +591,18 @@
         },
         "types-requests": {
             "hashes": [
-                "sha256:85383b4ef0535f639c3f06c5bbb6494bbf59570c4cd88bbcf540f0b2ac1b49ab",
-                "sha256:9863d16dfbb3fa55dcda64fa3b989e76e8859033b26c1e1623e30465cfe294d3"
+                "sha256:7a9f7b152d594a1c18dd4932cdd2596b8efbeedfd73caa4e4abb3755805b4685",
+                "sha256:b0421f9f2d0dd0f8df2c75f974686517ca67473f05b466232d4c6384d765ad7a"
             ],
             "index": "pypi",
-            "version": "==2.28.0"
+            "version": "==2.28.8"
         },
         "types-urllib3": {
             "hashes": [
-                "sha256:20588c285e5ca336d908d2705994830a83cfb6bda40fc356bbafaf430a262013",
-                "sha256:8bb3832c684c30cbed40b96e28bc04703becb2b97d82ac65ba4b968783453b0e"
+                "sha256:09a8783e1002472e8d1e1f3792d4c5cca1fffebb9b48ee1512aae6d16fe186bc",
+                "sha256:b05af90e73889e688094008a97ca95788db8bf3736e2776fd43fb6b171485d94"
             ],
-            "version": "==1.26.16"
+            "version": "==1.26.22"
         },
         "typing-extensions": {
             "hashes": [
@@ -532,11 +614,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
-                "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"
+                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
+                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
-            "version": "==1.26.10"
+            "version": "==1.26.11"
         },
         "validators": {
             "hashes": [
@@ -547,19 +629,19 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:288171134a2ff3bfb1a2f54f119e77cd1b81c29fc1265a2356f3e8d14c7d58c4",
-                "sha256:b30aefac647e86af6d82bfc944c556f8f1a9c90427b2fb4e3bfbf338cb82becf"
+                "sha256:4193b7bc8a6cd23e4eb251ac64f29b4398ab2c233531e66e40b19a6b7b0d30c1",
+                "sha256:d86ea0bb50e06252d79e6c241507cb904fcd66090c3271381372d6221a3970f9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.15.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==20.16.3"
         },
         "yamlfix": {
             "hashes": [
-                "sha256:ddcc14d6330c211d92a93d5662d3ef1cde61ab9b27d012f87f716a285425ccc8",
-                "sha256:ddf097c99fd572ccf6fb444227c0575308d16531cba7d231a689ccd6005e18a0"
+                "sha256:2d6752010d8c087cc0142840f77d3f7aeb092762d79514d0433e9e60b3c06569",
+                "sha256:a7e34d1bbd4d29a2b715c7b8b9ba62a766862f3b42489062d520569dd2289e48"
             ],
             "index": "pypi",
-            "version": "==0.9.0"
+            "version": "==1.0.1"
         },
         "yamllint": {
             "hashes": [
@@ -570,11 +652,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
-                "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"
+                "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+                "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.8.0"
+            "index": "pypi",
+            "version": "==3.8.1"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     - [Build Numbers](#build-numbers)
     - [Latest Distribution Url](#latest-distribution-url)
     - [Testing the Distribution](#testing-the-distribution)
+    - [Checking Release Notes](#checking-release-notes)
     - [Signing Artifacts](#signing-artifacts)
       - [PGP](#pgp)
       - [Windows](#windows)
@@ -136,6 +137,16 @@ Tests the OpenSearch distribution, including integration, backwards-compatibilit
 
 See [src/test_workflow](./src/test_workflow) for more information.
 
+#### Checking Release Notes
+
+Workflow to check if the release notes exists or not and shows the latest commit for OpenSearch and Dashboard distributions.
+
+To run:
+```bash
+./release_notes.sh check manifests/2.2.0/opensearch-2.2.0.yml --date 2022-07-26
+```
+
+See [src/release_notes_workflow](./src/release_notes_workflow) for more information.
 #### Signing Artifacts
 
 For all types of signing within OpenSearch project we use `opensearch-signer-client` (in progress of being open-sourced) which is a wrapper around internal signing system and is only available for authenticated users. The input requires a path to the build manifest or directory containing all the artifacts or a single artifact. 

--- a/release_notes.sh
+++ b/release_notes.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -e
+
+DIR="$(dirname "$0")"
+"$DIR/run.sh" "$DIR/src/run_releasenotes_check.py" $@

--- a/src/git/git_commit.py
+++ b/src/git/git_commit.py
@@ -1,0 +1,5 @@
+class GitCommit:
+
+    def __init__(self, id: str, date: str) -> None:
+        self.id = id
+        self.date = date

--- a/src/git/git_repository.py
+++ b/src/git/git_repository.py
@@ -10,6 +10,7 @@ import subprocess
 from pathlib import Path
 from typing import Any, List
 
+from git.git_commit import GitCommit
 from system.temporary_directory import TemporaryDirectory
 
 
@@ -87,3 +88,14 @@ class GitRepository:
         if subdirname:
             dirname = os.path.join(self.dir, subdirname)
         return Path(dirname)
+
+    def log(self, after: str) -> List[GitCommit]:
+        result = []
+        cmd = f'git log --date=short --after={after} --pretty=format:"%h %ad"'
+        log = self.output(cmd).split("\n")
+        for line in log:
+            if len(line) == 0:
+                continue
+            parts = line.split(" ")
+            result.append(GitCommit(parts[0], parts[1]))
+        return result

--- a/src/release_notes_workflow/README.md
+++ b/src/release_notes_workflow/README.md
@@ -1,0 +1,37 @@
+#### Components Release Notes Check 
+
+Pulls the latest code to check if the release notes exists and whether new commits have been made based on user passed argument `--date`. Outputs a formated markdown table as follows.
+
+*Usage*
+```
+./release_notes.sh check manifests/3.0.0/opensearch-3.0.0.yml --date 2022-07-26
+```
+
+*Sample Output*
+```
+#  OpenSearch CommitID(after 2022-07-26) & Release Notes info
+|          Repo           |   Branch   |CommitID|Commit Date|Release Notes|
+|-------------------------|------------|--------|-----------|-------------|
+|OpenSearch               |tags/2.2.0  |b1017fa |2022-08-08 |True         |
+|common-utils             |tags/2.2.0.0|7d53102 |2022-08-04 |False        |
+|job-scheduler            |tags/2.2.0.0|a501307 |2022-08-02 |True         |
+|ml-commons               |tags/2.2.0.0|a7d2695 |2022-08-08 |True         |
+|performance-analyzer     |tags/2.2.0.0|3a75d7d |2022-08-08 |True         |
+|security                 |tags/2.2.0.0|8e9e583 |2022-08-08 |True         |
+|geospatial               |tags/2.2.0.0|a71475a |2022-08-04 |True         |
+|k-NN                     |tags/2.2.0.0|53185a0 |2022-08-04 |True         |
+|cross-cluster-replication|tags/2.2.0.0|14d871a |2022-08-05 |False        |
+```
+
+The workflow uses the following arguments:
+* `--date`: To check if commit exists after a specific date (in format yyyy-mm-dd, example 2022-07-26).
+* `--output`: To dump the output into an `.md` file, example `--output table.md`).
+
+
+The following options are available.
+
+| name               | description                                                             |
+|--------------------|-------------------------------------------------------------------------|
+| --date             | Shows commit after a specific date.                                     |
+| --output           | Saves the table output to user specified file.  		       	       |
+| -v, --verbose      | Show more verbose output.                                               |

--- a/src/release_notes_workflow/__init__.py
+++ b/src/release_notes_workflow/__init__.py
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/src/release_notes_workflow/release_notes.py
+++ b/src/release_notes_workflow/release_notes.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import logging
+import os
+from typing import List
+
+from pytablewriter import MarkdownTableWriter
+
+from git.git_repository import GitRepository
+from manifests.input_manifest import InputComponentFromSource, InputManifest
+from release_notes_workflow.release_notes_component import ReleaseNotesComponents
+from system.temporary_directory import TemporaryDirectory
+
+
+class ReleaseNotes:
+
+    def __init__(self, manifest: InputManifest, date: str) -> None:
+        self.manifest = manifest
+        self.date = date
+
+    def table(self) -> MarkdownTableWriter:
+        table_result = []
+        for component in self.manifest.components.select():
+            if type(component) is InputComponentFromSource:
+                table_result.append(self.check(component))
+        writer = MarkdownTableWriter(
+            table_name=f" {self.manifest.build.name} CommitID(after {self.date}) & Release Notes info",
+            headers=["Repo", "Branch", "CommitID", "Commit Date", "Release Notes"],
+            value_matrix=table_result
+        )
+        return writer
+
+    def check(self, component: InputComponentFromSource) -> List:
+        results = []
+        with TemporaryDirectory(chdir=True) as work_dir:
+            results.append(component.name)
+            results.append(component.ref)
+            with GitRepository(
+                    component.repository,
+                    component.ref,
+                    os.path.join(work_dir.name, component.name),
+                    component.working_directory,
+            ) as repo:
+                logging.debug(f"Checked out {component.name} into {repo.dir}")
+                release_notes = ReleaseNotesComponents.from_component(component, self.manifest.build.version, repo.dir)
+                commits = repo.log(self.date)
+                if len(commits) > 0:
+                    last_commit = commits[-1]
+                    results.append(last_commit.id)
+                    results.append(last_commit.date)
+                else:
+                    results.append(None)
+                    results.append(None)
+                results.append(release_notes.exists())
+        return results

--- a/src/release_notes_workflow/release_notes_check_args.py
+++ b/src/release_notes_workflow/release_notes_check_args.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import argparse
+import datetime
+import logging
+from typing import IO
+
+
+class ReleaseNotesCheckArgs:
+    action: str
+    manifest: IO
+    date: str
+    output: str
+
+    def __init__(self) -> None:
+        parser = argparse.ArgumentParser(description="Checkout an OpenSearch Bundle and check for CommitID and Release Notes")
+        parser.add_argument("action", choices=["check"], help="Operation to perform.")
+        parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
+        parser.add_argument(
+            "-v",
+            "--verbose",
+            help="Show more verbose output.",
+            action="store_const",
+            default=logging.INFO,
+            const=logging.DEBUG,
+            dest="logging_level",
+        )
+        parser.add_argument(
+            "--date",
+            type=lambda s: datetime.datetime.strptime(s, "%Y-%m-%d").date(),
+            dest="date",
+            help="Date to retrieve the commit (in format yyyy-mm-dd, example 2022-07-26)."
+        )
+        parser.add_argument(
+            "--output",
+            help="Output file."
+        )
+        args = parser.parse_args()
+        self.logging_level = args.logging_level
+        self.action = args.action
+        self.manifest = args.manifest
+        self.date = args.date
+        self.output = args.output
+        if self.action == "check" and self.date is None:
+            parser.error("check option requires --date argument")

--- a/src/release_notes_workflow/release_notes_component.py
+++ b/src/release_notes_workflow/release_notes_component.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+from abc import abstractmethod
+
+from manifests.input_manifest import InputComponentFromSource
+
+
+class ReleaseNotesComponent:
+
+    def __init__(self, component: InputComponentFromSource, build_version: str, root: str) -> None:
+        self.component = component
+        self.build_version = build_version
+        self.root = root
+
+    @property
+    @abstractmethod
+    def filename(self) -> str:
+        pass
+
+    @property
+    def path(self) -> str:
+        return os.path.join(self.root, "release-notes")
+
+    def path_exists(self) -> bool:
+        return os.path.exists(self.path)
+
+    def exists(self) -> bool:
+        return self.path_exists() and any(fname.endswith(self.filename) for fname in os.listdir(self.path))
+
+
+class ReleaseNotesOpenSearch(ReleaseNotesComponent):
+
+    @property
+    def filename(self) -> str:
+        return f'.release-notes-{self.build_version}.md'
+
+
+class ReleaseNotesOpenSearchPlugin(ReleaseNotesComponent):
+
+    @property
+    def filename(self) -> str:
+        return f'.release-notes-{self.build_version}.0.md'
+
+
+class ReleaseNotesComponents:
+
+    @classmethod
+    def from_component(self, component: InputComponentFromSource, build_version: str, root: str) -> ReleaseNotesComponent:
+        if component.name == 'OpenSearch' or component.name == 'OpenSearch-Dashboards':
+            return ReleaseNotesOpenSearch(component, build_version, root)
+        else:
+            return ReleaseNotesOpenSearchPlugin(component, build_version, root)

--- a/src/run_releasenotes_check.py
+++ b/src/run_releasenotes_check.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+from manifests.input_manifest import InputManifest
+from release_notes_workflow.release_notes import ReleaseNotes
+from release_notes_workflow.release_notes_check_args import ReleaseNotesCheckArgs
+from system import console
+
+
+def main() -> int:
+    args = ReleaseNotesCheckArgs()
+    console.configure(level=args.logging_level)
+    manifest_file = InputManifest.from_file(args.manifest)
+    release_notes = ReleaseNotes(manifest_file, args.date)
+    if args.action == "check":
+        table_output = release_notes.table()
+        table_output.write_table()
+        if args.output is not None:
+            table_output.dump(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_run_releasenotes_check.py
+++ b/tests/test_run_releasenotes_check.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import datetime
+import os
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from release_notes_workflow.release_notes_check_args import ReleaseNotesCheckArgs
+from run_releasenotes_check import main
+
+
+class TestRunReleaseNotesCheck(unittest.TestCase):
+
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "manifests",
+            "templates",
+            "opensearch",
+            "2.x",
+            "manifest.yml"
+        )
+    )
+
+    @pytest.fixture(autouse=True)
+    def _capfd(self, capfd: Any) -> None:
+        self.capfd = capfd
+
+    @patch("argparse._sys.argv", ["run_releasenotes_check.py", "--help"])
+    def test_usage(self) -> None:
+        with self.assertRaises(SystemExit):
+            main()
+
+        out, _ = self.capfd.readouterr()
+        self.assertTrue(out.startswith("usage:"))
+
+    @patch("argparse._sys.argv", ["run_releasenotes_check.py", "check", OPENSEARCH_MANIFEST, "--date", "2022-07-26"])
+    @patch('subprocess.check_call')
+    @patch("run_releasenotes_check.ReleaseNotes")
+    @patch("run_releasenotes_check.main", return_value=0)
+    def test_main(self, *mocks: Any) -> None:
+        self.assertEqual(ReleaseNotesCheckArgs().action, 'check')
+        self.assertEqual(ReleaseNotesCheckArgs().date, datetime.date(2022, 7, 26))
+        self.assertTrue(ReleaseNotesCheckArgs().manifest)
+
+    @patch('subprocess.check_call')
+    @patch("argparse._sys.argv", ["run_releasenotes_check.py", "check", OPENSEARCH_MANIFEST, "--date", "2022-07-26", "--output", "test.md"])
+    @patch("run_releasenotes_check.ReleaseNotes")
+    @patch("run_releasenotes_check.main", return_value=0)
+    def test_main_with_save(self, *mocks: Any) -> None:
+        self.assertEqual(ReleaseNotesCheckArgs().output, "test.md")

--- a/tests/tests_git/test_git_repository.py
+++ b/tests/tests_git/test_git_repository.py
@@ -57,6 +57,26 @@ class TestGitRepository(unittest.TestCase):
         self.repo.output("echo hello")
         mock_subprocess.assert_called_with("echo hello", cwd=self.repo.dir, shell=True)
 
+    @patch("subprocess.check_output", return_value='927de30 2022-07-12'.encode())
+    def test_log(self, mock_subprocess: Any) -> None:
+        log = self.repo.log('2021-10-26')
+        last_commit = log[-1]
+        self.assertEqual(last_commit.id, "927de30")
+        self.assertEqual(last_commit.date, "2022-07-12")
+
+    @patch("subprocess.check_output", return_value=''.encode())
+    def test_log_empty(self, mock_subprocess: Any) -> None:
+        log = self.repo.log('2021-10-26')
+        self.assertEqual(len(log), 0)
+
+    @patch("subprocess.check_output", return_value='927de30 2022-07-12\n787d971 2022-04-28\n989143e 22-04-26\n8b376fc 2022-04-26\n023a2ac 2022-04-26'.encode())
+    def test_log_multiple(self, mock_subprocess: Any) -> None:
+        log = self.repo.log('2022-04-25')
+        self.assertEqual(len(log), 5)
+        last_commit = log[-1]
+        self.assertEqual(last_commit.id, "023a2ac")
+        self.assertEqual(last_commit.date, "2022-04-26")
+
 
 class TestGitRepositoryDir(unittest.TestCase):
     @patch('subprocess.check_call', return_value=0)

--- a/tests/tests_release_notes_workflow/__init__.py
+++ b/tests/tests_release_notes_workflow/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))

--- a/tests/tests_release_notes_workflow/test_release_notes.py
+++ b/tests/tests_release_notes_workflow/test_release_notes.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+from manifests.input_manifest import InputComponentFromSource, InputManifest
+from release_notes_workflow.release_notes import ReleaseNotes
+
+
+class TestReleaseNotes(unittest.TestCase):
+
+    def setUp(self) -> None:
+        MANIFESTS = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "manifests",
+        )
+        OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(MANIFESTS, "templates", "opensearch", "default", "manifest.yml"))
+        self.manifest_file = InputManifest.from_file(open(OPENSEARCH_MANIFEST))
+        self.release_notes = ReleaseNotes(self.manifest_file, "2022-07-26")
+        self.component = InputComponentFromSource({"name": "OpenSearch", "repository": "url", "ref": "ref"})
+
+    @patch("subprocess.check_output", return_value=''.encode())
+    @patch("subprocess.check_call")
+    def test_check(self, *mocks: Any) -> None:
+        self.assertEqual(self.release_notes.check(self.component), ['OpenSearch', 'ref', None, None, False])
+
+    @patch("subprocess.check_output", return_value=''.encode())
+    @patch("subprocess.check_call")
+    def test_check_with_manifest(self, *mocks: Any) -> None:
+        component = next(self.manifest_file.components.select())
+        if type(component) is InputComponentFromSource:
+            self.assertIsInstance(component, InputComponentFromSource)
+            self.assertEqual(self.release_notes.check(component), ['OpenSearch', 'main', None, None, False])
+
+    @patch('release_notes_workflow.release_notes.ReleaseNotes.check', return_value=['OpenSearch', 'main', 'ee26e01', '2022-08-18', False])
+    def test_table(self, *mocks: Any) -> None:
+        table_output = self.release_notes.table()
+        self.assertEqual(table_output._table_name.strip(), 'OpenSearch CommitID(after 2022-07-26) & Release Notes info')
+        self.assertEqual(table_output.headers, ['Repo', 'Branch', 'CommitID', 'Commit Date', 'Release Notes'])
+        self.assertEqual(table_output.value_matrix, [['OpenSearch', 'main', 'ee26e01', '2022-08-18', False]])

--- a/tests/tests_release_notes_workflow/test_release_notes_component.py
+++ b/tests/tests_release_notes_workflow/test_release_notes_component.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import unittest
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+from manifests.input_manifest import InputComponentFromSource
+from release_notes_workflow.release_notes_component import ReleaseNotesComponent, ReleaseNotesComponents, ReleaseNotesOpenSearch, ReleaseNotesOpenSearchPlugin
+
+
+class TestReleaseNotesComponent(unittest.TestCase):
+
+    class MyReleaseNotesComponent(ReleaseNotesComponent):
+
+        @property
+        def filename(self) -> str:
+            return "release-notes-2.0.0.md"
+
+    def setUp(self) -> None:
+        self.release_notes_component = self.MyReleaseNotesComponent(MagicMock(), "2.2.0", "path")
+
+    def test_path(self) -> None:
+        self.assertEqual(self.release_notes_component.path, os.path.join("path", "release-notes"))
+
+    @patch("os.path.exists", return_value=True)
+    def test_path_exists(self, mock_path_exists: Mock) -> None:
+        self.assertTrue(self.release_notes_component.path_exists())
+        mock_path_exists.assert_called_with(os.path.join("path", "release-notes"))
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.listdir", return_value=['release-notes-2.0.0.md'])
+    def test_exists(self, *mocks: Any) -> None:
+        self.assertTrue(self.release_notes_component.exists())
+
+    @patch("os.path.exists", return_value=False)
+    @patch("os.listdir", return_value=['release-notes-2.0.0.md'])
+    def test_does_not_exist(self, *mocks: Any) -> None:
+        self.assertFalse(self.release_notes_component.exists())
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.listdir", return_value=['release-notes-1.0.0.md'])
+    def test_does_not_exist_1x(self, *mocks: Any) -> None:
+        self.assertFalse(self.release_notes_component.exists())
+
+
+class TestReleaseNotesOpenSearch(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.release_notes_component = ReleaseNotesOpenSearch(MagicMock(), "2.2.0", "path")
+
+    def test_filename(self) -> None:
+        self.assertEqual(self.release_notes_component.filename, ".release-notes-2.2.0.md")
+
+
+class TestReleaseNotesOpenSearchPlugin(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.release_notes_component = ReleaseNotesOpenSearchPlugin(MagicMock(), "2.2.0", "path")
+
+    def test_filename(self) -> None:
+        self.assertEqual(self.release_notes_component.filename, ".release-notes-2.2.0.0.md")
+
+
+class TestComponentsReleaseNotes(unittest.TestCase):
+
+    def test_from_component(self) -> None:
+        self.assertIsInstance(ReleaseNotesComponents.from_component(MagicMock(), "2.2.0", "path"), ReleaseNotesComponent)
+
+    def test_from_component_open_search(self) -> None:
+        test_component_opensearch = InputComponentFromSource({"name": "OpenSearch", "repository": "url", "ref": "ref"})
+        self.assertIsInstance(ReleaseNotesComponents.from_component(test_component_opensearch, "2.2.0", "path"), ReleaseNotesOpenSearch)
+
+    def test_from_component_open_search_plugin(self) -> None:
+        test_component_plugin = InputComponentFromSource({"name": "common-utils", "repository": "url", "ref": "ref"})
+        self.assertIsInstance(ReleaseNotesComponents.from_component(test_component_plugin, "2.2.0", "path"), ReleaseNotesOpenSearchPlugin)

--- a/tests/tests_release_notes_workflow/test_releasenotes_check_args.py
+++ b/tests/tests_release_notes_workflow/test_releasenotes_check_args.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import datetime
+import logging
+import os
+import unittest
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from release_notes_workflow.release_notes_check_args import ReleaseNotesCheckArgs
+
+
+class TestReleaseNotesCheckArgs(unittest.TestCase):
+
+    RELEASE_NOTES_CHECK_PY = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "src", "run_releasenotes_check.py"))
+
+    OPENSEARCH_MANIFEST = os.path.realpath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "manifests",
+            "templates",
+            "opensearch",
+            "1.x",
+            "os-template-1.1.0.yml",
+        )
+    )
+
+    @pytest.fixture(autouse=True)
+    def _capfd(self, capfd: Any) -> None:
+        self.capfd = capfd
+
+    @patch("argparse._sys.argv", [RELEASE_NOTES_CHECK_PY, "check", OPENSEARCH_MANIFEST, "--date", '2022-07-26'])
+    def test_manifest(self) -> None:
+        self.assertEqual(ReleaseNotesCheckArgs().manifest.name, TestReleaseNotesCheckArgs.OPENSEARCH_MANIFEST)
+        self.assertEqual(ReleaseNotesCheckArgs().date, datetime.date(2022, 7, 26))
+
+    @patch("argparse._sys.argv", [RELEASE_NOTES_CHECK_PY, "check", OPENSEARCH_MANIFEST])
+    def test_manifest_withoutdate(self) -> None:
+        with self.assertRaises(SystemExit) as cm:
+            ReleaseNotesCheckArgs()
+        _, err = self.capfd.readouterr()
+        self.assertTrue("error: check option requires --date argument" in err)
+        self.assertEqual(cm.exception.code, 2)
+
+    @patch("argparse._sys.argv", [RELEASE_NOTES_CHECK_PY, "check", OPENSEARCH_MANIFEST, "--date", '2022-07-26', "--verbose"])
+    def test_verbose_true(self) -> None:
+        self.assertTrue(ReleaseNotesCheckArgs().logging_level, logging.DEBUG)
+
+    @patch("argparse._sys.argv", [RELEASE_NOTES_CHECK_PY, "check", OPENSEARCH_MANIFEST, "--date", '2022-07-26', "--output", "test.md"])
+    def test_output(self) -> None:
+        self.assertEqual(ReleaseNotesCheckArgs().output, "test.md")


### PR DESCRIPTION
### Description

- Release tracker for component repos, thats gives information about the most recent commitID after a specific date and checks if there are any associated release notes.
Expected inputs:
1) `GIT_LOG_DATE`: To check if commit exists after a specific date
2) `ADD_COMMENT`: true/false
3) `GIT_ISSUE_NUMBER`: release issue to add the generated table as comment.
4) `GITHUB_TOKEN`: token used to add the comment

- This PR adds code that adheres to existing workflows 

- Execution command: `./run_releasenotes_check.sh manifests/2.2.0/opensearch-2.2.0.yml `
- Create a mark-down table as follows, adding the latest commitID after a certain date, and if contains a release notes with YES/NO/NULL

```
|    Repo    |Branch|CommitID|Release Notes|
|------------|------|--------|-------------|
|OpenSearch  |2.x   |        |NO           |
|common-utils|2.x   |        |NO           |
|security    |main  |        |YES          |
```

- Pending: To update README

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2345

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
