### PR TITLE
Correction on CDK cluster destroyed issue when the perf-test job is aborted

### DIFF
--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -272,7 +272,7 @@ pipeline {
                     "test-single-security-${BUILD_ID}-${ARCHITECTURE}-${BUILD_NUMBER}"
                     ]
                     withCredentials([string(credentialsId: 'jenkins-aws-account-public', variable: 'AWS_ACCOUNT_PUBLIC')]) {
-                        withAWS(role: 'opensearch-test', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session', region: 'eu-west-1') {
+                        withAWS(role: 'cfn-set-up', roleAccount: "${AWS_ACCOUNT_PUBLIC}", duration: 900, roleSessionName: 'jenkins-session', region: 'eu-west-1') {
                             try {
                                 for (String stackName : stackNames) {
                                     def stack = null


### PR DESCRIPTION
### Description
After the testing from the previous fix, we found the CDK cluster was still not destroyed due to assuming role issue; hence, we want to update the role to fix it.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2504

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
