### PR TITLE
Increase timeout for performance tests

### DIFF
--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -6,7 +6,7 @@ lib = library(identifier: 'jenkins@1.0.4', retriever: modernSCM([
 pipeline {
     agent none
     options {
-        timeout(time: 15, unit: 'HOURS')
+        timeout(time: 14, unit: 'DAYS')
     }
     environment {
         AGENT_LABEL = 'Jenkins-Agent-AL2-X64-M52xlarge-Docker-Host-Perf-Test'

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test.jenkinsfile.txt
@@ -2,7 +2,7 @@
       perf-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
       perf-test.library({identifier=jenkins@1.0.4, retriever=null})
       perf-test.pipeline(groovy.lang.Closure)
-         perf-test.timeout({time=15, unit=HOURS})
+         perf-test.timeout({time=14, unit=DAYS})
          perf-test.echo(Executing on agent [label:none])
          perf-test.parameterizedCron(
             H 9 * * * %BUNDLE_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.2.1/latest/linux/arm64/tar/dist/opensearch/manifest.yml;TEST_ITERATIONS=3;WARMUP_ITERATIONS=2


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The longetvity tests takes more than 15hours to complete. Looks like 13 days. Increasing the timeout to see if this would clean up the resource leaks. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2768

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
