### PR TITLE
Enable neural search for 2.5

### DIFF
--- a/manifests/2.5.0/opensearch-2.5.0.yml
+++ b/manifests/2.5.0/opensearch-2.5.0.yml
@@ -64,6 +64,15 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: neural-search
+    repository: https://github.com/opensearch-project/neural-search.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
     ref: 2.x


### PR DESCRIPTION
### Description
Enable neural search for 2.5. Currently 2.x points to 2.5: https://github.com/opensearch-project/neural-search/blob/2.x/build.gradle#L76

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
