### PR TITLE
Reorder components in 2.2.2 manifest to fix build order

### DIFF
--- a/manifests/2.2.2/opensearch-2.2.2.yml
+++ b/manifests/2.2.2/opensearch-2.2.2.yml
@@ -21,7 +21,7 @@ components:
       - linux
     checks:
       - gradle:publish
-      - gradle:properties:versiong
+      - gradle:properties:version
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: '2.2'

--- a/manifests/2.2.2/opensearch-2.2.2.yml
+++ b/manifests/2.2.2/opensearch-2.2.2.yml
@@ -14,6 +14,17 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: '2.2'
+    platforms:
+      - linux
+    checks:
+      - gradle:publish
+      - gradle:properties:versiong
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: '2.2'
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
     ref: '2.2'
@@ -30,14 +41,3 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
-  - name: common-utils
-    repository: https://github.com/opensearch-project/common-utils.git
-    ref: '2.2'
-    platforms:
-      - linux
-    checks:
-      - gradle:publish
-      - gradle:properties:version
-  - name: security
-    repository: https://github.com/opensearch-project/security.git
-    ref: '2.2'


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
Moving common-utils and security earlier in the 2.2.2 manifest definition to make sure maven local has them for downstream components when building the distribution.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
