### PR TITLE
Pickup Java version from .properties in OpenSearch gradle check

### DIFF
--- a/tests/jenkins/jobs/RunGradleCheck_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/RunGradleCheck_Jenkinsfile.txt
@@ -24,16 +24,12 @@
 
                 echo "Get Major Version"
                 OS_VERSION=`cat buildSrc/version.properties | grep opensearch | cut -d= -f2 | grep -oE '[0-9.]+'`
+                JDK_MAJOR_VERSION=`cat buildSrc/version.properties | grep "bundled_jdk" | cut -d= -f2 | grep -oE '[0-9]+'  | head -n 1`
                 OS_MAJOR_VERSION=`echo $OS_VERSION | grep -oE '[0-9]+' | head -n 1`
                 echo "Version: $OS_VERSION, Major Version: $OS_MAJOR_VERSION"
 
-                if [ "$OS_MAJOR_VERSION" -lt 2 ]; then
-                    echo "Using JAVA 11"
-                    export JAVA_HOME=$JAVA11_HOME
-                else
-                    echo "Using JAVA 17"
-                    export JAVA_HOME=$JAVA17_HOME
-                fi
+                echo "Using JAVA $JDK_MAJOR_VERSION"
+                eval export JAVA_HOME='$JAVA'$JDK_MAJOR_VERSION'_HOME'
 
                 env | grep JAVA | grep HOME
 

--- a/vars/runGradleCheck.groovy
+++ b/vars/runGradleCheck.groovy
@@ -30,16 +30,12 @@ void call(Map args = [:]) {
 
                 echo "Get Major Version"
                 OS_VERSION=`cat buildSrc/version.properties | grep opensearch | cut -d= -f2 | grep -oE '[0-9.]+'`
+                JDK_MAJOR_VERSION=`cat buildSrc/version.properties | grep "bundled_jdk" | cut -d= -f2 | grep -oE '[0-9]+'  | head -n 1`
                 OS_MAJOR_VERSION=`echo \$OS_VERSION | grep -oE '[0-9]+' | head -n 1`
                 echo "Version: \$OS_VERSION, Major Version: \$OS_MAJOR_VERSION"
 
-                if [ "\$OS_MAJOR_VERSION" -lt 2 ]; then
-                    echo "Using JAVA 11"
-                    export JAVA_HOME=\$JAVA11_HOME
-                else
-                    echo "Using JAVA 17"
-                    export JAVA_HOME=\$JAVA17_HOME
-                fi
+                echo "Using JAVA \$JDK_MAJOR_VERSION"
+                eval export JAVA_HOME='\$JAVA'\$JDK_MAJOR_VERSION'_HOME'
 
                 env | grep JAVA | grep HOME
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Pickup Java version from .properties in OpenSearch gradle check

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/2395

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
