### PR TITLE
debian package: improve wording in `postinst` script

### DIFF
--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
@@ -28,9 +28,9 @@ fi
 systemd-tmpfiles --create opensearch-dashboards.conf
 
 # Messages
-echo "### NOT starting on installation, please execute the following statements to configure opensearch-dashboards service to start automatically using systemd"
+echo "### NOT starting on installation, please execute the following command to configure the opensearch-dashboards service to start automatically"
 echo " systemctl enable opensearch-dashboards.service"
-echo "### You can start opensearch-dashboards service by executing"
+echo "### You can start the opensearch-dashboards service by executing"
 echo " systemctl start opensearch-dashboards.service"
 
 # Set owner

--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
@@ -29,9 +29,9 @@ systemd-tmpfiles --create opensearch-dashboards.conf
 
 # Messages
 echo "### NOT starting on installation, please execute the following statements to configure opensearch-dashboards service to start automatically using systemd"
-echo " sudo systemctl enable opensearch-dashboards.service"
+echo " systemctl enable opensearch-dashboards.service"
 echo "### You can start opensearch-dashboards service by executing"
-echo " sudo systemctl start opensearch-dashboards.service"
+echo " systemctl start opensearch-dashboards.service"
 
 # Set owner
 chown -R opensearch-dashboards.opensearch-dashboards ${product_dir}

--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
@@ -29,7 +29,6 @@ systemd-tmpfiles --create opensearch-dashboards.conf
 
 # Messages
 echo "### NOT starting on installation, please execute the following statements to configure opensearch-dashboards service to start automatically using systemd"
-echo " sudo systemctl daemon-reload"
 echo " sudo systemctl enable opensearch-dashboards.service"
 echo "### You can start opensearch-dashboards service by executing"
 echo " sudo systemctl start opensearch-dashboards.service"

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -48,7 +48,6 @@ systemd-tmpfiles --create opensearch.conf
 
 # Messages
 echo "### NOT starting on installation, please execute the following statements to configure opensearch service to start automatically using systemd"
-echo " sudo systemctl daemon-reload"
 echo " sudo systemctl enable opensearch.service"
 echo "### You can start opensearch service by executing"
 echo " sudo systemctl start opensearch.service"

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -48,9 +48,9 @@ systemd-tmpfiles --create opensearch.conf
 
 # Messages
 echo "### NOT starting on installation, please execute the following statements to configure opensearch service to start automatically using systemd"
-echo " sudo systemctl enable opensearch.service"
+echo " systemctl enable opensearch.service"
 echo "### You can start opensearch service by executing"
-echo " sudo systemctl start opensearch.service"
+echo " systemctl start opensearch.service"
 
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
     echo "### Create opensearch demo certificates in ${config_dir}/"

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -47,9 +47,9 @@ sysctl -p /usr/lib/sysctl.d/opensearch.conf > /dev/null 2>&1
 systemd-tmpfiles --create opensearch.conf
 
 # Messages
-echo "### NOT starting on installation, please execute the following statements to configure opensearch service to start automatically using systemd"
+echo "### NOT starting on installation, please execute the following command to configure the opensearch service to start automatically"
 echo " systemctl enable opensearch.service"
-echo "### You can start opensearch service by executing"
+echo "### You can start the opensearch service by executing"
 echo " systemctl start opensearch.service"
 
 if [ -d ${product_dir}/plugins/opensearch-security ]; then


### PR DESCRIPTION
### Description
This pull request changes the wording in output of the postinst script of the new Debian packages for OpenSearch and OpenSearch Dashboards.

- Remove the call for a `daemon-reload`. This is already done in the postinst script and thus running it again would be redundant.
- Remove `sudo` from the commands for the following reasons: 
  - `dpkg` already has to be run as root to install the package
  - `sudo` is not shipped by Debian in all cases and other tools exist (such as `doas`, `su`, etc.)
  - `systemctl` can use Polkit to ask for a password when a user session exists which would make `sudo` redundant
- Change the wording and fix some grammatical issues

Let me know if you'd like me to revise this or if you have any other input. Thanks!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
