### PR TITLE
Update neural-search 2.4 to point to 2.4 branch

### DIFF
--- a/manifests/2.4.0/opensearch-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-2.4.0.yml
@@ -95,7 +95,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: neural-search
     repository: https://github.com/opensearch-project/neural-search.git
-    ref: '2.x'
+    ref: '2.4'
     platforms:
       - linux
       - windows


### PR DESCRIPTION
### Description
Update 2.4 manifest to point to neural-search 2.4 branch: https://github.com/opensearch-project/neural-search/tree/2.4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
