### PR TITLE
Resolve the OSD docker does not have notes and version in labels

### DIFF
--- a/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
@@ -18,8 +18,6 @@ ARG UID=1000
 ARG GID=1000
 ARG TEMP_DIR=/tmp/opensearch-dashboards
 ARG OPENSEARCH_DASHBOARDS_HOME=/usr/share/opensearch-dashboards
-ARG VERSION
-ARG NOTES
 
 # Update packages
 # Install the tools we need: tar and gzip to unpack the OpenSearch tarball, and shadow-utils to give us `groupadd` and `useradd`.
@@ -79,7 +77,9 @@ USER $UID
 # Expose port
 EXPOSE 5601
 
+ARG VERSION
 ARG BUILD_DATE
+ARG NOTES
 
 # Label
 LABEL org.label-schema.schema-version="1.0" \


### PR DESCRIPTION
### Description
Resolve the OSD docker does not have notes and version in labels

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3341

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
