### PR TITLE
Added git repo checkout in case the workspace has been cleaned

### DIFF
--- a/tests/jenkins/jobs/CreateGithubIssueExisting_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CreateGithubIssueExisting_Jenkinsfile.txt
@@ -4,6 +4,8 @@
          CreateGithubIssueExisting_Jenkinsfile.stage(notify, groovy.lang.Closure)
             CreateGithubIssueExisting_Jenkinsfile.script(groovy.lang.Closure)
                CreateGithubIssueExisting_Jenkinsfile.createGithubIssue({message=[Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot]})
+                  createGithubIssue.fileExists(/tmp/workspace/manifests)
+                  createGithubIssue.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   createGithubIssue.readYaml({file=manifests/2.0.0/opensearch-2.0.0.yml})
                   createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
                   createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)

--- a/tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/CreateGithubIssue_Jenkinsfile.txt
@@ -4,6 +4,8 @@
          CreateGithubIssue_Jenkinsfile.stage(notify, groovy.lang.Closure)
             CreateGithubIssue_Jenkinsfile.script(groovy.lang.Closure)
                CreateGithubIssue_Jenkinsfile.createGithubIssue({message=[Error building OpenSearch, retry with: ./build.sh manifests/2.2.0/opensearch-2.2.0.yml --component OpenSearch --snapshot]})
+                  createGithubIssue.fileExists(/tmp/workspace/manifests)
+                  createGithubIssue.git({url=https://github.com/opensearch-project/opensearch-build.git, branch=main})
                   createGithubIssue.readYaml({file=manifests/2.0.0/opensearch-2.0.0.yml})
                   createGithubIssue.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
                   createGithubIssue.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)

--- a/tests/jenkins/lib-testers/CreateGithubIssueLibTester.groovy
+++ b/tests/jenkins/lib-testers/CreateGithubIssueLibTester.groovy
@@ -29,6 +29,7 @@ class CreateGithubIssueLibTester extends LibFunctionTester{
     void configure(Object helper, Object binding) {
         helper.registerAllowedMethod("withCredentials", [Map])
         helper.registerAllowedMethod("sleep", [Map])
+        helper.registerAllowedMethod("git", [Map])
         binding.setVariable('BUILD_URL', 'www.example.com/jobs/test/123/')
         binding.setVariable('INPUT_MANIFEST', '2.0.0/opensearch-2.0.0.yml')
     }

--- a/vars/createGithubIssue.groovy
+++ b/vars/createGithubIssue.groovy
@@ -1,6 +1,14 @@
 def call(Map args = [:]){
     def failureMessages = args.message
     List<String> failedComponents = []
+    def manifestPath = "${WORKSPACE}/manifests"
+
+    if (fileExists(manifestPath)) {
+        println("Manifest path exists, not checking out git repo")
+    } else {
+        println("Manifest path does not exists, checking out git repo")
+        git url: 'https://github.com/opensearch-project/opensearch-build.git', branch: 'main'
+    }
 
     if (failureMessages.size() == 1 && failureMessages[0] == "Build failed") {
         println("No component failed, skip creating github issue.")


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>

### Description
This PR adds support to checkout `opensearch-build` repo in `post` action in case the workspace has been cleaned by build stage in `opensearch-distribution-build` job. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
