### PR TITLE
Add experimental flag for ml_commons_dashboards

### DIFF
--- a/config/opensearch_dashboards-2.x.yml
+++ b/config/opensearch_dashboards-2.x.yml
@@ -192,6 +192,10 @@
 # data_source.encryption.wrappingKeyNamespace: 'changeme'
 # data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 
+# 2.6 New ML Commons Dashboards Experimental Feature
+# Set the value of this setting to true to enable the experimental ml commons dashboards
+# ml_commons_dashboards.enabled: false
+
 opensearch.hosts: [https://localhost:9200]
 opensearch.ssl.verificationMode: none
 opensearch.username: kibanaserver

--- a/config/opensearch_dashboards-default.x.yml
+++ b/config/opensearch_dashboards-default.x.yml
@@ -192,6 +192,10 @@
 # data_source.encryption.wrappingKeyNamespace: 'changeme'
 # data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 
+# 2.6 New ML Commons Dashboards Experimental Feature
+# Set the value of this setting to true to enable the experimental ml commons dashboards
+# ml_commons_dashboards.enabled: false
+
 opensearch.hosts: [https://localhost:9200]
 opensearch.ssl.verificationMode: none
 opensearch.username: kibanaserver


### PR DESCRIPTION
### Description
Since we will released the [ml-commons-dashboards](https://github.com/opensearch-project/ml-commons-dashboards/) in 2.6, this plugin is experimental. Add this experimental feature flag to disable this plugin by default.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
