### PR TITLE
Update ref from 2.x -> 2.3 for OpenSearch component

### DIFF
--- a/manifests/2.3.0/opensearch-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-2.3.0.yml
@@ -10,7 +10,7 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: 2.x
+    ref: '2.3'
     checks:
       - gradle:publish
       - gradle:properties:version


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Updates the ref to `2.3` branch in Opensearch

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/4357

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
