### PR TITLE
Add jenkins file for manifest update workflow

### DIFF
--- a/jenkins/manifests-update.jenkinsFile
+++ b/jenkins/manifests-update.jenkinsFile
@@ -1,0 +1,55 @@
+pipeline {
+    options {
+        timeout(time: 1, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '7'))
+    }
+    agent none
+    triggers {
+        cron('H 0 * * *')
+    }
+    stages {
+        stage('Update Manifests') {
+            agent {
+                docker {
+                    label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
+                    image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2'
+                    args '-e JAVA_HOME=/opt/java/openjdk-11'
+                    registryUrl 'https://public.ecr.aws/'
+                    alwaysPull true
+                }
+            }
+            steps {
+                script {
+                    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+                        try {
+                            sh """
+                                git remote set-url origin https://opensearch-ci:${GITHUB_TOKEN}@github.com/opensearch-project/opensearch-build
+                                git config user.email "opensearch-infra@amazon.com"
+                                git config user.name "opensearch-ci"
+                                git checkout -b update-manifest
+                                ./manifests.sh update
+                        """
+                            def status = sh(returnStdout: true, script: 'git status --porcelain')
+                            if (status) {
+                                sh """
+                                    git add . && git commit -sm "Update manifests"
+                                    git push origin update-manifest --force
+                                    gh pr create --title '[AUTO] Update input manifests' --body 'I have noticed that a repo has incremented a version. This change updates the corresponding input manifests.' -H update-manifest -B main
+                                """
+                            } else {
+                                println 'Nothing to commit!'
+                            }
+                        } catch (e) {
+                            error 'An error occured while adding a new manifest!' + e.toString()
+                        }
+                    }
+                }
+            }
+            post() {
+                always {
+                    cleanWs disableDeferredWipeout: true, deleteDirs: true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description
This is a work around until #3068 gets resolved. Tested this jenkinsFile and it works as expected. Sample PR it opened https://github.com/opensearch-project/opensearch-build/pull/3428

### Issues Resolved
Related #3068

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
