### PR TITLE
Fix status code for gradle check with retry

### DIFF
--- a/scripts/gradle/gradle-check.sh
+++ b/scripts/gradle/gradle-check.sh
@@ -61,11 +61,11 @@ fi
 
 echo "Please check jenkins url for logs: $WORKFLOW_URL"
 
-if [ "$RESULT" != "SUCCESS" ]; then
-    echo "Result: $RESULT"
-    exit 1
-else
+if [ "$RESULT" == "SUCCESS" || "$RESULT" == "UNSTABLE" ]; then
     echo "Result: $RESULT"
     echo "Get codeCoverage.xml" && curl -SLO ${WORKFLOW_URL}artifact/codeCoverage.xml
     echo 0
+else
+    echo "Result: $RESULT"
+    exit 1
 fi


### PR DESCRIPTION
Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

### Description
- Fixes gradle check status code in case a test succeeds with retries
- Status value from [here](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/model/Result.java)

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/5239

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
