### PR TITLE
Remove test result messages and associated dependencies

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -383,12 +383,6 @@ pipeline {
                                             status: integTestResults.getId(),
                                             stage: "integ_test_x64" // TODO: change to integ_test_linux_x64_tar
                                         )
-
-                                        env.ARTIFACT_URL_LINUX_X64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (linux, x64, tar)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
                                     }
                                 },
                                 'bwc-test': {
@@ -410,12 +404,6 @@ pipeline {
                                             status: bwcTestResults.getId(),
                                             stage: "bwc_test_x64" // TODO: change to bwc_test_linux_x64_tar
                                         )
-
-                                        env.ARTIFACT_URL_LINUX_X64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (linux, 64, tar)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
                                     }
                                 }
                             ])
@@ -426,9 +414,7 @@ pipeline {
                             script {
                                 lib.jenkins.Messages.new(this).add(
                                     "${STAGE_NAME}",
-                                    lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                    "\n${env.ARTIFACT_URL_LINUX_X64_TAR_INTEG_TEST_RESULT}" +
-                                    "\n${env.ARTIFACT_URL_LINUX_X64_TAR_BWC_TEST_RESULT}"
+                                    lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
 
                                 postCleanup()
@@ -508,12 +494,6 @@ pipeline {
                                             string(name: 'BUNDLE_MANIFEST_URL', value: bundleManifestUrl),
                                             string(name: 'AGENT_LABEL', value: AGENT_X64)
                                         ]
-
-                                    env.RPM_VALIDATION_LINUX_X64_RPM_TEST_RESULT = createTestResultsMessage(
-                                        testType: "RPM Validation (linux, x64, rpm)",
-                                        status: rpmValidationResults.getResult(),
-                                        absoluteUrl: rpmValidationResults.getAbsoluteUrl()
-                                    )
                                 }
                             }
                             post {
@@ -521,8 +501,7 @@ pipeline {
                                     script {
                                         lib.jenkins.Messages.new(this).add(
                                             "${STAGE_NAME}",
-                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                            "\n${env.RPM_VALIDATION_LINUX_X64_RPM_TEST_RESULT}"
+                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                         )
 
                                         postCleanup()
@@ -663,12 +642,6 @@ pipeline {
                                             status: integTestResults.getId(),
                                             stage: "integ_test_arm64" // TODO: integ_test_linux_arm64_tar
                                         )
-
-                                        env.ARTIFACT_URL_LINUX_ARM64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (linux, arm64, tar)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
                                     }
                                 },
                                 'bwc-test': {
@@ -690,12 +663,6 @@ pipeline {
                                             status: bwcTestResults.getId(),
                                             stage: "bwc_test_arm64" // TODO: bwc_test_linux_arm64_tar
                                         )
-
-                                        env.ARTIFACT_URL_LINUX_ARM64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (linux, arm64, tar)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
                                     }
                                 }
                             ])
@@ -706,9 +673,7 @@ pipeline {
                             script {
                                 lib.jenkins.Messages.new(this).add(
                                     "${STAGE_NAME}",
-                                    lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                    "\n${env.ARTIFACT_URL_LINUX_ARM64_TAR_INTEG_TEST_RESULT}" +
-                                    "\n${env.ARTIFACT_URL_LINUX_ARM64_TAR_BWC_TEST_RESULT}"
+                                    lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
 
                                 postCleanup()
@@ -788,12 +753,6 @@ pipeline {
                                             string(name: 'BUNDLE_MANIFEST_URL', value: bundleManifestUrl),
                                             string(name: 'AGENT_LABEL', value: AGENT_ARM64)
                                         ]
-
-                                    env.RPM_VALIDATION_LINUX_ARM64_RPM_TEST_RESULT = createTestResultsMessage(
-                                        testType: "RPM Validation (linux, arm64, rpm)",
-                                        status: rpmValidationResults.getResult(),
-                                        absoluteUrl: rpmValidationResults.getAbsoluteUrl()
-                                    )
                                 }
                             }
                             post {
@@ -801,8 +760,7 @@ pipeline {
                                     script {
                                         lib.jenkins.Messages.new(this).add(
                                             "${STAGE_NAME}",
-                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                            "\n${env.RPM_VALIDATION_LINUX_ARM64_RPM_TEST_RESULT}"
+                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                         )
 
                                         postCleanup()


### PR DESCRIPTION


### Description
See: https://github.com/opensearch-project/opensearch-build/pull/3283 
Remove test result messages and associated dependencies from build pipeline
Since tests are running independent now we do not need to collect the status of those in the build pipeline. The getResults methods throw null pointer. Removing the messages and associated methods related to testing from build pipeline

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
