### PR TITLE
Add curl validation for standalone sign artifact workflows

### DIFF
--- a/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
+++ b/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
@@ -119,12 +119,10 @@ List downloadArtifactsFromUrls() {
                 if grep -qEo '[45][0-9][0-9]'; then
                     echo "Error url with error response code \$resp_code, exit 1"
                     exit 1
-                else
-                    echo "No error detected, valid response \$resp_code, downloading ${trimmedUrl}"
-                    curl -SL ${trimmedUrl} -o ${WORKSPACE}/artifacts/${filename}
-                fi
             done
 
+            echo "No error detected, valid response \$resp_code, downloading ${trimmedUrl}"
+            curl -SL ${trimmedUrl} -o ${WORKSPACE}/artifacts/${filename}
         """
     }
 

--- a/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
+++ b/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
@@ -116,7 +116,7 @@ List downloadArtifactsFromUrls() {
 
             STATUS_CODES=`curl -IL ${trimmedUrl} 2>&1 | grep -Eo "HTTP/[12] [0-9]+" | grep -Eo '[0-9][0-9][0-9]' | sort | uniq`
             for resp_code in \$STATUS_CODES; do
-                if grep -qEo '[45][0-9][0-9]'; then
+                if echo \$resp_code | grep -qEo '[45][0-9][0-9]'; then
                     echo "Error url with error response code \$resp_code, exit 1"
                     exit 1
             done

--- a/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
+++ b/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
@@ -110,7 +110,22 @@ List downloadArtifactsFromUrls() {
         trimmedUrl = url.trim()
         filename = trimmedUrl.substring(trimmedUrl.lastIndexOf('/') + 1)
         downloadedFiles.add(filename)
-        sh "curl -SL ${trimmedUrl} -o ${WORKSPACE}/artifacts/${filename}"
+        sh """
+            set +x
+            set -e
+
+            STATUS_CODES=`curl -IL ${trimmedUrl} 2>&1 | grep -Eo "HTTP/[12] [0-9]+" | grep -Eo '[0-9][0-9][0-9]' | sort | uniq`
+            for resp_code in \$STATUS_CODES; do
+                if grep -qEo '[45][0-9][0-9]'; then
+                    echo "Error url with error response code \$resp_code, exit 1"
+                    exit 1
+                else
+                    echo "No error detected, valid response \$resp_code, downloading ${trimmedUrl}"
+                    curl -SL ${trimmedUrl} -o ${WORKSPACE}/artifacts/${filename}
+                fi
+            done
+
+        """
     }
 
     return downloadedFiles

--- a/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
+++ b/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
@@ -119,6 +119,7 @@ List downloadArtifactsFromUrls() {
                 if echo \$resp_code | grep -qEo '[45][0-9][0-9]'; then
                     echo "Error url with error response code \$resp_code, exit 1"
                     exit 1
+                fi
             done
 
             echo "No error detected, valid response \$resp_code, downloading ${trimmedUrl}"

--- a/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
@@ -7,8 +7,36 @@
          sign-standalone-artifacts.stage(sign, groovy.lang.Closure)
             sign-standalone-artifacts.script(groovy.lang.Closure)
                sign-standalone-artifacts.sh(mkdir /tmp/workspace/artifacts)
-               sign-standalone-artifacts.sh(curl -SL https://www.dummy.com/dummy_1_artifact.tar.gz -o /tmp/workspace/artifacts/dummy_1_artifact.tar.gz)
-               sign-standalone-artifacts.sh(curl -SL https://www.dummy.com/dummy_2_artifact.tar.gz -o /tmp/workspace/artifacts/dummy_2_artifact.tar.gz)
+               sign-standalone-artifacts.sh(
+            set +x
+            set -e
+
+            STATUS_CODES=`curl -IL https://www.dummy.com/dummy_1_artifact.tar.gz 2>&1 | grep -Eo "HTTP/[12] [0-9]+" | grep -Eo '[0-9][0-9][0-9]' | sort | uniq`
+            for resp_code in $STATUS_CODES; do
+                if echo $resp_code | grep -qEo '[45][0-9][0-9]'; then
+                    echo "Error url with error response code $resp_code, exit 1"
+                    exit 1
+                fi
+            done
+
+            echo "No error detected, valid response $resp_code, downloading https://www.dummy.com/dummy_1_artifact.tar.gz"
+            curl -SL https://www.dummy.com/dummy_1_artifact.tar.gz -o /tmp/workspace/artifacts/dummy_1_artifact.tar.gz
+        )
+               sign-standalone-artifacts.sh(
+            set +x
+            set -e
+
+            STATUS_CODES=`curl -IL https://www.dummy.com/dummy_2_artifact.tar.gz 2>&1 | grep -Eo "HTTP/[12] [0-9]+" | grep -Eo '[0-9][0-9][0-9]' | sort | uniq`
+            for resp_code in $STATUS_CODES; do
+                if echo $resp_code | grep -qEo '[45][0-9][0-9]'; then
+                    echo "Error url with error response code $resp_code, exit 1"
+                    exit 1
+                fi
+            done
+
+            echo "No error detected, valid response $resp_code, downloading https://www.dummy.com/dummy_2_artifact.tar.gz"
+            curl -SL https://www.dummy.com/dummy_2_artifact.tar.gz -o /tmp/workspace/artifacts/dummy_2_artifact.tar.gz
+        )
                sign-standalone-artifacts.signArtifacts({artifactPath=/tmp/workspace/artifacts, sigtype=.sig, platform=linux})
                   signArtifacts.echo(PGP or Windows Signature Signing)
                   signArtifacts.fileExists(/tmp/workspace/sign.sh)


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add curl validation for standalone sign artifact workflows

### Issues Resolved
#2167

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
