### PR TITLE
Update template to add verify release date in Release verification section

### DIFF
--- a/meta/templates/releases/release_template.md
+++ b/meta/templates/releases/release_template.md
@@ -59,6 +59,7 @@ If including changes in this release, increment the version on `__{REPLACE_MAJOR
 
 - [ ] Complete [documentation](https://github.com/opensearch-project/documentation-website).
 - [ ] Verify all issued labeled for this release are closed or labelled for the next release.
+- [ ] Verify the release date mentioned in release notes is correct and matches actual release date.
 
 ### Post Release
 


### PR DESCRIPTION
Signed-off-by: Suraj Singh <surajrider@gmail.com>

### Description
Coming from https://github.com/opensearch-project/opensearch-build/issues/2925#issuecomment-1355238987, this change adds a verification step in `Release` section to verify the release date in release notes. 

### Issues Related
https://github.com/opensearch-project/opensearch-build/issues/2742
https://github.com/opensearch-project/opensearch-build/issues/2925


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
