### PR TITLE
Add windows specific params for OSD build core

### DIFF
--- a/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/scripts/components/OpenSearch-Dashboards/build.sh
@@ -90,7 +90,7 @@ case $PLATFORM-$DISTRIBUTION-$ARCHITECTURE in
         SUFFIX="$PLATFORM-arm64"
         ;;
     windows-zip-x64)
-        TARGET="--all-platforms"
+        TARGET="--windows"
         EXT="$DISTRIBUTION"
         BUILD_PARAMS="build-platform"
         EXTRA_PARAMS="--skip-os-packages"


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add windows specific params for OSD build core

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2306

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
