### PR TITLE
Add plugin on-boarding template to opensearch-build repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
@@ -42,8 +42,8 @@ body:
       required: true
   -
     attributes:
-      description: "Does this plugin has all the necessary automated tests?"
-      label: "Does this plugin have necessary scripts to invoke integration and BWC tests?"
+      description: "Does this plugin have necessary scripts to invoke integration and BWC tests?"
+      label: "Does this plugin has all the necessary automated tests?"
     id: tests
     type: textarea
     validations:

--- a/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
@@ -1,0 +1,61 @@
+---
+name: On-board plugins
+description: On-board plugins
+title: '[On-boarding]: '
+labels: [on-boarding, untriaged]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to submit on-boarding request!
+  -
+    attributes:
+      description: "Provide the GitHub link for your repository"
+      label: "What is the link to your GitHub repo?"
+    id: Github-link
+    type: textarea
+    validations:
+      required: true
+  -
+    attributes:
+      description: "What is the targeted OpenSearch release version for this plugin?"
+      label: "Targeted release version"
+    id: expected-release-version
+    type: textarea
+    validations:
+      required: true
+  -
+    attributes:
+      description: "Is this OpenSearch, OpenSearch-dashboards plugin?"
+      label: "What type of the plugin are we on-boarding?"
+    id: Type
+    type: textarea
+    validations:
+      required: true
+  -
+    attributes:
+      description: "Confirm that all the necessary reviews for this component has been completed."
+      label: "Have you completed the required reviews including Security reviews, UX reviews?"
+    id: reviews
+    type: textarea
+    validations:
+      required: true
+  -
+    attributes:
+      description: "Do we need to enable any automated CVE scanning on this repo?"
+      label: "Have you on-boarded automated security scanning for the GitHub repo associated with this plugin?"
+    id: repo-scanning
+    type: textarea
+    validations:
+      required: true
+  -
+    attributes:
+      description: "Add any additional context along with contact details for this component here."
+      label: "Additional context"
+    id: additional-context
+    type: textarea
+labels:
+  - on-boarding
+  - untriaged
+name: "On-board plugins"
+title: "[On-boarding] Onboard plugins to OpenSearch versions"

--- a/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
@@ -62,8 +62,3 @@ body:
       label: "Additional context"
     id: additional-context
     type: textarea
-labels:
-  - on-boarding
-  - untriaged
-name: "On-board plugins"
-title: "[On-boarding] Onboard plugins to OpenSearch versions"

--- a/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
@@ -42,6 +42,14 @@ body:
       required: true
   -
     attributes:
+      description: "Does this plugin has all the necessary automated tests?"
+      label: "Does this plugin have necessary scripts to invoke integration and BWC tests?"
+    id: tests
+    type: textarea
+    validations:
+      required: true
+  -
+    attributes:
       description: "Confirm that all the necessary reviews for this component has been completed."
       label: "Have you completed the required reviews including Security reviews, UX reviews?"
     id: reviews

--- a/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
@@ -10,6 +10,14 @@ body:
         Thanks for taking the time to submit on-boarding request!
   -
     attributes:
+      description: "Provide the name link of your plugin"
+      label: "What is the name of your plugin?"
+    id: plugin-name
+    type: textarea
+    validations:
+      required: true
+  -
+    attributes:
       description: "Provide the GitHub link for your repository"
       label: "What is the link to your GitHub repo?"
     id: Github-link


### PR DESCRIPTION
### Description
Adding plugin on-boarding template for on-boarding new plugins to OpenSearch distributions.

### Issues Resolved
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
