### PR TITLE
Add security-dashboards-plugin to the 2.5.0 manifests

### DIFF
--- a/manifests/2.5.0/opensearch-dashboards-2.5.0.yml
+++ b/manifests/2.5.0/opensearch-dashboards-2.5.0.yml
@@ -28,3 +28,6 @@ components:
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
     ref: 2.x
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+    ref: 2.x


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>

### Description
Add security-dashboards-plugin to the 2.5.0 manifests
### Issues Resolved
* Relate https://github.com/opensearch-project/security-dashboards-plugin/issues/1286

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
