### PR TITLE
Fix OS distribution jenkinsfile bug `build-opensearch-snapshot-linux-arm64-tar`

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -238,7 +238,7 @@ pipeline {
                                 componentName: "OpenSearch",
                                 inputManifest: "manifests/${INPUT_MANIFEST}",
                                 platform: 'linux',
-                                architecture: 'x64',
+                                architecture: 'arm64',
                                 distribution: 'tar',
                                 snapshot: true
                             )


### PR DESCRIPTION
Signed-off-by: Prudhvi Godithi <pgodithi@amazon.com>

### Description
Fix OS distribution jenkinsfile bug `build-opensearch-snapshot-linux-arm64-tar`

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
