### PR TITLE
Add security-dashboards-plugin's 2.x branch into 2.6.0 manifest

### DIFF
--- a/manifests/2.6.0/opensearch-dashboards-2.6.0.yml
+++ b/manifests/2.6.0/opensearch-dashboards-2.6.0.yml
@@ -13,3 +13,6 @@ components:
   - name: notificationsDashboards
     repository: https://github.com/opensearch-project/dashboards-notifications.git
     ref: '2.x'
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+    ref: '2.x'


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>

### Description
Add security-dashboards-plugin's 2.x branch into 2.6.0 manifest

### Issues Resolved
* Relate https://github.com/opensearch-project/security-dashboards-plugin/issues/1286
* Relate https://github.com/opensearch-project/security-dashboards-plugin/pull/1301

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
