### PR TITLE
Silent potential lxc container not able to set vm.max_map_count=262144 issues

### DIFF
--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -37,13 +37,22 @@ if ! grep -q '## OpenSearch Performance Analyzer' ${config_dir}/jvm.options; the
    echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> ${config_dir}/jvm.options
 fi
 
+# Set owner
+chown -R opensearch.opensearch ${product_dir}
+chown -R opensearch.opensearch ${config_dir}
+chown -R opensearch.opensearch ${log_dir}
+chown -R opensearch.opensearch ${data_dir}
+chown -R opensearch.opensearch ${pid_dir}
+
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then
     systemctl daemon-reload
 fi
 
 # Reload other configs
-sysctl -p /usr/lib/sysctl.d/opensearch.conf > /dev/null 2>&1
+if command -v systemctl > /dev/null; then
+    systemctl restart systemd-sysctl.service || true
+fi
 systemd-tmpfiles --create opensearch.conf
 
 # Messages
@@ -57,14 +66,6 @@ if [ -d ${product_dir}/plugins/opensearch-security ]; then
     echo "### Create opensearch demo certificates in ${config_dir}/"
     echo " See demo certs creation log in ${log_dir}/install_demo_configuration.log"
 fi
-
-# Set owner
-chown -R opensearch.opensearch ${product_dir}
-chown -R opensearch.opensearch ${config_dir}
-chown -R opensearch.opensearch ${log_dir}
-chown -R opensearch.opensearch ${data_dir}
-chown -R opensearch.opensearch ${pid_dir}
-
 exit 0
 
 

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -114,7 +114,9 @@ if command -v systemctl > /dev/null; then
     systemctl daemon-reload
 fi
 # Reload other configs
-sysctl -p %{_prefix}/lib/sysctl.d/%{name}.conf > /dev/null 2>&1
+if command -v systemctl > /dev/null; then
+    systemctl restart systemd-sysctl.service || true
+fi
 systemd-tmpfiles --create %{name}.conf
 # Messages
 echo "### NOT starting on installation, please execute the following statements to configure opensearch service to start automatically using systemd"


### PR DESCRIPTION


Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Silent potential lxc container not able to set vm.max_map_count=262144 issues

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3130

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
