### PR TITLE
Fix missing local cluster logs when running integration test

### DIFF
--- a/src/test_workflow/integ_test/service.py
+++ b/src/test_workflow/integ_test/service.py
@@ -64,8 +64,6 @@ class Service(abc.ABC):
 
         self.return_code = self.process_handler.terminate()
 
-        self.uninstall()
-
         return ServiceTerminationResult(
             self.return_code,
             self.process_handler.stdout_data,

--- a/src/test_workflow/test_cluster.py
+++ b/src/test_workflow/test_cluster.py
@@ -93,6 +93,8 @@ class TestCluster(abc.ABC):
 
         self.__save_test_result_data(self.termination_result)
 
+        self.service.uninstall()
+
     def __save_test_result_data(self, termination_result: ServiceTerminationResult) -> None:
         test_result_data = TestResultData(
             self.component_name,


### PR DESCRIPTION
### Description
Fix missing local cluster logs when running integration test.
Currently the local cluster is wiped out before the logs recorded. Rearrange the logics and record the logs after remove everything including the local cluster logs.

This is an alternative way of #3404 to resolve the issue. 

### Issues Resolved
#3382 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
