### PR TITLE
Updated integ-tests implementation to run all the OSD plugins. 

### DIFF
--- a/src/test_workflow/integ_test/integ_test_suite.py
+++ b/src/test_workflow/integ_test/integ_test_suite.py
@@ -6,22 +6,15 @@
 # compatible open source license.
 
 import abc
-import json
 import logging
-import os
 from pathlib import Path
 from typing import Any, Dict
 
-from git.git_repository import GitRepository
 from manifests.build_manifest import BuildManifest
 from manifests.bundle_manifest import BundleManifest
-from paths.script_finder import ScriptFinder
-from system.execute import execute
 from test_workflow.dependency_installer import DependencyInstaller
-from test_workflow.integ_test.topology import ClusterEndpoint, NodeEndpoint
 from test_workflow.test_recorder.log_recorder import LogRecorder
 from test_workflow.test_recorder.test_recorder import TestRecorder
-from test_workflow.test_recorder.test_result_data import TestResultData
 from test_workflow.test_result.test_component_results import TestComponentResults
 
 
@@ -33,7 +26,6 @@ class IntegTestSuite(abc.ABC):
     dependency_installer: DependencyInstaller
     bundle_manifest: BundleManifest
     build_manifest: BuildManifest
-    repo: GitRepository
     save_logs: LogRecorder
     additional_cluster_config: dict
 
@@ -61,13 +53,6 @@ class IntegTestSuite(abc.ABC):
         self.bundle_manifest = bundle_manifest
         self.build_manifest = build_manifest
 
-        self.repo = GitRepository(
-            self.component.repository,
-            self.component.commit_id,
-            os.path.join(self.work_dir, self.component.name),
-            test_config.working_directory
-        )
-
         self.save_logs = test_recorder.test_results_logs
         self.additional_cluster_config = None
 
@@ -75,46 +60,9 @@ class IntegTestSuite(abc.ABC):
     def execute_tests(self) -> TestComponentResults:
         pass
 
+    @abc.abstractmethod
     def multi_execute_integtest_sh(self, cluster_endpoints: list, security: bool, test_config: str) -> int:
-        script = ScriptFinder.find_integ_test_script(self.component.name, self.repo.working_directory)
-
-        def custom_node_endpoint_encoder(node_endpoint: NodeEndpoint) -> dict:
-            return {"endpoint": node_endpoint.endpoint, "port": node_endpoint.port, "transport": node_endpoint.transport}
-        if os.path.exists(script):
-            if len(cluster_endpoints) == 1:
-                single_data_node = cluster_endpoints[0].data_nodes[0]
-                cmd = f"bash {script} -b {single_data_node.endpoint} -p {single_data_node.port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
-            else:
-                endpoints_list = []
-                for cluster_details in cluster_endpoints:
-                    endpoints_list.append(cluster_details.__dict__)
-                endpoints_string = json.dumps(endpoints_list, indent=0, default=custom_node_endpoint_encoder)
-                cmd = f"bash {script} -e '"
-                cmd = cmd + endpoints_string + "'"
-                cmd = cmd + f" -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
-            self.repo_work_dir = os.path.join(
-                self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
-            (status, stdout, stderr) = execute(cmd, self.repo_work_dir, True, False)
-            test_result_data = TestResultData(
-                self.component.name,
-                test_config,
-                status,
-                stdout,
-                stderr,
-                self.test_artifact_files
-            )
-            self.save_logs.save_test_result_data(test_result_data)
-            if stderr:
-                logging.info("Stderr reported for component: " + self.component.name)
-                logging.info(stderr)
-            return status
-        else:
-            logging.info(f"{script} does not exist. Skipping integ tests for {self.component.name}")
-            return 0
-
-    def execute_integtest_sh(self, endpoint: str, port: int, security: bool, test_config: str) -> int:
-        cluster_endpoint_port = [ClusterEndpoint("cluster1", [NodeEndpoint(endpoint, port, 9300)], [])]
-        return self.multi_execute_integtest_sh(cluster_endpoint_port, security, test_config)
+        pass
 
     def is_security_enabled(self, config: str) -> bool:
         if config in ["with-security", "without-security"]:

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch.py
@@ -15,8 +15,7 @@ from git.git_repository import GitRepository
 from manifests.build_manifest import BuildManifest
 from manifests.bundle_manifest import BundleComponent, BundleManifest
 from manifests.test_manifest import TestComponent, TestManifest
-from test_workflow.integ_test.integ_test_suite import InvalidTestConfigError, ScriptFinder
-from test_workflow.integ_test.integ_test_suite_opensearch import IntegTestSuiteOpenSearch, Topology
+from test_workflow.integ_test.integ_test_suite_opensearch import IntegTestSuiteOpenSearch, InvalidTestConfigError, ScriptFinder, Topology
 
 
 @patch("os.makedirs")
@@ -51,15 +50,15 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
             mock_test_recorder
         )
         mock_topology.create().__enter__.return_value = [{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}]
