### PR TITLE
[Decouple testing and build] Remove dependent method calls

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -206,18 +206,6 @@ pipeline {
                                                 string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
                                                 string(name: 'AGENT_LABEL', value: AGENT_X64)
                                             ]
-
-                                        buildInfoYaml(
-                                            componentName: COMPONENT_NAME,
-                                            status: integTestResults.getId(),
-                                            stage: "integ_test_x64" // TODO: change to integ_test_linux_x64_tar
-                                        )
-
-                                        env.ARTIFACT_URL_LINUX_X64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                            testType: "Integ Tests (linux, x64, tar)",
-                                            status: integTestResults.getResult(),
-                                            absoluteUrl: integTestResults.getAbsoluteUrl()
-                                        )
                                     }
                                 },
                                 'bwc-test': {
@@ -233,18 +221,6 @@ pipeline {
                                                 string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
                                                 string(name: 'AGENT_LABEL', value: AGENT_X64)
                                             ]
-
-                                        buildInfoYaml(
-                                            componentName: COMPONENT_NAME,
-                                            status: bwcTestResults.getId(),
-                                            stage: "bwc_test_x64" // TODO: change to bwc_test_linux_x64_tar
-                                        )
-
-                                        env.ARTIFACT_URL_LINUX_X64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
-                                            testType: "BWC Tests (linux, x64, tar)",
-                                            status: bwcTestResults.getResult(),
-                                            absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                        )
                                     }
                                 }
                             ])
@@ -255,9 +231,7 @@ pipeline {
                             script {
                                 lib.jenkins.Messages.new(this).add(
                                     "${STAGE_NAME}",
-                                    lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                    "\n${env.ARTIFACT_URL_LINUX_X64_TAR_INTEG_TEST_RESULT}" +
-                                    "\n${env.ARTIFACT_URL_LINUX_X64_TAR_BWC_TEST_RESULT}"
+                                    lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
                                 postCleanup()
                             }
@@ -341,12 +315,6 @@ pipeline {
                                             string(name: 'BUNDLE_MANIFEST_URL', value: bundleManifestUrl),
                                             string(name: 'AGENT_LABEL', value: AGENT_X64)
                                         ]
-
-                                    env.RPM_VALIDATION_LINUX_X64_RPM_TEST_RESULT = createTestResultsMessage(
-                                        testType: "RPM Validation (linux, x64, rpm)",
-                                        status: rpmValidationResults.getResult(),
-                                        absoluteUrl: rpmValidationResults.getAbsoluteUrl()
-                                    )
                                 }
                             }
                             post {
@@ -354,8 +322,7 @@ pipeline {
                                     script {
                                         lib.jenkins.Messages.new(this).add(
                                             "${STAGE_NAME}",
-                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                            "\n${env.RPM_VALIDATION_LINUX_X64_RPM_TEST_RESULT}"
+                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                         )
                                         postCleanup()
                                     }
@@ -536,18 +503,6 @@ pipeline {
                                                         string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
                                                         string(name: 'AGENT_LABEL', value: AGENT_ARM64)
                                                     ]
-
-                                                buildInfoYaml(
-                                                    componentName: COMPONENT_NAME,
-                                                    status: integTestResults.getId(),
-                                                    stage: "integ_test_arm64" // TODO: change to integ_test_linux_arm64_tar
-                                                )
-
-                                                env.ARTIFACT_URL_LINUX_ARM64_TAR_INTEG_TEST_RESULT = createTestResultsMessage(
-                                                    testType: "Integ Tests (linux, arm64, tar)",
-                                                    status: integTestResults.getResult(),
-                                                    absoluteUrl: integTestResults.getAbsoluteUrl()
-                                                )
                                             }
                                         },
                                         'bwc-test': {
@@ -563,18 +518,6 @@ pipeline {
                                                         string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
                                                         string(name: 'AGENT_LABEL', value: AGENT_ARM64)
                                                     ]
-
-                                                buildInfoYaml(
-                                                    componentName: COMPONENT_NAME,
-                                                    status: bwcTestResults.getId(),
-                                                    stage: "bwc_test_arm64" // TODO: change to bwc_test_linux_arm64_tar
-                                                )
-
-                                                env.ARTIFACT_URL_LINUX_ARM64_TAR_BWC_TEST_RESULT = createTestResultsMessage(
-                                                    testType: "BWC Tests (linux, arm64, tar)",
-                                                    status: bwcTestResults.getResult(),
-                                                    absoluteUrl: bwcTestResults.getAbsoluteUrl()
-                                                )
                                             }
                                         }
                                     ])
