### PR TITLE
Increase timeout for OSD workflows

### DIFF
--- a/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
@@ -5,7 +5,7 @@ lib = library(identifier: 'jenkins@1.0.4', retriever: modernSCM([
 
 pipeline {
     options {
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
     }
     agent none
     environment {

--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -5,7 +5,7 @@ lib = library(identifier: 'jenkins@1.0.4', retriever: modernSCM([
 
 pipeline {
     options {
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
     }
     agent none
     environment {

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/bwc-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/bwc-test.jenkinsfile.txt
@@ -2,7 +2,7 @@
       bwc-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
       bwc-test.library({identifier=jenkins@1.0.4, retriever=null})
       bwc-test.pipeline(groovy.lang.Closure)
-         bwc-test.timeout({time=3, unit=HOURS})
+         bwc-test.timeout({time=4, unit=HOURS})
          bwc-test.echo(Executing on agent [label:none])
          bwc-test.stage(verify-parameters, groovy.lang.Closure)
             bwc-test.echo(Executing on agent [label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
@@ -2,7 +2,7 @@
       integ-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
       integ-test.library({identifier=jenkins@1.0.4, retriever=null})
       integ-test.pipeline(groovy.lang.Closure)
-         integ-test.timeout({time=3, unit=HOURS})
+         integ-test.timeout({time=4, unit=HOURS})
          integ-test.echo(Executing on agent [label:none])
          integ-test.stage(verify-parameters, groovy.lang.Closure)
             integ-test.echo(Executing on agent [label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host])


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
With increase in number of plugins, looks like 3hrs are not enough. Increasing the timeout for OSD workflows to 4hrs

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
