### PR TITLE
Add jenkinsfile for benchmark job and minor improvements

### DIFF
--- a/jenkins/opensearch/benchmark-test.jenkinsfile
+++ b/jenkins/opensearch/benchmark-test.jenkinsfile
@@ -1,0 +1,296 @@
+lib = library(identifier: 'jenkins@4.2.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+pipeline {
+    agent none
+    options {
+        timeout(time: 24, unit: 'HOURS')
+    }
+    environment {
+        AGENT_LABEL = 'Jenkins-Agent-AL2-X64-M52xlarge-Docker-Host-Benchmark-Test'
+        BUNDLE_MANIFEST = 'bundle-manifest.yml'
+        JOB_NAME = 'benchmark-test'
+    }
+    parameters {
+        string(
+            name: 'BUNDLE_MANIFEST_URL',
+            description: 'The distribution manifest URL, e.g. https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.3.0/6039/linux/x64/tar/dist/opensearch/manifest.yml',
+            trim: true
+        )
+        string(
+            defaultValue: 'nyc_taxis',
+            name: 'TEST_WORKLOAD',
+            description: 'The workload name from OpenSearch Benchmark Workloads.',
+            trim: true
+        )
+        booleanParam(
+            defaultValue: false,
+            name: 'SECURITY_DISABLED',
+            description: 'Force the security of the cluster to be disabled'
+        )
+        booleanParam(
+            name: 'SINGLE_NODE_CLUSTER',
+            description: 'Benchmark test on a single node cluster',
+            defaultValue: true
+        )
+        booleanParam(
+            name: 'MIN_DISTRIBUTION',
+            description: 'Use OpenSearch min distribution',
+            defaultValue: false
+        )
+        string(
+            name: 'MANAGER_NODE_COUNT',
+            description: 'Number of cluster manager nodes, empty value defaults to 3.',
+            trim: true
+        )
+        string(
+            name: 'DATA_NODE_COUNT',
+            description: 'Number of cluster data nodes, empty value defaults to 2.',
+            trim: true
+        )
+        string(
+            name: 'CLIENT_NODE_COUNT',
+            description: 'Number of cluster client nodes, empty value default to 0.',
+            trim: true
+        )
+        string(
+            name: 'INGEST_NODE_COUNT',
+            description: 'Number of cluster INGEST nodes, empty value defaults to 0.',
+            trim: true
+        )
+        string(
+            name: 'ML_NODE_COUNT',
+            description: 'Number of cluster ml nodes, empty value defaults to 0.',
+            trim: true
+        )
+        string(
+            name: 'DATA_NODE_STORAGE',
+            description: 'Data node ebs block storage size, empty value defaults to 100Gb',
+            trim: true
+        )
+        string(
+            name: 'ML_NODE_STORAGE',
+            description: 'ML node ebs block storage size, empty value defaults to 100Gb',
+            trim: true
+        )
+        string(
+            name: 'JVM_SYS_PROPS',
+            description: 'A comma-separated list of key=value pairs that will be added to jvm.options as JVM system properties.',
+            trim: true
+        )
+        string(
+            name: 'ADDITIONAL_CONFIG',
+            description: 'Additional opensearch.yml config parameters passed as JSON. e.g., `opensearch.experimental.feature.segment_replication_experimental.enabled:true cluster.indices.replication.strategy:SEGMENT`',
+            trim: true
+        )
+        booleanParam(
+            name: 'USE_50_PERCENT_HEAP',
+            description: 'Use 50 percent of physical memory as heap.',
+            defaultValue: false
+        )
+        string(
+            name: 'USER_TAGS',
+            description: 'Attach arbitrary text to the meta-data of each benchmark metric record, without any spaces. e.g., `run-type:adhoc,segrep:enabled,arch:x64`. ',
+            trim: true
+        )
+        string(
+            name: 'WORKLOAD_PARAMS',
+            description: 'With this parameter you can inject variables into workloads. e.g., `number_of_replicas:1,number_of_shards:5`',
+            trim: true
+        )
+        booleanParam(
+            name: 'CAPTURE_NODE_STAT',
+            description: 'Enable opensearch-benchmark node-stats telemetry to capture system level metrics.',
+            defaultValue: false
+        )
+    }
+
+    stages {
+        stage('validate-and-set-parameters') {
+            agent { label AGENT_LABEL }
+            steps {
+                script {
+                    if (BUNDLE_MANIFEST_URL == '') {
+                        currentBuild.result = 'ABORTED'
+                        error("Performance Tests failed to start. Missing parameter: BUNDLE_MANIFEST_URL.")
+                    }
+                    def bundleManifestObj = downloadBuildManifest(
+                        url: BUNDLE_MANIFEST_URL,
+                        path: BUNDLE_MANIFEST
+                    )
+                    String buildId = bundleManifestObj.getArtifactBuildId()
+                    env.BUILD_ID = buildId
+                    env.HAS_SECURITY = bundleManifestObj.components.containsKey("security")
+                    env.ARCHITECTURE = bundleManifestObj.getArtifactArchitecture()
+                    echo "HAS_SECURITY: ${env.HAS_SECURITY}"
+                    lib.jenkins.Messages.new(this).add(JOB_NAME, "Benchmark tests for #${BUILD_ID}")
+                    currentBuild.description = "Running benchmark test for build number: ${BUILD_ID} Manifest: ${BUNDLE_MANIFEST_URL}"
+                }
+            }
+            post {
+                always {
+                    postCleanup()
+                }
+            }
+        }
+        stage('benchmark-test') {
+            parallel {
+                stage('test-with-security') {
+                agent { label AGENT_LABEL }
+                    when {
+                        expression { return env.HAS_SECURITY.toBoolean() }
+                    }
+                    steps {
+                        script {
+                            def bundleManifestObj = downloadBuildManifest(
+                                url: BUNDLE_MANIFEST_URL,
+                                path: BUNDLE_MANIFEST
+                            )
+                            echo "BUNDLE_MANIFEST: ${BUNDLE_MANIFEST}"
+                            echo "BUILD_ID: ${BUILD_ID}"
+                            echo "Architecture: ${ARCHITECTURE}"
+
+                            runBenchmarkTestScript(
+                                bundleManifest: BUNDLE_MANIFEST,
+                                workload: TEST_WORKLOAD,
+                                insecure: "false",
+                                singleNode: SINGLE_NODE_CLUSTER,
+                                minDistribution: MIN_DISTRIBUTION,
+                                use50PercentHeap: USE_50_PERCENT_HEAP,
+                                suffix: "${BUILD_NUMBER}-secure",
+                                managerNodeCount: MANAGER_NODE_COUNT,
+                                dataNodeCount: DATA_NODE_COUNT,
+                                clientNodeCount: CLIENT_NODE_COUNT,
+                                ingestNodeCount: INGEST_NODE_COUNT,
+                                mlNodeCount: ML_NODE_COUNT,
+                                userTag: USER_TAGS.isEmpty() ? "security-enabled:true" : "${USER_TAGS},security-enabled:true",
+                                workloadParams: WORKLOAD_PARAMS,
+                                additionalConfig: ADDITIONAL_CONFIG,
+                                dataStorageSize: DATA_NODE_STORAGE,
+                                mlStorageSize: ML_NODE_STORAGE,
+                                jvmSysProps: JVM_SYS_PROPS,
+                                captureNodeStat: CAPTURE_NODE_STAT
+                            )
+                            lib.jenkins.Messages.new(this).add(JOB_NAME,
+                                lib.jenkins.Messages.new(this).get([JOB_NAME]) +
+                                    "\nBenchmark tests with security for ${BUILD_ID} completed")
+                        }
+                    }
+                    post {
+                        always {
+                            postCleanup()
+                        }
+                    }
+                }
+                stage('test-without-security') {
+                agent { label AGENT_LABEL }
+                    steps {
+                        script {
+                            def bundleManifestObj = downloadBuildManifest(
+                                url: BUNDLE_MANIFEST_URL,
+                                path: BUNDLE_MANIFEST
+                            )
+                            echo "BUNDLE_MANIFEST: ${BUNDLE_MANIFEST}"
+                            echo "BUILD_ID: ${BUILD_ID}"
+                            echo "Architecture: ${ARCHITECTURE}"
+
+                            runBenchmarkTestScript(
+                                bundleManifest: BUNDLE_MANIFEST,
+                                workload: TEST_WORKLOAD,
+                                insecure: "true",
+                                singleNode: SINGLE_NODE_CLUSTER,
+                                minDistribution: MIN_DISTRIBUTION,
+                                use50PercentHeap: USE_50_PERCENT_HEAP,
+                                suffix: "${BUILD_NUMBER}",
+                                managerNodeCount: MANAGER_NODE_COUNT,
+                                dataNodeCount: DATA_NODE_COUNT,
+                                clientNodeCount: CLIENT_NODE_COUNT,
+                                ingestNodeCount: INGEST_NODE_COUNT,
+                                mlNodeCount: ML_NODE_COUNT,
+                                userTag: USER_TAGS.isEmpty() ? "security-enabled:false" : "${USER_TAGS},security-enabled:false",
+                                workloadParams: WORKLOAD_PARAMS,
+                                additionalConfig: ADDITIONAL_CONFIG,
+                                dataStorageSize: DATA_NODE_STORAGE,
+                                mlStorageSize: ML_NODE_STORAGE,
+                                jvmSysProps: JVM_SYS_PROPS,
+                                captureNodeStat: CAPTURE_NODE_STAT
+                            )
+                            lib.jenkins.Messages.new(this).add(JOB_NAME,
+                                lib.jenkins.Messages.new(this).get([JOB_NAME]) +
+                                "\nBenchmark tests without security for ${BUILD_ID} completed")
+                        }
+                    }
+                    post {
+                        always {
+                            postCleanup()
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+    post {
+        success {
+            node(AGENT_LABEL) {
+                script {
+                    def stashed = lib.jenkins.Messages.new(this).get([JOB_NAME])
+                    publishNotification(
+                        icon: ':white_check_mark:',
+                        message: 'Benchmark Tests Successful',
+                        extra: stashed,
+                        credentialsId: 'jenkins-integ-test-webhook',
+                    )
+                    postCleanup()
+                }
+            }
+        }
+        failure {
+            node(AGENT_LABEL) {
+                script {
+                    def stashed = lib.jenkins.Messages.new(this).get([JOB_NAME])
+                    publishNotification(
+                        icon: ':warning:',
+                        message: 'Benchmark Tests Failed',
+                        extra: stashed,
+                        credentialsId: 'jenkins-integ-test-webhook',
+                    )
+                    postCleanup()
+                }
+            }
+        }
+        aborted {
+            node(AGENT_LABEL) {
+                script {
+                    def stackNames = [
+                    "opensearch-infra-stack-${BUILD_NUMBER}-${BUILD_ID}-${ARCHITECTURE}",
+                    "opensearch-infra-stack-${BUILD_NUMBER}-secure-${BUILD_ID}-${ARCHITECTURE}"
+                    ]
+                    withCredentials([string(credentialsId: 'perf-test-account-id', variable: 'PERF_TEST_ACCOUNT_ID')]) {
+                        withAWS(role: 'cfn-set-up', roleAccount: "${PERF_TEST_ACCOUNT_ID}", duration: 900, roleSessionName: 'jenkins-session', region: 'us-east-1') {
+                            try {
+                                for (String stackName : stackNames) {
+                                    def stack = null
+                                    try {
+                                        stack = cfnDescribe(stack: stackName)
+                                    } catch (Exception) {
+                                        echo "Stack '${stackName}' does not exist, nothing to remove"
+                                    }
+                                    if (stack != null) {
+                                        echo "Deleting stack '${stackName}'"
+                                        cfnDelete(stack: stackName, pollInterval:1000)
+                                    }
+                                }
+                            } catch (Exception e) {
+                                error "Exception occurred while deleting the CloudFormation stack: ${e.toString()}"
+                            }
+                        }
+                    }
+                }
+                postCleanup()
+            }
+        }
+    }
+}

--- a/src/test_workflow/benchmark_test/benchmark_args.py
+++ b/src/test_workflow/benchmark_test/benchmark_args.py
@@ -39,6 +39,7 @@ class BenchmarkArgs:
     benchmark_config: IO
     user_tag: str
     target_hosts: str
+    capture_node_stat: bool
     logging_level: int
 
     def __init__(self) -> None:
@@ -85,6 +86,8 @@ class BenchmarkArgs:
         parser.add_argument("--workload-params", dest="workload_params",
                             help="With this parameter you can inject variables into workloads. Parameters differs "
                                  "for each workload type. e.g., --workload-params \"number_of_replicas:1,number_of_shards:5\"")
+        parser.add_argument("--capture-node-stat", dest="capture_node_stat", action="store_true",
+                            help="Enable opensearch-benchmark to capture node stat metrics such as cpu, mem, jvm etc as well.")
         parser.add_argument("-v", "--verbose", help="Show more verbose output.", action="store_const", default=logging.INFO,
                             const=logging.DEBUG, dest="logging_level")
 
@@ -111,4 +114,5 @@ class BenchmarkArgs:
         self.user_tag = args.user_tag if args.user_tag else None
         self.additional_config = json.dumps(args.additional_config) if args.additional_config is not None else None
         self.use_50_percent_heap = args.use_50_percent_heap
+        self.capture_node_stat = args.capture_node_stat
         self.logging_level = args.logging_level

--- a/src/test_workflow/benchmark_test/benchmark_test_suite.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite.py
@@ -34,10 +34,10 @@ class BenchmarkTestSuite:
         self.security = security
         self.args = args
         # Pass the cluster endpoints with -t for multi-cluster use cases(e.g. cross-cluster-replication)
-        self.command = 'docker run'
+        self.command = 'docker run --rm'
         if args.benchmark_config:
             self.command += f" -v {args.benchmark_config}:/opensearch-benchmark/.benchmark/benchmark.ini"
-        self.command += f" opensearchproject/opensearch-benchmark:latest execute_test --workload={self.args.workload} " \
+        self.command += f" opensearchproject/opensearch-benchmark:latest execute-test --workload={self.args.workload} " \
                         f"--pipeline=benchmark-only --target-hosts={endpoint}"
 
         if args.workload_params:
@@ -47,6 +47,9 @@ class BenchmarkTestSuite:
         if args.user_tag:
             user_tag = f"--user-tag=\"{args.user_tag}\""
             self.command += f" {user_tag}"
+
+        if args.capture_node_stat:
+            self.command += " --telemetry node-stats"
 
     def execute(self) -> None:
         if self.security:

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
@@ -14,12 +14,13 @@ from test_workflow.benchmark_test.benchmark_test_suite import BenchmarkTestSuite
 
 class TestBenchmarkTestSuite(unittest.TestCase):
     def setUp(self, config: Optional[str] = None, tag: Optional[str] = None,
-              workload_params: Optional[str] = None) -> None:
+              workload_params: Optional[str] = None, telemetry: Optional[bool] = None) -> None:
         self.args = Mock()
         self.args.workload = "nyc_taxis"
         self.args.benchmark_config = config
         self.args.user_tag = tag
         self.args.workload_params = workload_params
+        self.args.capture_node_stat = telemetry
         self.endpoint = "abc.com"
         self.benchmark_test_suite = BenchmarkTestSuite(endpoint=self.endpoint, security=False, args=self.args)
 
@@ -28,7 +29,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
             self.benchmark_test_suite.execute()
             self.assertEqual(mock_check_call.call_count, 1)
             self.assertEqual(self.benchmark_test_suite.command,
-                             'docker run opensearchproject/opensearch-benchmark:latest execute_test --workload=nyc_taxis '
+                             'docker run --rm opensearchproject/opensearch-benchmark:latest execute-test --workload=nyc_taxis '
                              '--pipeline=benchmark-only --target-hosts=abc.com')
 
     def test_execute_security_enabled(self) -> None:
@@ -37,20 +38,20 @@ class TestBenchmarkTestSuite(unittest.TestCase):
             benchmark_test_suite.execute()
             self.assertEqual(mock_check_call.call_count, 1)
             self.assertEqual(benchmark_test_suite.command,
-                             'docker run opensearchproject/opensearch-benchmark:latest execute_test '
+                             'docker run --rm opensearchproject/opensearch-benchmark:latest execute-test '
                              '--workload=nyc_taxis --pipeline=benchmark-only '
                              '--target-hosts=abc.com --client-options="use_ssl:true,'
                              'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'"')
 
     def test_execute_default_with_optional_args(self) -> None:
-        TestBenchmarkTestSuite.setUp(self, "/home/test/benchmark.ini", "key1:value1,key2:value2", "number_of_replicas:1")
+        TestBenchmarkTestSuite.setUp(self, "/home/test/benchmark.ini", "key1:value1,key2:value2", "number_of_replicas:1", True)
         with patch("subprocess.check_call") as mock_check_call:
             self.benchmark_test_suite.execute()
             self.assertEqual(mock_check_call.call_count, 1)
-            self.assertEqual(self.benchmark_test_suite.command, 'docker run -v /home/test/benchmark.ini:'
+            self.assertEqual(self.benchmark_test_suite.command, 'docker run --rm -v /home/test/benchmark.ini:'
                                                                 '/opensearch-benchmark/.benchmark/benchmark.ini '
-                                                                'opensearchproject/opensearch-benchmark:latest execute_test '
+                                                                'opensearchproject/opensearch-benchmark:latest execute-test '
                                                                 '--workload=nyc_taxis '
                                                                 '--pipeline=benchmark-only --target-hosts=abc.com '
                                                                 '--workload-params "number_of_replicas:1" '
-                                                                '--user-tag="key1:value1,key2:value2"')
+                                                                '--user-tag="key1:value1,key2:value2" --telemetry node-stats')


### PR DESCRIPTION
### Description
This PR adds following:
1. Jenkinsfile for creating benchmark test job. 
2. Adds `--rm` flag to `docker run` command to clean up files and resources after each run. 
3. Adds option to enable `node-stats` telemetry to gather system level metrics during benchmark run. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
