### PR TITLE
[Bug] Fixing not correct path in Readme

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -14,26 +14,10 @@ To build the docker image for either x64 or arm64, run the below command on a x6
 ./build-image-single-arch.sh -r <Repo name> -v <Tag name> -f <Docker File Path>
 ```
 
-If you want to build multi-arch docker image for both x64 and arm64, make sure you are using Docker Desktop.
+If you want to build multi-arch docker image for both x64 and arm64, you can use the below command.
 
-Run these commands to setup the multi-arch builder, you can re-use this build later on, just need to re-bootstrap again if you restart Docker Desktop.
-
-```bash
-docker buildx create --name multiarch
-docker buildx use multiarch
-docker buildx inspect --bootstrap
-```
-
-You should be able to see similar output in `docker ps` like this.
-
-```
-123456789012 moby/buildkit:buildx-stable-1 "buildkitd" 11 minutes ago Up 11 minutes buildx_buildkit_multiarch0
-```
-
-Docker buildx is using a container to build multi-arch images and combine all the layers together, so you can only upload it to Docker Hub, or save it locally as cache, means `docker images` will not show the image due to your host cannot have more than one CPU architecture.
-
-Run these commands to actually build the docker image in multi-arch and push to Docker Hub (est. 1hr time depend on your host hardware specifications and network bandwidth).
+Make sure you are running it within the `opensearch-build/docker/ci` folder.
 
 ```bash
-docker buildx build --platform linux/amd64,linux/arm64 -t <Docker Hub RepoName>/<Docker Image Name>:<Tag Name> -f <Docker File Path> --push .
+./build-image-multi-arch.sh -r <Repo name> -v <Tag name> -f <Docker File Path>
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ We build, assemble, and test our artifacts on docker containers. All of our pipe
 To build the docker image for either x64 or arm64, run the below command on a x64 or arm64 host respectively within the `opensearch-build/docker/ci` folder:
 
 ```bash
-docker build -f ./dockerfiles/integtest-runner.al2.dockerfile . -t <Docker Hub RepoName>/<Docker Image Name>:<Tag Name>
+bash build-image-single-arch.sh -r <Repo name> -v <Tag name> -f <Docker File Path>
 ```
 
 If you want to build multi-arch docker image for both x64 and arm64, make sure you are using Docker Desktop.

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ We build, assemble, and test our artifacts on docker containers. All of our pipe
 To build the docker image for either x64 or arm64, run the below command on a x64 or arm64 host respectively within the `opensearch-build/docker/ci` folder:
 
 ```bash
-bash build-image-single-arch.sh -r <Repo name> -v <Tag name> -f <Docker File Path>
+./build-image-single-arch.sh -r <Repo name> -v <Tag name> -f <Docker File Path>
 ```
 
 If you want to build multi-arch docker image for both x64 and arm64, make sure you are using Docker Desktop.

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,8 +14,7 @@ To build the docker image for either x64 or arm64, run the below command on a x6
 ./build-image-single-arch.sh -r <Repo name> -v <Tag name> -f <Docker File Path>
 ```
 
-If you want to build multi-arch docker image for both x64 and arm64, you can use the below command.
-
+If you want to build multi-arch docker image for both x64 and arm64, you can use the below command.\
 Make sure you are running it within the `opensearch-build/docker/ci` folder.
 
 ```bash

--- a/docker/ci/README.md
+++ b/docker/ci/README.md
@@ -11,12 +11,16 @@ We build, assemble, and test our artifacts on docker containers. All of our pipe
 To build the docker image for either x64 or arm64, run the below command on a x64 or arm64 host respectively within the `opensearch-build/docker/ci` folder:
 
 ```bash
-./build-image-single-arch.sh -r <Repo name> -v <Tag name> -f <Docker File Path>
+./build-image-single-arch.sh -r <Repo Name> -v <Tag Name> -f <Docker File Path>
 ```
+After the build, you can locate an image in your host using the `docker images` command with the following format: `opensearchstaging/<Repo Name>:<Tag Name>`.
+
 
 If you want to build multi-arch docker image for both x64 and arm64, you can use the below command.\
 Make sure you are running it within the `opensearch-build/docker/ci` folder.
 
 ```bash
-./build-image-multi-arch.sh -r <Repo name> -v <Tag name> -f <Docker File Path>
+./build-image-multi-arch.sh -r <Repo Name> -v <Tag Name> -f <Docker File Path>
 ```
+Docker buildx is a tool utilized for building multi-arch images. It leverages a `moby/buildkit` container to construct these images, combining all the CPU architecture layers into a single entity. Consequently, you can only upload the resulting image to Docker Hub or store it locally as cache. Due to the limitation that your host cannot support multiple CPU architectures, the image will not be visible when running the `docker images` command.
+


### PR DESCRIPTION
### Description
First of all, './dockerfiles/integtest-runner.al2.dockerfile' this file does not exist. So we should replace it by '<Docker file path' anyway

In the readme, we say that we are launching on one of the platforms('either x64 or arm64'), that is, the single arch. So here probably its more suitable to use 'bash build-image-single-arch.sh' instead of 'docker-build'?
I think current Readme not newbie-friendly, so i tried to change it. I hope i understand all differences well (between single arch and multi-arch and etc). 
I'm ready to hear all your feedback and change my mind in case of mistakes! I'm still a beginner, but I'm trying to improve the problems that I have myself

### Issues Resolved
[#3458]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
