### PR TITLE
Fix CVE-2022-37866 and CVE-2022-37865

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation group: 'org.yaml', name: 'snakeyaml', version: '2.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.4.1'
     testImplementation group: 'com.lesfurets', name:'jenkins-pipeline-unit', version: '1.13'
+    implementation group: 'org.apache.ivy', name: 'ivy', version: '2.5.1'
 }
 
 configurations.all {


### PR DESCRIPTION
### Description
Upgrade ivy version from current 2.4.0/2.5.0 to 2.5.1

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2873
https://github.com/opensearch-project/opensearch-build/issues/2872


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
