### PR TITLE
Make trivy installation auto pickup latest version

### DIFF
--- a/docker/ci/dockerfiles/current/docker-builder.ubuntu2004.x64.dockerfile
+++ b/docker/ci/dockerfiles/current/docker-builder.ubuntu2004.x64.dockerfile
@@ -30,9 +30,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     apt-get update && apt-get install -y gh && apt-get clean
 
 # Install trivy to scan the docker images
-RUN curl -SL https://github.com/aquasecurity/trivy/releases/download/v0.30.4/trivy_0.30.4_Linux-64bit.deb -o /tmp/trivy_0.30.4_Linux-64bit.deb && \
-    dpkg -i /tmp/trivy_0.30.4_Linux-64bit.deb && rm /tmp/trivy_0.30.4_Linux-64bit.deb && \
-    trivy --version
+RUN apt-get install -y apt-transport-https gnupg lsb-release && \
+    curl -o- https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | tee /usr/share/keyrings/trivy.gpg > /dev/null && \
+    echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | tee -a /etc/apt/sources.list.d/trivy.list && \
+    apt-get update -y && apt-get install -y trivy && apt-get clean && trivy --version
 
 # Install JDK
 RUN curl -SL https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.15%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.15_10.tar.gz -o /opt/jdk11.tar.gz && \
@@ -67,4 +68,5 @@ RUN curl -L https://github.com/google/go-containerregistry/releases/latest/downl
 RUN curl -SL -o- https://apt.releases.hashicorp.com/gpg | gpg --dearmor > /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list && \
     apt-get update && \
-    apt-get install packer
+    apt-get install packer && \
+    apt-get clean


### PR DESCRIPTION
### Description
Make trivy installation auto pickup latest version

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3486

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
