### PR TITLE
Add support to overwrite an existing artifact for signing process and add verification for windows

### DIFF
--- a/src/run_sign.py
+++ b/src/run_sign.py
@@ -23,7 +23,8 @@ def main() -> int:
         components=args.components,
         artifact_type=args.type,
         signature_type=args.sigtype,
-        platform=args.platform
+        platform=args.platform,
+        overwrite=args.overwrite
     )
 
     sign.sign()

--- a/src/sign_workflow/sign_args.py
+++ b/src/sign_workflow/sign_args.py
@@ -20,14 +20,46 @@ class SignArgs:
     type: str
     sigtype: str
     platform: str
+    overwrite: bool
 
     def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="Sign artifacts")
-        parser.add_argument("target", type=Path, help="Path to local manifest file or artifact directory")
-        parser.add_argument("-c", "--component", type=str, nargs='*', dest="components", help="Component or components to sign")
-        parser.add_argument("--type", help="Artifact type")
-        parser.add_argument("--sigtype", choices=self.ACCEPTED_SIGNATURE_FILE_TYPES, help="Type of signature file.", default=".sig")
-        parser.add_argument("--platform", choices=self.ACCEPTED_PLATFORM, help="Distribution platform.", default="linux")
+        parser.add_argument(
+            "target",
+            type=Path,
+            help="Path to local manifest file or artifact directory"
+        )
+        parser.add_argument(
+            "-c",
+            "--component",
+            type=str,
+            nargs='*',
+            dest="components",
+            help="Component or components to sign"
+        )
+        parser.add_argument(
+            "--type",
+            help="Artifact type"
+        )
+        parser.add_argument(
+            "--sigtype",
+            choices=self.ACCEPTED_SIGNATURE_FILE_TYPES,
+            help="Type of signature file.",
+            default=".sig"
+        )
+        parser.add_argument(
+            "--platform",
+            choices=self.ACCEPTED_PLATFORM,
+            help="Distribution platform.",
+            default="linux"
+        )
+        parser.add_argument(
+            "--overwrite",
+            action="store_true",
+            help="Overwrite existing artifacts or signature files.",
+            default=False,
+            dest="overwrite"
+        )
         parser.add_argument(
             "-v",
             "--verbose",
@@ -45,3 +77,4 @@ class SignArgs:
         self.sigtype = args.sigtype
         self.components = args.components
         self.platform = args.platform
+        self.overwrite = args.overwrite

--- a/src/sign_workflow/sign_artifacts.py
+++ b/src/sign_workflow/sign_artifacts.py
@@ -25,13 +25,13 @@ class SignArtifacts:
     platform: str
     signer: Signer
 
-    def __init__(self, target: Path, components: List[str], artifact_type: str, signature_type: str, platform: str) -> None:
+    def __init__(self, target: Path, components: List[str], artifact_type: str, signature_type: str, platform: str, overwrite: bool) -> None:
         self.target = target
         self.components = components
         self.artifact_type = artifact_type
         self.signature_type = signature_type
         self.platform = platform
-        self.signer = Signers.create(platform)
+        self.signer = Signers.create(platform, overwrite)
 
     @abstractmethod
     def __sign__(self) -> None:
@@ -57,9 +57,9 @@ class SignArtifacts:
             return SignArtifactsExistingArtifactFile
 
     @classmethod
-    def from_path(self, path: Path, components: List[str], artifact_type: str, signature_type: str, platform: str) -> Any:
+    def from_path(self, path: Path, components: List[str], artifact_type: str, signature_type: str, platform: str, overwrite: bool) -> Any:
         klass = self.__signer_class__(path)
-        return klass(path, components, artifact_type, signature_type, platform)
+        return klass(path, components, artifact_type, signature_type, platform, overwrite)
 
 
 class SignWithBuildManifest(SignArtifacts):

--- a/src/sign_workflow/signer.py
+++ b/src/sign_workflow/signer.py
@@ -17,8 +17,10 @@ from git.git_repository import GitRepository
 
 class Signer(ABC):
     git_repo: GitRepository
+    overwrite: bool
 
-    def __init__(self) -> None:
+    def __init__(self, overwrite: bool) -> None:
+        self.overwrite = overwrite
         self.git_repo = GitRepository(self.get_repo_url(), "HEAD", working_subdirectory="src")
         self.git_repo.execute("./bootstrap")
         self.git_repo.execute("rm config.cfg")

--- a/src/sign_workflow/signer_pgp.py
+++ b/src/sign_workflow/signer_pgp.py
@@ -19,7 +19,6 @@ The signed artifacts will be found in the same location as the original artifact
 
 
 class SignerPGP(Signer):
-
     ACCEPTED_FILE_TYPES = [".zip", ".jar", ".war", ".pom", ".module", ".tar.gz", ".whl", ".crate", ".rpm", ".deb"]
 
     def generate_signature_and_verify(self, artifact: str, basepath: Path, signature_type: str) -> None:
@@ -35,7 +34,9 @@ class SignerPGP(Signer):
     def sign(self, artifact: str, basepath: Path, signature_type: str) -> None:
         filename = os.path.join(basepath, artifact)
         signature_file = filename + ".sig"
-        self.__remove_existing_signature__(signature_file)
+        if not self.overwrite:
+            self.__remove_existing_signature__(signature_file)
+
         signing_cmd = [
             "./opensearch-signer-client",
             "-i",
@@ -44,9 +45,11 @@ class SignerPGP(Signer):
             signature_file,
             "-p",
             "pgp",
+            "-r",
+            str(self.overwrite)
         ]
         self.git_repo.execute(" ".join(signing_cmd))
-        if(signature_type == ".asc"):
+        if (signature_type == ".asc"):
             self.__convert_to_asc(filename, signature_file)
 
     def __convert_to_asc(self, filename: str, signature_file: str) -> None:

--- a/src/sign_workflow/signer_windows.py
+++ b/src/sign_workflow/signer_windows.py
@@ -18,11 +18,13 @@ The signed artifacts will be found in the subfolder called signed under the orig
 
 
 class SignerWindows(Signer):
-
-    ACCEPTED_FILE_TYPES = [".msi", ".exe", ".dll", ".sys", ".ps1", ".psm1", ".psd1", ".cat", ".zip"]
+    ACCEPTED_FILE_TYPES = [".msi", ".exe", ".dll", ".sys", ".ps1", ".psm1", ".psd1", ".cat"]
 
     def generate_signature_and_verify(self, artifact: str, basepath: Path, signature_type: str) -> None:
+        filename = os.path.join(basepath, artifact)
+        signed_filename = filename if self.overwrite else os.path.join(basepath, "signed_" + artifact)
         self.sign(artifact, basepath, signature_type)
+        self.verify(signed_filename)
 
     def is_valid_file_type(self, file_name: str) -> bool:
         return any(
@@ -31,21 +33,20 @@ class SignerWindows(Signer):
 
     def sign(self, artifact: str, basepath: Path, signature_type: str) -> None:
         filename = os.path.join(basepath, artifact)
-        signed_prefix = "signed_"
-        signature_file = os.path.join(basepath, signed_prefix + artifact)
-        self.__remove_existing_signature__(signature_file)
+        signed_filename = filename if self.overwrite else os.path.join(basepath, "signed_" + artifact)
         signing_cmd = [
             "./opensearch-signer-client",
             "-i",
             filename,
             "-o",
-            signature_file,
+            signed_filename,
             "-p",
-            "windows",
+            "windows"
+            " -r",
+            str(self.overwrite)
         ]
         self.git_repo.execute(" ".join(signing_cmd))
-        signed_folder = os.path.join(basepath, "signed")
-        if not os.path.exists(signed_folder):
-            os.mkdir(signed_folder)
-        signed_location = os.path.join(signed_folder, artifact)
-        os.rename(signature_file, signed_location)
+
+    def verify(self, filename: str) -> None:
+        verify_cmd = ["osslsigncode", "verify", "-in", filename]
+        self.git_repo.execute(" ".join(verify_cmd))

--- a/src/sign_workflow/signers.py
+++ b/src/sign_workflow/signers.py
@@ -26,6 +26,6 @@ class Signers:
         return klass  # type: ignore[return-value]
 
     @classmethod
-    def create(cls, platform: str) -> Signer:
+    def create(cls, platform: str, overwrite: bool) -> Signer:
         klass = cls.from_platform(platform)
-        return klass()  # type: ignore[no-any-return, operator]
+        return klass(overwrite)  # type: ignore[no-any-return, operator]

--- a/tests/tests_sign_workflow/test_sign_args.py
+++ b/tests/tests_sign_workflow/test_sign_args.py
@@ -56,6 +56,14 @@ class TestSignArgs(unittest.TestCase):
     def test_platform_default(self) -> None:
         self.assertEqual(SignArgs().platform, "linux")
 
+    @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST])
+    def test_overwrite_default(self) -> None:
+        self.assertEqual(SignArgs().overwrite, False)
+
     @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST, "--platform", "windows"])
     def test_platform_windows(self) -> None:
         self.assertEqual(SignArgs().platform, "windows")
