### PR TITLE
Add custom map to 2.3.1, 2.4.0, and 3.0.0 manifests

### DIFF
--- a/manifests/2.3.1/opensearch-dashboards-2.3.1.yml
+++ b/manifests/2.3.1/opensearch-dashboards-2.3.1.yml
@@ -22,3 +22,7 @@ components:
     repository: https://github.com/opensearch-project/sql.git
     working_directory: workbench
     ref: '2.3'
+  - name: customImportMapDashboards
+    repository: https://github.com/opensearch-project/dashboards-maps.git
+    working_directory: src/plugins/custom_import_map
+    ref: '2.3'

--- a/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
@@ -9,7 +9,7 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: 2.x
+    ref: '2.x'
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
     ref: '2.x'
@@ -37,7 +37,11 @@ components:
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/sql.git
     working_directory: workbench
-    ref: 2.x
+    ref: '2.x'
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
+    ref: '2.x'
+  - name: customImportMapDashboards
+    repository: https://github.com/opensearch-project/dashboards-maps.git
+    working_directory: src/plugins/custom_import_map
     ref: '2.x'

--- a/manifests/3.0.0/opensearch-dashboards-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-dashboards-3.0.0.yml
@@ -28,3 +28,7 @@ components:
     repository: https://github.com/opensearch-project/sql.git
     working_directory: workbench
     ref: main
+  - name: customImportMapDashboards
+    repository: https://github.com/opensearch-project/dashboards-maps.git
+    working_directory: src/plugins/custom_import_map
+    ref: main


### PR DESCRIPTION
### Description
Add custom map to 2.3.1, 2.4.0, and 3.0.0 manifests

### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/60

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
