### PR TITLE
Update gradle file and add cron to verison increment workflow

### DIFF
--- a/.github/workflows/increment-plugin-versions.yml
+++ b/.github/workflows/increment-plugin-versions.yml
@@ -2,6 +2,8 @@
 name: Increment Plugin Versions
 
 on:
+  schedule:
+    - cron: 0 0 * * *
   workflow_dispatch:
     inputs:
       logLevel:

--- a/build.gradle
+++ b/build.gradle
@@ -57,15 +57,6 @@ sourceSets {
         }
     }
 
-    jobs {
-        groovy {
-            srcDirs 'src/jenkins/jobs'
-            compileClasspath += main.compileClasspath
-        }
-
-        compileClasspath += sourceSets.main.output
-        runtimeClasspath += sourceSets.main.output
-    }
 }
 
 sharedLibrary {
@@ -126,4 +117,8 @@ jacocoTestReport {
     reports {
         xml.required = true
     }
+}
+
+tasks.test {
+    maxParallelForks = Runtime.getRuntime().availableProcessors()
 }


### PR DESCRIPTION
Signed-off-by: prudhvigodithi <pgodithi@amazon.com>

### Description
Two changes being pushed with this PR:

- Update the gradle file `jobs` section clean thats not being used and add test tasks parallel execution, with this parallel execution all jenkins tests would run in parallel saving some time.
Note: There is no dependency of execution for each task, which are isolated and hence can be called parallel.

- Trigger version increment workflow with cron ` - cron: 0 0 * * *` (daily), so that all the branch entries part of the workflow are periodically checked if the version is different from core, if different it will [AUTO] raise a version increment PR
Note: There are chances, API limits might exceed, but this needs to be tested and we go through multiple runs 

### Issues Resolved
Part of: https://github.com/opensearch-project/opensearch-build/issues/1375

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
