### PR TITLE
Fix the path join for running integ test

### DIFF
--- a/src/test_workflow/dependency_installer_opensearch.py
+++ b/src/test_workflow/dependency_installer_opensearch.py
@@ -37,6 +37,6 @@ class DependencyInstallerOpenSearch(DependencyInstaller):
         """
         os.makedirs(dest, exist_ok=True)
         for dependency, version in dependency_dict.items():
-            path = f"{self.root_url}/builds/opensearch/plugins/{dependency}-{version}.zip"
+            path = os.path.join(self.root_url, f"builds/opensearch/plugins/{dependency}-{version}.zip")
             local_path = os.path.join(dest, f"{dependency}-{version}.zip")
             self.download_or_copy(path, local_path)

--- a/tests/tests_test_workflow/test_dependency_installer_opensearch.py
+++ b/tests/tests_test_workflow/test_dependency_installer_opensearch.py
@@ -138,3 +138,19 @@ class DependencyInstallerOpenSearchTests(unittest.TestCase):
             "https://ci.opensearch.org/x/y/builds/opensearch/plugins/opensearch-job-scheduler-1.1.0.0.zip",
             os.path.realpath(os.path.join(os.path.dirname(__file__), "opensearch-job-scheduler-1.1.0.0.zip")),
         )
+
+    @patch("os.makedirs")
+    @patch("shutil.copyfile")
+    @patch("urllib.request.urlretrieve")
+    def test_install_build_dependencies_remote_with_backslash_url(self, mock_request: Mock, mock_copyfile: Mock, mock_makedirs: Mock) -> None:
+        dependency_installer_url_with_backslash = DependencyInstallerOpenSearch(
+            "https://ci.opensearch.org/x/y/", BuildManifest.from_path(self.BUILD_MANIFEST), BundleManifest.from_path(self.DIST_MANIFEST_REMOTE)
+        )
+        dependencies = dict({"opensearch-job-scheduler": "1.1.0.0"})
+        dependency_installer_url_with_backslash.install_build_dependencies(dependencies, os.path.dirname(__file__))
+        mock_makedirs.assert_called_with(os.path.dirname(__file__), exist_ok=True)
+        mock_copyfile.assert_not_called()
+        mock_request.assert_called_once_with(
+            "https://ci.opensearch.org/x/y/builds/opensearch/plugins/opensearch-job-scheduler-1.1.0.0.zip",
+            os.path.realpath(os.path.join(os.path.dirname(__file__), "opensearch-job-scheduler-1.1.0.0.zip")),
+        )


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Fix the path by using `os.path.join` instead of hard connected. This would resolve the issue when there is a need to install dependency plugin for running tests. 
The origin error for the issue on installing maven artifacts was resolved earlier in this PR. https://github.com/opensearch-project/opensearch-build/pull/2892

### Issues Resolved
#969 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
