### PR TITLE
Version bump manifest for security dash

### DIFF
--- a/manifests/3.0.0/opensearch-dashboards-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-dashboards-3.0.0.yml
@@ -10,3 +10,6 @@ components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     ref: main
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+    ref: main


### PR DESCRIPTION
Signed-off-by: Stephen Crawford <steecraw@amazon.com>

Moves manifest up to security dashboard version 3.0.0 to match core branching strategy. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
