### PR TITLE
[Bug]: gradle check failing with java heap OutOfMemoryError, capturing heap dumps if available

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -133,6 +133,7 @@ pipeline {
                     sh ("cp -v `find search/build/reports/jacoco/ -name '*.xml' | head -n 1` codeCoverage.xml || echo")
                     junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
                     archiveArtifacts artifacts: 'codeCoverage.xml', onlyIfSuccessful: true
+                    archiveArtifacts artifacts: '**/build/heapdump/*.hprof', allowEmptyArchive: true
                     script {
                         sh("rm -rf *")
                         postCleanup()

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -129,11 +129,13 @@ pipeline {
                 }
             }
             post() {
+                failure {
+                    archiveArtifacts artifacts: '**/build/heapdump/*.hprof', allowEmptyArchive: true
+                }
                 always {
                     sh ("cp -v `find search/build/reports/jacoco/ -name '*.xml' | head -n 1` codeCoverage.xml || echo")
                     junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
                     archiveArtifacts artifacts: 'codeCoverage.xml', onlyIfSuccessful: true
-                    archiveArtifacts artifacts: '**/build/heapdump/*.hprof', allowEmptyArchive: true
                     script {
                         sh("rm -rf *")
                         postCleanup()


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Capturing heap dumps if available in case build fails with `OutOfMemoryError`. We do run build steps with `-XX:+HeapDumpOnOutOfMemoryError  -XX:HeapDumpPath=.../build/heapdump`, for example:

```
[-Dgradle.dist.lib=/home/opensearch/.gradle/wrapper/dists/gradle-7.5.1-all/1ehga6e77gqps5uk2kc5kf1vc/gradle-7.5.1/lib, -Dgradle.user.home=/home/opensearch/.gradle, -Dgradle.worker.jar=/home/opensearch/.gradle/caches/7.5.1/workerMain/gradle-worker.jar, -Dio.netty.noKeySetOptimization=true, -Dio.netty.noUnsafe=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Djava.awt.hea
dless=true, -Djna.nosys=true, -Dopensearch.scripting.update.ctx_in_params=false, -Dopensearch.search.rewrite_sort=true, -Dopensearch.transport.cname_in_publish_address=true, -Dtests.artifact=rest-api-spec, -Dtests.gradle=true, -Dtests.jvm.argline=-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m, -Dtests.logger.level=WARN, -Dtests.security.manager=true, -Dtests.seed=86BB942
FF1760033, -Dtests.task=:rest-api-spec:test, -XX:+HeapDumpOnOutOfMemoryError, -XX:TieredStopAtLevel=1, -XX:ReservedCodeCacheSize=64m, -esa, -XX:HeapDumpPath=/home/opensearch/rest-api-spec/build/heapdump, -javaagent:../../tmp/expandedArchives/org.jacoco.agent-0.8.8.jar_a33b649e552c51298e5a242c2f0d0e3c/jacocoagent.jar=destfile=../../jacoco
/test.exec,append=true,inclnolocationclasses=false,dumponexit=true,output=file,jmx=false, -Xms512m, -Xmx2g, -Dfile.encoding=UTF-8, -Djava.io.tmpdir=/home/opensearch/rest-api-spec/build/testrun/test/temp, -Duser.country=CA, -Duser.language=en, -Duser.variant, -ea]  
```

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/3973

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
