### PR TITLE
Add CCR and security to test manifest

### DIFF
--- a/manifests/2.7.0/opensearch-2.7.0-test.yml
+++ b/manifests/2.7.0/opensearch-2.7.0-test.yml
@@ -1,0 +1,25 @@
+---
+schema-version: '1.0'
+name: OpenSearch
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2
+    args: -e JAVA_HOME=/opt/java/openjdk-17
+components:
+  - name: cross-cluster-replication
+    integ-test:
+      topology:
+        - cluster_name: leader
+          data_nodes: 2
+          cluster_manager_nodes: 0
+        - cluster_name: follower
+          data_nodes: 2
+          cluster_manager_nodes: 0
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: security
+    integ-test:
+      test-configs:
+        - with-security

--- a/manifests/2.7.0/opensearch-2.7.0.yml
+++ b/manifests/2.7.0/opensearch-2.7.0.yml
@@ -32,3 +32,18 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: '2.x'
+    platforms:
+      - linux
+      - windows
+  - name: cross-cluster-replication
+    repository: https://github.com/opensearch-project/cross-cluster-replication.git
+    ref: '2.x'
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
Signed-off-by: Monu Singh <msnghgw@amazon.com>

### Description
Allow CCR integ tests to run on remote cluster using custom topology for 2.7 release.
Added security to build manifest as security is needed for CCR to work.
Security has not yet pushed version bump PR so ref'ed to '2.x' branch

### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/532
https://github.com/opensearch-project/opensearch-build/issues/2066

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
