### PR TITLE
Add new optional parameters for OS cluster and benchmark

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_args.py
+++ b/src/test_workflow/benchmark_test/benchmark_args.py
@@ -33,7 +33,9 @@ class BenchmarkArgs:
     ml_node_storage: int
     jvm_sys_props: str
     additional_config: str
+    use_50_percent_heap: bool
     workload: str
+    workload_params: str
     benchmark_config: IO
     user_tag: str
     target_hosts: str
@@ -47,9 +49,8 @@ class BenchmarkArgs:
         parser.add_argument("--component", dest="component", default="OpenSearch",
                             help="Component name that needs to be performance tested")
         parser.add_argument("--config", type=argparse.FileType("r"), help="Config file.", required=True)
-        parser.add_argument(
-            "--without-security", dest="insecure", action="store_true",
-            help="Force the security of the cluster to be disabled.", default=False)
+        parser.add_argument("--without-security", dest="insecure", action="store_true",
+                            help="Force the security of the cluster to be disabled.", default=False)
         parser.add_argument("--keep", dest="keep", action="store_true",
                             help="Do not delete the working temporary directory.")
         parser.add_argument("--single-node", dest="single_node", action="store_true",
@@ -69,20 +70,23 @@ class BenchmarkArgs:
                             help="A comma-separated list of key=value pairs that will be added to jvm.options as JVM system properties.")
         parser.add_argument("--additional-config", nargs='*', action=JsonArgs, dest="additional_config",
                             help="Additional opensearch.yml config parameters passed as JSON")
+        parser.add_argument("--use-50-percent-heap", dest="use_50_percent_heap", action="store_true",
+                            help="Use 50 percent of physical memory as heap.")
         parser.add_argument("--ml-node-storage", dest="ml_node_storage",
                             help="User provided ml-node ebs block storage size defaults to 100Gb")
         parser.add_argument("--data-node-storage", dest="data_node_storage",
                             help="User provided data-node ebs block storage size, defaults to 100Gb")
-        parser.add_argument("--workload", dest="workload", help="workload type for the OpenSearch benchmarking",
-                            required=True)
+        parser.add_argument("--workload", dest="workload", required=True,
+                            help="Name of the workload that OpenSearch Benchmark should run")
         parser.add_argument("--benchmark-config", dest="benchmark_config",
-                            help="absolute filepath to custom opensearch-benchmark.ini config")
+                            help="absolute filepath to custom benchmark.ini config")
         parser.add_argument("--user-tag", dest="user_tag",
                             help="Attach arbitrary text to the meta-data of each metric record")
-        parser.add_argument(
-            "-v", "--verbose", help="Show more verbose output.", action="store_const", default=logging.INFO,
-            const=logging.DEBUG, dest="logging_level"
-        )
+        parser.add_argument("--workload-params", dest="workload_params",
+                            help="With this parameter you can inject variables into workloads. Parameters differs "
+                                 "for each workload type. e.g., --workload-params \"number_of_replicas:1,number_of_shards:5\"")
+        parser.add_argument("-v", "--verbose", help="Show more verbose output.", action="store_const", default=logging.INFO,
+                            const=logging.DEBUG, dest="logging_level")
 
         args = parser.parse_args()
         self.bundle_manifest = args.bundle_manifest
@@ -102,7 +106,9 @@ class BenchmarkArgs:
         self.data_node_storage = args.data_node_storage if args.data_node_storage else None
         self.ml_node_storage = args.ml_node_storage if args.ml_node_storage else None
         self.workload = args.workload
+        self.workload_params = args.workload_params if args.workload_params else None
         self.benchmark_config = args.benchmark_config if args.benchmark_config else None
         self.user_tag = args.user_tag if args.user_tag else None
         self.additional_config = json.dumps(args.additional_config) if args.additional_config is not None else None
+        self.use_50_percent_heap = args.use_50_percent_heap
         self.logging_level = args.logging_level

