### PR TITLE
Changes to Tar, Rpm and Yum distributions in the validation workflow

### DIFF
--- a/src/validation_workflow/tar/validation_tar.py
+++ b/src/validation_workflow/tar/validation_tar.py
@@ -28,15 +28,9 @@ class ValidateTar(Validation, DownloadUtils):
         self.osd_process = Process()
 
     def download_artifacts(self) -> bool:
-        architectures = ["x64", "arm64"]
         for project in self.args.projects:
-            for architecture in architectures:
-                url = f"{self.base_url}{project}/{self.args.version}/{project}-{self.args.version}-linux-{architecture}.tar.gz"
-                if ValidateTar.is_url_valid(url) and ValidateTar.download(url, self.tmp_dir):
-                    logging.info(f"Valid URL - {url} and Download Successful !")
-                else:
-                    logging.info(f"Invalid URL - {url}")
-                    raise Exception(f"Invalid url - {url}")
+            url = f"{self.base_url}{project}/{self.args.version}/{project}-{self.args.version}-linux-{self.args.arch}.tar.gz"
+            self.check_url(url)
         return True
 
     def installation(self) -> bool:
@@ -72,5 +66,5 @@ class ValidateTar(Validation, DownloadUtils):
             self.os_process.terminate()
             self.osd_process.terminate()
         except:
-            raise Exception('Failed to Stop Cluster')
+            raise Exception('Failed to terminate the processes that started OS and OSD')
         return True

--- a/src/validation_workflow/validation.py
+++ b/src/validation_workflow/validation.py
@@ -6,6 +6,7 @@
 # compatible open source license.
 
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -18,11 +19,18 @@ class Validation(ABC):
         super().__init__()
         self.args = args
 
+    def check_url(self, url: str) -> bool:
+        if self.is_url_valid(url) and self.download(url, self.tmp_dir):  # type: ignore
+            logging.info(f"Valid URL - {url} and Download Successful !")
+            return True
+        else:
+            raise Exception(f"Invalid url - {url}")
+
     def run(self) -> Any:
         try:
             return self.download_artifacts() and self.installation() and self.start_cluster() and self.validation() and self.cleanup()
-        except Exception:
-            return False
+        except Exception as e:
+            raise Exception(f'An error occurred while running the validation tests: {str(e)}')
 
     @abstractmethod
     def download_artifacts(self) -> bool:

--- a/src/validation_workflow/yum/validation_yum.py
+++ b/src/validation_workflow/yum/validation_yum.py
@@ -26,11 +26,7 @@ class ValidateYum(Validation, DownloadUtils):
     def download_artifacts(self) -> bool:
         for project in self.args.projects:
             url = f"{self.base_url}{project}/{self.args.version[0:1]}.x/{project}-{self.args.version[0:1]}.x.repo"
-            if ValidateYum.is_url_valid(url) and ValidateYum.download(url, self.tmp_dir):
-                logging.info(f"Valid URL - {url} and Download Successful !")
-            else:
-                logging.info(f"Invalid URL - {url}")
-                raise Exception(f"Invalid url - {url}")
+            self.check_url(url)
         return True
 
     def installation(self) -> bool:
@@ -49,7 +45,6 @@ class ValidateYum(Validation, DownloadUtils):
     def start_cluster(self) -> bool:
         try:
             for project in self.args.projects:
-                execute(f'sudo systemctl enable {project}', ".")
                 execute(f'sudo systemctl start {project}', ".")
                 time.sleep(20)
                 execute(f'sudo systemctl status {project}', ".")
@@ -69,6 +64,7 @@ class ValidateYum(Validation, DownloadUtils):
         try:
             for project in self.args.projects:
                 execute(f'sudo systemctl stop {project}', ".")
-        except:
-            raise Exception('Failed to Stop Cluster')
+                execute(f'sudo yum remove {project} -y', ".")
+        except Exception as e:
+            raise Exception(f'Exception occurred either while attempting to stop cluster or removing OpenSearch/OpenSearch-Dashboards. {str(e)}')
         return True

--- a/tests/tests_validation_workflow/test_validation_rpm.py
+++ b/tests/tests_validation_workflow/test_validation_rpm.py
@@ -15,8 +15,9 @@ class TestValidationRpm(unittest.TestCase):
 
     @patch("validation_workflow.download_utils.DownloadUtils.is_url_valid", return_value=True)
     @patch("validation_workflow.download_utils.DownloadUtils.download", return_value=True)
+    @patch("validation_workflow.validation.Validation.check_url", return_value=True)
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
-    def test_download_artifacts(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock) -> None:
+    def test_download_artifacts(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock, mock_check_url: Mock) -> None:
         mock_validation_args.return_value.version.return_value = '2.3.0'
         mock_validation_args.return_value.projects.return_value = ["opensearch", "opensearch-dashboards"]
 
