### PR TITLE
allow find build script by repo component

### DIFF
--- a/src/paths/script_finder.py
+++ b/src/paths/script_finder.py
@@ -48,6 +48,7 @@ class ScriptFinder:
     def __find_named_script(cls, script_name: str, component_name: str, git_dir: str) -> str:
         paths = [
             os.path.realpath(os.path.join(cls.component_scripts_path, component_name, script_name)),
+            os.path.realpath(os.path.join(git_dir, component_name, script_name)),
             os.path.realpath(os.path.join(git_dir, script_name)),
             os.path.realpath(os.path.join(git_dir, "scripts", script_name)),
             os.path.realpath(os.path.join(cls.default_scripts_path, script_name)),
@@ -59,6 +60,7 @@ class ScriptFinder:
     def find_build_script(cls, project: str, component_name: str, git_dir: str) -> str:
         paths = [
             os.path.realpath(os.path.join(cls.component_scripts_path, component_name, "build.sh")),
+            os.path.realpath(os.path.join(git_dir, component_name, "build.sh")),
             os.path.realpath(os.path.join(git_dir, "build.sh")),
             os.path.realpath(os.path.join(git_dir, "scripts", "build.sh")),
             os.path.realpath(


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
At [dashboards-maps](https://github.com/opensearch-project/dashboards-maps) repo, it has two OSD plugins, raising this PR in order to allow find correct plugin  build script.

### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/83

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
