### PR TITLE
Remove quotes from parameters of windows script

### DIFF
--- a/scripts/startup/zip/windows/opensearch-windows-install.bat
+++ b/scripts/startup/zip/windows/opensearch-windows-install.bat
@@ -14,7 +14,7 @@ ECHO "OPENSEARCH_PATH_CONF: %OPENSEARCH_PATH_CONF%"
 
 :: Security Plugin Setups
 ECHO "Running Security Plugin Install Demo Configuration"
-CALL "%OPENSEARCH_HOME%/plugins/opensearch-security/tools/install_demo_configuration.bat" "-y" "-i" "-s"
+CALL "%OPENSEARCH_HOME%/plugins/opensearch-security/tools/install_demo_configuration.bat" -y -i -s
 
 :: k-NN Plugin Setups
 ECHO "Set KNN Dylib Path for Windows systems"


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove quotes from parameters of windows script.

The security batch script parameters is misinterpreted in the windows install script.
Without the quotes it will be naturally taken as parameters.
Else, the quotes sometimes is being treated as part of params.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2306

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
