### PR TITLE
Fixing CDK cluster left over issue when a performance testing job was aborted 

### DIFF
--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -172,10 +172,28 @@ pipeline {
                             }
                             postCleanup()
                         }
-                        failure {
+                        aborted {
+                            script {
+                                def stackName = "test-single-security-${BUILD_ID}-${ARCHITECTURE}-perf-test"
+                                withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
+                                    withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
+                                        try {
+                                            def stack = cfnDescribe(stack: stackName)
+                                            if (stack != null) {
+                                                cfnDelete(stack: stackName, pollInterval:1000)
+                                            } else {
+                                                echo "Stack '${stackName}' does not exist, nothing to remove"
+                                            }
+                                        } catch (e) {
+                                            echo "Exception occurred while deleting the cloudformation stacks" + e.toString()
+                                            throw e
+                                        }
+                                    }
+                                }
+                            }
                             postCleanup()
                         }
-                        aborted {
+                        failure {
                             postCleanup()
                         }
                     }
@@ -225,10 +243,28 @@ pipeline {
                             }
                             postCleanup()
                         }
-                        failure {
+                        aborted {
+                            script {
+                                def stackName = "test-single-${BUILD_ID}-${ARCHITECTURE}-perf-test"
+                                withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
+                                    withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
+                                        try {
+                                            def stack = cfnDescribe(stack: stackName)
+                                            if (stack != null) {
+                                                cfnDelete(stack: stackName, pollInterval:1000)
+                                            } else {
+                                                echo "Stack '${stackName}' does not exist, nothing to remove"
+                                            }
+                                        } catch (e) {
+                                            echo "Exception occurred while deleting the cloudformation stacks" + e.toString()
+                                            throw e
+                                        }
+                                    }
+                                }
+                            }
                             postCleanup()
                         }
-                        aborted {
+                        failure {
                             postCleanup()
                         }
                     }
@@ -262,30 +298,6 @@ pipeline {
                         extra: stashed,
                         credentialsId: 'jenkins-integ-test-webhook',
                     )
-                    postCleanup()
-                }
-            }
-        }
-        aborted {
-            node(AGENT_LABEL) {
-                script {
-                    def stackPrefix = env.HAS_SECURITY.toBoolean() ? "test-single-security" : "test-single"
-                    def stackName = "${stackPrefix}-${BUILD_ID}-${ARCHITECTURE}-perf-test"
-                    withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
-                        withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
-                            try {
-                                def stack = cfnDescribe(stack: stackName)
-                                if (stack != null) {
-                                    cfnDelete(stack: stackName, pollInterval:1000)
-                                } else {
-                                    echo "Stack '${stackName}' does not exist, nothing to remove"
-                                }
-                            } catch (e) {
-                                echo "Exception occurred:" + e.toString()
-                                throw e
-                            }
-                        }
-                    }
                     postCleanup()
                 }
             }

--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -251,6 +251,7 @@ pipeline {
                                         try {
                                             def stack = cfnDescribe(stack: stackName)
                                             if (stack != null) {
+                                                echo "Deleting stack '${stackName}'"
                                                 cfnDelete(stack: stackName, pollInterval:1000)
                                             } else {
                                                 echo "Stack '${stackName}' does not exist, nothing to remove"

--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -266,5 +266,29 @@ pipeline {
                 }
             }
         }
+        aborted {
+            node(AGENT_LABEL) {
+                script {
+                    def stackPrefix = env.HAS_SECURITY.toBoolean() ? "test-single-security" : "test-single"
+                    def stackName = "${stackPrefix}-${BUILD_ID}-${ARCHITECTURE}-perf-test"
+                    withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
+                        withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
+                            try {
+                                def stack = cfnDescribe(stack: stackName)
+                                if (stack != null) {
+                                    cfnDelete(stack: stackName, pollInterval:1000)
+                                } else {
+                                    echo "Stack '${stackName}' does not exist, nothing to remove"
+                                }
+                            } catch (e) {
+                                echo "Exception occurred:" + e.toString()
+                                throw e
+                            }
+                        }
+                    }
+                    postCleanup()
+                }
+            }
+        }
     }
 }

