### PR TITLE
Add AD plugins to 2.3 manifests

### DIFF
--- a/manifests/2.3.0/opensearch-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-2.3.0.yml
@@ -49,3 +49,9 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: anomaly-detection
+    repository: https://github.com/opensearch-project/anomaly-detection.git
+    ref: '2.3'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version

--- a/manifests/2.3.0/opensearch-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-2.3.0.yml
@@ -52,6 +52,8 @@ components:
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
     ref: '2.3'
+    platforms:
+      - linux
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/2.3.0/opensearch-dashboards-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-dashboards-2.3.0.yml
@@ -10,3 +10,6 @@ components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     ref: 2.x
+  - name: anomalyDetectionDashboards
+    repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
+    ref: '2.3'


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Add AD and AD dashboards plugins to 2.3 manifests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
