### PR TITLE
Add build platform param to cron for distribution build workflow

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H 1 * * * %INPUT_MANIFEST=2.5.0/opensearch-2.5.0.yml;TARGET_JOB_NAME=distribution-build-opensearch
+            H 1 * * * %INPUT_MANIFEST=2.5.0/opensearch-2.5.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows
             H 1 * * * %INPUT_MANIFEST=1.3.7/opensearch-1.3.7.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos
             H 1 * * * %INPUT_MANIFEST=1.3.7/opensearch-dashboards-1.3.7.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux
             H 1 * * * %INPUT_MANIFEST=1.4.0/opensearch-1.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Add build platform to cron for distribution build workflow
Current cron doesn't have this parameter and it aborted the auto build. 

I will create an issue for this and look for a fix.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
