### PR TITLE
Added support to run integTests, in either single-cluster or multi-cluster mode.

### DIFF
--- a/src/manifests/test_manifest.py
+++ b/src/manifests/test_manifest.py
@@ -61,6 +61,7 @@ class TestManifest(ComponentManifest['TestManifest', 'TestComponents']):
                         "type": "dict",
                         "schema": {
                             "build-dependencies": {"type": "list"},
+                            "topology": {"type": "string","required": False },
                             "test-configs": {"type": "list", "allowed": ["with-security", "without-security"]},
                             "additional-cluster-configs": {"type": "dict"},
                         },
@@ -137,3 +138,4 @@ TestManifest.VERSIONS = {"1.0": TestManifest}
 
 TestComponent.__test__ = False  # type: ignore[attr-defined]
 TestManifest.__test__ = False  # type: ignore[attr-defined]
+

--- a/src/test_workflow/integ_test/integ_test_suite.py
+++ b/src/test_workflow/integ_test/integ_test_suite.py
@@ -97,6 +97,39 @@ class IntegTestSuite(abc.ABC):
             logging.info(f"{script} does not exist. Skipping integ tests for {self.component.name}")
             return 0
 
+
+    def multi_execute_integtest_sh(self, endpoint1: str, port1:int , endpoint2:str, port2: int, security: bool, test_config: str) -> int:
+            print("integ Test suite opensearch Execute integtest")
+        # here
+            script = ScriptFinder.find_integ_test_script(self.component.name, self.repo.working_directory)
+            if os.path.exists(script):
+                cmd = f"{script} -m {endpoint1} -n {port1} -x {endpoint2} -y {port2}  -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
+                self.repo_work_dir = os.path.join(
+                    self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
+                (status, stdout, stderr) = execute(cmd, self.repo_work_dir, True, False)
+
+                test_result_data = TestResultData(
+                    self.component.name,
+                    test_config,
+                    status,
+                    stdout,
+                    stderr,
+                    self.test_artifact_files
+                )
+
+                self.save_logs.save_test_result_data(test_result_data)
+                print("Inside integ test suite")
+                if stderr:
+                    logging.info("Integration test run failed for component " + self.component.name)
+                    logging.info(stderr)
+                return status
+            else:
+                logging.info(f"{script} does not exist. Skipping integ tests for {self.component.name}")
+                return 0
+
+
+
+	
     def is_security_enabled(self, config: str) -> bool:
         if config in ["with-security", "without-security"]:
             return True if config == "with-security" else False

--- a/src/test_workflow/integ_test/local_test_cluster.py
+++ b/src/test_workflow/integ_test/local_test_cluster.py
@@ -34,6 +34,7 @@ class LocalTestCluster(TestCluster):
         security_enabled: bool,
         component_test_config: str,
         test_recorder: TestRecorder,
+		xport=9200
     ) -> None:
         super().__init__(
             work_dir,
@@ -41,9 +42,11 @@ class LocalTestCluster(TestCluster):
             component_test_config,
             security_enabled,
             additional_cluster_config,
-            test_recorder.local_cluster_logs
+            test_recorder.local_cluster_logs,
+			xport
         )
 
+        self.xport=xport
         self.manifest = bundle_manifest
         self.dependency_installer = dependency_installer
 
@@ -53,7 +56,8 @@ class LocalTestCluster(TestCluster):
             self.additional_cluster_config,
             self.security_enabled,
             self.dependency_installer,
-            self.work_dir
+            self.work_dir,
+			self.xport
         )
 
     @property
@@ -66,4 +70,4 @@ class LocalTestCluster(TestCluster):
 
     @property
     def port(self) -> int:
-        return 9200
+        return self.xport

--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -31,10 +31,11 @@ class ServiceOpenSearch(Service):
         additional_config: dict,
         security_enabled: bool,
         dependency_installer: DependencyInstaller,
-        work_dir: str
+        work_dir: str,
+		xport=9200
     ) -> None:
         super().__init__(work_dir, version, distribution, security_enabled, additional_config, dependency_installer)
-
+        self.xport=xport
         self.dist = Distributions.get_distribution("opensearch", distribution, version, work_dir)
         self.dependency_installer = dependency_installer
         self.install_dir = self.dist.install_dir
@@ -70,7 +71,7 @@ class ServiceOpenSearch(Service):
             yamlfile.write(yaml.dump(additional_config))
 
     def port(self) -> int:
-        return 9200
+        return self.xport
 
     def check_service_response_text(self, response_text: str) -> bool:
         return ('"status":"green"' in response_text) or ('"status":"yellow"' in response_text)

--- a/src/test_workflow/test_cluster.py
+++ b/src/test_workflow/test_cluster.py
@@ -36,9 +36,10 @@ class TestCluster(abc.ABC):
         component_test_config: str,
         security_enabled: bool,
         additional_cluster_config: dict,
-        save_logs: LogRecorder
+        save_logs: LogRecorder,
+		xport=9200
     ) -> None:
-        self.work_dir = os.path.join(work_dir, "local-test-cluster")
+        self.work_dir = os.path.join(work_dir, "local-test-cluster"+f"{xport}")
         self.component_name = component_name
         self.component_test_config = component_test_config
         self.security_enabled = security_enabled
@@ -60,6 +61,7 @@ class TestCluster(abc.ABC):
             cluster.start()
             yield cluster.endpoint, cluster.port
         finally:
+            print("Terminating service")
             cluster.terminate()
 
     def start(self) -> None:


### PR DESCRIPTION
This feature will allow opensearch-build test workflow to launch single or multiple cluster so that plugins which require multiple clusters can run their tests.


### Description

Parent issue https://github.com/opensearch-project/opensearch-build/issues/2066
issue on CCR repo https://github.com/opensearch-project/cross-cluster-replication/issues/532


PR on CCR repo https://github.com/opensearch-project/cross-cluster-replication/pull/543

This can be set using topology in manifest.
```
  - name: cross-cluster-replication
    integ-test:
      topology: single-cluster
      test-configs:
        - with-security
        - without-security
```
OR
  ```
- name: cross-cluster-replication
    integ-test:
      topology: multi-cluster
      test-configs:
        - with-security
        - without-security
```

Signed-off-by: Monu Singh <msnghgw@amazon.com>
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
