### PR TITLE
Make systemd-tmpfiles optional

### DIFF
--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
@@ -25,7 +25,9 @@ if command -v systemctl > /dev/null; then
 fi
 
 # Reload other configs
-systemd-tmpfiles --create opensearch-dashboards.conf
+if command -v systemd-tmpfiles > /dev/null; then
+    systemd-tmpfiles --create opensearch-dashboards.conf
+fi
 
 # Messages
 echo "### NOT starting on installation, please execute the following statements to configure opensearch-dashboards service to start automatically using systemd"

--- a/scripts/pkg/build_templates/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
@@ -80,7 +80,9 @@ if command -v systemctl > /dev/null; then
     systemctl daemon-reload
 fi
 # Reload other configs
-systemd-tmpfiles --create %{name}.conf
+if command -v systemd-tmpfiles > /dev/null; then
+    systemd-tmpfiles --create %{name}.conf
+fi
 # Messages
 echo "### NOT starting on installation, please execute the following statements to configure opensearch-dashboards service to start automatically using systemd"
 echo " sudo systemctl daemon-reload"

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -53,7 +53,10 @@ fi
 if command -v systemctl > /dev/null; then
     systemctl restart systemd-sysctl.service || true
 fi
-systemd-tmpfiles --create opensearch.conf
+
+if command -v systemd-tmpfiles > /dev/null; then
+    systemd-tmpfiles --create opensearch.conf
+fi
 
 # Messages
 echo "### NOT starting on installation, please execute the following statements to configure opensearch service to start automatically using systemd"

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -117,7 +117,11 @@ fi
 if command -v systemctl > /dev/null; then
     systemctl restart systemd-sysctl.service || true
 fi
-systemd-tmpfiles --create %{name}.conf
+
+if command -v systemd-tmpfiles > /dev/null; then
+    systemd-tmpfiles --create %{name}.conf
+fi
+
 # Messages
 echo "### NOT starting on installation, please execute the following statements to configure opensearch service to start automatically using systemd"
 echo " sudo systemctl daemon-reload"


### PR DESCRIPTION
### Description
Makes systemd-tmpfiles optional (when installing in container images not supplying systemd-tmpfiles)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
