### PR TITLE
Add AD Dashboards to 2.5 manifest

### DIFF
--- a/manifests/2.5.0/opensearch-dashboards-2.5.0.yml
+++ b/manifests/2.5.0/opensearch-dashboards-2.5.0.yml
@@ -25,3 +25,6 @@ components:
     repository: https://github.com/opensearch-project/observability.git
     working_directory: dashboards-observability
     ref: 2.x
+  - name: anomalyDetectionDashboards
+    repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
+    ref: 2.x


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description
Add AD Dashboards to 2.5 manifest

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
