### PR TITLE
Change security ref from 2.x to 2.3

### DIFF
--- a/manifests/2.3.0/opensearch-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-2.3.0.yml
@@ -32,7 +32,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: 2.x
+    ref: '2.3'
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: '2.3'


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Changes ref for security from 2.x to 2.3 in 2.3.0 manifest

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
