### PR TITLE
Add job-scheduler to 2.4.0 manifest

### DIFF
--- a/manifests/2.4.0/opensearch-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-2.4.0.yml
@@ -59,3 +59,11 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: notifications
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: '2.x'
+    platforms:
+      - linux
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Adding job-scheduler 2.x branch to 2.4.0 manifest

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
