### PR TITLE
Add some plugins to the 1.3.6 manifest

### DIFF
--- a/manifests/1.3.6/opensearch-1.3.6.yml
+++ b/manifests/1.3.6/opensearch-1.3.6.yml
@@ -14,3 +14,9 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: '1.3'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version

--- a/manifests/1.3.6/opensearch-1.3.6.yml
+++ b/manifests/1.3.6/opensearch-1.3.6.yml
@@ -32,3 +32,16 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: '1.3'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting
+  - name: dashboards-reports
+    repository: https://github.com/opensearch-project/dashboards-reports.git
+    ref: '1.3'
+    working_directory: reports-scheduler
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
### Description
Add security, dashboards reports and alerting plugins into the manifest

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/2650

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
