### PR TITLE
Add amd64 as a condition for system/os.py to support freebsd x64 architecture

### DIFF
--- a/src/system/os.py
+++ b/src/system/os.py
@@ -11,7 +11,7 @@ import subprocess
 
 def current_architecture() -> str:
     architecture = subprocess.check_output(["uname", "-m"]).decode().strip()
-    if architecture == "x86_64":
+    if architecture == "x86_64" or architecture == "amd64":
         return "x64"
     elif architecture == "aarch64" or architecture == "arm64":
         return "arm64"

--- a/tests/tests_system/test_os.py
+++ b/tests/tests_system/test_os.py
@@ -20,6 +20,10 @@ class TestOs(unittest.TestCase):
     def test_x86_64_return_x64_architecture(self, mock_subprocess: MagicMock) -> None:
         self.assertTrue(current_architecture() == "x64")
 
+    @patch("subprocess.check_output", return_value="amd64".encode())
+    def test_x86_64_return_x64_architecture(self, mock_subprocess: MagicMock) -> None:
+        self.assertTrue(current_architecture() == "x64")
+
     @patch("subprocess.check_output", return_value="aarch64".encode())
     def test_aarch64_return_arm64_architecture(self, mock_subprocess: MagicMock) -> None:
         self.assertTrue(current_architecture() == "arm64")

--- a/tests/tests_system/test_os.py
+++ b/tests/tests_system/test_os.py
@@ -21,7 +21,7 @@ class TestOs(unittest.TestCase):
         self.assertTrue(current_architecture() == "x64")
 
     @patch("subprocess.check_output", return_value="amd64".encode())
-    def test_x86_64_return_x64_architecture(self, mock_subprocess: MagicMock) -> None:
+    def test_amd64_return_x64_architecture(self, mock_subprocess: MagicMock) -> None:
         self.assertTrue(current_architecture() == "x64")
 
     @patch("subprocess.check_output", return_value="aarch64".encode())


### PR DESCRIPTION

### Description
Add amd64 as a condition for system/os.py to support freebsd x64 architecture

### Issues Resolved
#3236

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
