### PR TITLE
Fix failing manifest workflow

### DIFF
--- a/src/manifests_workflow/component_opensearch.py
+++ b/src/manifests_workflow/component_opensearch.py
@@ -21,12 +21,13 @@ class ComponentOpenSearch(Component):
         name: str,
         path: str,
         opensearch_version: str,
+        component_repo: str,
         branch: str = "main",
         snapshot: bool = False,
         working_directory: str = None,
     ) -> 'ComponentOpenSearch':
         with GitRepository(
-            f"https://github.com/opensearch-project/{name}.git",
+            component_repo,
             branch,
             path,
             working_directory,

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -104,6 +104,7 @@ class InputManifests(Manifests):
                         name=component.name,
                         path=os.path.join(work_dir.name, component.name),
                         opensearch_version=manifest.build.version,
+                        component_repo=component.repository,
                         branch="main",
                     )
 

--- a/tests/tests_manifests_workflow/test_component_opensearch.py
+++ b/tests/tests_manifests_workflow/test_component_opensearch.py
@@ -16,7 +16,7 @@ class TestComponentOpenSearch(unittest.TestCase):
     @patch("os.makedirs")
     @patch.object(GitRepository, "__checkout__")
     def test_checkout(self, *mocks: MagicMock) -> None:
-        component = ComponentOpenSearch.checkout("common-utils", "path", "1.1.0")
+        component = ComponentOpenSearch.checkout("common-utils", "path", "1.1.0", "git")
         self.assertEqual(component.name, "common-utils")
         self.assertFalse(component.snapshot)
 


### PR DESCRIPTION
### Description
This PR fixes version workflow to auto update input manifests. 

### Issues Resolved
#2854 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
