### PR TITLE
Adding test job for release-notes-check jenkinsfile

### DIFF
--- a/tests/jenkins/TestReleaseNotesCheck.groovy
+++ b/tests/jenkins/TestReleaseNotesCheck.groovy
@@ -33,6 +33,15 @@ class TestReleaseNotesCheck extends BuildPipelineTest {
         binding.setVariable('AGENT_X64','Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host')
         binding.setVariable('dockerAgent', [image:'opensearchstaging/ci-runner:ci-runner-centos7-v1', args:'-e JAVA_HOME=/opt/java/openjdk-11'])
 
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
     }
 
     @Test

--- a/tests/jenkins/TestReleaseNotesCheck.groovy
+++ b/tests/jenkins/TestReleaseNotesCheck.groovy
@@ -23,18 +23,15 @@ class TestReleaseNotesCheck extends BuildPipelineTest {
     @Override
     @Before
     void setUp() {
+        super.setUp()
+
         binding.setVariable('INPUT_MANIFEST', inputManifest)
         binding.setVariable('GIT_LOG_DATE', gitLogDate)
         binding.setVariable('COMMENT', comment)
         binding.setVariable('GIT_ISSUE_NUMBER', gitIssueNumber)
         binding.setVariable('COMMENT_UNIQUE_ID', commentUniqueID)
-
         binding.setVariable('AGENT_X64','Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host')
-        binding.setVariable('AGENT_ARM64','Jenkins-Agent-AL2-Arm64-C6g4xlarge-Docker-Host')
-
         binding.setVariable('dockerAgent', [image:'opensearchstaging/ci-runner:ci-runner-centos7-v1', args:'-e JAVA_HOME=/opt/java/openjdk-11'])
-
-        super.setUp()
 
         helper.registerSharedLibrary(
             library().name('jenkins')
@@ -45,14 +42,11 @@ class TestReleaseNotesCheck extends BuildPipelineTest {
                 .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
                 .build()
         )
-
     }
 
     @Test
     public void testReleaseNoteCheck() {
-
         super.testPipeline("jenkins/release-notes-check/release-notes-check.jenkinsfile",
                 "tests/jenkins/jenkinsjob-regression-files/release-notes-check/release-notes-check.jenkinsfile")
     }
-
 }

--- a/tests/jenkins/TestReleaseNotesCheck.groovy
+++ b/tests/jenkins/TestReleaseNotesCheck.groovy
@@ -33,15 +33,6 @@ class TestReleaseNotesCheck extends BuildPipelineTest {
         binding.setVariable('AGENT_X64','Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host')
         binding.setVariable('dockerAgent', [image:'opensearchstaging/ci-runner:ci-runner-centos7-v1', args:'-e JAVA_HOME=/opt/java/openjdk-11'])
 
-        helper.registerSharedLibrary(
-            library().name('jenkins')
-                .defaultVersion('1.0.0')
-                .allowOverride(true)
-                .implicit(true)
-                .targetPath('vars')
-                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
-                .build()
-        )
     }
 
     @Test

--- a/tests/jenkins/TestReleaseNotesCheck.groovy
+++ b/tests/jenkins/TestReleaseNotesCheck.groovy
@@ -18,7 +18,7 @@ class TestReleaseNotesCheck extends BuildPipelineTest {
     String comment = 'NO_COMMENT'
     String gitIssueNumber = '123456'
     String commentUniqueID = '123456'
-    String inputManifest = '2.0.0/opensearch-2.0.0.yml'
+    String inputManifest = '2.2.0/opensearch-2.2.0.yml'
 
     @Override
     @Before

--- a/tests/jenkins/TestReleaseNotesCheck.groovy
+++ b/tests/jenkins/TestReleaseNotesCheck.groovy
@@ -18,7 +18,6 @@ class TestReleaseNotesCheck extends BuildPipelineTest {
     String comment = 'NO_COMMENT'
     String gitIssueNumber = '123456'
     String commentUniqueID = '123456'
-    // String manifest = args.manifest ?: "manifests/${INPUT_MANIFEST}"
     String inputManifest = '2.0.0/opensearch-2.0.0.yml'
 
     @Override

--- a/tests/jenkins/TestReleaseNotesCheck.groovy
+++ b/tests/jenkins/TestReleaseNotesCheck.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+import jenkins.tests.BuildPipelineTest
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
+
+class TestReleaseNotesCheck extends BuildPipelineTest {
+
+    String gitLogDate = '2022-10-10'
+    String comment = 'NO_COMMENT'
+    String gitIssueNumber = '123456'
+    String commentUniqueID = '123456'
+    // String manifest = args.manifest ?: "manifests/${INPUT_MANIFEST}"
+    String inputManifest = '2.0.0/opensearch-2.0.0.yml'
+
+    @Override
+    @Before
+    void setUp() {
+        binding.setVariable('INPUT_MANIFEST', inputManifest)
+        binding.setVariable('GIT_LOG_DATE', gitLogDate)
+        binding.setVariable('COMMENT', comment)
+        binding.setVariable('GIT_ISSUE_NUMBER', gitIssueNumber)
+        binding.setVariable('COMMENT_UNIQUE_ID', commentUniqueID)
+
+        binding.setVariable('AGENT_X64','Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host')
+        binding.setVariable('AGENT_ARM64','Jenkins-Agent-AL2-Arm64-C6g4xlarge-Docker-Host')
+
+        binding.setVariable('dockerAgent', [image:'opensearchstaging/ci-runner:ci-runner-centos7-v1', args:'-e JAVA_HOME=/opt/java/openjdk-11'])
+
+        super.setUp()
+
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('1.0.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+        )
+
+    }
+
+    @Test
+    public void testReleaseNoteCheck() {
+
+        super.testPipeline("jenkins/release-notes-check/release-notes-check.jenkinsfile",
+                "tests/jenkins/jenkinsjob-regression-files/release-notes-check/release-notes-check.jenkinsfile")
+    }
+
+}

--- a/tests/jenkins/jenkinsjob-regression-files/release-notes-check/release-notes-check.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-notes-check/release-notes-check.jenkinsfile.txt
@@ -10,7 +10,7 @@
                release-notes-check.detectDockerAgent()
                   detectDockerAgent.legacySCM(groovy.lang.Closure)
                   detectDockerAgent.library({identifier=jenkins@main, retriever=null})
-                  detectDockerAgent.readYaml({file=manifests/2.0.0/opensearch-2.0.0.yml})
+                  detectDockerAgent.readYaml({file=manifests/2.2.0/opensearch-2.2.0.yml})
                   InputManifest.asBoolean()
                   detectDockerAgent.echo(Using Docker image opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2 (-e JAVA_HOME=/opt/java/openjdk-17))
                   detectDockerAgent.echo(Using java version openjdk-17)

--- a/tests/jenkins/jenkinsjob-regression-files/release-notes-check/release-notes-check.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-notes-check/release-notes-check.jenkinsfile.txt
@@ -1,0 +1,35 @@
+   release-notes-check.run()
+      release-notes-check.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      release-notes-check.library({identifier=jenkins@1.0.0, retriever=null})
+      release-notes-check.pipeline(groovy.lang.Closure)
+         release-notes-check.timeout({time=2, unit=HOURS})
+         release-notes-check.echo(Executing on agent [label:none])
+         release-notes-check.stage(detect docker image + args, groovy.lang.Closure)
+            release-notes-check.echo(Executing on agent [docker:[image:alpine:3, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])
+            release-notes-check.script(groovy.lang.Closure)
+               release-notes-check.detectDockerAgent()
+                  detectDockerAgent.legacySCM(groovy.lang.Closure)
+                  detectDockerAgent.library({identifier=jenkins@main, retriever=null})
+                  detectDockerAgent.readYaml({file=manifests/2.0.0/opensearch-2.0.0.yml})
+                  InputManifest.asBoolean()
+                  detectDockerAgent.echo(Using Docker image opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2 (-e JAVA_HOME=/opt/java/openjdk-17))
+                  detectDockerAgent.echo(Using java version openjdk-17)
+         release-notes-check.postCleanup()
+            postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})
+         release-notes-check.stage(Parameters Check, groovy.lang.Closure)
+            release-notes-check.script(groovy.lang.Closure)
+         release-notes-check.stage(Generate MarkDown table, groovy.lang.Closure)
+            release-notes-check.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ci-runner-centos7-v1, reuseNode:false, stages:[:], args:, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host]])
+            release-notes-check.script(groovy.lang.Closure)
+               release-notes-check.usernamePassword({credentialsId=jenkins-github-bot-token, usernameVariable=GITHUB_USER, passwordVariable=GITHUB_TOKEN})
+               release-notes-check.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                  release-notes-check.sh(
+                                #!/bin/bash
+                                set +e
+                                ./release_notes.sh check manifests/${INPUT_MANIFEST} --date ${GIT_LOG_DATE} --output table.md
+                                echo "Adding Comment on issue $GIT_ISSUE_NUMBER"
+                                gh repo clone https://github.com/opensearch-project/opensearch-build.git; cd opensearch-build
+                                gh issue comment ${GIT_ISSUE_NUMBER} --body-file ../table.md --repo opensearch-project/opensearch-build
+                            )
+         release-notes-check.postCleanup()
+            postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})


### PR DESCRIPTION
Signed-off-by: Jeff Lu <chunglu@amazon.com>

### Description
As part of the effort on META https://github.com/opensearch-project/opensearch-build/issues/1468 , we are adding missing test job for jenkinsfile(s).

Particularly, this PR is created to address missing test job for [release-notes-check.jenkinsfile [https://github.com/opensearch-project/opensearch-build/tree/main/jenkins/release-notes-check]](https://github.com/opensearch-project/opensearch-build/blob/main/jenkins/release-notes-check/release-notes-check.jenkinsfile)

### Issues Resolved
#2713 as part of #1468 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
