### PR TITLE
Add security 2.x branch into 2.6.0 manifest

### DIFF
--- a/manifests/2.6.0/opensearch-2.6.0.yml
+++ b/manifests/2.6.0/opensearch-2.6.0.yml
@@ -61,3 +61,9 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: '2.x'
+    platforms:
+      - linux
+      - windows


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>

### Description
Add security 2.x branch into 2.6.0 manifest

### Issues Resolved
* Relate https://github.com/opensearch-project/security/issues/2373

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
