### PR TITLE
Remove 1.x branch from the workflow for auto version bump

### DIFF
--- a/.github/workflows/increment-plugin-versions.yml
+++ b/.github/workflows/increment-plugin-versions.yml
@@ -43,7 +43,6 @@ jobs:
           - {repo: security-analytics}
           - {repo: sql}
         branch:
-          - 1.x
           - '1.3'
           - 2.x
           - '2.2'


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Remove 1.x branch from the workflow for auto version bump. It's not necessary to raise version bump PR on component repo as we decide[ not to launch 1.4.0 release](https://github.com/opensearch-project/opensearch-build/issues/1749#issuecomment-1081205946). Few plugins may not be available in order to merge the version bump PR. 
However it would continuously cut PR even we closed it. I'm removing it for now and we could always go back. 

### Issues Resolved
https://github.com/opensearch-project/ml-commons/pull/637#issuecomment-1356013304

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
