### PR TITLE
OSD Version Increment: Add subpath support

### DIFF
--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -22,7 +22,7 @@ jobs:
         entry:
           - {repo: dashboards-observability}
           - {repo: dashboards-reporting}
-          - {repo: dashboards-visualizations}
+          - {repo: dashboards-visualizations, path: gantt-chart}
           - {repo: dashboards-query-workbench}
           - {repo: dashboards-maps}
           - {repo: anomaly-detection-dashboards-plugin}
@@ -68,9 +68,20 @@ jobs:
         run: |
           cd OpenSearch-Dashboards/plugins/${{ matrix.entry.repo }}
           yarn osd bootstrap
-          node ../../scripts/plugin_helpers version --sync legacy
-          OSD_PLUGIN_VERSION=$(node -p "require('./package.json').version")
-          echo "OSD_PLUGIN_VERSION=$OSD_PLUGIN_VERSION" >> $GITHUB_ENV
+          if [ ${{ matrix.entry.path }} ]; then
+              cp -R ${{ matrix.entry.path }} ../
+              cd ../${{ matrix.entry.path }}
+              node ../../scripts/plugin_helpers version --sync legacy
+              OSD_PLUGIN_VERSION=$(node -p "require('./package.json').version")
+              echo "OSD_PLUGIN_VERSION=$OSD_PLUGIN_VERSION" >> $GITHUB_ENV
+              cd ../
+              cp -R ${{ matrix.entry.path }} ${{ matrix.entry.repo }}/
+              cd ${{ matrix.entry.repo }}/
+          else
+              node ../../scripts/plugin_helpers version --sync legacy
+              OSD_PLUGIN_VERSION=$(node -p "require('./package.json').version")
+              echo "OSD_PLUGIN_VERSION=$OSD_PLUGIN_VERSION" >> $GITHUB_ENV
+          fi
       - name: GitHub App token
         id: github_app_token
         uses: tibdex/github-app-token@v1.6.0


### PR DESCRIPTION
### Description
This fixes the issue with OSD plugins like dashboards-visualizations which has the actual plugin under a subpath. Example [dashboards-visualizations](https://github.com/opensearch-project/dashboards-visualizations) actual plugin is [gantt-chart](https://github.com/opensearch-project/dashboards-visualizations/tree/main/gantt-chart) which is at a depth 1.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3333

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
