### PR TITLE
Update lib location on jenkins/ to the remote repository opensearch-build-libraries 

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/cross-cluster-replication/perf-test.jenkinsfile
+++ b/jenkins/cross-cluster-replication/perf-test.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211118", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
+++ b/jenkins/data-prepper/release-data-prepper-all-artifacts.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/docker/docker-copy.jenkinsfile
+++ b/jenkins/docker/docker-copy.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/docker/docker-scan.jenkinsfile
+++ b/jenkins/docker/docker-scan.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211118", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211118", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/opensearch-maven-release/maven-sign-release.jenkinsfile
+++ b/jenkins/opensearch-maven-release/maven-sign-release.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent {

--- a/jenkins/opensearch-ruby/opensearch-ruby.jenkinsfile
+++ b/jenkins/opensearch-ruby/opensearch-ruby.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/opensearch/bwc-test.jenkinsfile
+++ b/jenkins/opensearch/bwc-test.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211118", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211118", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211118", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/jenkins/promotion/promote-artifacts.jenkinsfile
+++ b/jenkins/promotion/promote-artifacts.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/promotion/promote-docker-ecr.jenkinsfile
+++ b/jenkins/promotion/promote-docker-ecr.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/promotion/promote-yum-repos.jenkinsfile
+++ b/jenkins/promotion/promote-yum-repos.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/release-notes-check/release-notes-check.jenkinsfile
+++ b/jenkins/release-notes-check/release-notes-check.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/release-tag/release-tag.jenkinsfile
+++ b/jenkins/release-tag/release-tag.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     options {

--- a/jenkins/rpm-validation/rpm-validation.jenkinsfile
+++ b/jenkins/rpm-validation/rpm-validation.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
+++ b/jenkins/sign-artifacts/sign-standalone-artifacts.jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent {

--- a/tests/jenkins/BuildPipelineTest.groovy
+++ b/tests/jenkins/BuildPipelineTest.groovy
@@ -10,7 +10,6 @@ package jenkins.tests
 
 import org.junit.*
 import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
-// import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
 import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 import com.lesfurets.jenkins.unit.*
 import org.yaml.snakeyaml.Yaml

--- a/tests/jenkins/BuildPipelineTest.groovy
+++ b/tests/jenkins/BuildPipelineTest.groovy
@@ -11,6 +11,7 @@ package jenkins.tests
 import org.junit.*
 import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
 import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 import com.lesfurets.jenkins.unit.*
 import org.yaml.snakeyaml.Yaml
 
@@ -36,11 +37,11 @@ abstract class BuildPipelineTest extends CommonPipelineTest {
 
         helper.registerSharedLibrary(
             library().name('jenkins')
-                .defaultVersion('<notNeeded>')
+                .defaultVersion('1.0.0')
                 .allowOverride(true)
                 .implicit(true)
-                .targetPath('<notNeeded>')
-                .retriever(projectSource())
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
                 .build()
             )
 
@@ -51,6 +52,8 @@ abstract class BuildPipelineTest extends CommonPipelineTest {
         binding.setVariable('scm', {})
 
         helper.registerAllowedMethod("legacySCM", [Closure.class], null)
+        
+        helper.registerAllowedMethod("modernSCM", [Map.class], null)
 
         helper.registerAllowedMethod("library", [Map.class], { Map args ->
             helper.getLibLoader().loadLibrary(args["identifier"])

--- a/tests/jenkins/BuildPipelineTest.groovy
+++ b/tests/jenkins/BuildPipelineTest.groovy
@@ -10,7 +10,7 @@ package jenkins.tests
 
 import org.junit.*
 import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
-import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
+// import static com.lesfurets.jenkins.unit.global.lib.ProjectSource.projectSource
 import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 import com.lesfurets.jenkins.unit.*
 import org.yaml.snakeyaml.Yaml
@@ -37,7 +37,7 @@ abstract class BuildPipelineTest extends CommonPipelineTest {
 
         helper.registerSharedLibrary(
             library().name('jenkins')
-                .defaultVersion('1.0.0')
+                .defaultVersion('main')
                 .allowOverride(true)
                 .implicit(true)
                 .targetPath('vars')

--- a/tests/jenkins/TestCCRPerfTest.groovy
+++ b/tests/jenkins/TestCCRPerfTest.groovy
@@ -15,8 +15,12 @@ import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.MatcherAssert.assertThat
 
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
+
 class TestCCRPerfTest extends BuildPipelineTest {
 
+    @Override   
     @Before
     void setUp() {
         this.registerLibTester(new RunPerfTestScriptLibTester(
@@ -29,6 +33,16 @@ class TestCCRPerfTest extends BuildPipelineTest {
             true
         ))
         super.setUp()
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestCopyContainer.groovy
+++ b/tests/jenkins/TestCopyContainer.groovy
@@ -7,14 +7,18 @@
  */
 import jenkins.tests.BuildPipelineTest
 import org.junit.*
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 
 class TestCopyContainer extends BuildPipelineTest {
 
     String sourceImage = 'alpine:3.15.4'
     String destinationImage = 'alpine:3.15.4'
 
+    @Override
     @Before
     void setUp() {
+
         binding.setVariable('DOCKER_USERNAME', 'dummy_docker_username')
         binding.setVariable('DOCKER_PASSWORD', 'dummy_docker_password')
         binding.setVariable('ARTIFACT_PROMOTION_ROLE_NAME', 'sample-agent-AssumeRole')
@@ -23,6 +27,15 @@ class TestCopyContainer extends BuildPipelineTest {
         helper.registerAllowedMethod('withAWS', [Map, Closure], null)
         super.setUp()
 
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestDataPrepperReleaseArtifacts.groovy
+++ b/tests/jenkins/TestDataPrepperReleaseArtifacts.groovy
@@ -14,10 +14,14 @@ import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.notNullValue
 import static org.hamcrest.MatcherAssert.assertThat
 
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
+
 class TestDataPrepperReleaseArtifacts extends BuildPipelineTest {
 
     private String version
 
+    @Override
     @Before
     void setUp() {
 
@@ -45,6 +49,16 @@ class TestDataPrepperReleaseArtifacts extends BuildPipelineTest {
         })
 
         helper.registerAllowedMethod('s3Upload', [Map], {})
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestMavenSignReleaseJob.groovy
+++ b/tests/jenkins/TestMavenSignReleaseJob.groovy
@@ -7,9 +7,12 @@
 import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 
 class TestMavenSignReleaseJob extends BuildPipelineTest {
 
+    @Override
     @Before
     void setUp() {
 
@@ -35,6 +38,16 @@ class TestMavenSignReleaseJob extends BuildPipelineTest {
         binding.setVariable('SONATYPE_STAGING_PROFILE_ID', 'dummy_id')
 
         helper.registerAllowedMethod('checkout', [Map], {})
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
 
     }
 

--- a/tests/jenkins/TestOpenSearchBwcTest.groovy
+++ b/tests/jenkins/TestOpenSearchBwcTest.groovy
@@ -8,9 +8,12 @@ import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test
 import org.yaml.snakeyaml.Yaml
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 
 class TestOpenSearchBwcTest extends BuildPipelineTest {
 
+    @Override
     @Before
     void setUp() {
         def jobName = "dummy_job"
@@ -48,6 +51,16 @@ class TestOpenSearchBwcTest extends BuildPipelineTest {
         })
 
         helper.registerAllowedMethod('findFiles', [Map.class], null)
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestOpenSearchDashboardsBwcTest.groovy
+++ b/tests/jenkins/TestOpenSearchDashboardsBwcTest.groovy
@@ -8,9 +8,12 @@ import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test
 import org.yaml.snakeyaml.Yaml
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 
 class TestOpenSearchDashboardsBwcTest extends BuildPipelineTest {
 
+    @Override
     @Before
     void setUp() {
         def jobName = "dummy_job"
@@ -48,6 +51,16 @@ class TestOpenSearchDashboardsBwcTest extends BuildPipelineTest {
         })
 
         helper.registerAllowedMethod('findFiles', [Map.class], null)
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestOpenSearchDashboardsIntegTest.groovy
+++ b/tests/jenkins/TestOpenSearchDashboardsIntegTest.groovy
@@ -8,9 +8,12 @@ import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test
 import org.yaml.snakeyaml.Yaml
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 
 class TestOpenSearchDashboardsIntegTest extends BuildPipelineTest {
 
+    @Override
     @Before
     void setUp() {
         def jobName = "dummy_job"
@@ -49,6 +52,16 @@ class TestOpenSearchDashboardsIntegTest extends BuildPipelineTest {
 
         helper.registerAllowedMethod('findFiles', [Map.class], null)
         helper.registerAllowedMethod('unstash', [String.class], null)
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestOpenSearchIntegTest.groovy
+++ b/tests/jenkins/TestOpenSearchIntegTest.groovy
@@ -8,9 +8,12 @@ import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test
 import org.yaml.snakeyaml.Yaml
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 
 class TestOpenSearchIntegTest extends BuildPipelineTest {
 
+    @Override
     @Before
     void setUp() {
         def jobName = "dummy_job"
@@ -58,6 +61,16 @@ class TestOpenSearchIntegTest extends BuildPipelineTest {
         helper.registerAllowedMethod('fileExists', [String.class], { args ->
             return true;
         })
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestPromoteContainer.groovy
+++ b/tests/jenkins/TestPromoteContainer.groovy
@@ -8,12 +8,15 @@
 import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 
 class TestPromoteContainer extends BuildPipelineTest {
 
     String PROMOTE_PRODUCT = 'opensearch:2.0.1.2901, opensearch-dashboards:2.0.1-2345, data-prepper:2.0.1.123'
     String RELEASE_VERSION = '2.0.1'
 
+    @Override
     @Before
     void setUp() {
         binding.setVariable('SOURCE_IMAGES', PROMOTE_PRODUCT)
@@ -27,6 +30,16 @@ class TestPromoteContainer extends BuildPipelineTest {
 
         helper.registerAllowedMethod('withAWS', [Map, Closure], null)
         super.setUp()
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
 
     }
 

--- a/tests/jenkins/TestReleaseTagDashboardsJob.groovy
+++ b/tests/jenkins/TestReleaseTagDashboardsJob.groovy
@@ -7,9 +7,12 @@
 import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 
 class TestReleaseTagDashboardsJob extends BuildPipelineTest {
 
+    @Override
     @Before
     void setUp() {
 
@@ -23,6 +26,16 @@ class TestReleaseTagDashboardsJob extends BuildPipelineTest {
         binding.setVariable('VERSION', '2.0.0-rc1')
         binding.setVariable('PRODUCT', 'opensearch-dashboards')
         binding.setVariable('DISTRIBUTION_MANIFEST', distManifest)
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
 
     }
 

--- a/tests/jenkins/TestReleaseTagJob.groovy
+++ b/tests/jenkins/TestReleaseTagJob.groovy
@@ -7,9 +7,12 @@
 import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 
 class TestReleaseTagJob extends BuildPipelineTest {
 
+    @Override
     @Before
     void setUp() {
 
@@ -24,6 +27,15 @@ class TestReleaseTagJob extends BuildPipelineTest {
         binding.setVariable('PRODUCT', 'opensearch')
         binding.setVariable('DISTRIBUTION_MANIFEST', distManifest)
 
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
+++ b/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
@@ -15,8 +15,12 @@ import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.MatcherAssert.assertThat
 
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
+
 class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
 
+    @Override
     @Before
     void setUp() {
         this.registerLibTester(new RunPerfTestScriptLibTester(
@@ -29,6 +33,16 @@ class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
             false
         ))
         super.setUp()
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestRunPerfTestScript.groovy
+++ b/tests/jenkins/TestRunPerfTestScript.groovy
@@ -15,8 +15,12 @@ import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.MatcherAssert.assertThat
 
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
+
 class TestRunPerfTestScript extends BuildPipelineTest {
 
+    @Override
     @Before
     void setUp() {
         this.registerLibTester(new RunPerfTestScriptLibTester(
@@ -29,6 +33,16 @@ class TestRunPerfTestScript extends BuildPipelineTest {
             true
         ))
         super.setUp()
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestSignStandaloneArtifactsJob.groovy
+++ b/tests/jenkins/TestSignStandaloneArtifactsJob.groovy
@@ -8,9 +8,12 @@
 import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
 
 class TestSignStandaloneArtifactsJob extends BuildPipelineTest {
 
+    @Override
     @Before
     void setUp() {
 
@@ -35,6 +38,16 @@ class TestSignStandaloneArtifactsJob extends BuildPipelineTest {
         binding.setVariable('S3_FILE_UPLOAD_PATH', '/dummy/upload/path/')
         binding.setVariable('DISTRIBUTION_PLATFORM', platform)
         binding.setVariable('SIGNATURE_TYPE', sigtype)
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/jenkinsjob-regression-files/cross-cluster-replication/perf-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/cross-cluster-replication/perf-test.jenkinsfile.txt
@@ -1,6 +1,6 @@
    perf-test.run()
-      perf-test.legacySCM(groovy.lang.Closure)
-      perf-test.library({identifier=jenkins@20211118, retriever=null})
+      perf-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      perf-test.library({identifier=jenkins@1.0.0, retriever=null})
       perf-test.pipeline(groovy.lang.Closure)
          perf-test.timeout({time=10, unit=HOURS})
          perf-test.echo(Executing on agent [label:none])

--- a/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/data-prepper/release-data-prepper-all-artifacts.jenkinsfile.txt
@@ -1,6 +1,6 @@
    release-data-prepper-all-artifacts.run()
-      release-data-prepper-all-artifacts.legacySCM(groovy.lang.Closure)
-      release-data-prepper-all-artifacts.library({identifier=jenkins@20211123, retriever=null})
+      release-data-prepper-all-artifacts.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      release-data-prepper-all-artifacts.library({identifier=jenkins@1.0.0, retriever=null})
       release-data-prepper-all-artifacts.pipeline(groovy.lang.Closure)
          release-data-prepper-all-artifacts.credentials(jenkins-data-prepper-artifact-staging-site)
          release-data-prepper-all-artifacts.credentials(jenkins-data-prepper-staging-container-repository)

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerDockerProdtoEcrProd.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerDockerProdtoEcrProd.jenkinsfile.txt
@@ -1,6 +1,6 @@
    docker-copy.run()
-      docker-copy.legacySCM(groovy.lang.Closure)
-      docker-copy.library({identifier=jenkins@20211123, retriever=null})
+      docker-copy.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      docker-copy.library({identifier=jenkins@1.0.0, retriever=null})
       docker-copy.pipeline(groovy.lang.Closure)
          docker-copy.timeout({time=30})
          docker-copy.echo(Executing on agent [label:none])
@@ -14,10 +14,7 @@
                   copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                      copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                        copyContainer.sh(
-                        gcrane cp opensearchproject/alpine:3.15.4 public.ecr.aws/opensearchproject/alpine:3.15.4
-                        docker logout public.ecr.aws/opensearchproject
-                    )
+                        copyContainer.sh(gcrane cp opensearchproject/alpine:3.15.4 public.ecr.aws/opensearchproject/alpine:3.15.4; docker logout public.ecr.aws/opensearchproject)
          docker-copy.script(groovy.lang.Closure)
             docker-copy.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerDockerStagingToDockerProd.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerDockerStagingToDockerProd.jenkinsfile.txt
@@ -1,6 +1,6 @@
    docker-copy.run()
-      docker-copy.legacySCM(groovy.lang.Closure)
-      docker-copy.library({identifier=jenkins@20211123, retriever=null})
+      docker-copy.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      docker-copy.library({identifier=jenkins@1.0.0, retriever=null})
       docker-copy.pipeline(groovy.lang.Closure)
          docker-copy.timeout({time=30})
          docker-copy.echo(Executing on agent [label:none])
@@ -12,10 +12,7 @@
                   copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                   copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                      copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                     copyContainer.sh(
-                gcrane cp opensearchstaging/alpine:3.15.4 opensearchproject/alpine:3.15.4
-                docker logout
-            )
+                     copyContainer.sh(gcrane cp opensearchstaging/alpine:3.15.4 opensearchproject/alpine:3.15.4; docker logout)
          docker-copy.script(groovy.lang.Closure)
             docker-copy.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerDockerStagingToEcrProd.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerDockerStagingToEcrProd.jenkinsfile.txt
@@ -1,6 +1,6 @@
    docker-copy.run()
-      docker-copy.legacySCM(groovy.lang.Closure)
-      docker-copy.library({identifier=jenkins@20211123, retriever=null})
+      docker-copy.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      docker-copy.library({identifier=jenkins@1.0.0, retriever=null})
       docker-copy.pipeline(groovy.lang.Closure)
          docker-copy.timeout({time=30})
          docker-copy.echo(Executing on agent [label:none])
@@ -14,10 +14,7 @@
                   copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                      copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                        copyContainer.sh(
-                        gcrane cp opensearchstaging/alpine:3.15.4 public.ecr.aws/opensearchproject/alpine:3.15.4
-                        docker logout public.ecr.aws/opensearchproject
-                    )
+                        copyContainer.sh(gcrane cp opensearchstaging/alpine:3.15.4 public.ecr.aws/opensearchproject/alpine:3.15.4; docker logout public.ecr.aws/opensearchproject)
          docker-copy.script(groovy.lang.Closure)
             docker-copy.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerDockerStagingtoEcrStaging.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerDockerStagingtoEcrStaging.jenkinsfile.txt
@@ -1,6 +1,6 @@
    docker-copy.run()
-      docker-copy.legacySCM(groovy.lang.Closure)
-      docker-copy.library({identifier=jenkins@20211123, retriever=null})
+      docker-copy.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      docker-copy.library({identifier=jenkins@1.0.0, retriever=null})
       docker-copy.pipeline(groovy.lang.Closure)
          docker-copy.timeout({time=30})
          docker-copy.echo(Executing on agent [label:none])
@@ -10,10 +10,7 @@
             docker-copy.script(groovy.lang.Closure)
                docker-copy.copyContainer({sourceImage=alpine:3.15.4, sourceRegistry=opensearchstaging, destinationImage=alpine:3.15.4, destinationRegistry=public.ecr.aws/opensearchstaging})
                   copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchstaging})
-                  copyContainer.sh(
-                 gcrane cp opensearchstaging/alpine:3.15.4 public.ecr.aws/opensearchstaging/alpine:3.15.4
-                 docker logout public.ecr.aws/opensearchstaging
-            )
+                  copyContainer.sh(gcrane cp opensearchstaging/alpine:3.15.4 public.ecr.aws/opensearchstaging/alpine:3.15.4; docker logout public.ecr.aws/opensearchstaging)
          docker-copy.script(groovy.lang.Closure)
             docker-copy.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerECRStagingtoDockerProd.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerECRStagingtoDockerProd.jenkinsfile.txt
@@ -1,6 +1,6 @@
    docker-copy.run()
-      docker-copy.legacySCM(groovy.lang.Closure)
-      docker-copy.library({identifier=jenkins@20211123, retriever=null})
+      docker-copy.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      docker-copy.library({identifier=jenkins@1.0.0, retriever=null})
       docker-copy.pipeline(groovy.lang.Closure)
          docker-copy.timeout({time=30})
          docker-copy.echo(Executing on agent [label:none])
@@ -12,10 +12,7 @@
                   copyContainer.usernamePassword({credentialsId=jenkins-production-dockerhub-credential, usernameVariable=DOCKER_USERNAME, passwordVariable=DOCKER_PASSWORD})
                   copyContainer.withCredentials([[DOCKER_USERNAME, DOCKER_PASSWORD]], groovy.lang.Closure)
                      copyContainer.sh({returnStdout=true, script=echo DOCKER_PASSWORD | docker login --username DOCKER_USERNAME --password-stdin})
-                     copyContainer.sh(
-                gcrane cp public.ecr.aws/opensearchstaging/alpine:3.15.4 opensearchproject/alpine:3.15.4
-                docker logout
-            )
+                     copyContainer.sh(gcrane cp public.ecr.aws/opensearchstaging/alpine:3.15.4 opensearchproject/alpine:3.15.4; docker logout)
          docker-copy.script(groovy.lang.Closure)
             docker-copy.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerEcrStagingtoEcrProd.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-copy-testCopyContainerEcrStagingtoEcrProd.jenkinsfile.txt
@@ -1,6 +1,6 @@
    docker-copy.run()
-      docker-copy.legacySCM(groovy.lang.Closure)
-      docker-copy.library({identifier=jenkins@20211123, retriever=null})
+      docker-copy.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      docker-copy.library({identifier=jenkins@1.0.0, retriever=null})
       docker-copy.pipeline(groovy.lang.Closure)
          docker-copy.timeout({time=30})
          docker-copy.echo(Executing on agent [label:none])
@@ -14,10 +14,7 @@
                   copyContainer.withCredentials([ARTIFACT_PROMOTION_ROLE_NAME, AWS_ACCOUNT_ARTIFACT], groovy.lang.Closure)
                      copyContainer.withAWS({role=ARTIFACT_PROMOTION_ROLE_NAME, roleAccount=AWS_ACCOUNT_ARTIFACT, duration=900, roleSessionName=jenkins-session}, groovy.lang.Closure)
                         copyContainer.sh({returnStdout=true, script=aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/opensearchproject})
-                        copyContainer.sh(
-                        gcrane cp public.ecr.aws/opensearchstaging/alpine:3.15.4 public.ecr.aws/opensearchproject/alpine:3.15.4
-                        docker logout public.ecr.aws/opensearchproject
-                    )
+                        copyContainer.sh(gcrane cp public.ecr.aws/opensearchstaging/alpine:3.15.4 public.ecr.aws/opensearchproject/alpine:3.15.4; docker logout public.ecr.aws/opensearchproject)
          docker-copy.script(groovy.lang.Closure)
             docker-copy.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/maven-sign-release/maven-sign-release.jenkinsfile.txt
@@ -1,6 +1,6 @@
    maven-sign-release.run()
-      maven-sign-release.legacySCM(groovy.lang.Closure)
-      maven-sign-release.library({identifier=jenkins@20211123, retriever=null})
+      maven-sign-release.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      maven-sign-release.library({identifier=jenkins@1.0.0, retriever=null})
       maven-sign-release.pipeline(groovy.lang.Closure)
          maven-sign-release.credentials(jenkins-artifact-bucket-name)
          maven-sign-release.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211130, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/bwc-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/bwc-test.jenkinsfile.txt
@@ -1,6 +1,6 @@
    bwc-test.run()
-      bwc-test.legacySCM(groovy.lang.Closure)
-      bwc-test.library({identifier=jenkins@20211118, retriever=null})
+      bwc-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      bwc-test.library({identifier=jenkins@1.0.0, retriever=null})
       bwc-test.pipeline(groovy.lang.Closure)
          bwc-test.timeout({time=3, unit=HOURS})
          bwc-test.echo(Executing on agent [label:none])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
@@ -1,6 +1,6 @@
    integ-test.run()
-      integ-test.legacySCM(groovy.lang.Closure)
-      integ-test.library({identifier=jenkins@20211118, retriever=null})
+      integ-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      integ-test.library({identifier=jenkins@1.0.0, retriever=null})
       integ-test.pipeline(groovy.lang.Closure)
          integ-test.timeout({time=3, unit=HOURS})
          integ-test.echo(Executing on agent [label:none])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/bwc-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/bwc-test.jenkinsfile.txt
@@ -1,6 +1,6 @@
    bwc-test.run()
-      bwc-test.legacySCM(groovy.lang.Closure)
-      bwc-test.library({identifier=jenkins@20211118, retriever=null})
+      bwc-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      bwc-test.library({identifier=jenkins@1.0.0, retriever=null})
       bwc-test.pipeline(groovy.lang.Closure)
          bwc-test.timeout({time=3, unit=HOURS})
          bwc-test.echo(Executing on agent [label:none])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
@@ -1,6 +1,6 @@
    integ-test.run()
-      integ-test.legacySCM(groovy.lang.Closure)
-      integ-test.library({identifier=jenkins@20211118, retriever=null})
+      integ-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      integ-test.library({identifier=jenkins@1.0.0, retriever=null})
       integ-test.pipeline(groovy.lang.Closure)
          integ-test.credentials(jenkins-artifact-bucket-name)
          integ-test.timeout({time=3, unit=HOURS})

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test-with-security.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test-with-security.jenkinsfile.txt
@@ -1,6 +1,6 @@
    perf-test.run()
-      perf-test.legacySCM(groovy.lang.Closure)
-      perf-test.library({identifier=jenkins@20211118, retriever=null})
+      perf-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      perf-test.library({identifier=jenkins@1.0.0, retriever=null})
       perf-test.pipeline(groovy.lang.Closure)
          perf-test.timeout({time=15, unit=HOURS})
          perf-test.echo(Executing on agent [label:none])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test.jenkinsfile.txt
@@ -1,6 +1,6 @@
    perf-test.run()
-      perf-test.legacySCM(groovy.lang.Closure)
-      perf-test.library({identifier=jenkins@20211118, retriever=null})
+      perf-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      perf-test.library({identifier=jenkins@1.0.0, retriever=null})
       perf-test.pipeline(groovy.lang.Closure)
          perf-test.timeout({time=15, unit=HOURS})
          perf-test.echo(Executing on agent [label:none])

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDocker.jenkinsfile.txt
@@ -1,6 +1,6 @@
    promote-docker-ecr.run()
-      promote-docker-ecr.legacySCM(groovy.lang.Closure)
-      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      promote-docker-ecr.library({identifier=jenkins@1.0.0, retriever=null})
       promote-docker-ecr.pipeline(groovy.lang.Closure)
          promote-docker-ecr.timeout({time=1, unit=HOURS})
          promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerECRLatestMajor.jenkinsfile.txt
@@ -1,6 +1,6 @@
    promote-docker-ecr.run()
-      promote-docker-ecr.legacySCM(groovy.lang.Closure)
-      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      promote-docker-ecr.library({identifier=jenkins@1.0.0, retriever=null})
       promote-docker-ecr.pipeline(groovy.lang.Closure)
          promote-docker-ecr.timeout({time=1, unit=HOURS})
          promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatest.jenkinsfile.txt
@@ -1,6 +1,6 @@
    promote-docker-ecr.run()
-      promote-docker-ecr.legacySCM(groovy.lang.Closure)
-      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      promote-docker-ecr.library({identifier=jenkins@1.0.0, retriever=null})
       promote-docker-ecr.pipeline(groovy.lang.Closure)
          promote-docker-ecr.timeout({time=1, unit=HOURS})
          promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerLatestMajor.jenkinsfile.txt
@@ -1,6 +1,6 @@
    promote-docker-ecr.run()
-      promote-docker-ecr.legacySCM(groovy.lang.Closure)
-      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      promote-docker-ecr.library({identifier=jenkins@1.0.0, retriever=null})
       promote-docker-ecr.pipeline(groovy.lang.Closure)
          promote-docker-ecr.timeout({time=1, unit=HOURS})
          promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToDockerMajor.jenkinsfile.txt
@@ -1,6 +1,6 @@
    promote-docker-ecr.run()
-      promote-docker-ecr.legacySCM(groovy.lang.Closure)
-      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      promote-docker-ecr.library({identifier=jenkins@1.0.0, retriever=null})
       promote-docker-ecr.pipeline(groovy.lang.Closure)
          promote-docker-ecr.timeout({time=1, unit=HOURS})
          promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/promote-container/promote-container-testPromoteContainerToECRLatestMajor.jenkinsfile.txt
@@ -1,6 +1,6 @@
    promote-docker-ecr.run()
-      promote-docker-ecr.legacySCM(groovy.lang.Closure)
-      promote-docker-ecr.library({identifier=jenkins@20211123, retriever=null})
+      promote-docker-ecr.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      promote-docker-ecr.library({identifier=jenkins@1.0.0, retriever=null})
       promote-docker-ecr.pipeline(groovy.lang.Closure)
          promote-docker-ecr.timeout({time=1, unit=HOURS})
          promote-docker-ecr.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:false, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])

--- a/tests/jenkins/jenkinsjob-regression-files/release-tag/release-tag-dashboards.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-tag/release-tag-dashboards.jenkinsfile.txt
@@ -1,6 +1,6 @@
    release-tag.run()
-      release-tag.legacySCM(groovy.lang.Closure)
-      release-tag.library({identifier=jenkins@20211123, retriever=null})
+      release-tag.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      release-tag.library({identifier=jenkins@1.0.0, retriever=null})
       release-tag.pipeline(groovy.lang.Closure)
          release-tag.timeout({time=2, unit=HOURS})
          release-tag.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211130, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])

--- a/tests/jenkins/jenkinsjob-regression-files/release-tag/release-tag.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-tag/release-tag.jenkinsfile.txt
@@ -1,6 +1,6 @@
    release-tag.run()
-      release-tag.legacySCM(groovy.lang.Closure)
-      release-tag.library({identifier=jenkins@20211123, retriever=null})
+      release-tag.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      release-tag.library({identifier=jenkins@1.0.0, retriever=null})
       release-tag.pipeline(groovy.lang.Closure)
          release-tag.timeout({time=2, unit=HOURS})
          release-tag.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211130, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])

--- a/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt
@@ -1,6 +1,6 @@
    sign-standalone-artifacts.run()
-      sign-standalone-artifacts.legacySCM(groovy.lang.Closure)
-      sign-standalone-artifacts.library({identifier=jenkins@20211123, retriever=null})
+      sign-standalone-artifacts.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      sign-standalone-artifacts.library({identifier=jenkins@1.0.0, retriever=null})
       sign-standalone-artifacts.pipeline(groovy.lang.Closure)
          sign-standalone-artifacts.credentials(jenkins-artifact-bucket-name)
          sign-standalone-artifacts.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v2, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])

--- a/tests/jenkins/jobs/AssembleManifest_rpm_Jenkinsfile
+++ b/tests/jenkins/jobs/AssembleManifest_rpm_Jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/AssembleManifest_rpm_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/AssembleManifest_rpm_Jenkinsfile.txt
@@ -1,6 +1,6 @@
    AssembleManifest_rpm_Jenkinsfile.run()
-      AssembleManifest_rpm_Jenkinsfile.legacySCM(groovy.lang.Closure)
-      AssembleManifest_rpm_Jenkinsfile.library({identifier=jenkins@20211123, retriever=null})
+      AssembleManifest_rpm_Jenkinsfile.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      AssembleManifest_rpm_Jenkinsfile.library({identifier=jenkins@1.0.0, retriever=null})
       AssembleManifest_rpm_Jenkinsfile.pipeline(groovy.lang.Closure)
          AssembleManifest_rpm_Jenkinsfile.echo(Executing on agent [label:none])
          AssembleManifest_rpm_Jenkinsfile.stage(assembleManifest rpm, groovy.lang.Closure)

--- a/tests/jenkins/jobs/AssembleManifest_tar_Jenkinsfile
+++ b/tests/jenkins/jobs/AssembleManifest_tar_Jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/AssembleManifest_tar_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/AssembleManifest_tar_Jenkinsfile.txt
@@ -1,6 +1,6 @@
    AssembleManifest_tar_Jenkinsfile.run()
-      AssembleManifest_tar_Jenkinsfile.legacySCM(groovy.lang.Closure)
-      AssembleManifest_tar_Jenkinsfile.library({identifier=jenkins@20211123, retriever=null})
+      AssembleManifest_tar_Jenkinsfile.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      AssembleManifest_tar_Jenkinsfile.library({identifier=jenkins@1.0.0, retriever=null})
       AssembleManifest_tar_Jenkinsfile.pipeline(groovy.lang.Closure)
          AssembleManifest_tar_Jenkinsfile.echo(Executing on agent [label:none])
          AssembleManifest_tar_Jenkinsfile.stage(assembleManifest tar, groovy.lang.Closure)

--- a/tests/jenkins/jobs/BuildManifest_Jenkinsfile
+++ b/tests/jenkins/jobs/BuildManifest_Jenkinsfile
@@ -6,7 +6,10 @@
  * compatible open source license.
  */
 
-def lib = library("jenkins")
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/BuildManifest_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/BuildManifest_Jenkinsfile.txt
@@ -1,5 +1,6 @@
    BuildManifest_Jenkinsfile.run()
-      BuildManifest_Jenkinsfile.library(jenkins)
+      BuildManifest_Jenkinsfile.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      BuildManifest_Jenkinsfile.library({identifier=jenkins@1.0.0, retriever=null})
       BuildManifest_Jenkinsfile.pipeline(groovy.lang.Closure)
          BuildManifest_Jenkinsfile.echo(Executing on agent [label:none])
          BuildManifest_Jenkinsfile.stage(Build Manifest Properties, groovy.lang.Closure)

--- a/tests/jenkins/jobs/BuildManifest_Jenkinsfile_component_no_artifact
+++ b/tests/jenkins/jobs/BuildManifest_Jenkinsfile_component_no_artifact
@@ -6,7 +6,10 @@
  * compatible open source license.
  */
 
-def lib = library("jenkins")
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/BuildManifest_Jenkinsfile_component_no_artifact.txt
+++ b/tests/jenkins/jobs/BuildManifest_Jenkinsfile_component_no_artifact.txt
@@ -1,5 +1,6 @@
    BuildManifest_Jenkinsfile_component_no_artifact.run()
-      BuildManifest_Jenkinsfile_component_no_artifact.library(jenkins)
+      BuildManifest_Jenkinsfile_component_no_artifact.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      BuildManifest_Jenkinsfile_component_no_artifact.library({identifier=jenkins@1.0.0, retriever=null})
       BuildManifest_Jenkinsfile_component_no_artifact.pipeline(groovy.lang.Closure)
          BuildManifest_Jenkinsfile_component_no_artifact.echo(Executing on agent [label:none])
          BuildManifest_Jenkinsfile_component_no_artifact.stage(Build Manifest Properties, groovy.lang.Closure)

--- a/tests/jenkins/jobs/BuildYumRepo_Jenkinsfile
+++ b/tests/jenkins/jobs/BuildYumRepo_Jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/BuildYumRepo_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/BuildYumRepo_Jenkinsfile.txt
@@ -1,6 +1,6 @@
    BuildYumRepo_Jenkinsfile.run()
-      BuildYumRepo_Jenkinsfile.legacySCM(groovy.lang.Closure)
-      BuildYumRepo_Jenkinsfile.library({identifier=jenkins@20211123, retriever=null})
+      BuildYumRepo_Jenkinsfile.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      BuildYumRepo_Jenkinsfile.library({identifier=jenkins@1.0.0, retriever=null})
       BuildYumRepo_Jenkinsfile.pipeline(groovy.lang.Closure)
          BuildYumRepo_Jenkinsfile.echo(Executing on agent [label:none])
          BuildYumRepo_Jenkinsfile.stage(buildYumRepo, groovy.lang.Closure)

--- a/tests/jenkins/jobs/Build_OpenSearch_Dashboards_Jenkinsfile
+++ b/tests/jenkins/jobs/Build_OpenSearch_Dashboards_Jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: 'jenkins@20211123', retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/InputManifest_Jenkinsfile
+++ b/tests/jenkins/jobs/InputManifest_Jenkinsfile
@@ -6,7 +6,10 @@
  * compatible open source license.
  */
  
-def lib = library("jenkins")
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/InputManifest_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/InputManifest_Jenkinsfile.txt
@@ -1,5 +1,6 @@
    InputManifest_Jenkinsfile.run()
-      InputManifest_Jenkinsfile.library(jenkins)
+      InputManifest_Jenkinsfile.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      InputManifest_Jenkinsfile.library({identifier=jenkins@1.0.0, retriever=null})
       InputManifest_Jenkinsfile.pipeline(groovy.lang.Closure)
          InputManifest_Jenkinsfile.echo(Executing on agent [label:none])
          InputManifest_Jenkinsfile.stage(input manifest 1.1.0, groovy.lang.Closure)

--- a/tests/jenkins/jobs/Messages_Jenkinsfile
+++ b/tests/jenkins/jobs/Messages_Jenkinsfile
@@ -6,7 +6,10 @@
  * compatible open source license.
  */
 
-def lib = library("jenkins")
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/Messages_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/Messages_Jenkinsfile.txt
@@ -1,5 +1,6 @@
    Messages_Jenkinsfile.run()
-      Messages_Jenkinsfile.library(jenkins)
+      Messages_Jenkinsfile.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      Messages_Jenkinsfile.library({identifier=jenkins@1.0.0, retriever=null})
       Messages_Jenkinsfile.pipeline(groovy.lang.Closure)
          Messages_Jenkinsfile.echo(Executing on agent [label:none])
          Messages_Jenkinsfile.stage(Example Build, groovy.lang.Closure)

--- a/tests/jenkins/jobs/ParallelMessages_Jenkinsfile
+++ b/tests/jenkins/jobs/ParallelMessages_Jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/UploadIndexFile_Jenkinsfile
+++ b/tests/jenkins/jobs/UploadIndexFile_Jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/UploadIndexFile_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/UploadIndexFile_Jenkinsfile.txt
@@ -1,6 +1,6 @@
    UploadIndexFile_Jenkinsfile.run()
-      UploadIndexFile_Jenkinsfile.legacySCM(groovy.lang.Closure)
-      UploadIndexFile_Jenkinsfile.library({identifier=jenkins@20211123, retriever=null})
+      UploadIndexFile_Jenkinsfile.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      UploadIndexFile_Jenkinsfile.library({identifier=jenkins@1.0.0, retriever=null})
       UploadIndexFile_Jenkinsfile.pipeline(groovy.lang.Closure)
          UploadIndexFile_Jenkinsfile.echo(Executing on agent [label:none])
          UploadIndexFile_Jenkinsfile.stage(uploadIndexFile, groovy.lang.Closure)

--- a/tests/jenkins/jobs/uploadMinSnapshotsToS3_Jenkinsfile
+++ b/tests/jenkins/jobs/uploadMinSnapshotsToS3_Jenkinsfile
@@ -1,4 +1,7 @@
-lib = library(identifier: "jenkins@20211123", retriever: legacySCM(scm))
+lib = library(identifier: 'jenkins@1.0.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
 
 pipeline {
     agent none

--- a/tests/jenkins/jobs/uploadMinSnapshotsToS3_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/uploadMinSnapshotsToS3_Jenkinsfile.txt
@@ -30,10 +30,9 @@ ccc
 bbb
 ccc
 })
-                  uploadMinSnapshotsToS3.echo(Start copying files)
                   uploadMinSnapshotsToS3.sh(
-        cp -v tests/data/tar/builds/opensearch/dist/opensearch-min-1.2.2-SNAPSHOT-linux-x64.tar.gz tests/data/tar/builds/opensearch/dist/opensearch-min-1.2.2-SNAPSHOT-linux-x64-latest.tar.gz
-        cp -v tests/data/tar/builds/opensearch/dist/opensearch-min-1.2.2-SNAPSHOT-linux-x64.tar.gz.sha512 tests/data/tar/builds/opensearch/dist/opensearch-min-1.2.2-SNAPSHOT-linux-x64-latest.tar.gz.sha512
+        cp tests/data/tar/builds/opensearch/dist/opensearch-min-1.2.2-SNAPSHOT-linux-x64.tar.gz tests/data/tar/builds/opensearch/dist/opensearch-min-1.2.2-SNAPSHOT-linux-x64-latest.tar.gz
+        cp tests/data/tar/builds/opensearch/dist/opensearch-min-1.2.2-SNAPSHOT-linux-x64.tar.gz.sha512 tests/data/tar/builds/opensearch/dist/opensearch-min-1.2.2-SNAPSHOT-linux-x64-latest.tar.gz.sha512
         sed -i "s/.tar.gz/-latest.tar.gz/g" tests/data/tar/builds/opensearch/dist/opensearch-min-1.2.2-SNAPSHOT-linux-x64-latest.tar.gz.sha512
     )
                   uploadMinSnapshotsToS3.string({credentialsId=jenkins-artifact-promotion-role, variable=ARTIFACT_PROMOTION_ROLE_NAME})

--- a/tests/jenkins/jobs/uploadMinSnapshotsToS3_Jenkinsfile.txt
+++ b/tests/jenkins/jobs/uploadMinSnapshotsToS3_Jenkinsfile.txt
@@ -1,6 +1,6 @@
    uploadMinSnapshotsToS3_Jenkinsfile.run()
-      uploadMinSnapshotsToS3_Jenkinsfile.legacySCM(groovy.lang.Closure)
-      uploadMinSnapshotsToS3_Jenkinsfile.library({identifier=jenkins@20211123, retriever=null})
+      uploadMinSnapshotsToS3_Jenkinsfile.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      uploadMinSnapshotsToS3_Jenkinsfile.library({identifier=jenkins@1.0.0, retriever=null})
       uploadMinSnapshotsToS3_Jenkinsfile.pipeline(groovy.lang.Closure)
          uploadMinSnapshotsToS3_Jenkinsfile.echo(Executing on agent [label:none])
          uploadMinSnapshotsToS3_Jenkinsfile.stage(uploadMinSnapshotsToS3, groovy.lang.Closure)


### PR DESCRIPTION
### Description
Updating lib location on all jenkinsfiles/jobs at jenkins/ folder to use the lib located at new opensearch-build-libraries repository. 
#2646 

### Issues Resolved
This PR is to update lib location of existing jenkinsfile to use new lib location at remote opensearch-build-libraries repository.
The update includes jenkinsfiles and regression files and BuildPipelineTest.groovy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
