### PR TITLE
Correction on Fixing CDK cluster left over issue when a performance testing job was aborted

### DIFF
--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -287,8 +287,7 @@ pipeline {
                                     }
                                 }
                             } catch (Exception e) {
-                                echo "Exception occurred while deleting the CloudFormation stack: ${e.toString()}"
-                                throw e
+                                error "Exception occurred while deleting the CloudFormation stack: ${e.toString()}"
                             }
                         }
                     }

--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -177,19 +177,23 @@ pipeline {
                             postCleanup()
                         }
                         aborted {
-                            script {
-                                def stackName = "test-single-security-${BUILD_ID}-${ARCHITECTURE}-perf-test"
+                             script {
+                                stackName = "test-single-security-${BUILD_ID}-${ARCHITECTURE}-${BUILD_NUMBER}"
                                 withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
-                                    withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
+                                    withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session', region:'eu-west-1') {
                                         try {
-                                            def stack = cfnDescribe(stack: stackName)
-                                            if (stack != null) {
-                                                cfnDelete(stack: stackName, pollInterval:1000)
-                                            } else {
+                                            def stack = null
+                                            try {
+                                                stack = cfnDescribe(stack: stackName)
+                                            } catch (Exception e) {
                                                 echo "Stack '${stackName}' does not exist, nothing to remove"
                                             }
-                                        } catch (e) {
-                                            echo "Exception occurred while deleting the cloudformation stacks" + e.toString()
+                                            if (stack != null) {
+                                                echo "Deleting stack '${stackName}'"
+                                                cfnDelete(stack: stackName, pollInterval:1000)
+                                            }
+                                        } catch (Exception e) {
+                                            echo "Exception occurred while deleting the CloudFormation stack: ${e.toString()}"
                                             throw e
                                         }
                                     }
@@ -249,19 +253,22 @@ pipeline {
                         }
                         aborted {
                             script {
-                                def stackName = "test-single-${BUILD_ID}-${ARCHITECTURE}-perf-test"
+                                stackName = "test-single-${BUILD_ID}-${ARCHITECTURE}-${BUILD_NUMBER}"
                                 withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
-                                    withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session') {
+                                    withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session', region:'eu-west-1') {
                                         try {
-                                            def stack = cfnDescribe(stack: stackName)
+                                            def stack = null
+                                            try {
+                                                stack = cfnDescribe(stack: stackName)
+                                            } catch (Exception e) {
+                                                echo "Stack '${stackName}' does not exist, nothing to remove"
+                                            }
                                             if (stack != null) {
                                                 echo "Deleting stack '${stackName}'"
                                                 cfnDelete(stack: stackName, pollInterval:1000)
-                                            } else {
-                                                echo "Stack '${stackName}' does not exist, nothing to remove"
                                             }
-                                        } catch (e) {
-                                            echo "Exception occurred while deleting the cloudformation stacks" + e.toString()
+                                        } catch (Exception e) {
+                                            echo "Exception occurred while deleting the CloudFormation stack: ${e.toString()}"
                                             throw e
                                         }
                                     }

--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -176,31 +176,6 @@ pipeline {
                             }
                             postCleanup()
                         }
-                        aborted {
-                             script {
-                                stackName = "test-single-security-${BUILD_ID}-${ARCHITECTURE}-${BUILD_NUMBER}"
-                                withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
-                                    withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session', region:'eu-west-1') {
-                                        try {
-                                            def stack = null
-                                            try {
-                                                stack = cfnDescribe(stack: stackName)
-                                            } catch (Exception e) {
-                                                echo "Stack '${stackName}' does not exist, nothing to remove"
-                                            }
-                                            if (stack != null) {
-                                                echo "Deleting stack '${stackName}'"
-                                                cfnDelete(stack: stackName, pollInterval:1000)
-                                            }
-                                        } catch (Exception e) {
-                                            echo "Exception occurred while deleting the CloudFormation stack: ${e.toString()}"
-                                            throw e
-                                        }
-                                    }
-                                }
-                            }
-                            postCleanup()
-                        }
                         failure {
                             postCleanup()
                         }
@@ -251,31 +226,6 @@ pipeline {
                             }
                             postCleanup()
                         }
-                        aborted {
-                            script {
-                                stackName = "test-single-${BUILD_ID}-${ARCHITECTURE}-${BUILD_NUMBER}"
-                                withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
-                                    withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session', region:'eu-west-1') {
-                                        try {
-                                            def stack = null
-                                            try {
-                                                stack = cfnDescribe(stack: stackName)
-                                            } catch (Exception e) {
-                                                echo "Stack '${stackName}' does not exist, nothing to remove"
-                                            }
-                                            if (stack != null) {
-                                                echo "Deleting stack '${stackName}'"
-                                                cfnDelete(stack: stackName, pollInterval:1000)
-                                            }
-                                        } catch (Exception e) {
-                                            echo "Exception occurred while deleting the CloudFormation stack: ${e.toString()}"
-                                            throw e
-                                        }
-                                    }
-                                }
-                            }
-                            postCleanup()
-                        }
                         failure {
                             postCleanup()
                         }
@@ -312,6 +262,38 @@ pipeline {
                     )
                     postCleanup()
                 }
