### PR TITLE
Remove 3.0.0 observability OSD plugin to unblock distribution build

### DIFF
--- a/manifests/3.0.0/opensearch-dashboards-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-dashboards-3.0.0.yml
@@ -10,10 +10,6 @@ components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     ref: main
-  - name: observabilityDashboards
-    repository: https://github.com/opensearch-project/observability.git
-    working_directory: dashboards-observability
-    ref: main
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
     ref: main


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Remove 3.0.0 obs to unblock distribution build

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