+
+    @patch("argparse._sys.argv", [SIGN_PY, OPENSEARCH_MANIFEST, "--platform", "windows", "--overwrite"])
+    def test_platform_windows_overwrite(self) -> None:
+        self.assertEqual(SignArgs().overwrite, True)

--- a/tests/tests_sign_workflow/test_sign_artifacts.py
+++ b/tests/tests_sign_workflow/test_sign_artifacts.py
@@ -24,14 +24,15 @@ class TestSignArtifacts(unittest.TestCase):
         artifact_type = 'dummy'
         sigtype = '.asc'
         platform = 'linux'
+        overwrite = False
 
-        klass = SignArtifacts.from_path(Path(r"/dummy/path/manifest.yml"), components, artifact_type, sigtype, platform)
+        klass = SignArtifacts.from_path(Path(r"/dummy/path/manifest.yml"), components, artifact_type, sigtype, platform, overwrite)
         self.assertEqual(type(SignWithBuildManifest), type(klass.__class__))
 
-        klass = SignArtifacts.from_path(Path(os.path.dirname(__file__)), components, artifact_type, sigtype, platform)
+        klass = SignArtifacts.from_path(Path(os.path.dirname(__file__)), components, artifact_type, sigtype, platform, overwrite)
         self.assertEqual(type(SignExistingArtifactsDir), type(klass.__class__))
 
