### PR TITLE
Add missing comma to fix syntax error

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
                             build job: "${TARGET_JOB_NAME}", parameters: [
                             string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
                             string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}"),
-                            string(name: 'BUILD_PLATFORM', value: "${BUILD_PLATFORM}")
+                            string(name: 'BUILD_PLATFORM', value: "${BUILD_PLATFORM}"),
                             string(name: 'BUILD_DISTRIBUTION', value: "${BUILD_DISTRIBUTION}")
                             ], wait: true
 


### PR DESCRIPTION
Signed-off-by: Zelin Hao <zelinhao@amazon.com>

### Description
Our `check-for-build` workflow has been failing so no auto trigger for distribution build. 
Add missing comma to fix syntax error

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3158

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
