### PR TITLE
Remove ml-commons section in the 3.0.0 manifest YAML file

### DIFF
--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -23,15 +23,6 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
-  - name: ml-commons
-    repository: https://github.com/opensearch-project/ml-commons.git
-    ref: main
-    platforms:
-      - linux
-      - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: opensearch-ml-plugin
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
     ref: main


### PR DESCRIPTION
Signed-off-by: Sicheng Song <114637679+b4sjoo@users.noreply.github.com>

### Description
Delete ml-commons chunk in the 3.0.0 manifest YAML file.
  - name: ml-commons
    repository: https://github.com/opensearch-project/ml-commons.git
    ref: main
    platforms:
      - linux
      - windows
    checks:
      - gradle:properties:version
      - gradle:dependencies:opensearch.version: opensearch-ml-plugin

### Issues Resolved
Previously ml-commons will fail in CI workflow becuase OpenSearch 3.0 removed some deprecated class. So we remove ml-commons from manifest file temporarily to unblock infra team's CI workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
