### PR TITLE
Updating integ-test.jenkinsfile with 2.8.0

### DIFF
--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -32,14 +32,12 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H 14 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
-            H 14 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
-            H 15 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-segment-replication-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
-            H 15 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-segment-replication-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
-            H 16 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/arm64/rpm/builds/opensearch/manifest.yml
-            H 16 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/x64/rpm/builds/opensearch/manifest.yml
-            H 17 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/arm64/deb/builds/opensearch/manifest.yml
-            H 17 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/x64/deb/builds/opensearch/manifest.yml
+            H 14 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
+            H 14 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
+            H 16 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/arm64/rpm/builds/opensearch/manifest.yml
+            H 16 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/x64/rpm/builds/opensearch/manifest.yml
+            H 17 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/arm64/deb/builds/opensearch/manifest.yml
+            H 17 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/x64/deb/builds/opensearch/manifest.yml
             '''
     }
     parameters {

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
@@ -6,15 +6,13 @@
          integ-test.timeout({time=3, unit=HOURS})
          integ-test.echo(Executing on agent [label:none])
          integ-test.parameterizedCron(
-            H 14 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
-            H 14 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
-            H 15 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-segment-replication-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
-            H 15 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-segment-replication-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
-            H 16 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/arm64/rpm/builds/opensearch/manifest.yml
-            H 16 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/x64/rpm/builds/opensearch/manifest.yml
-            H 17 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/arm64/deb/builds/opensearch/manifest.yml
-            H 17 * * * %TEST_MANIFEST=2.7.0/opensearch-2.7.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/latest/linux/x64/deb/builds/opensearch/manifest.yml
-            )
+            H 14 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
+            H 14 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
+            H 16 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/arm64/rpm/builds/opensearch/manifest.yml
+            H 16 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/x64/rpm/builds/opensearch/manifest.yml
+            H 17 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/arm64/deb/builds/opensearch/manifest.yml
+            H 17 * * * %TEST_MANIFEST=2.8.0/opensearch-2.8.0-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/latest/linux/x64/deb/builds/opensearch/manifest.yml
+           )
          integ-test.stage(verify-parameters, groovy.lang.Closure)
             integ-test.echo(Executing on agent [label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host])
             integ-test.script(groovy.lang.Closure)


### PR DESCRIPTION
### Description
Updating integ-test.jenkinsfile with 2.8.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
