### PR TITLE
Added index-management and dashboard plugin to 2.3 manifest files

### DIFF
--- a/manifests/2.3.0/opensearch-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-2.3.0.yml
@@ -141,3 +141,10 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
+  - name: index-management
+    repository: https://github.com/opensearch-project/index-management.git
+    ref: '2.3'
+    platforms:
+      - linux
+    checks:
+      - gradle:properties:version

--- a/manifests/2.3.0/opensearch-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-2.3.0.yml
@@ -141,7 +141,7 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
- - name: index-management
+  - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
     ref: '2.3'
     platforms:

--- a/manifests/2.3.0/opensearch-dashboards-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-dashboards-2.3.0.yml
@@ -46,3 +46,6 @@ components:
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
     ref: '2.3'
+  - name: indexManagementDashboards
+    repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
+    ref: '2.3'

--- a/manifests/2.3.0/opensearch-dashboards-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-dashboards-2.3.0.yml
@@ -48,6 +48,3 @@ components:
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
     ref: '2.3'
-  - name: indexManagementDashboards
-    repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
-    ref: '2.3'

--- a/manifests/2.3.0/opensearch-dashboards-2.3.0.yml
+++ b/manifests/2.3.0/opensearch-dashboards-2.3.0.yml
@@ -45,6 +45,7 @@ components:
     ref: '2.3'
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
+    ref: '2.3'
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
     ref: '2.3'


### PR DESCRIPTION
### Description
Added index-management and dashboard plugin to 2.3 manifest files

### Issues Resolved
https://github.com/opensearch-project/index-management/issues/481
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/242

Redirected from https://github.com/opensearch-project/opensearch-build/pull/2579

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