-        klass = SignArtifacts.from_path(Path(r"/dummy/path/artifact.tar.gz"), components, artifact_type, sigtype, platform)
+        klass = SignArtifacts.from_path(Path(r"/dummy/path/artifact.tar.gz"), components, artifact_type, sigtype, platform, overwrite)
         self.assertEqual(type(SignArtifactsExistingArtifactFile), type(klass.__class__))
 
     def test_signer_class(self) -> None:
@@ -52,12 +53,14 @@ class TestSignArtifacts(unittest.TestCase):
         manifest = Path(os.path.join(os.path.dirname(__file__), "data", "opensearch-build-1.1.0.yml"))
         sigtype = '.asc'
         platform = 'windows'
+        overwrite = False
         signer_with_manifest = SignWithBuildManifest(
             target=manifest,
             components=[],
             artifact_type="maven",
             signature_type=sigtype,
-            platform=platform
+            platform=platform,
+            overwrite=overwrite
         )
         signer = MagicMock()
         signer_with_manifest.signer = signer
@@ -77,12 +80,14 @@ class TestSignArtifacts(unittest.TestCase):
         path = Path(r"/dummy/path/file.tar.gz")
         sigtype = '.sig'
         platform = 'linux'
+        overwrite = False
         signer_with_manifest = SignArtifactsExistingArtifactFile(
             target=path,
             components=['maven'],
             artifact_type='dummy',
             signature_type=sigtype,
-            platform=platform
+            platform=platform,
+            overwrite=overwrite
         )
         signer = MagicMock()
         signer_with_manifest.signer = signer
@@ -99,12 +104,14 @@ class TestSignArtifacts(unittest.TestCase):
         path = Path('dummy')
         sigtype = '.sig'
         platform = 'linux'
