### PR TITLE
Add test manifest in cron for 3.0.0 and add parameterized cron for 2.7.0

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
             H 1 * * * %INPUT_MANIFEST=2.7.0/opensearch-2.7.0.yml;TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=1.4.0/opensearch-1.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm zip
             H 1 * * * %INPUT_MANIFEST=1.4.0/opensearch-dashboards-1.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm zip
-            H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
+            H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TEST_MANIFEST=3.0.0/opensearch-3.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''
     }

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -28,6 +28,12 @@ pipeline {
         BUILD_JOB_NAME = "distribution-build-opensearch"
         ARTIFACT_BUCKET_NAME = credentials('jenkins-artifact-bucket-name')
     }
+    triggers {
+        parameterizedCron '''
+            H 15 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
+            H 15 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
+            '''
+    }
     parameters {
         string(
             name: 'COMPONENT_NAME',

--- a/tests/jenkins/TestOpenSearchIntegTest.groovy
+++ b/tests/jenkins/TestOpenSearchIntegTest.groovy
@@ -68,6 +68,7 @@ class TestOpenSearchIntegTest extends BuildPipelineTest {
             return helper.callClosure(closure)
         })
         helper.registerAllowedMethod("withCredentials", [Map])
+        helper.registerAllowedMethod('parameterizedCron', [String], null)
         helper.registerAllowedMethod('readYaml', [Map.class], { args ->
             return new Yaml().load((this.testManifest ?: binding.getVariable('TEST_MANIFEST') as File).text)
         })

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
@@ -5,6 +5,10 @@
          integ-test.credentials(jenkins-artifact-bucket-name)
          integ-test.timeout({time=3, unit=HOURS})
          integ-test.echo(Executing on agent [label:none])
+         integ-test.parameterizedCron(
+            H 15 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
+            H 15 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
+            )
          integ-test.stage(verify-parameters, groovy.lang.Closure)
             integ-test.echo(Executing on agent [label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host])
             integ-test.script(groovy.lang.Closure)


### PR DESCRIPTION
### Description
Add test manifest in cron for 3.0.0 and add parameterized cron for 2.7.0 integration tests. 
Right now integtest only runs when we build. But we want to run integtests more often irrespective of build. Starting with 2.7.0 for now.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
