### PR TITLE
Use non-deprecated args in Dashboards Docker image

### DIFF
--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint.sh
@@ -206,13 +206,13 @@ function runOpensearchDashboards {
     # paths. Therefore, OpenSearch-Dashboards provides a mechanism to override
     # reading the cgroup path from /proc/self/cgroup and instead uses the
     # cgroup path defined the configuration properties
-    # cpu.cgroup.path.override and cpuacct.cgroup.path.override.
+    # ops.cGroupOverrides.cpuPath and ops.cGroupOverrides.cpuAcctPath.
     # Therefore, we set this value here so that cgroup statistics are
     # available for the container this process will run in.
 
     exec "$@" \
-        --cpu.cgroup.path.override=/ \
-        --cpuacct.cgroup.path.override=/ \
+        --ops.cGroupOverrides.cpuPath=/ \
+        --ops.cGroupOverrides.cpuAcctPath=/ \
         "${longopts[@]}"
 }
 


### PR DESCRIPTION
### Description

Currently the OpenSearch Dashboards Docker entrypoint script passes the deprecated `cpu.cgroup.path.override` and `cpuacct.cgroup.path.override` arguments to Dashboards which causes deprecation warnings to be written to the container log at startup:

```
{"type":"log","@timestamp":"2022-09-15T08:36:49Z","tags":["warning","config","deprecation"],"pid":1,"message":"\"cpu.cgroup.path.override\" is deprecated and has been replaced by \"ops.cGroupOverrides.cpuPath\""}
{"type":"log","@timestamp":"2022-09-15T08:36:49Z","tags":["warning","config","deprecation"],"pid":1,"message":"\"cpuacct.cgroup.path.override\" is deprecated and has been replaced by \"ops.cGroupOverrides.cpuAcctPath\""}
```

This PR switches these out for the non-deprecated replacement arguments `ops.cGroupOverrides.cpuPath` and `ops.cGroupOverrides.cpuAcctPath`.

### Issues Resolved

N/A

-----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
