### PR TITLE
Upgrade node version to 14.20.1 for 2.5.0

### DIFF
--- a/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
@@ -94,7 +94,7 @@ ENV PATH=/usr/share/opensearch/.gem/gems/fpm-1.14.2/bin:$PATH
 # nvm environment variables
 ENV NVM_DIR /usr/share/opensearch/.nvm
 ENV NODE_VERSION 10.24.1
-ARG NODE_VERSION_LIST="10.24.1 14.19.1 14.20.0"
+ARG NODE_VERSION_LIST="10.24.1 14.19.1 14.20.0 14.20.1"
 COPY --chown=1000:1000 config/build-opensearch-dashboards-entrypoint.sh /usr/share/opensearch
 # install nvm
 # https://github.com/creationix/nvm#install-script


### PR DESCRIPTION
Signed-off-by: Zilong Xia <zilongx@amazon.com>

### Description
* Upgrade node version from 14.20.0 to 14.20.1 for Opensearch Dashboards

### Issues Resolved
* This node version bump is required to resolve CVE issue https://github.com/advisories/GHSA-rc2m-q589-vpqx
* This is the PR on OSD side https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3166 which is pending the current PR to be merged in first to avoid any build failure

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
