### PR TITLE
Fix signing the artifacts for .asc signatures

### DIFF
--- a/src/sign_workflow/sign_args.py
+++ b/src/sign_workflow/sign_args.py
@@ -26,7 +26,7 @@ class SignArgs:
         parser.add_argument("target", type=Path, help="Path to local manifest file or artifact directory")
         parser.add_argument("-c", "--component", type=str, nargs='*', dest="components", help="Component or components to sign")
         parser.add_argument("--type", help="Artifact type")
-        parser.add_argument("--sigtype", choices=self.ACCEPTED_SIGNATURE_FILE_TYPES, help="Type of signature file.", default=".asc")
+        parser.add_argument("--sigtype", choices=self.ACCEPTED_SIGNATURE_FILE_TYPES, help="Type of signature file.", default=".sig")
         parser.add_argument("--platform", choices=self.ACCEPTED_PLATFORM, help="Distribution platform.", default="linux")
         parser.add_argument(
             "-v",

--- a/src/sign_workflow/signer_pgp.py
+++ b/src/sign_workflow/signer_pgp.py
@@ -22,9 +22,9 @@ class SignerPGP(Signer):
     ACCEPTED_FILE_TYPES = [".zip", ".jar", ".war", ".pom", ".module", ".tar.gz", ".whl", ".crate", ".rpm"]
 
     def generate_signature_and_verify(self, artifact: str, basepath: Path, signature_type: str) -> None:
-        location = os.path.join(basepath, artifact)
-        self.sign(artifact, basepath, signature_type)
-        self.verify(location + signature_type)
+            location = os.path.join(basepath, artifact)
+            self.sign(artifact, basepath, signature_type)
+            self.verify(location + signature_type)
 
     def is_valid_file_type(self, file_name: str) -> bool:
         return any(
@@ -35,35 +35,35 @@ class SignerPGP(Signer):
         filename = os.path.join(basepath, artifact)
         signature_file = filename + ".sig"
         self.__remove_existing_signature__(signature_file)
-        # signing_cmd = [
-        #     "./opensearch-signer-client",
-        #     "-i",
-        #     filename,
-        #     "-o",
-        #     signature_file,
-        #     "-p",
-        #     "pgp",
-        # ]
-        signing_cmd = ["echo signed"]
+        signing_cmd = [
+            "./opensearch-signer-client",
+            "-i",
+            filename,
+            "-o",
+            signature_file,
+            "-p",
+            "pgp",
+        ]
         self.git_repo.execute(" ".join(signing_cmd))
         if(signature_type == ".asc"):
-            self.__convert_to_asc(filename)
+            self.__convert_to_asc(filename, signature_file)
 
-    def __convert_to_asc(self, filename: str) -> None:
-        signature_file = filename + ".asc"       
-        self.__remove_existing_signature__(signature_file)
+    def __convert_to_asc(self, filename: str, signature_file: str) -> None:
+        asc_signature_file = filename + ".asc"       
+        self.__remove_existing_signature__(asc_signature_file)
         conversion_cmd = [
             "gpg --enarmor",
             "<",
-            filename,
-            ">",
             signature_file,
+            ">",
+            asc_signature_file,
             "&&",
             "sed -i 's/ARMORED FILE/SIGNATURE/g'",
-            signature_file
+            asc_signature_file
         ]
-        logging.info('Coverting sig to asc signatures')
+        logging.info('Coverting .sig to .asc')
         self.git_repo.execute(" ".join(conversion_cmd))
+        self.__remove_existing_signature__(signature_file)
 
     def verify(self, filename: str) -> None:
         verify_cmd = ["gpg", "--verify-files", filename]

--- a/src/sign_workflow/signer_pgp.py
+++ b/src/sign_workflow/signer_pgp.py
@@ -6,9 +6,10 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import logging
 import os
 from pathlib import Path
-import logging
+
 from sign_workflow.signer import Signer
 
 """
@@ -22,9 +23,9 @@ class SignerPGP(Signer):
     ACCEPTED_FILE_TYPES = [".zip", ".jar", ".war", ".pom", ".module", ".tar.gz", ".whl", ".crate", ".rpm"]
 
     def generate_signature_and_verify(self, artifact: str, basepath: Path, signature_type: str) -> None:
-            location = os.path.join(basepath, artifact)
-            self.sign(artifact, basepath, signature_type)
-            self.verify(location + signature_type)
+        location = os.path.join(basepath, artifact)
+        self.sign(artifact, basepath, signature_type)
+        self.verify(location + signature_type)
 
     def is_valid_file_type(self, file_name: str) -> bool:
         return any(
@@ -49,7 +50,7 @@ class SignerPGP(Signer):
             self.__convert_to_asc(filename, signature_file)
 
     def __convert_to_asc(self, filename: str, signature_file: str) -> None:
-        asc_signature_file = filename + ".asc"       
+        asc_signature_file = filename + ".asc"
         self.__remove_existing_signature__(asc_signature_file)
         conversion_cmd = [
             "gpg --enarmor",

--- a/tests/tests_sign_workflow/test_sign_args.py
+++ b/tests/tests_sign_workflow/test_sign_args.py
@@ -34,7 +34,7 @@ class TestSignArgs(unittest.TestCase):
 
     @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST])
     def test_sigtype_default(self) -> None:
-        self.assertEqual(SignArgs().sigtype, ".asc")
+        self.assertEqual(SignArgs().sigtype, ".sig")
 
     @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST, "--verbose"])
     def test_verbose_true(self) -> None:

--- a/tests/tests_sign_workflow/test_signer_pgp.py
+++ b/tests/tests_sign_workflow/test_signer_pgp.py
@@ -80,7 +80,6 @@ class TestSignerPGP(unittest.TestCase):
         signer = SignerPGP()
         signer.sign = MagicMock()  # type: ignore
         signer.verify = MagicMock()  # type: ignore
-        signer.__convert_to_asc = MagicMock() # type: ignore
         signer.sign_artifacts(artifacts, Path("path"), ".sig")
         self.assertEqual(signer.sign.call_args_list, expected)
 
@@ -101,7 +100,9 @@ class TestSignerPGP(unittest.TestCase):
         signer = SignerPGP()
         signer.sign("the-jar.jar", Path("/path/"), ".asc")
         command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"), 'the-jar.jar') + " -o " + os.path.join(Path("/path/"), 'the-jar.jar.sig') + " -p pgp"
-        conversion_cmd = "gpg --enarmor < " + os.path.join(Path("/path/"), 'the-jar.jar.sig') + " > " + os.path.join(Path("/path/"), 'the-jar.jar.asc') + " && sed -i 's/ARMORED FILE/SIGNATURE/g' " + os.path.join(Path("/path/"), 'the-jar.jar.asc')
+        conversion_cmd = "gpg --enarmor < " + os.path.join(Path("/path/"), 'the-jar.jar.sig') + " > " +\
+                         os.path.join(Path("/path/"), 'the-jar.jar.asc') + " && sed -i 's/ARMORED FILE/SIGNATURE/g' " +\
+                         os.path.join(Path("/path/"), 'the-jar.jar.asc')
         mock_repo.assert_has_calls(
             [call().execute(command)])
         mock_repo.assert_has_calls([call().execute(conversion_cmd)])


### PR DESCRIPTION
### Description
Currently when we say we want `.asc` signature, we only change the extension of the signature file which it is still a binary. This PR fixes the issue where an actual enamored  signature is generated based on the binary signature.
This PR also changes the default signature_type from `.asc` to `.sig`.

Follow up, need to make changes in jenkinsFiles that assumes default signature as `.asc`

### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-build/issues/368

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
