### PR TITLE
Reuse existing pull request in increment plugin workflow

### DIFF
--- a/.github/workflows/increment-plugin-versions.yml
+++ b/.github/workflows/increment-plugin-versions.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           repository: opensearch-project/${{ matrix.entry.repo }}
           ref: ${{ matrix.branch }}
+          fetch-depth: 0
       - name: Attempt to reuse existing pull request in plugin repo
         run: git checkout create-pull-request/${{ env.OPENSEARCH_VERSION }}
         continue-on-error: true

--- a/.github/workflows/increment-plugin-versions.yml
+++ b/.github/workflows/increment-plugin-versions.yml
@@ -68,6 +68,9 @@ jobs:
         with:
           repository: opensearch-project/${{ matrix.entry.repo }}
           ref: ${{ matrix.branch }}
+      - name: Attempt to reuse existing pull request in plugin repo
+        run: git checkout create-pull-request/${{ env.OPENSEARCH_VERSION }}
+        continue-on-error: true
       - name: Increment Version in ${{ matrix.entry.repo }}
         run: |
           echo "OpenSearch Core repo version on branch ${{ matrix.branch }} is ${{ env.OPENSEARCH_VERSION_NUMBER }}"


### PR DESCRIPTION
### Description
Not all plugins can immediately merge changes from this workflow and need to add changes before the generated pull request can be merged.  This update prevents that existing branch from being overridden if the job is re-run while we wait for health builds.

Aspiring issue: https://github.com/opensearch-project/security/pull/2210#issuecomment-1308987770

### Issues Resolved
- Related https://github.com/opensearch-project/security/pull/2210

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
