### PR TITLE
[Release 2.2.1] Remove 2.2.1 manifests from cron

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -11,8 +11,6 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H/60 * * * * %INPUT_MANIFEST=2.2.1/opensearch-2.2.1.yml;TEST_MANIFEST=2.2.1/opensearch-2.2.1-test.yml;TARGET_JOB_NAME=distribution-build-opensearch
-            H/60 * * * * %INPUT_MANIFEST=2.2.1/opensearch-dashboards-2.2.1.yml;TEST_MANIFEST=2.2.1/opensearch-dashboards-2.2.1-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H 1 * * * %INPUT_MANIFEST=2.3.0/opensearch-dashboards-2.3.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards
             H 1 * * * %INPUT_MANIFEST=2.3.0/opensearch-2.3.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch


### PR DESCRIPTION
Signed-off-by: prudhvigodithi <pgodithi@amazon.com>

### Description
[Release 2.2.1] Remove 2.2.1 manifests from cron

### Issues Resolved
Part of: https://github.com/opensearch-project/opensearch-build/issues/2481

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