@@ -585,9 +528,7 @@ pipeline {
                                     script {
                                         lib.jenkins.Messages.new(this).add(
                                             "${STAGE_NAME}",
-                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                            "\n${env.ARTIFACT_URL_LINUX_ARM64_TAR_INTEG_TEST_RESULT}" +
-                                            "\n${env.ARTIFACT_URL_LINUX_ARM64_TAR_BWC_TEST_RESULT}"
+                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                         )
                                         postCleanup()
                                     }
@@ -678,12 +619,6 @@ pipeline {
                                             string(name: 'BUNDLE_MANIFEST_URL', value: bundleManifestUrl),
                                             string(name: 'AGENT_LABEL', value: AGENT_ARM64)
                                         ]
-
-                                    env.RPM_VALIDATION_LINUX_ARM64_RPM_TEST_RESULT = createTestResultsMessage(
-                                        testType: "RPM Validation (linux, arm64, rpm)",
-                                        status: rpmValidationResults.getResult(),
-                                        absoluteUrl: rpmValidationResults.getAbsoluteUrl()
-                                    )
                                 }
                             }
                             post {
@@ -691,8 +626,7 @@ pipeline {
                                     script {
                                         lib.jenkins.Messages.new(this).add(
                                             "${STAGE_NAME}",
-                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]) +
-                                            "\n${env.RPM_VALIDATION_LINUX_ARM64_RPM_TEST_RESULT}"
+                                            lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                         )
                                         postCleanup()
                                     }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -377,12 +377,6 @@ pipeline {
                                                 string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
                                                 string(name: 'AGENT_LABEL', value: AGENT_X64)
                                             ]
-
-                                        buildInfoYaml(
-                                            componentName: COMPONENT_NAME,
-                                            status: integTestResults.getId(),
-                                            stage: "integ_test_x64" // TODO: change to integ_test_linux_x64_tar
-                                        )
                                     }
                                 },
                                 'bwc-test': {
@@ -398,12 +392,6 @@ pipeline {
                                                 string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
                                                 string(name: 'AGENT_LABEL', value: AGENT_X64)
                                             ]
-
-                                        buildInfoYaml(
-                                            componentName: COMPONENT_NAME,
-                                            status: bwcTestResults.getId(),
-                                            stage: "bwc_test_x64" // TODO: change to bwc_test_linux_x64_tar
-                                        )
                                     }
                                 }
                             ])
@@ -636,12 +624,6 @@ pipeline {
                                                 string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
                                                 string(name: 'AGENT_LABEL', value: AGENT_ARM64)
                                             ]
-
-                                        buildInfoYaml(
-                                            componentName: COMPONENT_NAME,
-                                            status: integTestResults.getId(),
-                                            stage: "integ_test_arm64" // TODO: integ_test_linux_arm64_tar
-                                        )
                                     }
                                 },
                                 'bwc-test': {
@@ -657,12 +639,6 @@ pipeline {
                                                 string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
                                                 string(name: 'AGENT_LABEL', value: AGENT_ARM64)
                                             ]
-
-                                        buildInfoYaml(
-                                            componentName: COMPONENT_NAME,
-                                            status: bwcTestResults.getId(),
-                                            stage: "bwc_test_arm64" // TODO: bwc_test_linux_arm64_tar
-                                        )
                                     }
                                 }
                             ])


### PR DESCRIPTION
### Description
Follow up PR for decoupling the test workflows from build workflows. Remoes dependent method calls from build pipeline

See:
https://github.com/opensearch-project/opensearch-build/pull/3283
https://github.com/opensearch-project/opensearch-build/pull/3297




### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
