### PR TITLE
Change order of neural and ml-commons due to dependency issue

### DIFF
--- a/manifests/2.7.0/opensearch-2.7.0.yml
+++ b/manifests/2.7.0/opensearch-2.7.0.yml
@@ -65,15 +65,6 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
-  - name: neural-search
-    repository: https://github.com/opensearch-project/neural-search.git
-    ref: 2.x
-    platforms:
-      - linux
-      - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
     ref: 2.x
@@ -83,6 +74,15 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
+  - name: neural-search
+    repository: https://github.com/opensearch-project/neural-search.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
     ref: 2.x


### PR DESCRIPTION
### Description
Neural depends on ml-commons. This change fixes the order so that dependency is present before building.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
