### PR TITLE
Add cypress 5.6.0 for the 1.x releases in integTest images

### DIFF
--- a/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
@@ -70,6 +70,11 @@ RUN if [ `uname -m` = "aarch64" ]; then echo compile arm64 cypress && /tmp/cypre
 RUN if [ `uname -m` = "aarch64" ]; then rm -rf $CYPRESS_LOCATION/* && \
     unzip -q /tmp/cypress-$CYPRESS_VERSION.zip -d $CYPRESS_LOCATION/ && chown 1000:1000 -R $CYPRESS_LOCATION; fi && rm -rf /tmp/cypress*
 
+# Add legacy cypress@5.6.0 for 1.x line
+RUN npm install -g cypress@5.6.0 && npm cache verify && \
+    if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
+    curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-5.6.0-arm64.tar.gz && tar -xzf Cypress-5.6.0-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
+    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/5.6.0 && rm -vf Cypress-5.6.0-arm64.tar.gz; fi
 
 ########################### Stage 1 ########################
 FROM rockylinux:8

--- a/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
@@ -75,6 +75,11 @@ RUN if [ `uname -m` = "aarch64" ]; then echo compile arm64 cypress && /tmp/cypre
 RUN if [ `uname -m` = "aarch64" ]; then rm -rf $CYPRESS_LOCATION/* && \
     unzip -q /tmp/cypress-$CYPRESS_VERSION.zip -d $CYPRESS_LOCATION/ && chown 1000:1000 -R $CYPRESS_LOCATION; fi && rm -rf /tmp/cypress*
 
+# Add legacy cypress@5.6.0 for 1.x line
+RUN npm install -g cypress@5.6.0 && npm cache verify && \
+    if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
+    curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-5.6.0-arm64.tar.gz && tar -xzf Cypress-5.6.0-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
+    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/5.6.0 && rm -vf Cypress-5.6.0-arm64.tar.gz; fi
 
 ########################### Stage 1 ########################
 FROM rockylinux:8


### PR DESCRIPTION
### Description
Add cypress 5.6.0 for the 1.x releases in integTest images

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3190

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
