### PR TITLE
[Release 1.3.5]  Set `CREATE_GITHUB_ISSUE` parameter default to `false`

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
         booleanParam(
                     name: 'CREATE_GITHUB_ISSUE',
                     description: 'To create a github issue for failing component or not.',
-                    defaultValue: true
+                    defaultValue: false
                 )
     }
     stages {


### PR DESCRIPTION
Signed-off-by: prudhvigodithi <pgodithi@amazon.com>

### Description
Changing the CREATE_GITHUB_ISSUE to false until the issue gets fixed
`java.io.FileNotFoundException: /var/jenkins/workspace/distribution-build-opensearch/manifests/1.3.5/opensearch-1.3.5.yml does not exists`

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
