### PR TITLE
Resolve lychee errors in build repo push

### DIFF
--- a/.lychee.excludes
+++ b/.lychee.excludes
@@ -3,5 +3,5 @@ https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/*
 http://public.ecr.aws/data-prepper-container-repository
 https://www.dummy.com/*
 # Too many redirects in playground.opensearch.org due to not having user agent information
-# See https://github.com/lycheeverse/lychee/issues/715
+# https://github.com/lycheeverse/lychee/issues/715
 https://playground.opensearch.org/*

--- a/.lychee.excludes
+++ b/.lychee.excludes
@@ -1,3 +1,6 @@
 http://staging-artifacts.cloudfront.net/*
 https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/*
 http://public.ecr.aws/data-prepper-container-repository
+https://www.dummy.com/*
+# Too many redirects in playground.opensearch.org, see https://github.com/lycheeverse/lychee/issues/715
+https://playground.opensearch.org/*

--- a/.lychee.excludes
+++ b/.lychee.excludes
@@ -2,5 +2,6 @@ http://staging-artifacts.cloudfront.net/*
 https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/*
 http://public.ecr.aws/data-prepper-container-repository
 https://www.dummy.com/*
-# Too many redirects in playground.opensearch.org, see https://github.com/lycheeverse/lychee/issues/715
+# Too many redirects in playground.opensearch.org due to not having user agent information
+# See https://github.com/lycheeverse/lychee/issues/715
 https://playground.opensearch.org/*


### PR DESCRIPTION
### Description
Resolve lychee errors in build repo push

### Issues Resolved

```
Run lycheeverse/lychee-action@v1.5.4
Run curl -sLO 'https://github.com/lycheeverse/lychee/releases/download/v0.10.3/lychee-v0.10.3-x86_64-unknown-linux-gnu.tar.gz'
lychee
Run /home/runner/work/_actions/lycheeverse/lychee-action/v1.5.4/entrypoint.sh
## Summary

| Status        | Count |
|---------------|-------|
| 🔍 Total      | 4085  |
| ✅ Successful | 3912  |
| ⏳ Timeouts   | 0     |
| 🔀 Redirected | 0     |
| 👻 Excluded   | 170   |
| ❓ Unknown    | 0     |
| 🚫 Errors     | 3     |

## Errors per input

### Errors in tests/jenkins/jenkinsjob-regression-files/sign-standalone-artifacts/sign-standalone-artifacts.jenkinsfile.txt

* [ERR] [https://www.dummy.com/dummy_1_artifact.tar.gz](https://www.dummy.com/dummy_1_artifact.tar.gz) | Failed: Network error: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1921: (unable to get local issuer certificate)
* [ERR] [https://www.dummy.com/dummy_2_artifact.tar.gz](https://www.dummy.com/dummy_2_artifact.tar.gz) | Failed: Network error: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1921: (unable to get local issuer certificate)

### Errors in release-notes/opensearch-release-notes-2.6.0.md

* [ERR] [https://playground.opensearch.org/](https://playground.opensearch.org/) | Failed: Network error: error following redirect for url (https://playground.opensearch.org/): too many redirects


Error: Process completed with exit code 2.

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
