### PR TITLE
Added scm checkout to support github issue creation in post failure block

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -694,6 +694,7 @@ pipeline {
         }
         failure {
             node(AGENT_X64) {
+                checkout scm
                 script {
                     if (params.PUBLISH_NOTIFICATION) {
                         publishNotification(


### PR DESCRIPTION


Signed-off-by: Rishabh Singh <sngri@amazon.com>

### Description
This PR adds step to checkout opensearch-build repo in the global post failure block. This is to make sure the manifest file is present when github issue creation workflow kicks in and tries to read the manifest file. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