+        overwrite = False
         signer_with_manifest = SignExistingArtifactsDir(
             target=path,
             components=['maven'],
             artifact_type='dummy',
             signature_type=sigtype,
-            platform=platform
+            platform=platform,
+            overwrite=overwrite
         )
         signer = MagicMock()
         signer_with_manifest.signer = signer

--- a/tests/tests_sign_workflow/test_signer.py
+++ b/tests/tests_sign_workflow/test_signer.py
@@ -27,34 +27,34 @@ class TestSigner(unittest.TestCase):
 
     @patch("sign_workflow.signer.GitRepository")
     def test_signer_checks_out_tool(self, mock_repo: Mock) -> None:
-        self.DummySigner()
+        self.DummySigner(True)
         self.assertEqual(mock_repo.return_value.execute.call_count, 2)
         mock_repo.return_value.execute.assert_has_calls([call("./bootstrap"), call("rm config.cfg")])
 
     @patch("sign_workflow.signer.GitRepository")
     def test_sign_artifact_not_called(self, mock_repo: Mock) -> None:
-        signer = self.DummySigner()
+        signer = self.DummySigner(True)
         signer.generate_signature_and_verify = MagicMock()  # type: ignore
         signer.sign_artifact("the-jar.notvalid", Path("/path"), ".sig")
         signer.generate_signature_and_verify.assert_not_called()
 
     @patch("sign_workflow.signer.GitRepository")
     def test_sign_artifact_called(self, mock_repo: Mock) -> None:
-        signer = self.DummySigner()
+        signer = self.DummySigner(True)
         signer.generate_signature_and_verify = MagicMock()  # type: ignore
         signer.sign_artifact("the-jar.zip", Path("/path"), ".sig")
         signer.generate_signature_and_verify.assert_called_with("the-jar.zip", Path("/path"), ".sig")
 
     @patch("sign_workflow.signer.GitRepository")
     def test_remove_existing_signature_found(self, mock_repo: Mock) -> None:
-        signer = self.DummySigner()
+        signer = self.DummySigner(False)
         os.remove = MagicMock()
         signer.__remove_existing_signature__("tests/tests_sign_workflow/data/signature/tar_dummy_artifact_1.0.0.tar.gz.sig")
         os.remove.assert_called_with("tests/tests_sign_workflow/data/signature/tar_dummy_artifact_1.0.0.tar.gz.sig")
 
     @patch("sign_workflow.signer.GitRepository")
     def test_remove_existing_signature_not_found(self, mock_repo: Mock) -> None:
-        signer = self.DummySigner()
+        signer = self.DummySigner(False)
         os.remove = MagicMock()
         signer.__remove_existing_signature__("tests/tests_sign_workflow/data/signature/not_found.tar.gz.sig")
         os.remove.assert_not_called()

--- a/tests/tests_sign_workflow/test_signer_pgp.py
+++ b/tests/tests_sign_workflow/test_signer_pgp.py
@@ -41,7 +41,7 @@ class TestSignerPGP(unittest.TestCase):
             call("the-tar.tar.gz", Path("path"), ".asc"),
             call("something-1.0.0.0.jar", Path("path"), ".asc"),
         ]
-        signer = SignerPGP()
+        signer = SignerPGP(False)
         signer.sign = MagicMock()  # type: ignore
         signer.verify = MagicMock()  # type: ignore
         signer.sign_artifacts(artifacts, Path("path"), ".asc")
@@ -77,7 +77,7 @@ class TestSignerPGP(unittest.TestCase):
             call("opensearch_sql_cli-1.0.0-py3-none-any.whl", Path("path"), ".sig"),
             call("cratefile.crate", Path("path"), ".sig")
         ]
-        signer = SignerPGP()
+        signer = SignerPGP(False)
         signer.sign = MagicMock()  # type: ignore
         signer.verify = MagicMock()  # type: ignore
         signer.sign_artifacts(artifacts, Path("path"), ".sig")
@@ -85,21 +85,21 @@ class TestSignerPGP(unittest.TestCase):
 
     @patch("sign_workflow.signer.GitRepository")
     def test_signer_verify_asc(self, mock_repo: Mock) -> None:
