### PR TITLE
switching searchRelevanceDashboards from 2.x to 2.7

### DIFF
--- a/manifests/2.7.0/opensearch-dashboards-2.7.0.yml
+++ b/manifests/2.7.0/opensearch-dashboards-2.7.0.yml
@@ -52,4 +52,4 @@ components:
     ref: '2.7'
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
-    ref: '2.x'
+    ref: '2.7'


### PR DESCRIPTION
### Description
switching searchRelevanceDashboards from 2.x to 2.7

### Issues Resolved
makes progress on https://github.com/opensearch-project/dashboards-search-relevance/issues/170

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
