### PR TITLE
Update k-NN in 2.6.0 manifest

### DIFF
--- a/manifests/2.6.0/opensearch-2.6.0.yml
+++ b/manifests/2.6.0/opensearch-2.6.0.yml
@@ -32,3 +32,12 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: k-NN
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: '2.x'
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
### Description
Points k-NN in 2.6 manifest to 2.x.

~Dont merge until https://github.com/opensearch-project/k-NN/pull/722 is merged.~ 722 has been merged. This can be merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
