### PR TITLE
Jenkins job for release notes workflow

### DIFF
--- a/jenkins/release-notes-check/release-notes-check.jenkinsfile
+++ b/jenkins/release-notes-check/release-notes-check.jenkinsfile
@@ -1,0 +1,125 @@
+lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+
+pipeline {
+    options {
+            timeout(time: 2, unit: 'HOURS')
+    }
+    agent none
+    parameters {
+        string(
+            name: 'INPUT_MANIFEST',
+            description: 'Input manifest under the manifests folder, e.g. 2.0.0/opensearch-2.0.0.yml.',
+            trim: true
+        )
+        string(
+            name: 'GIT_LOG_DATE',
+            description: 'in format yyyy-mm-dd, example 2022-07-26.',
+            trim: true
+        )
+        choice(
+                choices: ['ADD', 'UPDATE', 'NO_COMMENT'],
+                name: 'COMMENT',
+                description: 'Adds MardownTable output as comment on GIT_ISSUE_NUMBER.', 
+        )
+        string(
+            name: 'GIT_ISSUE_NUMBER',
+            description: 'The release issue number from opensearch-build repo.',
+            trim: true
+        )
+        string(
+            name: 'COMMENT_UNIQUE_ID',
+            description: 'Use only with COMMENT: UPDATE',
+            trim: true
+        )
+    }
+    environment {
+        AGENT_X64 = 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
+    }
+    stages {
+        stage('detect docker image + args') {
+            agent {
+                docker {
+                    label AGENT_X64
+                    image 'alpine:3'
+                    alwaysPull true
+                }
+            }
+            steps {
+                script {
+                    dockerAgent = detectDockerAgent()
+                    currentBuild.description = INPUT_MANIFEST
+                }
+            }
+            post {
+                always {
+                    postCleanup()
+                }
+            }
+        }
+        stage('Parameters Check') {
+            steps {
+                script {
+                    currentBuild.description = "Comment:${COMMENT}, Manifest:${INPUT_MANIFEST}"
+                    if (GIT_LOG_DATE.isEmpty() || INPUT_MANIFEST.isEmpty()) {
+                                currentBuild.result = 'ABORTED'
+                                error('Make sure all the parameters are passed in.')
+                    }
+                    if (COMMENT == "ADD" && GIT_ISSUE_NUMBER.isEmpty()) {
+                                currentBuild.result = 'ABORTED'
+                                error('Make sure all the parameters are passed in.')
+                    }
+                    if (COMMENT == "UPDATE" && COMMENT_UNIQUE_ID.isEmpty()) {
+                                currentBuild.result = 'ABORTED'
+                                error('Make sure all the parameters are passed in.')
+                    }
+                }
+            }
+        }
+        stage('Generate MarkDown table') {
+            agent {
+                docker {
+                    label AGENT_X64
+                    image dockerAgent.image
+                    alwaysPull true
+                }
+            }
+            steps {
+                script {
+                    withCredentials([usernamePassword(credentialsId: "jenkins-github-bot-token", usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
+                        if (params.COMMENT == "ADD") {
+                            sh '''
+                                #!/bin/bash
+                                set +e
+                                ./release_notes.sh check manifests/${INPUT_MANIFEST} --date ${GIT_LOG_DATE} --output table.md
+                                echo "Adding Comment on issue $GIT_ISSUE_NUMBER"
+                                gh repo clone https://github.com/opensearch-project/opensearch-build.git; cd opensearch-build
+                                gh issue comment ${GIT_ISSUE_NUMBER} --body-file ../table.md --repo opensearch-project/opensearch-build
+                            '''
+                        }
+                        if (params.COMMENT == "UPDATE") {
+                            sh '''
+                                #!/bin/bash
+                                set +e
+                                ./release_notes.sh check manifests/${INPUT_MANIFEST} --date ${GIT_LOG_DATE} --output table.md
+                                echo "Updating Comment on issue $GIT_ISSUE_NUMBER"
+                                gh repo clone https://github.com/opensearch-project/opensearch-build.git; cd opensearch-build
+                                IFS=
+                                gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/opensearch-project/opensearch-build/issues/comments/${COMMENT_UNIQUE_ID} -f body=$(cat ../table.md)
+                            '''
+                        }
+                        if (params.COMMENT == "NO_COMMENT") {
+                            sh '''
+                            ./release_notes.sh check manifests/${INPUT_MANIFEST} --date ${GIT_LOG_DATE}
+                            '''
+                        }
+                    }
+                }
+            }
+            post {
+                always {
+                    postCleanup()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
Jenkins job to call the [release_notes_workflow](https://github.com/opensearch-project/opensearch-build/tree/main/src/release_notes_workflow).

### Issues Resolved
Part of: https://github.com/opensearch-project/opensearch-build/issues/2345

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
