### PR TITLE
Auto version increment for 2.2.

### DIFF
--- a/.github/workflows/increment-plugin-versions.yml
+++ b/.github/workflows/increment-plugin-versions.yml
@@ -39,9 +39,6 @@ jobs:
           - {repo: security}
           - {repo: sql}
         branch:
-          - 'main'
-          - '2.x'
-          - '2.1'
           - '2.2'
     steps:
       - name: Check out OpenSearch repo


### PR DESCRIPTION
### Description
Auto version increment for 2.2.
This is to test the workflow execution with to create [AUTO] version increment PR's for 2.2 branch only.

### Issues Resolved
Part of: https://github.com/opensearch-project/opensearch-build/issues/1375

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
