### PR TITLE
Remove test-mode flag from opensearch-benchmark command

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_test_suite.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite.py
@@ -38,7 +38,7 @@ class BenchmarkTestSuite:
         if args.benchmark_config:
             self.command += f" -v {args.benchmark_config}:/opensearch-benchmark/.benchmark/benchmark.ini"
         self.command += f" opensearchproject/opensearch-benchmark:latest execute_test --workload={self.args.workload} " \
-                        f"--test-mode --pipeline=benchmark-only --target-hosts={endpoint}"
+                        f"--pipeline=benchmark-only --target-hosts={endpoint}"
 
         if args.workload_params:
             logging.info(f"Workload Params are {args.workload_params}")

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
@@ -28,7 +28,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
             self.benchmark_test_suite.execute()
             self.assertEqual(mock_check_call.call_count, 1)
             self.assertEqual(self.benchmark_test_suite.command,
-                             'docker run opensearchproject/opensearch-benchmark:latest execute_test --workload=nyc_taxis --test-mode '
+                             'docker run opensearchproject/opensearch-benchmark:latest execute_test --workload=nyc_taxis '
                              '--pipeline=benchmark-only --target-hosts=abc.com')
 
     def test_execute_security_enabled(self) -> None:
@@ -38,7 +38,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
             self.assertEqual(mock_check_call.call_count, 1)
             self.assertEqual(benchmark_test_suite.command,
                              'docker run opensearchproject/opensearch-benchmark:latest execute_test '
-                             '--workload=nyc_taxis --test-mode --pipeline=benchmark-only '
+                             '--workload=nyc_taxis --pipeline=benchmark-only '
                              '--target-hosts=abc.com --client-options="use_ssl:true,'
                              'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'"')
 
@@ -50,7 +50,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
             self.assertEqual(self.benchmark_test_suite.command, 'docker run -v /home/test/benchmark.ini:'
                                                                 '/opensearch-benchmark/.benchmark/benchmark.ini '
                                                                 'opensearchproject/opensearch-benchmark:latest execute_test '
-                                                                '--workload=nyc_taxis --test-mode '
+                                                                '--workload=nyc_taxis '
                                                                 '--pipeline=benchmark-only --target-hosts=abc.com '
                                                                 '--workload-params "number_of_replicas:1" '
                                                                 '--user-tag="key1:value1,key2:value2"')


### PR DESCRIPTION
### Description
Remove test-mode flag from opensearch-benchmark command. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
