### PR TITLE
[OSD] include Node 14.21.3

### DIFF
--- a/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
@@ -95,7 +95,7 @@ ENV PATH=/usr/share/opensearch/.gem/gems/fpm-1.14.2/bin:$PATH
 # nvm environment variables
 ENV NVM_DIR /usr/share/opensearch/.nvm
 ENV NODE_VERSION 10.24.1
-ARG NODE_VERSION_LIST="10.24.1 14.19.1 14.20.0 14.20.1"
+ARG NODE_VERSION_LIST="10.24.1 14.19.1 14.20.0 14.20.1 14.21.3"
 COPY --chown=1000:1000 config/build-opensearch-dashboards-entrypoint.sh /usr/share/opensearch
 # install nvm
 # https://github.com/creationix/nvm#install-script

--- a/docker/ci/dockerfiles/current/release.centos.clients.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/release.centos.clients.x64.arm64.dockerfile
@@ -135,7 +135,7 @@ ENV PATH=$RUBY_HOME:$RVM_HOME:$PATH
 # nvm environment variables
 ENV NVM_DIR /usr/share/opensearch/.nvm
 ENV NODE_VERSION 14.19.1
-ARG NODE_VERSION_LIST="10.24.1 14.19.1 14.20.0 14.20.1"
+ARG NODE_VERSION_LIST="10.24.1 14.19.1 14.20.0 14.20.1 14.21.3"
 
 # Installing nvm
 # https://github.com/creationix/nvm#install-script

--- a/manifests/1.4.0/opensearch-dashboards-1.4.0.yml
+++ b/manifests/1.4.0/opensearch-dashboards-1.4.0.yml
@@ -5,7 +5,7 @@ build:
   version: 1.4.0
 ci:
   image:
-    name: opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v2
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git


### PR DESCRIPTION
### Description
Including Node 14.21.3 to the env image since this is the version we call out in the nvm file.

We do a relaxed version check on main branch.

### Issues Resolved
Potentially related to:
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3282

I see the failures on fiber for arm deb which could be the case if the system but will need to verify it's not the diff in Node first.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
