### PR TITLE
Add osslsigncode compilation on CentOS7 Docker Image

### DIFF
--- a/docker/ci/dockerfiles/current/release.centos.clients.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/release.centos.clients.x64.arm64.dockerfile
@@ -91,7 +91,7 @@ RUN pip3 install twine cmake==3.24.1.1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/local/lib64:/usr/lib
 RUN yum install -y curl libcurl-devel libfaketime && yum remove -y openssl-devel perl-core pcre-devel && yum clean all && \
     mkdir -p /tmp/openssl && cd /tmp/openssl && \
-    curl -sSL -o- https://ftp.openssl.org/source/openssl-1.1.1g.tar.gz | tar -xz --strip-components 1 && \
+    curl -sSL -o- https://www.openssl.org/source/openssl-1.1.1g.tar.gz | tar -xz --strip-components 1 && \
     ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib shared zlib-dynamic && make && make install && \
     echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/local/lib64:/usr/lib" > /etc/profile.d/openssl.sh && openssl version
 

--- a/docker/ci/dockerfiles/current/release.centos.clients.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/release.centos.clients.x64.arm64.dockerfile
@@ -89,7 +89,7 @@ RUN pip3 install twine cmake==3.24.1.1
 
 # Install openssl1.1.1
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:/usr/local/lib64:/usr/lib
-RUN yum install -y curl libcurl-devel libfaketime && yum remove -y openssl-devel perl-core pcre-devel && yum clean all && \
+RUN yum install -y curl libcurl-devel libfaketime perl-core pcre-devel && yum remove -y openssl-devel && yum clean all && \
     mkdir -p /tmp/openssl && cd /tmp/openssl && \
     curl -sSL -o- https://www.openssl.org/source/openssl-1.1.1g.tar.gz | tar -xz --strip-components 1 && \
     ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib shared zlib-dynamic && make && make install && \

--- a/docker/ci/dockerfiles/current/release.centos.clients.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/release.centos.clients.x64.arm64.dockerfile
@@ -8,9 +8,14 @@
 # for both developers and ci/cd pipeline for releasing Opensearch clients and other products
 # Please read the README.md file for all the information before using this dockerfile
 
+
 FROM centos:7
 
 ARG MAVEN_DIR=/usr/local/apache-maven
+
+# Ensure localedef running correct with root permission
+USER 0
+
 # Setup ENV to prevent ASCII data issues with Python3
 RUN echo "export LC_ALL=en_US.utf-8" >> /etc/profile.d/python3_ascii.sh && \
     echo "export LANG=en_US.utf-8" >> /etc/profile.d/python3_ascii.sh && \


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Add osslsigncode compilation on CentOS7 Docker Image

### Issues Resolved
#3118 
See this comment:
https://github.com/opensearch-project/opensearch-build/pull/3118#discussion_r1091326973

This resolves the issue where the osslsigncode tool only compile on Ubuntu not on CentOS7.
And also update to the current latest stable 2.5 release, compares to EPEL 8 having 2.2 release only, with openssl1.1.1g.
https://download-ib01.fedoraproject.org/pub/epel/8/Everything/$arch/Packages/o/osslsigncode-2.2-1.el8.$arch.rpm

Thanks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
