### PR TITLE
Remove working directory for reports-scheduler

### DIFF
--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -47,7 +47,6 @@ components:
     platforms:
       - linux
       - windows
-    working_directory: reports-scheduler
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/3.0.0/opensearch-dashboards-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-dashboards-3.0.0.yml
@@ -14,8 +14,7 @@ components:
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
     ref: main
   - name: reportsDashboards
-    repository: https://github.com/opensearch-project/reporting.git
-    working_directory: dashboards-reports
+    repository: https://github.com/opensearch-project/dashboards-reporting.git
     ref: main
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git


### PR DESCRIPTION
Signed-off-by: Rupal Mahajan <maharup@amazon.com>

### Description
- Removed working directory for reports-scheduler. (Repo split is done so this is not required anymore)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/pull/3074#issuecomment-1377929017

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
