### PR TITLE
Install gh package from git-cli

### DIFF
--- a/docker/ci/dockerfiles/current/docker-builder.ubuntu2004.x64.dockerfile
+++ b/docker/ci/dockerfiles/current/docker-builder.ubuntu2004.x64.dockerfile
@@ -23,6 +23,12 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y binfmt-support
     apt-get install -y debmake debhelper-compat && \
     apt-get clean -y && pip3 install awscli==1.22.12
 
+# Install gh cli
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=`dpkg --print-architecture` signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list && \
+    apt-get update && apt-get install -y gh && apt-get clean
+
 # Install trivy to scan the docker images
 RUN curl -SL https://github.com/aquasecurity/trivy/releases/download/v0.30.4/trivy_0.30.4_Linux-64bit.deb -o /tmp/trivy_0.30.4_Linux-64bit.deb && \
     dpkg -i /tmp/trivy_0.30.4_Linux-64bit.deb && rm /tmp/trivy_0.30.4_Linux-64bit.deb && \

--- a/docker/ci/dockerfiles/current/test.centos7.performance-test.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.centos7.performance-test.x64.arm64.dockerfile
@@ -19,9 +19,10 @@ RUN echo "export LC_ALL=en_US.utf-8" >> /etc/profile.d/python3_ascii.sh && \
     localedef -v -c -i en_US -f UTF-8 en_US.UTF-8 || echo set locale
 
 # Add normal dependencies
-RUN yum clean all && \
+RUN yum clean all && yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
+    yum install epel-release -y && \
     yum update -y && \
-    yum install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
+    yum install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq gh
 
 # Create user group
 RUN groupadd -g 1000 opensearch && \

--- a/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
@@ -14,14 +14,9 @@ FROM rockylinux:8 AS linux_stage_0
 USER 0
 
 # Add normal dependencies
-RUN yum clean all && \
-    yum update -y && \
-    yum install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip
-
-# Install gh cli
 RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
     dnf update -y && \
-    dnf install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq gh
+    dnf install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip gh
 
 # Add Dashboards dependencies (mainly for cypress)
 RUN yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib

--- a/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
@@ -18,6 +18,11 @@ RUN yum clean all && \
     yum update -y && \
     yum install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip
 
+# Install gh cli
+RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
+    dnf update -y && \
+    dnf install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq gh
+
 # Add Dashboards dependencies (mainly for cypress)
 RUN yum install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib
 

--- a/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
@@ -23,6 +23,11 @@ RUN dnf clean all && \
     dnf update -y && \
     dnf install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
 
+# Install gh cli
+RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
+    dnf update -y && \
+    dnf install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq gh
+
 # Add Dashboards dependencies (mainly for cypress)
 RUN dnf install -y xorg-x11-server-Xvfb gtk2-devel gtk3-devel libnotify-devel GConf2 nss libXScrnSaver alsa-lib
 

--- a/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
@@ -19,11 +19,6 @@ ENV container docker
 USER 0
 
 # Add normal dependencies
-RUN dnf clean all && \
-    dnf update -y && \
-    dnf install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq
-
-# Install gh cli
 RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
     dnf update -y && \
     dnf install -y which curl git gnupg2 tar net-tools procps-ng python3 python3-devel python3-pip zip unzip jq gh


### PR DESCRIPTION
### Description

gh package from git-cli repo is added to the dependencies list

### Issues Resolved
This PR enables the use of gh package which is used to create Github issue when a component fails while running integtests in https://github.com/opensearch-project/opensearch-build/pull/3465

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
