### PR TITLE
Fix zip distribution does not include leading directory

### DIFF
--- a/src/assemble_workflow/dist.py
+++ b/src/assemble_workflow/dist.py
@@ -103,11 +103,17 @@ class DistZip(Dist):
 
     def __build__(self, name: str, dest: str) -> None:
         with ZipFile(name, "w", zipfile.ZIP_DEFLATED) as zip:
-            rootlen = len(self.archive_path) + 1
+            # root               : /tmp/tmp********/opensearch-<version+qualifier>
+            # leadingdir         : opensearch-<version+qualifier>
+            # root no leading dir: /tmp/tmp********/
+            # This is to preserve the leading directory `opensearch-<version+qualifier>` in zip
+            rootlen = len(self.archive_path)
+            leadingdirlen = len(os.path.basename(self.archive_path))
+            noleadingdirlen = rootlen - leadingdirlen
             for base, _, files in os.walk(self.archive_path):
                 for file in files:
                     fn = os.path.join(base, file)
-                    zip.write(fn, fn[rootlen:])
+                    zip.write(fn, fn[noleadingdirlen:])
 
 
 class DistRpm(Dist):

--- a/tests/tests_assemble_workflow/test_bundle_opensearch.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch.py
@@ -251,5 +251,5 @@ class TestBundleOpenSearch(unittest.TestCase):
             with patch("shutil.copyfile") as mock_copyfile:
                 bundle.package(os.path.dirname(__file__))
                 mock_zipfile_open.assert_called_with("opensearch.zip", "w", zipfile.ZIP_DEFLATED)
-                mock_zipfile_write.assert_called_with(os.path.join(bundle.tmp_dir.name, "opensearch-1.3.0", "opensearch.txt"), "opensearch-1.3.0/opensearch.txt")
+                mock_zipfile_write.assert_called_with(os.path.join(bundle.tmp_dir.name, "opensearch-1.3.0", "opensearch.txt"), os.path.join("opensearch-1.3.0", "opensearch.txt"))
                 self.assertEqual(mock_copyfile.call_count, 1)

--- a/tests/tests_assemble_workflow/test_bundle_opensearch.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch.py
@@ -251,5 +251,5 @@ class TestBundleOpenSearch(unittest.TestCase):
             with patch("shutil.copyfile") as mock_copyfile:
                 bundle.package(os.path.dirname(__file__))
                 mock_zipfile_open.assert_called_with("opensearch.zip", "w", zipfile.ZIP_DEFLATED)
-                mock_zipfile_write.assert_called_with(os.path.join(bundle.tmp_dir.name, "opensearch-1.3.0", "opensearch.txt"), "opensearch.txt")
+                mock_zipfile_write.assert_called_with(os.path.join(bundle.tmp_dir.name, "opensearch-1.3.0", "opensearch.txt"), "opensearch-1.3.0/opensearch.txt")
                 self.assertEqual(mock_copyfile.call_count, 1)


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Fix zip distribution does not include leading directory

### Issues Resolved
#2306 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
