### PR TITLE
Add dashboards-search-relevance to 2.7 manifest

### DIFF
--- a/manifests/2.7.0/opensearch-dashboards-2.7.0.yml
+++ b/manifests/2.7.0/opensearch-dashboards-2.7.0.yml
@@ -47,3 +47,6 @@ components:
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
     ref: '2.7'
+  - name: searchRelevanceDashboards
+    repository: https://github.com/opensearch-project/dashboards-search-relevance.git
+    ref: '2.x'


### PR DESCRIPTION
### Description
Add dashboards-search-relevance to 2.7 manifest

### Issues Resolved
Part of #3230

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