--- a/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
+++ b/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
@@ -170,6 +170,7 @@ class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
     void testRunNonSecurityPerfTestScript_verifyJob_aborted() {
         binding.setVariable('BUNDLE_MANIFEST', 'tests/jenkins/data/opensearch-1.3.0-non-security-bundle.yml')
         binding.setVariable('HAS_SECURITY', false)
+        helper.registerAllowedMethod("cfnDescribe", [Map]) { args -> return 'anything'}
         helper.registerAllowedMethod('sh', [String.class], { String cmd ->
             updateBuildStatus('ABORTED')
         })
@@ -178,7 +179,7 @@ class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
         assertJobStatusAborted() 
         assertCallStack()
         assertCallStack().contains("perf-test.cfnDescribe({stack=test-single-1236-x64-perf-test})")
-        assertCallStack().contains("'test-single-1236-x64-perf-test' does not exist, nothing to remove")
+        assertCallStack().contains("perf-test.cfnDelete({stack=test-single-1236-x64-perf-test, pollInterval=1000})")
     }  
 
     def getCommandExecutions(methodName, command) {

--- a/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
+++ b/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
@@ -58,6 +58,8 @@ class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
             c -> lib.jenkins.BuildManifest.new(readYaml(file: 'tests/jenkins/data/opensearch-1.3.0-non-security-bundle.yml'))
         })
         helper.registerAllowedMethod('parameterizedCron', [String], null)
+        helper.registerAllowedMethod("cfnDescribe", [Map])
+        helper.registerAllowedMethod("cfnDelete", [Map])
         binding.setVariable('AGENT_LABEL', 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host')
         binding.setVariable('AGENT_IMAGE', 'opensearchstaging/ci-runner:ci-runner-centos7-v1')
         binding.setVariable('ARCHITECTURE', 'x64')
@@ -148,6 +150,36 @@ class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
             "{file=test-results, bucket=ARTIFACT_BUCKET_NAME, path=307/1.3.0/1236/linux/x64/tar/test-results}".toString()
         ))
     }
+
+    @Test
+    void testRunSecurityPerfTestScript_verifyJob_aborted() {
+        binding.setVariable('BUNDLE_MANIFEST', 'tests/jenkins/data/opensearch-1.3.0-bundle.yml')
+        binding.setVariable('HAS_SECURITY', true)
+        helper.registerAllowedMethod('sh', [String.class], { String cmd ->
+            updateBuildStatus('ABORTED')
+        })
+        runScript("jenkins/opensearch/perf-test.jenkinsfile")
+        
+        assertJobStatusAborted() 
+        assertCallStack()
+        assertCallStack().contains("perf-test.cfnDescribe({stack=test-single-security-1236-x64-perf-test})")
+        assertCallStack().contains("'test-single-security-1236-x64-perf-test' does not exist, nothing to remove")
+    }    
+
+    @Test
+    void testRunNonSecurityPerfTestScript_verifyJob_aborted() {
+        binding.setVariable('BUNDLE_MANIFEST', 'tests/jenkins/data/opensearch-1.3.0-non-security-bundle.yml')
+        binding.setVariable('HAS_SECURITY', false)
+        helper.registerAllowedMethod('sh', [String.class], { String cmd ->
+            updateBuildStatus('ABORTED')
+        })
+        runScript("jenkins/opensearch/perf-test.jenkinsfile")
+        
+        assertJobStatusAborted() 
+        assertCallStack()
+        assertCallStack().contains("perf-test.cfnDescribe({stack=test-single-1236-x64-perf-test})")
+        assertCallStack().contains("'test-single-1236-x64-perf-test' does not exist, nothing to remove")
+    }  
 
     def getCommandExecutions(methodName, command) {
         def shCommands = helper.callStack.findAll {


### PR DESCRIPTION
### Description
Fixing CDK cluster left over issue when a performance testing job was aborted 

### Issues Resolved
Fix for https://github.com/opensearch-project/opensearch-build/issues/2504

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
