### PR TITLE
Opensearch 2.4.0 switch from 2.x to 2.4 branches and add test manifest

### DIFF
--- a/manifests/2.4.0/opensearch-2.4.0-test.yml
+++ b/manifests/2.4.0/opensearch-2.4.0-test.yml
@@ -1,0 +1,109 @@
+---
+schema-version: '1.0'
+name: OpenSearch
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2
+    args: -e JAVA_HOME=/opt/java/openjdk-17
+components:
+  - name: index-management
+    integ-test:
+      build-dependencies:
+        - job-scheduler
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        path.repo: [/tmp]
+
+  - name: anomaly-detection
+    integ-test:
+      build-dependencies:
+        - job-scheduler
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: asynchronous-search
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: alerting
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        plugins.destination.host.deny_list: [10.0.0.0/8, 127.0.0.1]
+
+  - name: notifications
+    working-directory: notifications
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: sql
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        script.context.field.max_compilations_rate: 1000/1m
+
+  - name: k-NN
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: neural-search
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: dashboards-reports
+    working-directory: reports-scheduler
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: opensearch-observability
+    working-directory: opensearch-observability
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: ml-commons
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: cross-cluster-replication
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: security
+    integ-test:
+      test-configs:
+        - with-security
+
+  - name: geospatial
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: security-analytics
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security

--- a/manifests/2.4.0/opensearch-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-2.4.0.yml
@@ -43,13 +43,13 @@ components:
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: 2.x
+    ref: '2.4'
     platforms:
       - linux
       - windows
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: 2.x
+    ref: '2.4'
     platforms:
       - linux
     checks:
@@ -104,7 +104,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: '2.x'
+    ref: '2.4'
     platforms:
       - linux
       - windows
@@ -114,7 +114,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: dashboards-reports
     repository: https://github.com/opensearch-project/dashboards-reports.git
-    ref: '2.x'
+    ref: '2.4'
     platforms:
       - linux
       - windows
@@ -133,7 +133,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: '2.x'
+    ref: '2.4'
     platforms:
       - linux
       - windows

--- a/manifests/2.4.0/opensearch-dashboards-2.4.0-test.yml
+++ b/manifests/2.4.0/opensearch-dashboards-2.4.0-test.yml
@@ -1,0 +1,17 @@
+---
+schema-version: '1.0'
+name: OpenSearch Dashboards
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2
+components:
+  - name: OpenSearch-Dashboards
+    bwc-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: functionalTestDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security

--- a/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
@@ -9,46 +9,46 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: '2.x'
+    ref: '2.4'
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '2.x'
+    ref: '2.4'
   - name: notificationsDashboards
     repository: https://github.com/opensearch-project/notifications.git
     working_directory: dashboards-notifications
-    ref: '2.x'
+    ref: '2.4'
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/observability.git
     working_directory: dashboards-observability
-    ref: '2.x'
+    ref: '2.4'
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reports.git
     working_directory: dashboards-reports
-    ref: '2.x'
+    ref: '2.4'
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '2.x'
+    ref: '2.4'
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     ref: '2.4'
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: '2.x'
+    ref: '2.4'
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/sql.git
     working_directory: workbench
-    ref: '2.x'
+    ref: '2.4'
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
     working_directory: gantt-chart
-    ref: '2.x'
+    ref: '2.4'
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
-    ref: '2.x'
+    ref: '2.4'
   - name: customImportMapDashboards
     repository: https://github.com/opensearch-project/dashboards-maps.git
     working_directory: src/plugins/custom_import_map
     ref: '2.4'
   - name: securityAnalyticsDashboards
     repository: https://github.com/opensearch-project/security-analytics-dashboards-plugin
-    ref: '2.x'
+    ref: '2.4'


### PR DESCRIPTION
### Description
Opensearch 2.4.0 switch from 2.x to 2.4 branches and add test manifest

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2649

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
