### PR TITLE
Add heap dump files if the run failed

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -129,6 +129,9 @@ pipeline {
                 }
             }
             post() {
+                failure {
+                    archiveArtifacts artifacts: 'java_pid*.hprof'
+                }
                 always {
                     sh ("cp -v `find search/build/reports/jacoco/ -name '*.xml' | head -n 1` codeCoverage.xml || echo")
                     junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
             }
             post() {
                 failure {
-                    archiveArtifacts artifacts: 'search/java_pid*.hprof'
+                    archiveArtifacts artifacts: '**/build/heapdump/*.hprof', allowEmptyArchive: true
                 }
                 always {
                     sh ("cp -v `find search/build/reports/jacoco/ -name '*.xml' | head -n 1` codeCoverage.xml || echo")

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
             }
             post() {
                 failure {
-                    archiveArtifacts artifacts: 'java_pid*.hprof'
+                    archiveArtifacts artifacts: 'search/java_pid*.hprof'
                 }
                 always {
                     sh ("cp -v `find search/build/reports/jacoco/ -name '*.xml' | head -n 1` codeCoverage.xml || echo")


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add heap dump files if the run failed

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/3973#issuecomment-1227886974

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
