### PR TITLE
Changed paths of observability and reporting Repos in version increment plugin

### DIFF
--- a/.github/workflows/increment-plugin-versions.yml
+++ b/.github/workflows/increment-plugin-versions.yml
@@ -28,7 +28,6 @@ jobs:
           - {repo: asynchronous-search}
           - {repo: common-utils}
           - {repo: cross-cluster-replication}
-          - {repo: dashboards-reports, path: reports-scheduler}
           - {repo: geospatial}
           - {repo: index-management}
           - {repo: job-scheduler}
@@ -36,9 +35,10 @@ jobs:
           - {repo: neural-search}
           - {repo: ml-commons}
           - {repo: notifications, path: notifications}
-          - {repo: observability, path: opensearch-observability}
+          - {repo: observability}
           - {repo: performance-analyzer}
           - {repo: performance-analyzer-rca}
+          - {repo: reporting}
           - {repo: security}
           - {repo: security-analytics}
           - {repo: sql}


### PR DESCRIPTION
Signed-off-by: Divya Madala <divyaasm@amazon.com>

Pointed the observability plugin and reporting plugin to https://github.com/opensearch-project/observability and https://github.com/opensearch-project/reporting respectively.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
