### PR TITLE
Release 1.3.9 - update manifest with commit ID to lock RC

### DIFF
--- a/manifests/1.3.9/opensearch-1.3.9.yml
+++ b/manifests/1.3.9/opensearch-1.3.9.yml
@@ -10,13 +10,13 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: '1.3'
+    ref: 64d2aa341cf591dd20ab3966792e564a467fdcf7
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: '1.3'
+    ref: 3b31f9629816db248fabd98ef0b13d26f632a5ea
     checks:
       - gradle:publish
       - gradle:properties:version
@@ -25,7 +25,7 @@ components:
       - windows
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: '1.3'
+    ref: 3daa73897df51aa99b16a24287aa10aef9899b0d
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -34,7 +34,7 @@ components:
       - windows
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: '1.3'
+    ref: e187763730b6d71a913c24eff08c1b586c18304b
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
@@ -43,7 +43,7 @@ components:
       - windows
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: '1.3'
+    ref: 7e6e1cd79b052570ce7eeed0af46a3ae4860aba3
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
@@ -52,7 +52,7 @@ components:
       - windows
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: '1.3'
+    ref: de58399034d83cfa7aad0581d72b35dc3e64a3b7
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -61,7 +61,7 @@ components:
       - windows
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: '1.3'
+    ref: 04fd3c31d99a1f9205099e8528fd7307e81fa2bb
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -69,7 +69,7 @@ components:
       - linux
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: '1.3'
+    ref: 59d8b1e1912f6263257d504838300c9ab2b48dc5
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
@@ -78,7 +78,7 @@ components:
       - windows
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: '1.3'
+    ref: 002d3b139a60844d3e344ed7e7ce95f7c5e5bb66
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -87,7 +87,7 @@ components:
       - windows
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: '1.3'
+    ref: aeadb542a73a9b1474ae336ef902abdc504d3412
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -96,7 +96,7 @@ components:
       - windows
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '1.3'
+    ref: 0004aba21d56ff62ea2f445758b51fd21f431e63
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -105,7 +105,7 @@ components:
       - windows
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: '1.3'
+    ref: 1ca534c00ea9192a4366bb694086df3600d84f4f
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -114,7 +114,7 @@ components:
       - windows
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: '1.3'
+    ref: 2c2e257db62bc892d958a191ba47c4f711196952
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -123,7 +123,7 @@ components:
       - windows
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '1.3'
+    ref: 316c3a10a4677cfcc662ddb3a733668adf4e0534
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -132,7 +132,7 @@ components:
       - windows
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: '1.3'
+    ref: 88a3f2b85ce2bcf4ced144d42f5bf96111b82743
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/1.3.9/opensearch-dashboards-1.3.9.yml
+++ b/manifests/1.3.9/opensearch-dashboards-1.3.9.yml
@@ -9,32 +9,32 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: '1.3'
+    ref: 3d6b2f6cf1e505ceddd2d442af28398f2fb776e3
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '1.3'
+    ref: 3cf343cbc627224c3a70c6c03c32ffacdd9021b6
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: '1.3'
+    ref: f05d1f1e6abc92cc22e78027556df24bfba2499d
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
     working_directory: gantt-chart
-    ref: '1.3'
+    ref: c8da52fb4bf6cd64c66b32ad64a3ec08b3791813
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
-    ref: '1.3'
+    ref: b404175d96548a2e45e197740d95d23016abb1e7
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: '1.3'
+    ref: e02a5d954f43221de5ffe5ea53406213b6dabd83
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
-    ref: '1.3'
+    ref: 09a3200fedd3ed213190d4c0644e26ce5c559470
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
-    ref: '1.3'
+    ref: e98670b70c06f9e3027a9e748edbdc31290bc0f7
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '1.3'
+    ref: 713ccb7a00e4d8098032d9c2620d8202223038ba
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
-    ref: '1.3'
+    ref: 63505a6cd0768554313774f1e46ae05a36d0409a


### PR DESCRIPTION
### Description
Release 1.3.9 - update manifest with commit ID to lock RC

### Issues Resolved
Release 1.3.9 - update manifest with commit ID to lock RC

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
