### PR TITLE
Add alerting plugin to 2.5.0 manifest

### DIFF
--- a/manifests/2.5.0/opensearch-2.5.0.yml
+++ b/manifests/2.5.0/opensearch-2.5.0.yml
@@ -112,3 +112,12 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Adding alerting plugin to our 2.5.0 manifest for build as the version bump [PR](https://github.com/opensearch-project/alerting/pull/629) is merged and I confirmed with @lezzago that there wasn't any known issue with it. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
