### PR TITLE
Test and document build finder script at component folder

### DIFF
--- a/src/paths/script_finder.py
+++ b/src/paths/script_finder.py
@@ -26,6 +26,7 @@ class ScriptFinder:
     For build.sh and integtest.sh scripts, given a component name and a checked-out Git repository,
     it will look in the following locations, in order:
       * <component_scripts_path>/<component_name>/<script-name>
+      * /<component_name>/<script-name> in the component's Git repository
       * root of the component's Git repository
       * /scripts/<script-name> in the component's Git repository
       * <default_scripts_path>/<script-name>

--- a/tests/tests_paths/data/git/component_with_scripts_in_component_folder/Component/build.sh
+++ b/tests/tests_paths/data/git/component_with_scripts_in_component_folder/Component/build.sh
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright OpenSearch Contributors
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/tests/tests_paths/data/git/component_with_scripts_in_component_folder/Component/bwctest.sh
+++ b/tests/tests_paths/data/git/component_with_scripts_in_component_folder/Component/bwctest.sh
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright OpenSearch Contributors
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/tests/tests_paths/data/git/component_with_scripts_in_component_folder/Component/install.sh
+++ b/tests/tests_paths/data/git/component_with_scripts_in_component_folder/Component/install.sh
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright OpenSearch Contributors
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/tests/tests_paths/data/git/component_with_scripts_in_component_folder/Component/integtest.sh
+++ b/tests/tests_paths/data/git/component_with_scripts_in_component_folder/Component/integtest.sh
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright OpenSearch Contributors
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/tests/tests_paths/test_script_finder.py
+++ b/tests/tests_paths/test_script_finder.py
@@ -20,6 +20,7 @@ class TestScriptFinder(unittest.TestCase):
         self.component_with_scripts = os.path.join(self.data_path, "git", "component-with-scripts")
         self.component_with_scripts_folder = os.path.join(self.data_path, "git", "component-with-scripts-folder")
         self.component_without_scripts = os.path.join(self.data_path, "git", "component-without-scripts")
+        self.component_with_scripts_in_component_folder = os.path.join(self.data_path, "git", "component_with_scripts_in_component_folder")
 
     # find_build_script
 
@@ -65,6 +66,13 @@ class TestScriptFinder(unittest.TestCase):
             msg="A component with a scripts folder resolves to the override.",
         )
 
+    def test_find_build_script_component_script_in_component_folder(self) -> None:
+        self.assertEqual(
+            os.path.join(self.component_with_scripts_in_component_folder, "Component", "build.sh"),
+            ScriptFinder.find_build_script("Component", "Component", self.component_with_scripts_in_component_folder),
+            msg="A component with a script in component folder resolves to the override.",
+        )
+
     @patch("os.path.exists", return_value=False)
     def test_find_build_script_does_not_exist(self, *mocks: MagicMock) -> None:
         with self.assertRaisesRegex(
@@ -108,6 +116,13 @@ class TestScriptFinder(unittest.TestCase):
             os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "integtest.sh"),
             ScriptFinder.find_integ_test_script("OpenSearch", self.component_with_scripts_folder),
             msg="A component with a scripts folder resolves to a script in that folder.",
+        )
+
+    def test_find_integ_test_script_component_script_in_component_folder(self) -> None:
+        self.assertEqual(
+            os.path.join(self.component_with_scripts_in_component_folder, "Component", "integtest.sh"),
+            ScriptFinder.find_integ_test_script("Component", self.component_with_scripts_in_component_folder),
+            msg="A component with a script in component folder resolves to the override.",
         )
 
     @patch("os.path.exists", return_value=False)
@@ -177,6 +192,13 @@ class TestScriptFinder(unittest.TestCase):
             os.path.join(ScriptFinder.component_scripts_path, "OpenSearch", "bwctest.sh"),
             ScriptFinder.find_bwc_test_script("OpenSearch", self.component_with_scripts_folder),
             msg="A component with a scripts folder resolves to a script in that folder.",
+        )
+
+    def test_find_bwc_test_script_component_script_in_component_folder(self) -> None:
+        self.assertEqual(
+            os.path.join(self.component_with_scripts_in_component_folder, "Component", "bwctest.sh"),
+            ScriptFinder.find_bwc_test_script("Component", self.component_with_scripts_in_component_folder),
+            msg="A component with a script in component folder resolves to the override.",
         )
 
     @patch("os.path.exists", return_value=False)


### PR DESCRIPTION
Signed-off-by: Junqiu Lei <junqiu@amazon.com>

### Description
 Following up with PR https://github.com/opensearch-project/opensearch-build/pull/2934, updating test and document to script finder.

### Issues Resolved
https://github.com/opensearch-project/dashboards-maps/issues/83
https://github.com/opensearch-project/opensearch-build/issues/2945

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
