### PR TITLE
Update docker-compose latest label to major release number 

### DIFF
--- a/docker/release/dockercomposefiles/docker-compose-1.x.yml
+++ b/docker/release/dockercomposefiles/docker-compose-1.x.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   opensearch-node1:
-    image: opensearchproject/opensearch:latest
+    image: opensearchproject/opensearch:1
     container_name: opensearch-node1
     environment:
       - cluster.name=opensearch-cluster
@@ -26,7 +26,7 @@ services:
     networks:
       - opensearch-net
   opensearch-node2:
-    image: opensearchproject/opensearch:latest
+    image: opensearchproject/opensearch:1
     container_name: opensearch-node2
     environment:
       - cluster.name=opensearch-cluster
@@ -47,7 +47,7 @@ services:
     networks:
       - opensearch-net
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:latest
+    image: opensearchproject/opensearch-dashboards:1
     container_name: opensearch-dashboards
     ports:
       - 5601:5601

--- a/docker/release/dockercomposefiles/docker-compose-2.x.yml
+++ b/docker/release/dockercomposefiles/docker-compose-2.x.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   opensearch-node1:
-    image: opensearchproject/opensearch:latest
+    image: opensearchproject/opensearch:2
     container_name: opensearch-node1
     environment:
       - cluster.name=opensearch-cluster
@@ -26,7 +26,7 @@ services:
     networks:
       - opensearch-net
   opensearch-node2:
-    image: opensearchproject/opensearch:latest
+    image: opensearchproject/opensearch:2
     container_name: opensearch-node2
     environment:
       - cluster.name=opensearch-cluster
@@ -47,7 +47,7 @@ services:
     networks:
       - opensearch-net
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:latest
+    image: opensearchproject/opensearch-dashboards:2
     container_name: opensearch-dashboards
     ports:
       - 5601:5601


### PR DESCRIPTION
### Description
Based on the latest design to use major release number in representing the 'latest' in each major release, we want to update the docker-compose.yml at build repo to reflect with the design.

### Issues Resolved
To be in sync with the latest design of using :1 representing :latest for OpenSearch and OpenSearchDashboard ver 1.x
As well as, using :2 representing :latest for OpenSearch and OpenSearchDashboard ver 2.x

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