--- a/src/test_workflow/benchmark_test/benchmark_test_cluster.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_cluster.py
@@ -141,7 +141,9 @@ class BenchmarkTestCluster:
             "mlNodeCount": self.args.ml_node_count,
             "dataNodeStorage": self.args.data_node_storage,
             "mlNodeStorage": self.args.ml_node_storage,
-            "jvmSysProps": self.args.jvm_sys_props
+            "jvmSysProps": self.args.jvm_sys_props,
+            "use50PercentHeap": str(self.args.use_50_percent_heap).lower(),
+            "isInternal": config["Constants"]["isInternal"]
         }
 
     @classmethod

--- a/src/test_workflow/benchmark_test/benchmark_test_suite.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite.py
@@ -40,6 +40,10 @@ class BenchmarkTestSuite:
         self.command += f" opensearchproject/opensearch-benchmark:latest execute_test --workload={self.args.workload} " \
                         f"--test-mode --pipeline=benchmark-only --target-hosts={endpoint}"
 
+        if args.workload_params:
+            logging.info(f"Workload Params are {args.workload_params}")
+            self.command += f" --workload-params \"{args.workload_params}\""
+
         if args.user_tag:
             user_tag = f"--user-tag=\"{args.user_tag}\""
             self.command += f" {user_tag}"

--- a/tests/data/test-config.yml
+++ b/tests/data/test-config.yml
@@ -9,4 +9,5 @@ Constants:
   serverAccessType: prefixList
   restrictServerAccessTo: pl-01a74268
   Region: eu-west-1
+  isInternal: true
   Role: test-set-up

--- a/tests/tests_test_workflow/data/test-config.yml
+++ b/tests/tests_test_workflow/data/test-config.yml
@@ -9,4 +9,5 @@ Constants:
   serverAccessType: prefixList
   restrictServerAccessTo: pl-01a74268
   Region: eu-west-1
+  isInternal: true
   Role: test-set-up

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/data/test-config.yml
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/data/test-config.yml
@@ -9,4 +9,5 @@ Constants:
   serverAccessType: prefixList
   restrictServerAccessTo: pl-01a74268
   Region: eu-west-1
+  isInternal: true
   Role: test-set-up

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_cluster.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_cluster.py
@@ -32,7 +32,8 @@ class TestBenchmarkTestCluster(unittest.TestCase):
         self.stack_name = "stack"
         self.security = True
         self.config = {"Constants": {"SecurityGroupId": "sg-00000000", "VpcId": "vpc-12345", "AccountId": "12345678",
-                                     "Region": "us-west-2", "Role": "role-arn", "serverAccessType": "prefixList", "restrictServerAccessTo": "pl-1234"}}
+                                     "Region": "us-west-2", "Role": "role-arn", "serverAccessType": "prefixList", "restrictServerAccessTo": "pl-1234",
+                                     "isInternal": "true"}}
         self.benchmark_test_cluster = BenchmarkTestCluster(bundle_manifest=self.manifest, config=self.config, args=self.args, current_workspace="current_workspace")
 
     @patch("test_workflow.benchmark_test.benchmark_test_cluster.BenchmarkTestCluster.wait_for_processing")
@@ -48,6 +49,7 @@ class TestBenchmarkTestCluster(unittest.TestCase):
         self.assertTrue("opensearch-infra-stack-test-suffix-007-x64" in self.benchmark_test_cluster.stack_name)
         self.assertTrue("securityDisabled=false" in self.benchmark_test_cluster.params)
         self.assertTrue("singleNodeCluster=true" in self.benchmark_test_cluster.params)
+        self.assertTrue("isInternal=true" in self.benchmark_test_cluster.params)
         with patch("subprocess.check_call") as mock_check_call:
             self.benchmark_test_cluster.terminate()
             self.assertEqual(mock_check_call.call_count, 1)
@@ -76,6 +78,7 @@ class TestBenchmarkTestCluster(unittest.TestCase):
     @patch("test_workflow.benchmark_test.benchmark_test_cluster.BenchmarkTestCluster.wait_for_processing")
     def test_create_multi_node(self, mock_wait_for_processing: Optional[Mock]) -> None:
         self.args.single_node = False
