### PR TITLE
Change ref to 2.7 for cross-cluster-replication

### DIFF
--- a/manifests/2.7.0/opensearch-2.7.0.yml
+++ b/manifests/2.7.0/opensearch-2.7.0.yml
@@ -58,7 +58,7 @@ components:
       - windows
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '2.x'
+    ref: '2.7'
     platforms:
       - linux
       - windows


### PR DESCRIPTION
### Description
Add cross-cluster-replication to 2.7 manifest

### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/763

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
