### PR TITLE
Enable knn in 2.8

### DIFF
--- a/manifests/2.8.0/opensearch-2.8.0.yml
+++ b/manifests/2.8.0/opensearch-2.8.0.yml
@@ -32,3 +32,12 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: k-NN
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
### Description
Enable k-NN in 2.8.

Upgraded 2.x to 2.8 in https://github.com/opensearch-project/k-NN/pull/886

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
