### PR TITLE
Fix status syntax for gradle check

### DIFF
--- a/scripts/gradle/gradle-check.sh
+++ b/scripts/gradle/gradle-check.sh
@@ -61,7 +61,7 @@ fi
 
 echo "Please check jenkins url for logs: $WORKFLOW_URL"
 
-if [ "$RESULT" == "SUCCESS" || "$RESULT" == "UNSTABLE" ]; then
+if [ "$RESULT" == "SUCCESS" ] || [ "$RESULT" == "UNSTABLE" ]; then
     echo "Result: $RESULT"
     echo "Get codeCoverage.xml" && curl -SLO ${WORKFLOW_URL}artifact/codeCoverage.xml
     echo 0


### PR DESCRIPTION
Signed-off-by: Kunal Kotwani <kkotwani@amazon.com>

### Description
- Fixes wrong sh syntax for status check with multiple conditions

### Issues Resolved
- https://github.com/opensearch-project/OpenSearch/issues/5239

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
