### PR TITLE
Make repo_name var to allow user specify different docker repo and increase Jenkins docker build timeout

### DIFF
--- a/docker/ci/build-image-single-arch.sh
+++ b/docker/ci/build-image-single-arch.sh
@@ -18,6 +18,7 @@ function usage() {
     echo "Usage: $0 [args]"
     echo ""
     echo "Required arguments:"
+    echo -e "-r REPO_NAME\tSpecify the image repo name such as 'ci-runner'"
     echo -e "-v TAG_NAME\tSpecify the image tag name such as 'centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211019'"
     echo -e "-f DOCKERFILE\tSpecify the dockerfile full path, e.g. dockerfile/opensearch.al2.dockerfile."
     echo ""
@@ -26,11 +27,14 @@ function usage() {
     echo "--------------------------------------------------------------------------"
 }
 
-while getopts ":hv:f:" arg; do
+while getopts ":hr:v:f:" arg; do
     case $arg in
         h)
             usage
             exit 1
+            ;;
+        r)
+            REPO_NAME=$OPTARG
             ;;
         v)
             TAG_NAME=$OPTARG
@@ -51,14 +55,14 @@ while getopts ":hv:f:" arg; do
 done
 
 # Validate the required parameters to present
-if [ -z "$TAG_NAME" ] || [ -z "$DOCKERFILE" ]; then
-  echo "You must specify '-v TAG_NAME', '-f DOCKERFILE'"
+if [ -z "$REPO_NAME" ] || [ -z "$TAG_NAME" ] || [ -z "$DOCKERFILE" ]; then
+  echo "You must specify '-r REPO_NAME', '-v TAG_NAME', '-f DOCKERFILE'"
   usage
   exit 1
 else
-  echo $TAG_NAME $DOCKERFILE
+  echo "$TAG_NAME $DOCKERFILE"
 fi
 
 # Docker build
-docker build -f $DOCKERFILE $DIR -t opensearchstaging/ci-runner:$TAG_NAME .
+docker build -f ${DOCKERFILE} ${DIR} -t opensearchstaging/${REPO_NAME}:${TAG_NAME} .
 

--- a/jenkins/docker/docker-build.jenkinsfile
+++ b/jenkins/docker/docker-build.jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
             trim: true
         )
         string(
-            defaultValue: 'bash docker/ci/build-image-multi-arch.sh -v <TAG_NAME> -f <DOCKERFILE PATH>',
+            defaultValue: 'Example: cd docker/ci && bash build-image-multi-arch.sh -r <REPO_NAME> -v <TAG_NAME> -f <DOCKERFILE PATH>',
             name: 'DOCKER_BUILD_SCRIPT_WITH_COMMANDS',
             description: 'The script path of the docker build script, assuming you are already in root dir of DOCKER_BUILD_GIT_REPOSITORY.',
             trim: true

--- a/jenkins/docker/docker-build.jenkinsfile
+++ b/jenkins/docker/docker-build.jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     options {
-        timeout(time: 4, unit: 'HOURS')
+        timeout(time: 5, unit: 'HOURS')
     }
     agent none
     parameters {

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-build.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-build.jenkinsfile.txt
@@ -1,6 +1,6 @@
    docker-build.run()
       docker-build.pipeline(groovy.lang.Closure)
-         docker-build.timeout({time=4, unit=HOURS})
+         docker-build.timeout({time=5, unit=HOURS})
          docker-build.echo(Executing on agent [label:none])
          docker-build.stage(Parameters Check, groovy.lang.Closure)
             docker-build.script(groovy.lang.Closure)


### PR DESCRIPTION
### Description
Make repo_name var to allow user specify different docker repo and increase Jenkins docker build timeout

### Issues Resolved
https://github.com/opensearch-project/opensearch-benchmark/issues/255


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
