### PR TITLE
Make OSD docker to use OpenSearch as vendor like OS docker

### DIFF
--- a/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
@@ -88,7 +88,7 @@ LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.url="https://opensearch.org" \
   org.label-schema.vcs-url="https://github.com/opensearch-project/OpenSearch-Dashboards" \
   org.label-schema.license="Apache-2.0" \
-  org.label-schema.vendor="Amazon" \
+  org.label-schema.vendor="OpenSearch" \
   org.label-schema.description="$NOTES" \
   org.label-schema.build-date="$BUILD_DATE"
 


### PR DESCRIPTION
### Description
Make OSD docker to use OpenSearch as vendor like OS docker

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
