### PR TITLE
Disable tests with security for knn in 2.7.0

### DIFF
--- a/manifests/2.7.0/opensearch-2.7.0-test.yml
+++ b/manifests/2.7.0/opensearch-2.7.0-test.yml
@@ -71,7 +71,6 @@ components:
   - name: k-NN
     integ-test:
       test-configs:
-        - with-security
         - without-security
 
   - name: neural-search


### PR DESCRIPTION
### Description
We need to disable tests with security for knn in 2.7.0 release.
Plugin tests need special adjustments for checks that security plugin start enforcing. Team has been working on solution from 2.6 (https://github.com/opensearch-project/security/issues/2265), but this requires more effort/time. This is to unblock pipeline for other plugins/components. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