+            }
+        }
+        aborted {
+            node(AGENT_LABEL) {
+                script {
+                    def stackNames = [
+                    "test-single-${BUILD_ID}-${ARCHITECTURE}-${BUILD_NUMBER}", 
+                    "test-single-security-${BUILD_ID}-${ARCHITECTURE}-${BUILD_NUMBER}"
+                    ]
+                    withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
+                        withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session', region: 'eu-west-1') {
+                            try {
+                                for (String stackName : stackNames) {
+                                    def stack = null
+                                    try {
+                                        stack = cfnDescribe(stack: stackName)
+                                    } catch (Exception) {
+                                        echo "Stack '${stackName}' does not exist, nothing to remove"
+                                    }
+                                    if (stack != null) {
+                                        echo "Deleting stack '${stackName}'"
+                                        cfnDelete(stack: stackName, pollInterval:1000)
+                                    }
+                                }
+                            } catch (Exception e) {
+                                echo "Exception occurred while deleting the CloudFormation stack: ${e.toString()}"
+                                throw e
+                            }
+                        }
+                    }
+                }
+                postCleanup()
             }
         }
     }

--- a/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
+++ b/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
@@ -34,15 +34,6 @@ class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
                 .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
                 .build()
             )
-        // this.registerLibTester(new RunPerfTestScriptLibTester(
-        //     'tests/jenkins/data/opensearch-1.3.0-non-security-bundle.yml',
-        //     '1236',
-        //     'true',
-        //     'nyc_taxis',
-        //     '1',
-        //     '1',
-        //     false
-        // ))
         helper.registerAllowedMethod("s3Download", [Map])
         helper.registerAllowedMethod("uploadTestResults", [Map])
         helper.registerAllowedMethod("s3Upload", [Map])
@@ -152,34 +143,34 @@ class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
     }
 
     @Test
-    void testRunSecurityPerfTestScript_verifyJob_aborted() {
+    void testRunSecurityPerfTestScript_verifyJob_aborted() throws Exception{
         binding.setVariable('BUNDLE_MANIFEST', 'tests/jenkins/data/opensearch-1.3.0-bundle.yml')
         binding.setVariable('HAS_SECURITY', true)
+        helper.registerAllowedMethod("cfnDescribe", [Map.class]) { args -> return null}
         helper.registerAllowedMethod('sh', [String.class], { String cmd ->
             updateBuildStatus('ABORTED')
         })
         runScript("jenkins/opensearch/perf-test.jenkinsfile")
-        
+
         assertJobStatusAborted() 
         assertCallStack()
-        assertCallStack().contains("perf-test.cfnDescribe({stack=test-single-security-1236-x64-perf-test})")
-        assertCallStack().contains("'test-single-security-1236-x64-perf-test' does not exist, nothing to remove")
+        assertCallStack().contains("cfnDescribe({stack=test-single-security-1236-x64-307})")
     }    
 
     @Test
-    void testRunNonSecurityPerfTestScript_verifyJob_aborted() {
+    void testRunNonSecurityPerfTestScript_verifyJob_aborted() throws Exception{
         binding.setVariable('BUNDLE_MANIFEST', 'tests/jenkins/data/opensearch-1.3.0-non-security-bundle.yml')
         binding.setVariable('HAS_SECURITY', false)
-        helper.registerAllowedMethod("cfnDescribe", [Map]) { args -> return 'anything'}
+        helper.registerAllowedMethod("cfnDescribe", [Map.class]) { args -> return true}
         helper.registerAllowedMethod('sh', [String.class], { String cmd ->
             updateBuildStatus('ABORTED')
         })
         runScript("jenkins/opensearch/perf-test.jenkinsfile")
-        
+
         assertJobStatusAborted() 
         assertCallStack()
-        assertCallStack().contains("perf-test.cfnDescribe({stack=test-single-1236-x64-perf-test})")
-        assertCallStack().contains("perf-test.cfnDelete({stack=test-single-1236-x64-perf-test, pollInterval=1000})")
+        assertCallStack().contains("cfnDescribe({stack=test-single-1236-x64-307})")
+        assertCallStack().contains("cfnDelete({stack=test-single-1236-x64-307, pollInterval=1000})")
     }  
 
     def getCommandExecutions(methodName, command) {

--- a/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
+++ b/tests/jenkins/TestRunNonSecurityPerfTestScript.groovy
@@ -143,10 +143,10 @@ class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
     }
 
     @Test
-    void testRunSecurityPerfTestScript_verifyJob_aborted() throws Exception{
+    void testRunSecurityPerfTestScript_verifyJob_aborted() {
         binding.setVariable('BUNDLE_MANIFEST', 'tests/jenkins/data/opensearch-1.3.0-bundle.yml')
         binding.setVariable('HAS_SECURITY', true)
-        helper.registerAllowedMethod("cfnDescribe", [Map.class]) { args -> return null}
+        helper.registerAllowedMethod("cfnDescribe", [Map.class]) { throw exception } 
         helper.registerAllowedMethod('sh', [String.class], { String cmd ->
             updateBuildStatus('ABORTED')
         })
@@ -154,7 +154,9 @@ class TestRunNonSecurityPerfTestScript extends BuildPipelineTest {
 
         assertJobStatusAborted() 
         assertCallStack()
+        printCallStack()
         assertCallStack().contains("cfnDescribe({stack=test-single-security-1236-x64-307})")
+        assertCallStack().contains("Stack 'test-single-security-1236-x64-307' does not exist, nothing to remove")
     }    
 
     @Test


### PR DESCRIPTION
### Description

- Correction on target CDK cluster naming and asserting cfnDescribe exception when the cluster does not exist
- Aslo, adding region parameter in withAWS Jenkins Pipeline to ensure the code will be running at the region we want

### Issues Resolved
Fix for https://github.com/opensearch-project/opensearch-build/issues/2504

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
