### PR TITLE
Add Common Utils to 2.2.2 manifest

### DIFF
--- a/manifests/2.2.2/opensearch-2.2.2.yml
+++ b/manifests/2.2.2/opensearch-2.2.2.yml
@@ -22,3 +22,12 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: '2.2'
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:publish
+      - gradle:properties:version

--- a/manifests/2.2.2/opensearch-2.2.2.yml
+++ b/manifests/2.2.2/opensearch-2.2.2.yml
@@ -27,7 +27,6 @@ components:
     ref: '2.2'
     platforms:
       - linux
-      - windows
     checks:
       - gradle:publish
       - gradle:properties:version


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Adding Common Utils to 2.2.2 manifest to unblock dependent plugins from bumping up to 2.2.2

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
