### PR TITLE
Add check for dockerbuild

### DIFF
--- a/jenkins/docker/docker-build.jenkinsfile
+++ b/jenkins/docker/docker-build.jenkinsfile
@@ -24,6 +24,16 @@ pipeline {
         )
     }
     stages {
+        stage('Parameters Check') {
+            steps {
+                script {
+                    if(! DOCKER_BUILD_GIT_REPOSITORY.startsWith('https://github.com/opensearch-project/')) {
+                        currentBuild.result = 'ABORTED'
+                        error('The repository needs to be an opensearch-project repository')
+                    }
+                }
+            }
+        }
         stage('docker-build') {
             agent {
                 docker {

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-build.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-build.jenkinsfile.txt
@@ -2,6 +2,8 @@
       docker-build.pipeline(groovy.lang.Closure)
          docker-build.timeout({time=3, unit=HOURS})
          docker-build.echo(Executing on agent [label:none])
+         docker-build.stage(Parameters Check, groovy.lang.Closure)
+            docker-build.script(groovy.lang.Closure)
          docker-build.stage(docker-build, groovy.lang.Closure)
             docker-build.echo(Executing on agent [docker:[image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk14, reuseNode:false, stages:[:], args:-u root -v /var/run/docker.sock:/var/run/docker.sock, alwaysPull:true, containerPerStageRoot:false, label:Jenkins-Agent-Ubuntu2004-X64-M52xlarge-Docker-Builder]])
             docker-build.script(groovy.lang.Closure)


### PR DESCRIPTION
### Description
This change is to ensure that anything that is pushed to any https://hub.docker.com/u/opensearchstaging is authored, reviewed and then pushed and build. Since the blast radius (even though in development) is high, we need to ensure the change is reviewed and has a source code.

check works as below:
```
Started by user [gaiksaya](https://ci-staging.opensearch.org/user/gaiksaya)
Obtained jenkins/docker/docker-build.jenkinsfile from git https://github.com/gaiksaya/opensearch-build
[Pipeline] Start of Pipeline
[Pipeline] timeout
Timeout set to expire in 3 hr 0 min
[Pipeline] {
[Pipeline] stage
[Pipeline] { (Parameters Check)
[Pipeline] script
[Pipeline] {
[Pipeline] error
[Pipeline] }
[Pipeline] // script
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (docker-build)
Stage "docker-build" skipped due to earlier failure(s)
[Pipeline] }
[Pipeline] // stage
[Pipeline] }
[Pipeline] // timeout
[Pipeline] End of Pipeline
ERROR: The repository needs to be an opensearch-project repository
Finished: ABORTED
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
