### PR TITLE
Add Security Dashboards Plugin into 2.7 manifest

### DIFF
--- a/manifests/2.7.0/opensearch-dashboards-2.7.0.yml
+++ b/manifests/2.7.0/opensearch-dashboards-2.7.0.yml
@@ -44,3 +44,6 @@ components:
   - name: securityAnalyticsDashboards
     repository: https://github.com/opensearch-project/security-analytics-dashboards-plugin.git
     ref: 2.x
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+    ref: '2.7'


### PR DESCRIPTION
### Description
Add Security Dashboards Plugin into 2.7 manifest

### Issues Resolved
* Relate: https://github.com/opensearch-project/security-dashboards-plugin/issues/1392

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
