### PR TITLE
Enable k-NN in 2.5 manifest

### DIFF
--- a/manifests/2.5.0/opensearch-2.5.0.yml
+++ b/manifests/2.5.0/opensearch-2.5.0.yml
@@ -46,3 +46,12 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: k-NN
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
Enables k-NN in 2.5 manifest to point to 2.x. k-NN 2.x was upgraded to 2.5: https://github.com/opensearch-project/k-NN/blob/2.x/build.gradle#L13.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
