### PR TITLE
Update manifest to point to 2.x for dashboards-search-relevance

### DIFF
--- a/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
@@ -45,10 +45,15 @@ components:
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
     ref: '2.x'
+<<<<<<< HEAD
   - name: customImportMapDashboards
     repository: https://github.com/opensearch-project/dashboards-maps.git
     working_directory: src/plugins/custom_import_map
     ref: '2.x'
   - name: securityAnalyticsDashboards
     repository: https://github.com/opensearch-project/security-analytics-dashboards-plugin
+=======
+  - name: searchRelevanceDashboards
+    repository: https://github.com/opensearch-project/dashboards-search-relevance.git
+>>>>>>> 8b35085 (updated with dashboards-search-relevance)
     ref: '2.x'

--- a/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
@@ -54,4 +54,4 @@ components:
     ref: '2.x'
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
-    ref: '2.4'
+    ref: '2.x'

--- a/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
@@ -45,15 +45,13 @@ components:
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
     ref: '2.x'
-<<<<<<< HEAD
   - name: customImportMapDashboards
     repository: https://github.com/opensearch-project/dashboards-maps.git
     working_directory: src/plugins/custom_import_map
     ref: '2.x'
   - name: securityAnalyticsDashboards
     repository: https://github.com/opensearch-project/security-analytics-dashboards-plugin
-=======
+    ref: '2.x'
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
->>>>>>> 8b35085 (updated with dashboards-search-relevance)
     ref: '2.x'

--- a/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
@@ -54,4 +54,4 @@ components:
     ref: '2.x'
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
-    ref: '2.x'
+    ref: '2.4'

--- a/manifests/3.0.0/opensearch-dashboards-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-dashboards-3.0.0.yml
@@ -32,3 +32,6 @@ components:
     repository: https://github.com/opensearch-project/dashboards-maps.git
     working_directory: src/plugins/custom_import_map
     ref: main
+  - name: searchRelevanceDashboards
+    repository: https://github.com/opensearch-project/dashboards-search-relevance.git
+    ref: main


### PR DESCRIPTION
### Description
Update manifest to point to 2.x for dashboards-search-relevance

### Issues Resolved
closes #https://github.com/opensearch-project/dashboards-search-relevance/issues/13

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
