### PR TITLE
Remove jq pasing to show correct output in gradle check payload

### DIFF
--- a/scripts/gradle/gradle-check.sh
+++ b/scripts/gradle/gradle-check.sh
@@ -25,7 +25,7 @@ JENKINS_REQ=`curl -s -XPOST \
      "$JENKINS_URL/generic-webhook-trigger/invoke" \
      --data "$(echo $PAYLOAD_JSON)"`
 
-echo $PAYLOAD_JSON | jq
+echo $PAYLOAD_JSON
 echo $JENKINS_REQ
 
 QUEUE_URL=$(echo $JENKINS_REQ | jq --raw-output '.jobs."gradle-check".url')


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove jq pasing to show correct output in gradle check payload

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
