### PR TITLE
Add the with security test for reports scheduler/observability

### DIFF
--- a/manifests/2.3.0/opensearch-2.3.0-test.yml
+++ b/manifests/2.3.0/opensearch-2.3.0-test.yml
@@ -70,6 +70,7 @@ components:
     working-directory: opensearch-observability
     integ-test:
       test-configs:
+        - with-security
         - without-security
 
   - name: ml-commons

--- a/manifests/2.3.0/opensearch-2.3.0-test.yml
+++ b/manifests/2.3.0/opensearch-2.3.0-test.yml
@@ -63,6 +63,7 @@ components:
     working-directory: reports-scheduler
     integ-test:
       test-configs:
+        - with-security
         - without-security
 
   - name: opensearch-observability


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add the with security test for reports scheduler/observability.
Since @joshuali925 already created the security integTest implementation: 

https://github.com/opensearch-project/dashboards-reports/pull/354
https://github.com/opensearch-project/observability/pull/699

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/58

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