@@ -28,13 +29,15 @@ class TestValidationRpm(unittest.TestCase):
 
     @patch("validation_workflow.download_utils.DownloadUtils.is_url_valid", return_value=False)
     @patch("validation_workflow.download_utils.DownloadUtils.download", return_value=False)
+    @patch("validation_workflow.validation.Validation.check_url", return_value=False)
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
-    def test_download_artifacts_error(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock) -> None:
+    def test_download_artifacts_error(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock, mock_check_url: Mock) -> None:
         mock_validation_args.return_value.version.return_value = '2.11.0'
+        url = "https://opensearch.org/release/2.11.0/opensearch-2.11.0-linux-arm64.rpm"
 
         validate_rpm = ValidateRpm(mock_validation_args)
 
-        self.assertRaises(Exception, validate_rpm.download_artifacts())
+        self.assertRaises(Exception, validate_rpm.check_url(url))
 
     @patch("validation_workflow.rpm.validation_rpm.execute", return_value=True)
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')

--- a/tests/tests_validation_workflow/test_validation_tar.py
+++ b/tests/tests_validation_workflow/test_validation_tar.py
@@ -16,8 +16,9 @@ class TestValidationTar(unittest.TestCase):
 
     @patch("validation_workflow.download_utils.DownloadUtils.is_url_valid", return_value=True)
     @patch("validation_workflow.download_utils.DownloadUtils.download", return_value=True)
+    @patch("validation_workflow.validation.Validation.check_url", return_value=True)
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_download_artifacts(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock) -> None:
+    def test_download_artifacts(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock, mock_check_url: Mock) -> None:
         mock_validation_args.return_value.version.return_value = '2.3.0'
         mock_validation_args.return_value.projects.return_value = ["opensearch", "opensearch-dashboards"]
 
@@ -29,13 +30,15 @@ class TestValidationTar(unittest.TestCase):
 
     @patch("validation_workflow.download_utils.DownloadUtils.is_url_valid", return_value=False)
     @patch("validation_workflow.download_utils.DownloadUtils.download", return_value=False)
+    @patch("validation_workflow.validation.Validation.check_url", return_value=False)
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_download_artifacts_error(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock) -> None:
+    def test_download_artifacts_error(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock, mock_check_url: Mock) -> None:
         mock_validation_args.return_value.version.return_value = '2.11.0'
+        url = "https://opensearch.org/release/2.11.0/opensearch-2.11.0-linux-arm64.tar.gz"
 
         validate_tar = ValidateTar(mock_validation_args)
 
-        self.assertRaises(Exception, validate_tar.download_artifacts())
+        self.assertRaises(Exception, validate_tar.check_url(url))
 
     @patch("validation_workflow.tar.validation_tar.execute", return_value=True)
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')

--- a/tests/tests_validation_workflow/test_validation_yum.py
+++ b/tests/tests_validation_workflow/test_validation_yum.py
@@ -15,8 +15,9 @@ class TestValidationYum(unittest.TestCase):
 
     @patch("validation_workflow.download_utils.DownloadUtils.is_url_valid", return_value=True)
     @patch("validation_workflow.download_utils.DownloadUtils.download", return_value=True)
+    @patch("validation_workflow.validation.Validation.check_url", return_value=True)
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
-    def test_download_artifacts(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock) -> None:
+    def test_download_artifacts(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock, mock_check_url: Mock) -> None:
         mock_validation_args.return_value.version.return_value = '2.3.0'
         mock_validation_args.return_value.projects.return_value = ["opensearch", "opensearch-dashboards"]
 
@@ -28,13 +29,15 @@ class TestValidationYum(unittest.TestCase):
 
     @patch("validation_workflow.download_utils.DownloadUtils.is_url_valid", return_value=False)
     @patch("validation_workflow.download_utils.DownloadUtils.download", return_value=False)
+    @patch("validation_workflow.validation.Validation.check_url", return_value=False)
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
-    def test_download_artifacts_error(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock) -> None:
+    def test_download_artifacts_error(self, mock_validation_args: Mock, mock_is_url_valid: Mock, mock_download: Mock, mock_check_url: Mock) -> None:
         mock_validation_args.return_value.version.return_value = '2.11.0'
+        url = "https://opensearch.org/release/2.11.0/opensearch-2.11.0-linux-x64.yum"
 
         validate_yum = ValidateYum(mock_validation_args)
 
-        self.assertRaises(Exception, validate_yum.download_artifacts())
+        self.assertRaises(Exception, validate_yum.check_url(url))
 
     @patch("validation_workflow.yum.validation_yum.execute", return_value=True)
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')


### PR DESCRIPTION
### Description
Changes to Yum and Rpm.
1. Removed 'sudo system enable ' from rpm and yum distributions
2. Added code to remove open-search at the end of rpm and yum validation.
3. Constrained download_artifacts method to download the artifacts based on architecture  and eventually validate them later, earlier artifacts related to both x64 and arm64 used to get downloaded.
4. Added a statement to print the type of exception occurred if the workflow fails.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
