### PR TITLE
Revert OS build workflow to original state due to method too large error

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -44,14 +44,8 @@ pipeline {
         )
         string( // Note: need to update 'verify-parameters' entries if you add new platform(s)
             name: 'BUILD_PLATFORM',
-            description: "Build selected platform related artifacts, choices include 'linux', 'macos', 'windows'. Can combine multiple platforms with space in between (maven snapshot/docker is only available on linux)",
+            description: "Build selected platform related artifacts, choices include 'linux', 'macos', 'windows'. Can combine multiple platforms with space in between (maven snapshot is only on linux)",
             defaultValue: 'linux macos windows',
-            trim: true
-        )
-        string( // Note: need to update 'verify-parameters' entries if you add new distribution(s)
-            name: 'BUILD_DISTRIBUTION',
-            description: "Build selected distribution related artifacts, choices include 'tar', 'rpm', 'deb', 'zip'. Can combine multiple distributions with space in between (docker is only available on tar)",
-            defaultValue: 'tar rpm deb zip',
             trim: true
         )
         choice(
@@ -107,24 +101,6 @@ pipeline {
                             error("Missing parameter: BUILD_PLATFORM (possible entries: ${all_platforms}).")
                         }
                     }
-
-                    echo("Verify Build Distributions")
-                    def build_distribution_array = params.BUILD_DISTRIBUTION.tokenize(' ')
-                    echo("User Entry Distributions: '${params.BUILD_DISTRIBUTION}', ${build_distribution_array}")
-                    def all_distributions = "tar rpm deb zip"
-                    echo("All Supported Platforms: '${all_distributions}'")
-
-                    if (params.BUILD_DISTRIBUTION == null || params.BUILD_DISTRIBUTION == '') {
-                        currentBuild.result = 'ABORTED'
-                        error("Missing parameter: BUILD_DISTRIBUTION (possible entries: ${all_distributions}).")
-                    }
-
-                    for (String plat : build_distribution_array) {
-                        if (! all_distributions.contains(plat)) {
-                            currentBuild.result = 'ABORTED'
-                            error("Missing parameter: BUILD_DISTRIBUTION (possible entries: ${all_distributions}).")
-                        }
-                    }
                 }
             }
         }
@@ -157,13 +133,8 @@ pipeline {
                 stage('build-distribution-snapshot-linux-x64-tar') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('linux')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('tar')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('linux')
                         }
                     }
                     environment {
@@ -208,13 +179,8 @@ pipeline {
                 stage('build-opensearch-snapshot-linux-x64-tar') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('linux')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('tar')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('linux')
                         }
                     }
                     environment {
@@ -254,13 +220,8 @@ pipeline {
                 stage('build-opensearch-snapshot-linux-arm64-tar') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('linux')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('tar')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('linux')
                         }
                     }
                     agent {
@@ -297,13 +258,8 @@ pipeline {
                 stage('build-opensearch-snapshot-macos-x64-tar') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('macos')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('tar')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('macos')
                         }
                     }
                     agent {
@@ -340,13 +296,8 @@ pipeline {
                 stage('build-opensearch-snapshot-windows-x64-zip') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('windows')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('zip')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('windows')
                         }
                     }
                     agent {
@@ -383,13 +334,8 @@ pipeline {
                 stage('build-and-test-linux-x64-tar') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('linux')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('tar')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('linux')
                         }
                     }
                     agent {
@@ -493,13 +439,8 @@ pipeline {
                 stage('build-and-test-linux-x64-rpm') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('linux')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('rpm')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('linux')
                         }
                     }
                     agent { label AGENT_X64 }
@@ -594,13 +535,8 @@ pipeline {
                 stage('build-and-test-linux-x64-deb') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('linux')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('deb')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('linux')
                         }
                     }
                     agent { label AGENT_X64 }
@@ -679,13 +615,8 @@ pipeline {
                 stage('build-and-test-linux-arm64-tar') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('linux')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('tar')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('linux')
                         }
                     }
                     agent {
@@ -788,13 +719,8 @@ pipeline {
                 stage('build-and-test-linux-arm64-rpm') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('linux')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('rpm')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('linux')
                         }
                     }
                     agent { label AGENT_X64 }
@@ -889,13 +815,8 @@ pipeline {
                 stage('build-and-test-linux-arm64-deb') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('linux')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('deb')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('linux')
                         }
                     }
                     agent { label AGENT_ARM64 }
@@ -974,13 +895,8 @@ pipeline {
                 stage('build-and-test-windows-x64-zip') {
                     when {
                         beforeAgent true
-                        allOf{
-                            expression {
-                                params.BUILD_PLATFORM.contains('windows')
-                            }
-                            expression{
-                                params.BUILD_DISTRIBUTION.contains('zip')
-                            }
+                        expression{
+                            params.BUILD_PLATFORM.contains('windows')
                         }
                     }
                     agent {
@@ -1054,9 +970,6 @@ pipeline {
                     expression{
                         params.BUILD_PLATFORM.contains('linux')
                     }
-                    expression{
-                        params.BUILD_DISTRIBUTION.contains('tar')
-                    }
                 }
             }
             agent {
@@ -1103,25 +1016,17 @@ pipeline {
                 script {
                     List<String> stages = []
                     if (params.BUILD_PLATFORM.contains('linux')) {
-                        if (params.BUILD_DISTRIBUTION.contains('tar')) {
-                            stages = [
-                                'build-and-test-linux-x64-tar',
-                                'build-and-test-linux-arm64-tar',
-                            ]
-                        }
-                        if (params.BUILD_DISTRIBUTION.contains('rpm')) {
-                            stages.add('assemble-archive-and-test-linux-x64-rpm')
-                            stages.add('assemble-archive-and-test-linux-arm64-rpm')
-                        }
-                        if (params.BUILD_DISTRIBUTION.contains('deb')) {
-                            stages.add('assemble-archive-and-test-linux-x64-deb')
-                            stages.add('assemble-archive-and-test-linux-arm64-deb')
-                        }
+                        stages = [
+                            'build-and-test-linux-x64-tar',
+                            'assemble-archive-and-test-linux-x64-rpm',
+                            'assemble-archive-and-test-linux-x64-deb',
+                            'build-and-test-linux-arm64-tar',
+                            'assemble-archive-and-test-linux-arm64-rpm',
+                            'assemble-archive-and-test-linux-arm64-deb',
+                        ]
                     }
                     if (params.BUILD_PLATFORM.contains('windows')){
-                        if (params.BUILD_DISTRIBUTION.contains('zip')) {
-                            stages.add('build-and-test-windows-x64-zip')
-                        }
+                        stages.add('build-and-test-windows-x64-zip')
                     }
 
                     if (params.PUBLISH_NOTIFICATION) {


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Revert OS build workflow to original state due to method too large error

### Issues Resolved
#3012

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
