### PR TITLE
Change security backend branch ref to 2.7 in manifest

### DIFF
--- a/manifests/2.7.0/opensearch-2.7.0.yml
+++ b/manifests/2.7.0/opensearch-2.7.0.yml
@@ -52,7 +52,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '2.x'
+    ref: '2.7'
     platforms:
       - linux
       - windows


### PR DESCRIPTION
### Description
Change security backend branch ref to 2.7 in manifest

### Issues Resolved
* Relate https://github.com/opensearch-project/security/issues/2635

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