-        mock_execute_integtest_sh = MagicMock()
-        IntegTestSuiteOpenSearch.multi_execute_integtest_sh = mock_execute_integtest_sh  # type: ignore
-        mock_execute_integtest_sh.return_value = "success"
+        mock_multi_execute_integtest_sh = MagicMock()
+        IntegTestSuiteOpenSearch.multi_execute_integtest_sh = mock_multi_execute_integtest_sh  # type: ignore
+        mock_multi_execute_integtest_sh.return_value = "success"
 
         test_results = integ_test_suite.execute_tests()
         self.assertEqual(len(test_results), 2)
         self.assertTrue(test_results.failed)
 
-        mock_execute_integtest_sh.assert_has_calls([
+        mock_multi_execute_integtest_sh.assert_has_calls([
             call([{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}], True, "with-security"),
             call([{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}], False, "without-security")
         ])
@@ -81,22 +80,21 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
 
         mock_topology.create().__enter__.return_value = [{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}]
 
-        mock_execute_integtest_sh = MagicMock()
-        IntegTestSuiteOpenSearch.multi_execute_integtest_sh = mock_execute_integtest_sh  # type: ignore
-        mock_execute_integtest_sh.return_value = "success"
+        mock_multi_execute_integtest_sh = MagicMock()
+        IntegTestSuiteOpenSearch.multi_execute_integtest_sh = mock_multi_execute_integtest_sh  # type: ignore
+        mock_multi_execute_integtest_sh.return_value = "success"
 
         integ_test_suite.execute_tests()
         dependency_installer.install_build_dependencies.assert_called_with(
             {"opensearch-job-scheduler": "1.1.0.0"}, os.path.join(self.work_dir, "index-management", "src", "test", "resources", "job-scheduler")
         )
 
-        mock_execute_integtest_sh.assert_has_calls([
-            call([{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}], True, "with-security"),
-            call([{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}], False, "without-security")
-        ])
+        mock_multi_execute_integtest_sh.assert_has_calls([call(
+            [{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}], False, "without-security")]
+        )
 
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
-    @patch("test_workflow.integ_test.integ_test_suite.execute")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch.execute")
     def test_execute_without_build_dependencies(self, mock_execute: Mock, *mock: Any) -> None:
         dependency_installer = MagicMock()
         test_config, component = self.__get_test_config_and_bundle_component("job-scheduler")
@@ -180,13 +178,13 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
         mock_topology.create().__enter__.return_value = [{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}]
         mock_script_finder.return_value = "integtest.sh"
 
-        mock_execute_integtest_sh = MagicMock()
-        IntegTestSuiteOpenSearch.multi_execute_integtest_sh = mock_execute_integtest_sh  # type: ignore
-        mock_execute_integtest_sh.return_value = "success"
+        mock_multi_execute_integtest_sh = MagicMock()
+        IntegTestSuiteOpenSearch.multi_execute_integtest_sh = mock_multi_execute_integtest_sh  # type: ignore
+        mock_multi_execute_integtest_sh.return_value = "success"
 
         integ_test_suite.execute_tests()  # type: ignore
 
-        mock_execute_integtest_sh.assert_called_with(
+        mock_multi_execute_integtest_sh.assert_called_with(
             [{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}],
             True,
             "with-security"

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch_dashboards.py
@@ -9,6 +9,7 @@ import logging
 import os
 import unittest
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, Mock, call, patch
 
 from paths.script_finder import ScriptFinder
@@ -44,11 +45,10 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
 
     @patch("os.chdir")
     @patch("os.path.exists")
-    @patch("test_workflow.integ_test.integ_test_suite.TestResultData")
-    @patch("test_workflow.integ_test.integ_test_suite.GitRepository")
-    @patch("test_workflow.integ_test.integ_test_suite.execute", return_value=True)
-    def test_execute_tests(self, mock_execute: Mock, mock_git: Mock, mock_test_result_data: Mock, mock_path_exists: Mock, mock_chdir: Mock) -> None:
-
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.TestResultData")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.GitRepository")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.execute", return_value=True)
+    def test_execute_tests(self, mock_execute: Mock, mock_git: Mock, mock_test_result_data: Mock, mock_localTestClusterOSD: Mock, mock_path_exists: Mock, *mock: Any) -> None:
         mock_find = MagicMock()
         mock_find.return_value = "./integtest.sh"
 
@@ -96,9 +96,9 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
     # test base class
 
     @patch("os.path.exists")
-    @patch("test_workflow.integ_test.integ_test_suite.TestResultData")
-    @patch("test_workflow.integ_test.integ_test_suite.GitRepository")
-    @patch("test_workflow.integ_test.integ_test_suite.execute", return_value=True)
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.TestResultData")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.GitRepository")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.execute", return_value=True)
     def test_execute_integtest_sh(self, mock_execute: Mock, mock_git: Mock, mock_test_result_data: Mock, mock_path_exists: Mock) -> None:
         logging.info(locals())
 
@@ -135,8 +135,7 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
         status = suite.execute_integtest_sh("test_endpoint", 1234, True, "with-security")
 
         self.assertEqual(status, "test_status")
-        mock_execute.assert_called_once_with('bash ./integtest.sh -b test_endpoint -p 1234 -s true -v 1.2.0',
-                                             os.path.join("dir", "test_working_directory"), True, False)
+        mock_execute.assert_called_once_with('bash ./integtest.sh -b test_endpoint -p 1234 -s true -t sql -v 1.2.0 -o default', os.path.join("dir", "test_working_directory"), True, False)
 
         mock_test_result_data.assert_called_once_with(
             "sql",
@@ -153,9 +152,9 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
         self.save_logs.save_test_result_data.assert_called_once_with(mock_test_result_data_object)
 
     @patch("os.path.exists")
-    @patch("test_workflow.integ_test.integ_test_suite.TestResultData")
-    @patch("test_workflow.integ_test.integ_test_suite.GitRepository")
-    @patch("test_workflow.integ_test.integ_test_suite.execute", return_value=True)
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.TestResultData")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.GitRepository")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.execute", return_value=True)
     def test_execute_integtest_sh_script_do_not_exist(self, mock_execute: Mock, mock_git: Mock, mock_test_result_data: Mock, mock_path_exists: Mock) -> None:
         mock_find = MagicMock()
         mock_find.return_value = "./integtest.sh"
@@ -191,9 +190,9 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
         self.save_logs.assert_not_called()
 
     @patch("os.path.exists")
-    @patch("test_workflow.integ_test.integ_test_suite.TestResultData")
-    @patch("test_workflow.integ_test.integ_test_suite.GitRepository")
-    @patch("test_workflow.integ_test.integ_test_suite.execute", return_value=True)
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.TestResultData")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.GitRepository")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.execute", return_value=True)
     def test_is_security_enabled(self, mock_execute: Mock, mock_git: Mock, mock_test_result_data: Mock, mock_path_exists: Mock) -> None:
         mock_find = MagicMock()
         mock_find.return_value = "./integtest.sh"
@@ -229,9 +228,9 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
 
     @patch("test_workflow.integ_test.integ_test_suite.logging")
     @patch("os.path.exists")
-    @patch("test_workflow.integ_test.integ_test_suite.TestResultData")
-    @patch("test_workflow.integ_test.integ_test_suite.GitRepository")
-    @patch("test_workflow.integ_test.integ_test_suite.execute", return_value=True)
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.TestResultData")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.GitRepository")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.execute", return_value=True)
     def test_pretty_print_message(self, mock_execute: Mock, mock_git: Mock, mock_test_result_data: Mock, mock_path_exists: Mock, mock_logging: Mock) -> None:
 
         mock_find = MagicMock()


### PR DESCRIPTION
Signed-by: divyaasm@amazon.com

Fix to issue https://github.com/opensearch-project/opensearch-build/issues/2144
### Description
-Made changes to run OSD plugins altogether or individually using --component arg.
-OSD integtests when triggered from buildrepo are now executed via opensearch-dashboards-functional-test repo.
-Updated test-cases accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
