### PR TITLE
Resolve test topology check if there is no integ-test

### DIFF
--- a/src/manifests/test_manifest.py
+++ b/src/manifests/test_manifest.py
@@ -158,7 +158,7 @@ class TestComponent(Component):
         self.working_directory = data.get("working-directory", None)
         self.integ_test = data.get("integ-test", None)
         self.bwc_test = data.get("bwc-test", None)
-        self.topology = TestComponentTopology(self.integ_test.get("topology", None))
+        self.topology = TestComponentTopology(self.integ_test.get("topology", None)) if self.integ_test is not None else TestComponentTopology(None)
         self.components = TestComponents(data.get("components", []))  # type: ignore[assignment]
 
     def __to_dict__(self) -> dict:


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Resolve test topology check if there is no integ-test

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2649

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
