### PR TITLE
Add security & security dashboards to manifest for 2.4

### DIFF
--- a/manifests/2.4.0/opensearch-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-2.4.0.yml
@@ -43,7 +43,7 @@ components:
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '2.4'
+    ref: tags/2.4.0.0
     platforms:
       - linux
       - windows

--- a/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
@@ -27,7 +27,7 @@ components:
     ref: '2.4'
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: tags/2.4.0.0
+    ref: '2.4'
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     ref: '2.4'

--- a/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
+++ b/manifests/2.4.0/opensearch-dashboards-2.4.0.yml
@@ -27,7 +27,7 @@ components:
     ref: '2.4'
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '2.4'
+    ref: tags/2.4.0.0
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     ref: '2.4'


### PR DESCRIPTION
Signed-off-by: Stephen Crawford <steecraw@amazon.com>

### Description
Adds security repos to build manifest for 2.4 release. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