-        signer = SignerPGP()
+        signer = SignerPGP(True)
         signer.verify("/path/the-jar.jar.asc")
         mock_repo.assert_has_calls([call().execute("gpg --verify-files /path/the-jar.jar.asc")])
 
     @patch("sign_workflow.signer.GitRepository")
     def test_signer_verify_sig(self, mock_repo: Mock) -> None:
-        signer = SignerPGP()
+        signer = SignerPGP(True)
         signer.verify("/path/the-jar.jar.sig")
         mock_repo.assert_has_calls([call().execute("gpg --verify-files /path/the-jar.jar.sig")])
 
     @patch("sign_workflow.signer.GitRepository")
     def test_signer_sign_asc(self, mock_repo: Mock) -> None:
-        signer = SignerPGP()
+        signer = SignerPGP(False)
         signer.sign("the-jar.jar", Path("/path/"), ".asc")
-        command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"), 'the-jar.jar') + " -o " + os.path.join(Path("/path/"), 'the-jar.jar.sig') + " -p pgp"
+        command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"), 'the-jar.jar') + " -o " + os.path.join(Path("/path/"), 'the-jar.jar.sig') + " -p pgp -r False"
         conversion_cmd = "gpg --enarmor < " + os.path.join(Path("/path/"), 'the-jar.jar.sig') + " > " +\
                          os.path.join(Path("/path/"), 'the-jar.jar.asc') + " && sed -i 's/ARMORED FILE/SIGNATURE/g' " +\
                          os.path.join(Path("/path/"), 'the-jar.jar.asc')
@@ -109,8 +109,8 @@ class TestSignerPGP(unittest.TestCase):
 
     @patch("sign_workflow.signer.GitRepository")
     def test_signer_sign_sig(self, mock_repo: Mock) -> None:
-        signer = SignerPGP()
+        signer = SignerPGP(False)
         signer.sign("the-jar.jar", Path("/path/"), ".sig")
-        command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"), 'the-jar.jar') + " -o " + os.path.join(Path("/path/"), 'the-jar.jar.sig') + " -p pgp"
+        command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"), 'the-jar.jar') + " -o " + os.path.join(Path("/path/"), 'the-jar.jar.sig') + " -p pgp -r False"
         mock_repo.assert_has_calls(
             [call().execute(command)])

--- a/tests/tests_sign_workflow/test_signers.py
+++ b/tests/tests_sign_workflow/test_signers.py
@@ -17,15 +17,15 @@ class TestSigners(unittest.TestCase):
 
     @patch("sign_workflow.signer.GitRepository")
     def test_signer_PGP(self, mock_repo: Mock) -> None:
-        signer = Signers.create("linux")
+        signer = Signers.create("linux", True)
         self.assertIs(type(signer), SignerPGP)
 
     @patch("sign_workflow.signer.GitRepository")
     def test_signer_windows(self, mock_repo: Mock) -> None:
-        signer = Signers.create("windows")
+        signer = Signers.create("windows", True)
         self.assertIs(type(signer), SignerWindows)
 
     def test_signer_invalid(self) -> None:
         with self.assertRaises(ValueError) as ctx:
-            Signers.create("mac")
+            Signers.create("mac", False)
         self.assertEqual(str(ctx.exception), "Unsupported type of platform for signing: mac")


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
- Currently the signer workflow does not allow the existing artifact to be overwritten. This change adds a functionality to add that option. The current use case is windows `.dll` artifacts. The same artifact needs to be overwritten in same exact location to proceed with further packaging. Defaults to `False` so the earlier is not changing just that the check can be disabled at will.
- Also adds verification of signed artifact for windows which was missing until now.
- Removes `.zip` as supported artifact in windows signing as it is not supported by backend code. 
- Adds `osssigncode` and `dotnet` installations on release-clients docker file. 

Depends on and the Backend PR: https://github.com/opensearch-project/opensearch-signer-client/pull/11

Next steps:
- Update jenkins library to accommodate this change PR: https://github.com/opensearch-project/opensearch-build-libraries/pull/115
- Publish new docker images with sigtool installed
   - release client docker image

### Issues Resolved
needed for signing of #2965 
closes https://github.com/opensearch-project/opensearch-build/issues/2290

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
