### PR TITLE
Add security dashboards plugin to manifest for 2.4.0

### DIFF
--- a/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
@@ -14,3 +14,6 @@ components:
     repository: https://github.com/opensearch-project/notifications.git
     working_directory: dashboards-notifications
     ref: '2.x'
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+    ref: '2.x'


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description
Adds security dashboards plugin to the manifest for 2.4.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
