### PR TITLE
Adding dashboards-search-relevance to 2.8 and 2.7.1 manifests

### DIFF
--- a/manifests/2.7.1/opensearch-dashboards-2.7.1.yml
+++ b/manifests/2.7.1/opensearch-dashboards-2.7.1.yml
@@ -10,3 +10,7 @@ components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     ref: '2.7'
+  - name: searchRelevanceDashboards
+    repository: https://github.com/opensearch-project/dashboards-search-relevance.git
+    ref: tags/2.7.1.0
+    

--- a/manifests/2.7.1/opensearch-dashboards-2.7.1.yml
+++ b/manifests/2.7.1/opensearch-dashboards-2.7.1.yml
@@ -12,5 +12,4 @@ components:
     ref: '2.7'
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
-    ref: tags/2.7.1.0
-    
+    ref: '2.7'

--- a/manifests/2.8.0/opensearch-dashboards-2.8.0.yml
+++ b/manifests/2.8.0/opensearch-dashboards-2.8.0.yml
@@ -10,3 +10,7 @@ components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     ref: 2.x
+  - name: searchRelevanceDashboards
+    repository: https://github.com/opensearch-project/dashboards-search-relevance.git
+    ref: tags/2.8.0.0
+    

--- a/manifests/2.8.0/opensearch-dashboards-2.8.0.yml
+++ b/manifests/2.8.0/opensearch-dashboards-2.8.0.yml
@@ -12,5 +12,4 @@ components:
     ref: 2.x
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
-    ref: tags/2.8.0.0
-    
+    ref: 2.x


### PR DESCRIPTION
### Description
Adds `dashboards-search-relevance` to the `opensearch-dashboards-2.7.1` and `opensearch-dashboards-2.8.0` manifests.

### Issues Resolved
[#170](https://github.com/opensearch-project/dashboards-search-relevance/issues/170)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
