### PR TITLE
Add license headers to missed jenkins libraries

### DIFF
--- a/tests/jenkins/LibFunctionTester.groovy
+++ b/tests/jenkins/LibFunctionTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import jenkins.tests.BuildPipelineTest
 
 abstract class LibFunctionTester extends BuildPipelineTest {

--- a/tests/jenkins/TestCopyContainer.groovy
+++ b/tests/jenkins/TestCopyContainer.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import jenkins.tests.BuildPipelineTest
 import org.junit.*
 

--- a/tests/jenkins/TestCreateGithubIssue.groovy
+++ b/tests/jenkins/TestCreateGithubIssue.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 package jenkins.tests
 
 import jenkins.tests.BuildPipelineTest

--- a/tests/jenkins/TestPromoteContainer.groovy
+++ b/tests/jenkins/TestPromoteContainer.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test

--- a/tests/jenkins/TestSignStandaloneArtifactsJob.groovy
+++ b/tests/jenkins/TestSignStandaloneArtifactsJob.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test

--- a/tests/jenkins/TestUploadTestResults.groovy
+++ b/tests/jenkins/TestUploadTestResults.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test

--- a/tests/jenkins/TestUploadToS3.groovy
+++ b/tests/jenkins/TestUploadToS3.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test

--- a/tests/jenkins/lib-testers/AssembleManifestLibTester.groovy
+++ b/tests/jenkins/lib-testers/AssembleManifestLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/BuildFailureMessageLibTester.groovy
+++ b/tests/jenkins/lib-testers/BuildFailureMessageLibTester.groovy
@@ -1,5 +1,10 @@
-import static org.hamcrest.CoreMatchers.notNullValue
-import static org.hamcrest.MatcherAssert.assertThat
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 
 class BuildFailureMessageLibTester extends LibFunctionTester {
 

--- a/tests/jenkins/lib-testers/BuildInfoYamlLibTester.groovy
+++ b/tests/jenkins/lib-testers/BuildInfoYamlLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/BuildYumRepoTester.groovy
+++ b/tests/jenkins/lib-testers/BuildYumRepoTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/CreateGithubIssueLibTester.groovy
+++ b/tests/jenkins/lib-testers/CreateGithubIssueLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.CoreMatchers.nullValue
 import static org.hamcrest.MatcherAssert.assertThat

--- a/tests/jenkins/lib-testers/CreateReleaseTagLibTester.groovy
+++ b/tests/jenkins/lib-testers/CreateReleaseTagLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import jenkins.BundleManifest
 import org.yaml.snakeyaml.Yaml
 

--- a/tests/jenkins/lib-testers/CreateTestResultsMessageLibTester.groovy
+++ b/tests/jenkins/lib-testers/CreateTestResultsMessageLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 
@@ -20,7 +27,7 @@ class CreateTestResultsMessageLibTester extends LibFunctionTester {
 
     void configure(helper, binding) {
         binding.setVariable('STAGE_NAME', 'stage')
-        helper.registerAllowedMethod('findFiles', [Map.class], null)  
+        helper.registerAllowedMethod('findFiles', [Map.class], null)
     }
 
     void parameterInvariantsAssertions(call) {

--- a/tests/jenkins/lib-testers/DetectTestDockerAgentLibTester.groovy
+++ b/tests/jenkins/lib-testers/DetectTestDockerAgentLibTester.groovy
@@ -1,5 +1,10 @@
-import static org.hamcrest.CoreMatchers.notNullValue
-import static org.hamcrest.MatcherAssert.assertThat
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import org.yaml.snakeyaml.Yaml
 
 

--- a/tests/jenkins/lib-testers/DownloadBuildManifestLibTester.groovy
+++ b/tests/jenkins/lib-testers/DownloadBuildManifestLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 import org.yaml.snakeyaml.Yaml

--- a/tests/jenkins/lib-testers/DownloadFromS3LibTester.groovy
+++ b/tests/jenkins/lib-testers/DownloadFromS3LibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.CoreMatchers.anyOf

--- a/tests/jenkins/lib-testers/PrintArtifactDownloadUrlsForStagingLibTester.groovy
+++ b/tests/jenkins/lib-testers/PrintArtifactDownloadUrlsForStagingLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.core.IsNull.notNullValue
 

--- a/tests/jenkins/lib-testers/PublishNotificationLibTester.groovy
+++ b/tests/jenkins/lib-testers/PublishNotificationLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/RpmDashboardsDistValidationLibTester.groovy
+++ b/tests/jenkins/lib-testers/RpmDashboardsDistValidationLibTester.groovy
@@ -1,4 +1,11 @@
 
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/RpmMetaValidationLibTester.groovy
+++ b/tests/jenkins/lib-testers/RpmMetaValidationLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/RpmOpenSearchDistValidationLibTester.groovy
+++ b/tests/jenkins/lib-testers/RpmOpenSearchDistValidationLibTester.groovy
@@ -1,4 +1,10 @@
-
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/RunBwcTestScriptLibTest.groovy
+++ b/tests/jenkins/lib-testers/RunBwcTestScriptLibTest.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/RunGradleCheckLibTester.groovy
+++ b/tests/jenkins/lib-testers/RunGradleCheckLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/RunIntegTestScriptLibTest.groovy
+++ b/tests/jenkins/lib-testers/RunIntegTestScriptLibTest.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/RunPerfTestScriptLibTest.groovy
+++ b/tests/jenkins/lib-testers/RunPerfTestScriptLibTest.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/ScanDockerImageLibTester.groovy
+++ b/tests/jenkins/lib-testers/ScanDockerImageLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/SignArtifactsLibTester.groovy
+++ b/tests/jenkins/lib-testers/SignArtifactsLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/UploadIndexFileLibTester.groovy
+++ b/tests/jenkins/lib-testers/UploadIndexFileLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/UploadMinSnapshotsToS3LibTester.groovy
+++ b/tests/jenkins/lib-testers/UploadMinSnapshotsToS3LibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/UploadTestResultsLibTester.groovy
+++ b/tests/jenkins/lib-testers/UploadTestResultsLibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/lib-testers/UploadToS3LibTester.groovy
+++ b/tests/jenkins/lib-testers/UploadToS3LibTester.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/vars/archiveAssembleUpload.groovy
+++ b/vars/archiveAssembleUpload.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 def call(Map args = [:]) {
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
     def inputManifestObj = lib.jenkins.InputManifest.new(readYaml(file: args.inputManifest))

--- a/vars/assembleManifest.groovy
+++ b/vars/assembleManifest.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
     def buildManifest = lib.jenkins.BuildManifest.new(readYaml(file: args.buildManifest))

--- a/vars/assembleUpload.groovy
+++ b/vars/assembleUpload.groovy
@@ -1,4 +1,10 @@
-
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
 
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))

--- a/vars/buildArchive.groovy
+++ b/vars/buildArchive.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     def lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
     buildManifest(args)

--- a/vars/buildAssembleUpload.groovy
+++ b/vars/buildAssembleUpload.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 def call(Map args = [:]) {
     def lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
     def inputManifestObj = lib.jenkins.InputManifest.new(readYaml(file: args.inputManifest))

--- a/vars/buildDockerImage.groovy
+++ b/vars/buildDockerImage.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     def lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
     def inputManifest = lib.jenkins.InputManifest.new(readYaml(file: args.inputManifest))

--- a/vars/buildFailureMessage.groovy
+++ b/vars/buildFailureMessage.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 import com.cloudbees.groovy.cps.NonCPS
 import org.apache.commons.io.IOUtils
 @NonCPS
@@ -11,7 +18,7 @@ def call(){
     logContent.eachLine() { line ->
         line=line.replace("\"", "")
         //Gets the exact match for Error building
-        def java.util.regex.Matcher match = (line =~ /$ERROR_STRING.*/) 
+        def java.util.regex.Matcher match = (line =~ /$ERROR_STRING.*/)
         if (match.find()) {
             line=match[0]
             message.add(line)

--- a/vars/buildInfoYaml.groovy
+++ b/vars/buildInfoYaml.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 def call(Map args = [:]) {
 
     try {

--- a/vars/buildManifest.groovy
+++ b/vars/buildManifest.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     sh(([
         './build.sh',

--- a/vars/buildUploadManifestSHA.groovy
+++ b/vars/buildUploadManifestSHA.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
 

--- a/vars/buildYumRepo.groovy
+++ b/vars/buildYumRepo.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
 

--- a/vars/copyContainer.groovy
+++ b/vars/copyContainer.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 /**@
  * Copies a container from one docker registry to another
  *
@@ -23,7 +30,7 @@ void call(Map args = [:]) {
     if (args.destinationRegistry == 'public.ecr.aws/opensearchproject') {
         withCredentials([
             string(credentialsId: 'jenkins-artifact-promotion-role', variable: 'ARTIFACT_PROMOTION_ROLE_NAME'),
-            string(credentialsId: 'jenkins-aws-production-account', variable: 'AWS_ACCOUNT_ARTIFACT')]) 
+            string(credentialsId: 'jenkins-aws-production-account', variable: 'AWS_ACCOUNT_ARTIFACT')])
             {
                 withAWS(role: "${ARTIFACT_PROMOTION_ROLE_NAME}", roleAccount: "${AWS_ACCOUNT_ARTIFACT}", duration: 900, roleSessionName: 'jenkins-session') {
                     def ecrLogin = sh(returnStdout: true, script: "aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin ${args.destinationRegistry}").trim()

--- a/vars/createGithubIssue.groovy
+++ b/vars/createGithubIssue.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 def call(Map args = [:]){
     def failureMessages = args.message
     List<String> failedComponents = []

--- a/vars/createReleaseTag.groovy
+++ b/vars/createReleaseTag.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 def call(Map args = [:]) {
 
     def lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))

--- a/vars/createSha512Checksums.groovy
+++ b/vars/createSha512Checksums.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 Closure call() {
     allowedFileTypes = [".tar.gz", ".zip", ".rpm"]
 

--- a/vars/createSignatureFiles.groovy
+++ b/vars/createSignatureFiles.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 Closure call() {
 
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))

--- a/vars/createTestResultsMessage.groovy
+++ b/vars/createTestResultsMessage.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 def call(Map args = [:]) {
     String testType = args.testType
     String status = args.status

--- a/vars/detectDockerAgent.groovy
+++ b/vars/detectDockerAgent.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 Map call(Map args = [:]) {
     def lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
     String manifest = args.manifest ?: "manifests/${INPUT_MANIFEST}"
@@ -6,7 +13,7 @@ Map call(Map args = [:]) {
     dockerArgs = inputManifest.ci?.image?.args
     // Using default javaVersion as openjdk-17
     String javaVersion = 'openjdk-17'
-    java.util.regex.Matcher jdkMatch = (dockerArgs =~ /openjdk-\d+/) 
+    java.util.regex.Matcher jdkMatch = (dockerArgs =~ /openjdk-\d+/)
     if (jdkMatch.find()) {
         def jdkMatchLine = jdkMatch[0]
         javaVersion = jdkMatchLine

--- a/vars/detectTestDockerAgent.groovy
+++ b/vars/detectTestDockerAgent.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 Map call(Map args = [:]) {
     def lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
     String manifest = args.testManifest ?: "manifests/${TEST_MANIFEST}"

--- a/vars/downloadBuildManifest.groovy
+++ b/vars/downloadBuildManifest.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 def call(Map args = [:]) {
     def lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
 

--- a/vars/downloadFromS3.groovy
+++ b/vars/downloadFromS3.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
             withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {

--- a/vars/getManifestSHA.groovy
+++ b/vars/getManifestSHA.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 Map call(Map args = [:]) {
     String inputManifest = args.inputManifest ?: "manifests/${INPUT_MANIFEST}"
     String jobName = args.jobName ?: "${JOB_NAME}"

--- a/vars/postCleanup.groovy
+++ b/vars/postCleanup.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     cleanWs(disableDeferredWipeout: true, deleteDirs: true)
 }

--- a/vars/printArtifactDownloadUrlsForStaging.groovy
+++ b/vars/printArtifactDownloadUrlsForStaging.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]){
 
     for(filename in args.artifactFileNames){

--- a/vars/promoteContainer.groovy
+++ b/vars/promoteContainer.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 /**@
  * Promote image from staging docker to production docker hub or ECR repository.
  *

--- a/vars/publishNotification.groovy
+++ b/vars/publishNotification.groovy
@@ -1,6 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     text = ([
-        "${args.icon}", 
+        "${args.icon}",
         "JOB_NAME=${JOB_NAME}",
         "BUILD_NUMBER=[${BUILD_NUMBER}]",
         "MESSAGE=${args.message}",

--- a/vars/rpmCommands.groovy
+++ b/vars/rpmCommands.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 /**
  * This is a helper method for package manager yum call.
  * @param Map args = [:]

--- a/vars/rpmDashboardsDistValidation.groovy
+++ b/vars/rpmDashboardsDistValidation.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 /**
  * This is a general function for RPM distribution validation.
  * @param Map args = [:]

--- a/vars/rpmDistValidation.groovy
+++ b/vars/rpmDistValidation.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 /**
  * This is a general function for RPM distribution validation.
  * @param Map args = [:]

--- a/vars/rpmMetaValidation.groovy
+++ b/vars/rpmMetaValidation.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 /**
  * This is a general function for RPM distribution validation.
  * @param Map args = [:]

--- a/vars/rpmOpenSearchDistValidation.groovy
+++ b/vars/rpmOpenSearchDistValidation.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 /**
  * This is a general function for RPM distribution validation.
  * @param Map args = [:]

--- a/vars/runBwcTestScript.groovy
+++ b/vars/runBwcTestScript.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     String jobName = args.jobName ?: 'distribution-build-opensearch'
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
@@ -19,7 +26,7 @@ void call(Map args = [:]) {
 
 String generatePaths(buildManifest, artifactRootUrl) {
     String name = buildManifest.build.name
-    return name == 'OpenSearch' ? 
+    return name == 'OpenSearch' ?
         "opensearch=${artifactRootUrl}" :
         "opensearch-dashboards=${artifactRootUrl}"
 }

--- a/vars/runGradleCheck.groovy
+++ b/vars/runGradleCheck.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     def lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
     def git_repo_url = args.gitRepoUrl ?: 'null'

--- a/vars/runIntegTestScript.groovy
+++ b/vars/runIntegTestScript.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
 
@@ -33,11 +40,11 @@ String generatePaths(buildManifest, artifactRootUrl, localPath) {
     String platform = buildManifest.build.platform
     String architecture = buildManifest.build.architecture
     String distribution = buildManifest.build.distribution
-    
+
     String latestOpenSearchArtifactRootUrl = "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${version}/latest/${platform}/${architecture}/${distribution}"
     if (localPath.equals('None')) {
         echo "No localPath found, download from url"
-        return name == 'OpenSearch' ? 
+        return name == 'OpenSearch' ?
             "opensearch=${artifactRootUrl}" :
             "opensearch=${latestOpenSearchArtifactRootUrl} opensearch-dashboards=${artifactRootUrl}"
     }

--- a/vars/runPerfTestScript.groovy
+++ b/vars/runPerfTestScript.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
     def buildManifest = lib.jenkins.BuildManifest.new(readYaml(file: args.bundleManifest))

--- a/vars/scanDockerImage.groovy
+++ b/vars/scanDockerImage.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
 
     sh """

--- a/vars/signArtifacts.groovy
+++ b/vars/signArtifacts.groovy
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-/*
+/**
 SignArtifacts signs the given artifacts and saves the signature in the same directory
 @param Map[artifactPath] <Required> - Path to yml or artifact file.
 @param Map[component] <Optional> - Path to yml or artifact file.

--- a/vars/systemdCommands.groovy
+++ b/vars/systemdCommands.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 /**
  * This is a helper method for process manager systemD call.
  * @param Map args = [:]

--- a/vars/uploadArtifacts.groovy
+++ b/vars/uploadArtifacts.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     def lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
 

--- a/vars/uploadIndexFile.groovy
+++ b/vars/uploadIndexFile.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     def latestBuildData = ['latest': "${BUILD_NUMBER}"]
     writeJSON file: 'index.json', json: latestBuildData

--- a/vars/uploadMinSnapshotsToS3.groovy
+++ b/vars/uploadMinSnapshotsToS3.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     def lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
     List<Closure> fileActions = args.fileActions ?: []

--- a/vars/uploadTestResults.groovy
+++ b/vars/uploadTestResults.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     def lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
 

--- a/vars/uploadToS3.groovy
+++ b/vars/uploadToS3.groovy
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 void call(Map args = [:]) {
     withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
         withAWS(role: 'opensearch-bundle', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Some of the jenkins library files were missing license headers. This PR adds them.
This is in preparation to move jenkins shared libraries to new repo.

### Issues Resolved
Part of #2489 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
