### PR TITLE
Add common-utils to 2.3 manifest

### DIFF
--- a/manifests/2.3.0/opensearch-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-2.3.0.yml
@@ -14,6 +14,14 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: 2.x
+    platforms:
+      - linux
+    checks:
+      - gradle:publish
+      - gradle:properties:version
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: 2.x


### PR DESCRIPTION
Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

### Description
Add common-utils 2.x to the 2.3 manifest so other plugins can build on 2.3 in their 2.x branches

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
