### PR TITLE
Updated commit id's to OS and OSD manifests for 1.3.8

### DIFF
--- a/manifests/1.3.8/opensearch-1.3.8.yml
+++ b/manifests/1.3.8/opensearch-1.3.8.yml
@@ -10,13 +10,13 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: '1.3'
+    ref: 2ac1c13e3877692bc9cbbab4c796d7244fe8486a
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: '1.3'
+    ref: 745bf040439394e4896030afda7a5b935944c4a5
     checks:
       - gradle:publish
       - gradle:properties:version
@@ -25,7 +25,7 @@ components:
       - windows
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: '1.3'
+    ref: 32523e02e8b25f5f2f2e0f636ed717173e8a0070
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -34,7 +34,7 @@ components:
       - windows
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: '1.3'
+    ref: fe3d31153c1334e63103d534bb786a8f4f362357
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
@@ -43,7 +43,7 @@ components:
       - windows
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: '1.3'
+    ref: 81d7b43f8e8bb73d0c73cb2713dd739e9effcd2a
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -52,7 +52,7 @@ components:
       - windows
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: '1.3'
+    ref: 160ef9645a12b22d3912dfbde15f9e0a3abc2d30
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -60,7 +60,7 @@ components:
       - linux
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: '1.3'
+    ref: cbef85651e23cacc01ae05b8771d0e2415195177
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -69,7 +69,7 @@ components:
       - windows
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: '1.3'
+    ref: bf3df8b6fa21f8db4602341a721cea19dacb964b
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
@@ -78,7 +78,7 @@ components:
       - windows
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: '1.3'
+    ref: d828398c1d40ac0fea67682f2154d109f84c8320
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -87,7 +87,7 @@ components:
       - windows
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: '1.3'
+    ref: df51076b25dd8be9e65e38a6d94ee140a6286e1c
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
@@ -96,7 +96,7 @@ components:
       - windows
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: '1.3'
+    ref: 5d5a70c4bbf42de271928ef9a7fc0827cb2677ee
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -105,7 +105,7 @@ components:
       - windows
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '1.3'
+    ref: da8da39cd0e84db11fb06a3b8c4171e8f8ece695
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -114,7 +114,7 @@ components:
       - windows
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: '1.3'
+    ref: 0773edf2d3bba57cc99f914982386e4f20c6e5cc
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -123,7 +123,7 @@ components:
       - windows
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: '1.3'
+    ref: ea473423f0906772a39ea73dd3ef18ea5e0d0c73
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -132,7 +132,7 @@ components:
       - windows
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '1.3'
+    ref: 7fabf39a82538aebea925f5ab901ffad2d1366a4
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/1.3.8/opensearch-dashboards-1.3.8.yml
+++ b/manifests/1.3.8/opensearch-dashboards-1.3.8.yml
@@ -9,32 +9,32 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: '1.3'
+    ref: 55783c976d503fc1de2611d1c56b967d453bbf27
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '1.3'
+    ref: bc232a82ebfeede6bfc5631d5d6538fb4bf69d81
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '1.3'
+    ref: 8e101672d9e9c8bc0bb03d88c9aac7054a2f79e0
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: '1.3'
+    ref: c14b0ac43ee420cde284232478a0d8fd42226ccf
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
-    ref: '1.3'
+    ref: fe619d21348e61205da00823a83e20c5143b2142
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
     working_directory: gantt-chart
-    ref: '1.3'
+    ref: aa38960a5d339091be36f1b87dad26e6f2e53201
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
-    ref: '1.3'
+    ref: b6ed90fc99ad82333a74c2883fecf03a070ff110
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: '1.3'
+    ref: c7e9c76527ec23720e99baf9ce87dd6575e9760e
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
-    ref: '1.3'
+    ref: ac5c375a6b19bf00eb79391920c3a7a792e86f01
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
-    ref: '1.3'
+    ref: f6008d1902e2bce8f4ea63afa184ff48fcd3e2ab


### PR DESCRIPTION
Signed-off-by: Divya Madala <divyaasm@amazon.com>

### Description
_Describe what this change achieves._

Changed ref from 1.3 to commit-id in 1.3.8 manifests 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
