### PR TITLE
Improve output on gradle check timeout

### DIFF
--- a/scripts/gradle/gradle-check.sh
+++ b/scripts/gradle/gradle-check.sh
@@ -53,19 +53,21 @@ if [ -z "$QUEUE_URL" ] || [ "$QUEUE_URL" != "null" ]; then
             RUNNING=$(curl -s -XGET ${WORKFLOW_URL}api/json | jq --raw-output .building)
         done
 
-        echo "Complete the run, checking results now......"
-        RESULT=$(curl -s -XGET ${WORKFLOW_URL}api/json | jq --raw-output .result)
+        if [ "$RUNNING" = "true" ]; then
+            echo "Timed out"
+            RESULT="TIMEOUT"
+        else
+            echo "Complete the run, checking results now......"
+            RESULT=$(curl -s -XGET ${WORKFLOW_URL}api/json | jq --raw-output .result)
+        fi
 
     fi
 fi
 
 echo "Please check jenkins url for logs: $WORKFLOW_URL"
-
+echo "Result: $RESULT"
 if [ "$RESULT" == "SUCCESS" ] || [ "$RESULT" == "UNSTABLE" ]; then
-    echo "Result: $RESULT"
     echo "Get codeCoverage.xml" && curl -SLO ${WORKFLOW_URL}artifact/codeCoverage.xml
-    echo 0
 else
-    echo "Result: $RESULT"
     exit 1
 fi


### PR DESCRIPTION
The result ends up being reported as 'null' when this script times out. Also the output never directly indicates that a timeout occurred, so this commit makes the output more explicit.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
