### PR TITLE
Tweak the cypress install order for 5.6.0 version

### DIFF
--- a/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
@@ -60,6 +60,8 @@ COPY --chown=1000:1000 config/yarn-version.sh /tmp
 RUN npm install -g yarn@`/tmp/yarn-version.sh main`
 # install cypress last known version that works for all existing opensearch-dashboards plugin integtests
 RUN npm install -g cypress@$CYPRESS_VERSION && npm cache verify
+# Add legacy cypress@5.6.0 for 1.x line
+RUN npm install -g cypress@5.6.0 && npm cache verify
 
 # Need root to get pass the build due to chrome sandbox needs to own by the root
 USER 0
@@ -70,9 +72,8 @@ RUN if [ `uname -m` = "aarch64" ]; then echo compile arm64 cypress && /tmp/cypre
 RUN if [ `uname -m` = "aarch64" ]; then rm -rf $CYPRESS_LOCATION/* && \
     unzip -q /tmp/cypress-$CYPRESS_VERSION.zip -d $CYPRESS_LOCATION/ && chown 1000:1000 -R $CYPRESS_LOCATION; fi && rm -rf /tmp/cypress*
 
-# Add legacy cypress@5.6.0 for 1.x line
-RUN npm install -g cypress@5.6.0 && npm cache verify && \
-    if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
+# Add legacy cypress@5.6.0 for ARM64 Architecture
+RUN if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
     curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-5.6.0-arm64.tar.gz && tar -xzf Cypress-5.6.0-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
     chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/5.6.0 && rm -vf Cypress-5.6.0-arm64.tar.gz; fi
 

--- a/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
@@ -65,6 +65,8 @@ COPY --chown=1000:1000 config/yarn-version.sh /tmp
 RUN npm install -g yarn@`/tmp/yarn-version.sh main`
 # install cypress last known version that works for all existing opensearch-dashboards plugin integtests
 RUN npm install -g cypress@$CYPRESS_VERSION && npm cache verify
+# Add legacy cypress@5.6.0 for 1.x line
+RUN npm install -g cypress@5.6.0 && npm cache verify
 
 # Need root to get pass the build due to chrome sandbox needs to own by the root
 USER 0
@@ -75,9 +77,8 @@ RUN if [ `uname -m` = "aarch64" ]; then echo compile arm64 cypress && /tmp/cypre
 RUN if [ `uname -m` = "aarch64" ]; then rm -rf $CYPRESS_LOCATION/* && \
     unzip -q /tmp/cypress-$CYPRESS_VERSION.zip -d $CYPRESS_LOCATION/ && chown 1000:1000 -R $CYPRESS_LOCATION; fi && rm -rf /tmp/cypress*
 
-# Add legacy cypress@5.6.0 for 1.x line
-RUN npm install -g cypress@5.6.0 && npm cache verify && \
-    if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
+# Add legacy cypress@5.6.0 for ARM64 Architecture
+RUN if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
     curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-5.6.0-arm64.tar.gz && tar -xzf Cypress-5.6.0-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
     chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/5.6.0 && rm -vf Cypress-5.6.0-arm64.tar.gz; fi
 


### PR DESCRIPTION
### Description
Tweak the cypress install order for 5.6.0 version

### Issues Resolved
#3190

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
