### PR TITLE
Use 2.0.2 lib version for apt repository promotion

### DIFF
--- a/jenkins/promotion/promote-repos.jenkinsfile
+++ b/jenkins/promotion/promote-repos.jenkinsfile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@2.0.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@2.0.2', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Use 2.0.2 lib version for apt repository promotion

### Issues Resolved
#3069

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
