### PR TITLE
Enable geo plugin for 2.5

### DIFF
--- a/manifests/2.5.0/opensearch-2.5.0.yml
+++ b/manifests/2.5.0/opensearch-2.5.0.yml
@@ -41,6 +41,15 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
+  - name: geospatial
+    repository: https://github.com/opensearch-project/geospatial.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: 2.x


### PR DESCRIPTION
### Description
Enable geo for 2.5. Currently 2.x points to 2.5: https://github.com/opensearch-project/geospatial/blob/2.x/build.gradle#L48

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
