### PR TITLE
Match the jenkins version to the one in CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ sourceSets {
 }
 
 sharedLibrary {
-    coreVersion = '2.378' // https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-core/
+    coreVersion = '2.346.3' // https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-core/
     testHarnessVersion = '1934.v90a_c07cf5b_21' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-test-harness?repo=jenkins-releases
     pluginDependencies {
         // see https://mvnrepository.com/artifact/org.jenkins-ci.plugins/<name>?repo=jenkins-releases for latest


### PR DESCRIPTION
### Description
Match the jenkins version to the one in https://build.ci.opensearch.org/
Depends on https://github.com/opensearch-project/opensearch-ci/pull/260

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
