### PR TITLE
Add neural search plugin to 2.4.0 manifest linux

### DIFF
--- a/manifests/2.4.0/opensearch-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-2.4.0.yml
@@ -92,6 +92,14 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: neural-search
+    repository: https://github.com/opensearch-project/neural-search.git
+    ref: '2.x'
+    platforms:
+      - linux
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
     ref: '2.x'


### PR DESCRIPTION
### Description
Adds neural search plugin to 2.4.0 manifest. Adds support for linux platform. Skip windows platform for now because k-NN dependency does not support windows.

neural search needs to be added after ml-commons and k-NN because it takes these as dependencies.

### Issues Resolved
#2736 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
