### PR TITLE
Fix syntax error in OpenSearch-Dashboards/build.sh

### DIFF
--- a/scripts/components/OpenSearch-Dashboards/build.sh
+++ b/scripts/components/OpenSearch-Dashboards/build.sh
@@ -95,12 +95,14 @@ case $PLATFORM-$DISTRIBUTION-$ARCHITECTURE in
         BUILD_PARAMS="build-platform"
         EXTRA_PARAMS="--skip-os-packages"
         SUFFIX="$PLATFORM-x64"
+        ;;
     linux-deb-arm64)
         TARGET="--$DISTRIBUTION-arm"
         EXT="$DISTRIBUTION"
         BUILD_PARAMS="build"
         EXTRA_PARAMS="--skip-archives"
         SUFFIX="arm64"
+        ;;
     linux-deb-x64)
         TARGET="--$DISTRIBUTION"
         EXT="$DISTRIBUTION"


### PR DESCRIPTION
Signed-off-by: Martin Wilhelmi <mnin@mnin.de>

### Description

Fix syntax error in `build.sh` file.

### Issues Resolved

- fix [#2960](https://github.com/opensearch-project/opensearch-build/issues/2942)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