+        self.args.use_50_percent_heap = True
         TestBenchmarkTestCluster.setUp(self, self.args)
         mock_file = MagicMock(side_effect=[{"opensearch-infra-stack-test-suffix-007-x64": {"loadbalancerurl": "www.example.com"}}])
         with patch("subprocess.check_call") as mock_check_call:
@@ -85,3 +88,4 @@ class TestBenchmarkTestCluster(unittest.TestCase):
                     self.assertEqual(mock_check_call.call_count, 1)
 
         self.assertTrue("singleNodeCluster=false" in self.benchmark_test_cluster.params)
+        self.assertTrue("use50PercentHeap=true" in self.benchmark_test_cluster.params)

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
@@ -13,12 +13,13 @@ from test_workflow.benchmark_test.benchmark_test_suite import BenchmarkTestSuite
 
 
 class TestBenchmarkTestSuite(unittest.TestCase):
-    def setUp(self, config: Optional[str] = None, tag: Optional[str] = None) -> None:
-
+    def setUp(self, config: Optional[str] = None, tag: Optional[str] = None,
+              workload_params: Optional[str] = None) -> None:
         self.args = Mock()
         self.args.workload = "nyc_taxis"
         self.args.benchmark_config = config
         self.args.user_tag = tag
+        self.args.workload_params = workload_params
         self.endpoint = "abc.com"
         self.benchmark_test_suite = BenchmarkTestSuite(endpoint=self.endpoint, security=False, args=self.args)
 
@@ -35,20 +36,21 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         with patch("subprocess.check_call") as mock_check_call:
             benchmark_test_suite.execute()
             self.assertEqual(mock_check_call.call_count, 1)
-            self.assertEqual(benchmark_test_suite.command, 'docker run opensearchproject/opensearch-benchmark:latest execute_test '
-                                                           '--workload=nyc_taxis --test-mode --pipeline=benchmark-only '
-                                                           '--target-hosts=abc.com --client-options="use_ssl:true,'
-                                                           'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'"')
+            self.assertEqual(benchmark_test_suite.command,
+                             'docker run opensearchproject/opensearch-benchmark:latest execute_test '
+                             '--workload=nyc_taxis --test-mode --pipeline=benchmark-only '
+                             '--target-hosts=abc.com --client-options="use_ssl:true,'
+                             'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'"')
 
     def test_execute_default_with_optional_args(self) -> None:
-        TestBenchmarkTestSuite.setUp(self, "/home/test/benchmark.ini", "key1:value1,key2:value2")
+        TestBenchmarkTestSuite.setUp(self, "/home/test/benchmark.ini", "key1:value1,key2:value2", "number_of_replicas:1")
         with patch("subprocess.check_call") as mock_check_call:
             self.benchmark_test_suite.execute()
             self.assertEqual(mock_check_call.call_count, 1)
-
             self.assertEqual(self.benchmark_test_suite.command, 'docker run -v /home/test/benchmark.ini:'
                                                                 '/opensearch-benchmark/.benchmark/benchmark.ini '
                                                                 'opensearchproject/opensearch-benchmark:latest execute_test '
                                                                 '--workload=nyc_taxis --test-mode '
                                                                 '--pipeline=benchmark-only --target-hosts=abc.com '
+                                                                '--workload-params "number_of_replicas:1" '
                                                                 '--user-tag="key1:value1,key2:value2"')


### PR DESCRIPTION
### Description
This PR adds 3 new parameters (2 for opensearch-cluster-cdk and 1 for opensearch-benchmark) that are required to roll out P0 `benchmark-test` workflow. The new parameters added are:
1. `use_50_percent_heap`: Optional parameter to enable 50% heap usage on OpenSearch cluster.  
2. `isInteral`: Immutable `isInternal` parameter passed from config file. The will create internal network load balancer that can be accessed in a VPC peered environment between jenkins and cluster accounts. 
3. `workload_params`: Optional parameter to pass additional parameters to `opensearch-benchmark`. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
