### PR TITLE
Fix missing logs of local test cluster of test workflow

### DIFF
--- a/src/test_workflow/integ_test/distribution_tar.py
+++ b/src/test_workflow/integ_test/distribution_tar.py
@@ -39,5 +39,9 @@ class DistributionTar(Distribution):
         return start_cmd_map[self.filename]
 
     def uninstall(self) -> None:
-        logging.info(f"Cleanup {self.work_dir}/* content after the test")
-        subprocess.check_call(f"rm -rf {self.work_dir}/*", shell=True)
+        logging.info(f"Cleanup {self.work_dir}/* content after the test and keep {self.install_dir}/logs for recording.")
+        subprocess.check_call(f"mv {self.install_dir}/logs {self.work_dir}", shell=True)
+        subprocess.check_call(f"rm -rf {self.install_dir}", shell=True)
+        subprocess.check_call(f"mkdir {self.install_dir}", shell=True)
+        subprocess.check_call(f"mv {self.work_dir}/logs {self.install_dir}", shell=True)
+        logging.info(f"{self.work_dir}/* would be deleted or kept subject to TemporaryDirectory rules.")

--- a/src/test_workflow/integ_test/distribution_zip.py
+++ b/src/test_workflow/integ_test/distribution_zip.py
@@ -39,5 +39,9 @@ class DistributionZip(Distribution):
         return start_cmd_map[self.filename]
 
     def uninstall(self) -> None:
-        logging.info(f"Cleanup {self.work_dir}/* content after the test")
-        subprocess.check_call(f"rm -rf {self.work_dir}/*", shell=True)
+        logging.info(f"Cleanup {self.work_dir}/* content after the test and keep {self.install_dir}/logs for recording.")
+        subprocess.check_call(f"mv {self.install_dir}/logs {self.work_dir}", shell=True)
+        subprocess.check_call(f"rm -rf {self.install_dir}", shell=True)
+        subprocess.check_call(f"mkdir {self.install_dir}", shell=True)
+        subprocess.check_call(f"mv {self.work_dir}/logs {self.install_dir}", shell=True)
+        logging.info(f"{self.work_dir}/* would be deleted or kept subject to TemporaryDirectory rules.")

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_tar.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_tar.py
@@ -19,6 +19,7 @@ class TestDistributionTar(unittest.TestCase):
         self.work_dir = os.path.join(os.path.dirname(__file__), "data")
         self.distribution_tar = DistributionTar("opensearch", "1.3.0", self.work_dir)
         self.distribution_tar_dashboards = DistributionTar("opensearch-dashboards", "1.3.0", self.work_dir)
+        self.install_dir = os.path.join(self.work_dir, "opensearch-1.3.0")
 
     def test_distribution_tar_vars(self) -> None:
         self.assertEqual(self.distribution_tar.filename, 'opensearch')
@@ -53,5 +54,8 @@ class TestDistributionTar(unittest.TestCase):
         self.distribution_tar.uninstall()
         args_list = check_call_mock.call_args_list
 
-        self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"rm -rf {self.work_dir}/*", args_list[0][0][0])
+        self.assertEqual(check_call_mock.call_count, 4)
+        self.assertEqual(f"mv {self.install_dir}/logs {self.work_dir}", args_list[0][0][0])
+        self.assertEqual(f"rm -rf {self.install_dir}", args_list[1][0][0])
+        self.assertEqual(f"mkdir {self.install_dir}", args_list[2][0][0])
+        self.assertEqual(f"mv {self.work_dir}/logs {self.install_dir}", args_list[3][0][0])

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_zip.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_zip.py
@@ -22,6 +22,7 @@ class TestDistributionZipOpenSearch(unittest.TestCase):
         self.version = "2.4.0"
         self.distribution_zip = DistributionZip(self.product, self.version, self.work_dir)
         self.distribution_zip_dashboards = DistributionZip(self.product_dashboards, self.version, self.work_dir)
+        self.install_dir = os.path.join(self.work_dir, f"{self.product}-{self.version}")
 
     def test_distribution_zip_vars(self) -> None:
         self.assertEqual(self.distribution_zip.filename, self.product)
@@ -54,8 +55,11 @@ class TestDistributionZipOpenSearch(unittest.TestCase):
         self.distribution_zip.uninstall()
         args_list = check_call_mock.call_args_list
 
-        self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"rm -rf {self.work_dir}/*", args_list[0][0][0])
+        self.assertEqual(check_call_mock.call_count, 4)
+        self.assertEqual(f"mv {self.install_dir}/logs {self.work_dir}", args_list[0][0][0])
+        self.assertEqual(f"rm -rf {self.install_dir}", args_list[1][0][0])
+        self.assertEqual(f"mkdir {self.install_dir}", args_list[2][0][0])
+        self.assertEqual(f"mv {self.work_dir}/logs {self.install_dir}", args_list[3][0][0])
 
 
 class TestDistributionZipOpenSearchDashboards(unittest.TestCase):
@@ -66,6 +70,7 @@ class TestDistributionZipOpenSearchDashboards(unittest.TestCase):
         self.product = "opensearch-dashboards"
         self.version = "2.4.0"
         self.distribution_zip = DistributionZip(self.product, self.version, self.work_dir)
+        self.install_dir = os.path.join(self.work_dir, f"{self.product}-{self.version}")
 
     def test_distribution_zip_vars(self) -> None:
         self.assertEqual(self.distribution_zip.filename, self.product)
@@ -96,5 +101,8 @@ class TestDistributionZipOpenSearchDashboards(unittest.TestCase):
         self.distribution_zip.uninstall()
         args_list = check_call_mock.call_args_list
 
-        self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"rm -rf {self.work_dir}/*", args_list[0][0][0])
+        self.assertEqual(check_call_mock.call_count, 4)
+        self.assertEqual(f"mv {self.install_dir}/logs {self.work_dir}", args_list[0][0][0])
+        self.assertEqual(f"rm -rf {self.install_dir}", args_list[1][0][0])
+        self.assertEqual(f"mkdir {self.install_dir}", args_list[2][0][0])
+        self.assertEqual(f"mv {self.work_dir}/logs {self.install_dir}", args_list[3][0][0])

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py
@@ -175,6 +175,7 @@ class ServiceOpenSearchTests(unittest.TestCase):
         mock_file_handler_for_security.write.assert_not_called()
         mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result_for_additional_config)
 
+    @patch("subprocess.check_call")
     @patch("test_workflow.integ_test.service.Process.terminate", return_value=123)
     @patch('test_workflow.integ_test.service.Process.started', new_callable=PropertyMock, return_value=True)
     @patch('test_workflow.integ_test.service.Process.stdout_data', new_callable=PropertyMock, return_value="test stdout_data")
@@ -184,7 +185,8 @@ class ServiceOpenSearchTests(unittest.TestCase):
         mock_process_stderr_data: Mock,
         mock_process_stdout_data: Mock,
         mock_process_started: Mock,
-        mock_process_terminate: Mock
+        mock_process_terminate: Mock,
+        check_call_mock: Mock
     ) -> None:
         service = ServiceOpenSearch(
             self.version,


### PR DESCRIPTION
### Description
Currently, we force to delete everything from the local cluster when uninstalling. This process would also remove the local cluster logs so that the test_recorder is not able to record it after tests. 
This PR is to restore missing logs of local test cluster but remove everything else when uninstalling.

### Issues Resolved
#3382 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
