### PR TITLE
Add security-dashboards-plugin to 2.3.0 manifest

### DIFF
--- a/manifests/2.3.0/opensearch-dashboards-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-dashboards-2.3.0.yml
@@ -13,6 +13,9 @@ components:
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
     ref: '2.3'
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+    ref: '2.3'
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     ref: '2.3'


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Add security-dashboards-plugin to 2.3.0 manifest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
