### PR TITLE
Add 1.3.10 manifest as 1.3.9 is released

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
+            H 1 * * * %INPUT_MANIFEST=1.3.10/opensearch-1.3.10.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.6.1/opensearch-2.6.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.7.0/opensearch-2.7.0.yml;TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=1.4.0/opensearch-1.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm zip

--- a/manifests/1.3.10/opensearch-1.3.10.yml
+++ b/manifests/1.3.10/opensearch-1.3.10.yml
@@ -1,0 +1,16 @@
+---
+schema-version: '1.0'
+build:
+  name: OpenSearch
+  version: 1.3.10
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2
+    args: -e JAVA_HOME=/opt/java/openjdk-11
+components:
+  - name: OpenSearch
+    repository: https://github.com/opensearch-project/OpenSearch.git
+    ref: '1.3'
+    checks:
+      - gradle:publish
+      - gradle:properties:version

--- a/tests/test_run_manifests.py
+++ b/tests/test_run_manifests.py
@@ -35,6 +35,7 @@ class TestRunManifests(unittest.TestCase):
         mock_logging.info.assert_has_calls([
             call("OpenSearch 1.3.0"),
             call("OpenSearch 1.3.1"),
+            call("OpenSearch 1.3.10"),
             call("OpenSearch 1.3.2"),
             call("OpenSearch 1.3.3"),
             call("OpenSearch 1.3.4")


### PR DESCRIPTION
### Description
Add 1.3.10 manifest as 1.3.9 is released

### Issues Resolved
Preparation for 1.3.10 release 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
