### PR TITLE
Increase the timeout for docker build

### DIFF
--- a/jenkins/docker/docker-build.jenkinsfile
+++ b/jenkins/docker/docker-build.jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     options {
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 4, unit: 'HOURS')
     }
     agent none
     parameters {

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-build.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-build.jenkinsfile.txt
@@ -1,6 +1,6 @@
    docker-build.run()
       docker-build.pipeline(groovy.lang.Closure)
-         docker-build.timeout({time=3, unit=HOURS})
+         docker-build.timeout({time=4, unit=HOURS})
          docker-build.echo(Executing on agent [label:none])
          docker-build.stage(Parameters Check, groovy.lang.Closure)
             docker-build.script(groovy.lang.Closure)


### PR DESCRIPTION
### Description
Increase the timeout for docker build. The recent docker build for release clients docker image failed due to timeout issue: https://build.ci.opensearch.org/job/docker-build/3158/

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
