### PR TITLE
Remove AS plugin from 3.0.0 manifest

### DIFF
--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -137,15 +137,6 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: notifications
-  - name: asynchronous-search
-    repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: main
-    platforms:
-      - linux
-      - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
     ref: main


### PR DESCRIPTION
### Description
Remove AS plugin from 3.0.0 manifest to unblock our CI checks.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
