### PR TITLE
Fix #3116 - [BUG] DEB is using RPM default file path

### DIFF
--- a/scripts/pkg/service_templates/opensearch/usr/lib/systemd/system/opensearch.service
+++ b/scripts/pkg/service_templates/opensearch/usr/lib/systemd/system/opensearch.service
@@ -15,6 +15,7 @@ Documentation=https://opensearch.org/
 Type=notify
 RuntimeDirectory=opensearch
 PrivateTmp=true
+EnvironmentFile=-/etc/default/opensearch
 EnvironmentFile=-/etc/sysconfig/opensearch
 WorkingDirectory=/usr/share/opensearch
 User=opensearch


### PR DESCRIPTION
### Description

In this PR is a code-change to fix #3116 - add the Debian location of default env vars to the `opensearch.service` template.

The fix is to take advantage of the dash (`-`) prefix of SystemD's `EnvironmentFile=` option. We can add multiple options, as if the file does not exist, it will not be read and no error or warning message is logged per SystemD [documentation](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=):

>"The argument passed should be an absolute filename or wildcard expression, optionally prefixed with "-", which indicates that if the file does not exist, it will not be read and no error or warning message is logged. This option may be specified more than once in which case all specified files are read. If the empty string is assigned to this option, the list of file to read is reset, all prior assignments have no effect."

This approach is also used currently for the [opensearch-dashboards.service](https://github.com/opensearch-project/opensearch-build/blob/main/scripts/pkg/service_templates/opensearch-dashboards/usr/lib/systemd/system/opensearch-dashboards.service) as well.

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/3116

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
