### PR TITLE
Added use_50_percent_heap configurable parameter for using 50% heap m…

### DIFF
--- a/src/test_workflow/perf_test/perf_multi_node_cluster.py
+++ b/src/test_workflow/perf_test/perf_multi_node_cluster.py
@@ -50,5 +50,6 @@ class PerfMultiNodeCluster(PerfTestCluster):
             "master_node_count": int(self.cluster_config.master_nodes),
             "data_node_count": int(self.cluster_config.data_nodes),
             "ingest_node_count": int(self.cluster_config.ingest_nodes),
-            "client_node_count": int(self.cluster_config.client_nodes)
+            "client_node_count": int(self.cluster_config.client_nodes),
+            "use_50_percent_heap": self.cluster_config.use_50_percent_heap
         }

--- a/src/test_workflow/perf_test/perf_single_node_cluster.py
+++ b/src/test_workflow/perf_test/perf_single_node_cluster.py
@@ -50,5 +50,6 @@ class PerfSingleNodeCluster(PerfTestCluster):
             "security": "enable" if self.cluster_config.security else "disable",
             "platform": self.manifest.build.platform,
             "architecture": self.manifest.build.architecture,
-            "public_ip": config["Constants"].get("PublicIp", "disable")
+            "public_ip": config["Constants"].get("PublicIp", "disable"),
+            "use_50_percent_heap": self.cluster_config.use_50_percent_heap
         }

--- a/src/test_workflow/perf_test/perf_test_cluster_config.py
+++ b/src/test_workflow/perf_test/perf_test_cluster_config.py
@@ -12,11 +12,12 @@ class PerfTestClusterConfig():
     ingest_nodes: int
     client_nodes: int
     _is_single_node_cluster: bool
+    use_50_percent_heap: str
 
     """
     Maintains the cluster level configuration.
     """
-    def __init__(self, security: bool = False, data_nodes: int = 1, master_nodes: int = 0, ingest_nodes: int = 0, client_nodes: int = 0) -> None:
+    def __init__(self, security: bool = False, data_nodes: int = 1, master_nodes: int = 0, ingest_nodes: int = 0, client_nodes: int = 0, use_50_percent_heap: str = "disable") -> None:
         self.security = security
         self.data_nodes = data_nodes
         self.master_nodes = master_nodes
@@ -24,6 +25,7 @@ class PerfTestClusterConfig():
         self.client_nodes = client_nodes
         self._is_single_node_cluster = (self.data_nodes == 1 and self.master_nodes == 0
                                         and self.ingest_nodes == 0 and self.client_nodes == 0)
+        self.use_50_percent_heap = use_50_percent_heap
 
     @property
     def is_single_node_cluster(self) -> bool:

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_multi_node_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_multi_node_cluster.py
@@ -34,6 +34,7 @@ class TestPerfMultiNodeCluster(unittest.TestCase):
         self.assertTrue("master_node_count=3" in test_cluster.params)
         self.assertTrue("client_node_count=0" in test_cluster.params)
         self.assertTrue("ingest_node_count=0" in test_cluster.params)
+        self.assertTrue("use_50_percent_heap=disable" in test_cluster.params)
 
     def test_multi_node_cluster_invalid_configuration(self) -> None:
         self.assertRaises(

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster_config.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster_config.py
@@ -23,7 +23,7 @@ class TestPerfTestClusterConfig(unittest.TestCase):
         self.assertEqual(config.use_50_percent_heap, "disable")
 
     def test_non_default_args(self) -> None:
-        config = PerfTestClusterConfig(True, 1, 2, 3, 4,"enable")
+        config = PerfTestClusterConfig(True, 1, 2, 3, 4, "enable")
         self.assertEqual(config.security, True)
         self.assertEqual(config.data_nodes, 1)
         self.assertEqual(config.master_nodes, 2)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster_config.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster_config.py
@@ -20,6 +20,7 @@ class TestPerfTestClusterConfig(unittest.TestCase):
         self.assertEqual(config.ingest_nodes, 0)
         self.assertEqual(config.client_nodes, 0)
         self.assertEqual(config.is_single_node_cluster, True)
+        self.assertEqual(config.use_50_percent_heap, "disable")
 
     def test_non_default_args(self) -> None:
         config = PerfTestClusterConfig(True, 1, 2, 3, 4)
@@ -29,3 +30,5 @@ class TestPerfTestClusterConfig(unittest.TestCase):
         self.assertEqual(config.ingest_nodes, 3)
         self.assertEqual(config.client_nodes, 4)
         self.assertEqual(config.is_single_node_cluster, False)
+        self.assertEqual(config.use_50_percent_heap, "enable")
+        self.assertEqual(config.use_50_percent_heap, None)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster_config.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster_config.py
@@ -30,5 +30,5 @@ class TestPerfTestClusterConfig(unittest.TestCase):
         self.assertEqual(config.ingest_nodes, 3)
         self.assertEqual(config.client_nodes, 4)
         self.assertEqual(config.is_single_node_cluster, False)
-        self.assertEqual(config.use_50_percent_heap, "enable")
+        self.assertEqual(config.use_50_percent_heap, "disable")
         self.assertEqual(config.use_50_percent_heap, None)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster_config.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster_config.py
@@ -23,12 +23,11 @@ class TestPerfTestClusterConfig(unittest.TestCase):
         self.assertEqual(config.use_50_percent_heap, "disable")
 
     def test_non_default_args(self) -> None:
-        config = PerfTestClusterConfig(True, 1, 2, 3, 4)
+        config = PerfTestClusterConfig(True, 1, 2, 3, 4,"enable")
         self.assertEqual(config.security, True)
         self.assertEqual(config.data_nodes, 1)
         self.assertEqual(config.master_nodes, 2)
         self.assertEqual(config.ingest_nodes, 3)
         self.assertEqual(config.client_nodes, 4)
         self.assertEqual(config.is_single_node_cluster, False)
-        self.assertEqual(config.use_50_percent_heap, "disable")
-        self.assertEqual(config.use_50_percent_heap, None)
+        self.assertEqual(config.use_50_percent_heap, "enable")


### PR DESCRIPTION

Signed-off-by: Mohit Kumar <mohitamg@amazon.com>

### Description

Currently, the CC perf test uses 1GB of heap memory irrespective of node heap size for cluster nodes participating in the test.
These changes that have been made include a variable and if its value is true then use 50% of total heap memory for CC perf test.
Added a optional boolean type parameter to let clusters participating in the cross cluster performance test to use 50% of heap memory for system processes **_but for the opensearch-build repo in general kept it "disable"_**
### Issues Resolved
https://github.com/opensearch-project/opensearch-infra/issues/170

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
