### PR TITLE
Disable auto build for 2.4.0

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -20,8 +20,6 @@ pipeline {
             H 1 * * * %INPUT_MANIFEST=1.4.0/opensearch-dashboards-1.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux
             H 1 * * * %INPUT_MANIFEST=2.3.1/opensearch-2.3.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows
             H 1 * * * %INPUT_MANIFEST=2.3.1/opensearch-dashboards-2.3.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows
-            H/60 * * * * %INPUT_MANIFEST=2.4.0/opensearch-2.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows
-            H/60 * * * * %INPUT_MANIFEST=2.4.0/opensearch-dashboards-2.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows
         '''


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Disable auto build for 2.4.0 as we are working to generate the release candidates.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/2649

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
