### PR TITLE
docker validation improvement

### DIFF
--- a/src/run_validation.py
+++ b/src/run_validation.py
@@ -21,7 +21,7 @@ def main() -> int:
 
     test_result = ValidationTestRunner.dispatch(args, args.distribution).run()
     logging.info(f'final test_result = {test_result}')
-    return test_result  # type: ignore
+    return 0 if test_result else 1  # type: ignore
 
 
 if __name__ == "__main__":

--- a/src/validation_workflow/api_request.py
+++ b/src/validation_workflow/api_request.py
@@ -6,9 +6,8 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import subprocess
 from typing import Any
-
-import requests
 
 """
 This class is to run API test againt on local OpenSearch API URL with default port 9200.
@@ -20,15 +19,11 @@ class ApiTest:
 
     def __init__(self, request_url: str) -> None:
         self.request_url = request_url
-        self.apiHeaders_auth = {"Authorization": "Basic YWRtaW46YWRtaW4="}  # default user/pass "admin/admin" in Base64 format
-        self.apiHeaders_accept = {"Accept": "*/*"}
-        self.apiHeaders_content_type = {"Content-Type": "application/json"}
-        self.apiHeaders = {}
-        self.apiHeaders.update(self.apiHeaders_auth)
-        self.apiHeaders.update(self.apiHeaders_accept)
-        self.apiHeaders.update(self.apiHeaders_content_type)
 
     def api_get(self) -> Any:
-
-        response = requests.get(self.request_url, headers=self.apiHeaders, verify=False)
-        return response.status_code, response.text
+        self.command = ['curl', self.request_url, '-u', 'admin:admin', '--insecure', '-i']
+        result = subprocess.run(self.command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        response = result.stdout.decode().strip()
+        response_code = int(response.split()[1])
+        response_content = response.split('\r\n\r\n', 1)[1]
+        return response_code, response_content

--- a/src/validation_workflow/api_test_cases.py
+++ b/src/validation_workflow/api_test_cases.py
@@ -39,9 +39,10 @@ class ApiTestCases:
             success_status_code = test_case.__getitem__(1)
             validate_string = test_case.__getitem__(2)
 
-            status_code, response_text = ApiTest(str(request_url)).api_get()
-            logging.info(f"\nStatus_code ->{status_code} \nresponse_text ->{response_text}")
             time.sleep(3)
+            status_code, response_text = ApiTest(str(request_url)).api_get()
+            logging.info(f"Test Request -> {str(request_url)}")
+            logging.info(f"\nStatus_code ->{status_code} \nresponse_text ->{response_text}")
 
             if status_code == success_status_code and (not validate_string or validate_string in response_text):
                 pass_counter += 1

--- a/src/validation_workflow/docker/validation_docker.py
+++ b/src/validation_workflow/docker/validation_docker.py
@@ -13,10 +13,7 @@ import time
 from subprocess import PIPE
 from typing import Any
 
-import requests
-
 from system.temporary_directory import TemporaryDirectory
-from validation_workflow.api_request import ApiTest
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.docker.inspect_docker_image import InspectDockerImage
 from validation_workflow.validation import Validation
@@ -29,23 +26,56 @@ class ValidateDocker(Validation):
         super().__init__(args)
 
     def download_artifacts(self) -> bool:
+        try:
+            assert self.is_container_daemon_running(), 'Docker Daemon is not running. Exiting the docker validation.'
 
-        # Check if the docker daemon is running; or else, bring it up
-        if (self.is_container_daemon_running()):
+            image_names = {
+                'dockerhub': {
+                    'os': {
+                        True: 'opensearchstaging/opensearch',
+                        False: 'opensearchproject/opensearch'
+                    },
+                    'osd': {
+                        True: 'opensearchstaging/opensearch-dashboards',
+                        False: 'opensearchproject/opensearch-dashboards'
+                    }
+                },
+                'ecr': {
+                    'os': {
+                        True: 'public.ecr.aws/opensearchstaging/opensearch',
+                        False: 'public.ecr.aws/opensearchproject/opensearch'
+                    },
+                    'osd': {
+                        True: 'public.ecr.aws/opensearchstaging/opensearch-dashboards',
+                        False: 'public.ecr.aws/opensearchproject/opensearch-dashboards'
+                    }
+                }
+            }
 
-            # STEP 1 . pull the images for OS and OSD
-            self._OS_image_name = 'opensearchproject/opensearch' if self.args.docker_source == 'dockerhub' else 'public.ecr.aws/opensearchproject/opensearch'
-            self._OSD_image_name = 'opensearchproject/opensearch-dashboards' if self.args.docker_source == 'dockerhub' else 'public.ecr.aws/opensearchproject/opensearch-dashboards'
+            # Choose image names based on input arguments
+            self._OS_image_name = image_names[self.args.docker_source]['os'][self.args.using_staging_artifact_only]
+            self._OSD_image_name = image_names[self.args.docker_source]['osd'][self.args.using_staging_artifact_only]
 
-            self.local_image_OS_id = self.get_image_id(self._OS_image_name, self.args.version)
-            self.local_image_OSD_id = self.get_image_id(self._OSD_image_name, self.args.version)
+            self.local_image_OS_id = (
+                self.get_image_id(self._OS_image_name, ValidationArgs().stg_tag('opensearch').replace(" ", ""))
+                if self.args.using_staging_artifact_only
+                else self.get_image_id(self._OS_image_name, self.args.version)
+            )
+            self.local_image_OSD_id = (
+                self.get_image_id(self._OSD_image_name, ValidationArgs().stg_tag('opensearch_dashboards').replace(" ", ""))
+                if self.args.using_staging_artifact_only
+                else self.get_image_id(self._OSD_image_name, self.args.version)
+            )
             logging.info(f'the OS image ID is : {self.local_image_OS_id}')
             logging.info(f'the OSD image ID is : {self.local_image_OSD_id} \n\n')
-
             return True
 
-        else:
-            raise Exception('Docker Daemon is not running. Exiting the docker validation.')
+        except AssertionError as e:
+            logging.error(str(e))
+            return False
+
+        finally:
+            pass
 
     # Pass this method for docker as no installation required in docker
     def installation(self) -> bool:
@@ -56,15 +86,21 @@ class ValidateDocker(Validation):
         return True
 
     def validation(self) -> bool:
-        # STEP 2 . inspect image digest betwwen opensearchproject(downloaed/local) and opensearchstaging(dockerHub)
+        # STEP 2 . inspect image digest between opensearchproject(downloaed/local) and opensearchstaging(dockerHub)
+        if not self.args.using_staging_artifact_only:
+            self._OS_inspect_digest = InspectDockerImage(self.local_image_OS_id, self.args.OS_image, self.args.version).inspect_digest()
+            self._OSD_inspect_digest = InspectDockerImage(self.local_image_OSD_id, self.args.OSD_image, self.args.version).inspect_digest()
 
-        self._OS_inspect_digest = InspectDockerImage(self.local_image_OS_id, self.args.OS_image, self.args.version)
-        self._OSD_inspect_digest = InspectDockerImage(self.local_image_OSD_id, self.args.OSD_image, self.args.version)
+            if self._OS_inspect_digest and self._OSD_inspect_digest:
+                logging.info('Image digest is validated.\n\n')
+                if self.args.validate_digest_only:
+                    return True
+            else:
+                logging.info('\n\nImage digest is Not validated. Exiting..\n\n')
+                raise Exception('Image digest does not match between the opensearchstaging at dockerHub/ecr and opensearchproject at local download. Exiting the validation.')
 
-        if self._OS_inspect_digest.inspect_digest() and self._OSD_inspect_digest.inspect_digest():
-            logging.info('Image digest is validated\n\n')
-
-            # STEP 3 . spin-up OS/OSD cluster
+        # STEP 3 . spin-up OS/OSD cluster
+        if not self.args.validate_digest_only:
             return_code, self._target_yml_file = self.run_container(
                 self._OS_image_name,
                 self._OSD_image_name,
@@ -73,12 +109,19 @@ class ValidateDocker(Validation):
             if (return_code):
                 logging.info('Cluster is running now')
                 logging.info('Checking if cluster is ready for API test every 10 seconds\n\n')
-                while True:
+
+                self.max_retry = 20
+                self.retry_count = 0
+                while self.retry_count < self.max_retry:
+                    logging.info(f'sleeping 10sec for retry {self.retry_count + 1}/{self.max_retry}')
+                    time.sleep(10)
                     if self.check_http_request():
                         logging.info('\n\ncluster is now ready for API test\n\n')
                         break
-                    logging.info('sleeping 10sec')
-                    time.sleep(10)
+                    self.retry_count += 1
+                else:
+                    logging.warning(f"Maximum number of retries ({self.max_retry}) reached. Cluster is not ready for API test.")
+                    raise Exception(f"Maximum number of retries ({self.max_retry}) reached. Cluster is not ready for API test.")
 
                 # STEP 4 . OS, OSD API validation
                 _test_result, _counter = ApiTestCases().test_cases()
@@ -87,43 +130,50 @@ class ValidateDocker(Validation):
                     logging.info(f'All tests Pass : {_counter}')
                     return True
                 else:
+                    logging.info(f'Not all tests Pass : {_counter}')
+                    self.cleanup()
                     raise Exception(f'Not all tests Pass : {_counter}')
             else:
                 raise Exception('The container failed to start. Exiting the validation.')
         else:
-            logging.info('\n\nImage digest is Not validated. Exiting..\n\n')
-            raise Exception('Image digest does not match between the opensearchstaging at dockerHub/ecr and opensearchproject at local download. Exiting the validation.')
+            return True
 
     def check_http_request(self) -> bool:
         try:
-            status_code, response_text = ApiTest('https://localhost:9200/').api_get()
-            if status_code == 200:
-                return True
-            else:
-                return False
-        except (requests.exceptions.ConnectionError, requests.exceptions.ConnectTimeout) as e:
-            logging.error(f'Error connecting to https://localhost:9200/: {e}')
+            subprocess.check_output(['curl', 'https://localhost:9200', '-u', 'admin:admin', '--insecure', '-s'])
+            logging.info('status code : 200')
+            return True
+        except subprocess.CalledProcessError as e:
+            logging.error(f'Error connecting to https://localhost:9200: {e}')
             return False
 
     def cleanup(self) -> bool:
-        # clean up
-        if self.cleanup_process():
-            logging.info('cleanup is completed')
-            return True
-        else:
-            logging.info('cleanup is Not completed')
+        try:
+            # clean up
+            if self.args.validate_digest_only:
+                return True
+            if self.cleanup_process():
+                logging.info('cleanup is completed')
+                return True
+            else:
+                logging.info('cleanup is Not completed')
+                return False
+        except Exception as e:
+            logging.error(f'An error occurred during cleanup: {e}')
             return False
+        finally:
+            pass
 
     def cleanup_process(self) -> bool:
         # stop the containers
-        docker_command = f'docker-compose -f {self._target_yml_file} down'
-        result = subprocess.run(docker_command, shell=True, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+        self.docker_compose_down = f'docker-compose -f {self._target_yml_file} down'
+        result = subprocess.run(self.docker_compose_down, shell=True, stdout=PIPE, stderr=PIPE, universal_newlines=True)
 
         # remove docker-compose.yml from the tmp folder
         try:
             os.remove(self._target_yml_file)
         except OSError as e:
-            print("Error: %s - %s." % (e.filename, e.strerror))
+            logging.info("Error: %s - %s." % (e.filename, e.strerror))
 
         return('returncode=0' in (str(result)))
 
@@ -137,7 +187,6 @@ class ValidateDocker(Validation):
             return False
 
     def run_container(self, OpenSearch_image: str, OpenSearchDashboard_image: str, version: str) -> Any:
-        # use the docker-compose.yml files at opensearch-build repo to spin up docker container per 1.x and 2.x
         self.docker_compose_files = {
             '1': 'docker-compose-1.x.yml',
             '2': 'docker-compose-2.x.yml'
@@ -147,17 +196,41 @@ class ValidateDocker(Validation):
         self.target_yml_file = os.path.join(self.tmp_dir.name, 'docker-compose.yml')
 
         self.version_number = version[0]
-        if self.version_number in self.docker_compose_files:
-            self.source_file = os.path.join('docker', 'release', 'dockercomposefiles', self.docker_compose_files[self.version_number])
-            shutil.copy2(self.source_file, self.target_yml_file)
+        try:
+            source_file = None
+            if self.version_number in self.docker_compose_files:
+                source_file = os.path.join('docker', 'release', 'dockercomposefiles', self.docker_compose_files[self.version_number])
+                shutil.copy2(source_file, self.target_yml_file)
 
-        self.inplace_change(self.target_yml_file, f'opensearchproject/opensearch:{version[0]}', f'{OpenSearch_image}:{version}')
-        self.inplace_change(self.target_yml_file, f'opensearchproject/opensearch-dashboards:{version[0]}', f'{OpenSearchDashboard_image}:{version}')
+            if (self.args.using_staging_artifact_only):
+                self.images_used = f'{OpenSearch_image}:{version}'
+            else:
+                self.images_used = f'{OpenSearch_image}:{version}'
 
-        # spin up containers
-        docker_compose_up = f'docker-compose -f {self.target_yml_file} up -d'
-        result = subprocess.run(docker_compose_up, shell=True, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-        return ('returncode=0' in (str(result)), self.target_yml_file)
+            self.inplace_change(
+                self.target_yml_file,
+                f'opensearchproject/opensearch:{version[0]}',
+                f'{OpenSearch_image}:{version}.{self.args.os_build_number}'
+                if self.args.using_staging_artifact_only
+                else f'{OpenSearch_image}:{version}'
+            )
+
+            self.inplace_change(
+                self.target_yml_file,
+                f'opensearchproject/opensearch-dashboards:{version[0]}',
+                f'{OpenSearchDashboard_image}:{version}.{self.args.osd_build_number}'
+                if self.args.using_staging_artifact_only
+                else f'{OpenSearchDashboard_image}:{version}'
+            )
+            # spin up containers
+            self.docker_compose_up = f'docker-compose -f {self.target_yml_file} up -d'
+            result = subprocess.run(self.docker_compose_up, shell=True, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+            return ('returncode=0' in (str(result)), self.target_yml_file)
+
+        except Exception as e:
+            print(f"An error occurred: {e}")
+        finally:
+            pass
 
     def inplace_change(self, filename: str, old_string: str, new_string: str) -> None:
 

--- a/src/validation_workflow/validation_args.py
+++ b/src/validation_workflow/validation_args.py
@@ -84,6 +84,17 @@ class ValidationArgs:
             choices=["x64", "arm64"],
             default="x64"
         )
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--validate_digest_only",
+            action="store_true",
+            default=False,
+            help="(optional) Validate digest only; will not run docker to test API")
+        group.add_argument(
+            "--using_staging_artifact_only",
+            action="store_true",
+            default=False,
+            help="(optional) Use only staging artifact to run docker and API test, will not validate digest")
 
         args = parser.parse_args()
         self.version = args.version
@@ -97,6 +108,8 @@ class ValidationArgs:
         self.os_build_number = args.os_build_number
         self.osd_build_number = args.osd_build_number
         self.docker_source = args.docker_source
+        self.validate_digest_only = args.validate_digest_only
+        self.using_staging_artifact_only = args.using_staging_artifact_only
 
     def stg_tag(self, image_type: str) -> str:
         return " ".join(

--- a/tests/test_run_validation.py
+++ b/tests/test_run_validation.py
@@ -35,4 +35,4 @@ class TestRunValidation(unittest.TestCase):
     def test_main(self, mock_tar: Mock, *mocks: Any) -> None:
 
         result = main()
-        self.assertTrue(result)
+        self.assertEqual(result, 0)

--- a/tests/tests_validation_workflow/test_api_request.py
+++ b/tests/tests_validation_workflow/test_api_request.py
@@ -8,21 +8,28 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from validation_workflow.api_request import ApiTest
+from validation_workflow.api_request import ApiTest, subprocess
 
 
 class TestApiTest(unittest.TestCase):
 
-    @patch('validation_workflow.api_request.requests.get')
-    def test_api_get(self, mock_get: Mock) -> None:
-        mock_get.return_value.status_code = 200
-        mock_get.return_value.text = '{"key": "value"}'
+    @patch('validation_workflow.api_request.subprocess.run')
+    def test_api_get(self, mock_run: Mock) -> None:
+        mock_run.return_value.stdout = b'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{"key": "value"}'
+        mock_run.return_value.stderr = b''
+
         request_url = 'http://localhost:9200'
         api_test = ApiTest(request_url)
         status_code, response_text = api_test.api_get()
+
         self.assertEqual(status_code, 200)
         self.assertEqual(response_text, '{"key": "value"}')
-        mock_get.assert_called_once_with(request_url, headers={'Authorization': 'Basic YWRtaW46YWRtaW4=', 'Accept': '*/*', 'Content-Type': 'application/json'}, verify=False)
+
+        mock_run.assert_called_once_with(
+            ['curl', request_url, '-u', 'admin:admin', '--insecure', '-i'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Description
This PR is to address https://github.com/opensearch-project/opensearch-build/issues/3205

Issues Resolved

- Adding a flag/argument to do Only the digest validaiton without moving to run cluster, nor the API test
- Adding a flag/argument to use Only staging images ( in which, we will not check digest )
- Adding a max retry for testing if the OpenSearch cluster is ready for accepting HTTP request
- Using Curl to replace 'requests' library in Python
- Return 0 instead of True to the caller when the script ends successfully

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
