### PR TITLE
OSD jenkinsfile bug

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -692,7 +692,6 @@ pipeline {
                     if (params.BUILD_PLATFORM.contains('linux')) {
                         stages = [
                             'build-and-test-linux-x64-tar',
-                            'build-and-test-linux-arm64-tar',
                             'assemble-archive-and-test-linux-x64-rpm',
                             'assemble-archive-and-test-linux-arm64-tar',
                             'assemble-archive-and-test-linux-arm64-rpm',


### PR DESCRIPTION
Signed-off-by: Prudhvi Godithi <pgodithi@amazon.com>

### Description
Fix error:
Jenkins build error for OSD distribution [No messages found for build-and-test-linux-arm64-tar]

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3028

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
