### PR TITLE
Restricting git issue creation to OpenSearch

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -49,10 +49,10 @@ pipeline {
             defaultValue: true
         )
         booleanParam(
-                    name: 'CREATE_GITHUB_ISSUE',
-                    description: 'To create a github issue for failing component or not.',
-                    defaultValue: false
-                )
+            name: 'CREATE_GITHUB_ISSUE',
+            description: 'To create a github issue for failing component or not.',
+            defaultValue: true
+        )
     }
     stages {
         stage('detect docker image + args') {

--- a/vars/createGithubIssue.groovy
+++ b/vars/createGithubIssue.groovy
@@ -27,7 +27,10 @@ def call(Map args = [:]){
             if (failedComponents.contains(component.name)) {
                 println("Component ${component.name} failed, creating github issue")
                 compIndex = failedComponents.indexOf(component.name)
-                create_issue(component.name, component.repository, currentVersion, failureMessages[compIndex])
+                if (component.name == "OpenSearch"){
+                    create_issue(component.name, component.repository, currentVersion, failureMessages[compIndex])
+                }
+                // create_issue(component.name, component.repository, currentVersion, failureMessages[compIndex])
                 sleep(time:3,unit:"SECONDS")
             }
         }

--- a/vars/createGithubIssue.groovy
+++ b/vars/createGithubIssue.groovy
@@ -27,10 +27,7 @@ def call(Map args = [:]){
             if (failedComponents.contains(component.name)) {
                 println("Component ${component.name} failed, creating github issue")
                 compIndex = failedComponents.indexOf(component.name)
-                if (component.name == "OpenSearch"){
-                    create_issue(component.name, component.repository, currentVersion, failureMessages[compIndex])
-                }
-                // create_issue(component.name, component.repository, currentVersion, failureMessages[compIndex])
+                create_issue(component.name, component.repository, currentVersion, failureMessages[compIndex])
                 sleep(time:3,unit:"SECONDS")
             }
         }


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>

### Description
As per discussion restricting github issue creation to one component on component failure during distribution build. Once we are sure that the solution is stable will enable for all components. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
