### PR TITLE
Support pgp signing for .tgz files

### DIFF
--- a/src/sign_workflow/signer_pgp.py
+++ b/src/sign_workflow/signer_pgp.py
@@ -19,7 +19,7 @@ The signed artifacts will be found in the same location as the original artifact
 
 
 class SignerPGP(Signer):
-    ACCEPTED_FILE_TYPES = [".zip", ".jar", ".war", ".pom", ".module", ".tar.gz", ".whl", ".crate", ".rpm", ".deb"]
+    ACCEPTED_FILE_TYPES = [".zip", ".jar", ".war", ".pom", ".module", ".tar.gz", ".whl", ".crate", ".rpm", ".deb", ".tgz"]
 
     def generate_signature_and_verify(self, artifact: str, basepath: Path, signature_type: str) -> None:
         location = os.path.join(basepath, artifact)

--- a/tests/tests_sign_workflow/test_signer_pgp.py
+++ b/tests/tests_sign_workflow/test_signer_pgp.py
@@ -29,6 +29,7 @@ class TestSignerPGP(unittest.TestCase):
             "the-tar.tar.gz",
             "random-file.txt",
             "something-1.0.0.0.jar",
+            "the-tgz.tgz"
         ]
         expected = [
             call("the-jar.jar", Path("path"), ".asc"),
@@ -40,6 +41,7 @@ class TestSignerPGP(unittest.TestCase):
             call("the-module.module", Path("path"), ".asc"),
             call("the-tar.tar.gz", Path("path"), ".asc"),
             call("something-1.0.0.0.jar", Path("path"), ".asc"),
+            call("the-tgz.tgz", Path("path"), ".asc")
         ]
         signer = SignerPGP(False)
         signer.sign = MagicMock()  # type: ignore
@@ -62,7 +64,8 @@ class TestSignerPGP(unittest.TestCase):
             "random-file.txt",
             "something-1.0.0.0.jar",
             "opensearch_sql_cli-1.0.0-py3-none-any.whl",
-            "cratefile.crate"
+            "cratefile.crate",
+            "the-tgz.tgz"
         ]
         expected = [
             call("the-jar.jar", Path("path"), ".sig"),
@@ -75,7 +78,8 @@ class TestSignerPGP(unittest.TestCase):
             call("the-tar.tar.gz", Path("path"), ".sig"),
             call("something-1.0.0.0.jar", Path("path"), ".sig"),
             call("opensearch_sql_cli-1.0.0-py3-none-any.whl", Path("path"), ".sig"),
-            call("cratefile.crate", Path("path"), ".sig")
+            call("cratefile.crate", Path("path"), ".sig"),
+            call("the-tgz.tgz", Path("path"), ".sig")
         ]
         signer = SignerPGP(False)
         signer.sign = MagicMock()  # type: ignore


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
Support pgp signing for `.tgz`  files.

### Issues Resolved
Needed for https://github.com/opensearch-project/opensearch-build/issues/3112

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
