### PR TITLE
Release 1.3.10 commit lock

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -18,8 +18,6 @@ pipeline {
             H 1 * * * %INPUT_MANIFEST=2.7.1/opensearch-dashboards-2.7.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.7.1/opensearch-2.7.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.8.0/opensearch-2.8.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H/60 * * * * %INPUT_MANIFEST=1.3.10/opensearch-dashboards-1.3.10.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H/60 * * * * %INPUT_MANIFEST=1.3.10/opensearch-1.3.10.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=1.4.0/opensearch-1.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm zip
             H 1 * * * %INPUT_MANIFEST=1.4.0/opensearch-dashboards-1.4.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TEST_MANIFEST=3.0.0/opensearch-3.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip

--- a/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
+++ b/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H/60 * * * * %INPUT_MANIFEST=1.3.10/opensearch-1.3.10.yml
+            H 1 * * * %INPUT_MANIFEST=1.3.10/opensearch-1.3.10.yml
         '''
     }
     parameters {

--- a/manifests/1.3.10/opensearch-1.3.10.yml
+++ b/manifests/1.3.10/opensearch-1.3.10.yml
@@ -10,13 +10,13 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: '1.3'
+    ref: b2150b9f6f6c8a15059ef415d3e24bdedd3e253c
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: '1.3'
+    ref: c224695d6250ca8f96869773c61d86bbf0972a7d
     checks:
       - gradle:publish
       - gradle:properties:version
@@ -25,7 +25,7 @@ components:
       - windows
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: '1.3'
+    ref: 019acf326223e0d657cf94871a2930addcfdd4dd
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -34,7 +34,7 @@ components:
       - windows
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: '1.3'
+    ref: b456af60afd11a74ae95378e138e0ba5803ff2df
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
@@ -43,7 +43,7 @@ components:
       - windows
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: '1.3'
+    ref: 2be0f46878b192b954c53b57b14f4756c8b8364d
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
@@ -52,7 +52,7 @@ components:
       - windows
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: '1.3'
+    ref: e1592dd601013957732d32658740efd051f09c35
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -61,7 +61,7 @@ components:
       - windows
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: '1.3'
+    ref: b679711a29d4954912b6ad90059677062f2ec7ba
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -69,7 +69,7 @@ components:
       - linux
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: '1.3'
+    ref: 9cef2aa75d1d8a2b3c13a7bbb0adc4ba609812f3
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
@@ -78,7 +78,7 @@ components:
       - windows
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: '1.3'
+    ref: b9d18f818fec38d38632731da11ad0ba164355eb
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -87,7 +87,7 @@ components:
       - windows
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: '1.3'
+    ref: 2aad6dc346e6fda7579d21f35cde3543b3a5ed11
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -96,7 +96,7 @@ components:
       - windows
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '1.3'
+    ref: 87c8e468f4c47bea0a140b52e39197aef4ff45ba
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -105,7 +105,7 @@ components:
       - windows
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: '1.3'
+    ref: 8fb7684ae4d336d9f60c51c009f57f2408dcc86d
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -114,7 +114,7 @@ components:
       - windows
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: '1.3'
+    ref: d9ce057608b85afc552631d2e19aef6ab2480817
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -123,7 +123,7 @@ components:
       - windows
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '1.3'
+    ref: f56a4cabb5cf34690c7366af21d7fc4b750892d4
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -132,7 +132,7 @@ components:
       - windows
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: '1.3'
+    ref: ecb2f8c157edf73ef655fc5c3f6791cc012db992
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/1.3.10/opensearch-dashboards-1.3.10.yml
+++ b/manifests/1.3.10/opensearch-dashboards-1.3.10.yml
@@ -9,32 +9,32 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: '1.3'
+    ref: 97a1ec1911824adcef143f17c2c12ba86955ae65
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '1.3'
+    ref: 510f8fd38311690bf44e7d24b1cd71a5751fc6af
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: '1.3'
+    ref: 3e6425c22cc52167a24894a50461b51668e5c701
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
     working_directory: gantt-chart
-    ref: '1.3'
+    ref: c6a89251760730dc88ea18301b954f5b789e20af
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
-    ref: '1.3'
+    ref: 551fd9071deb84f37bd7d6f81e5d56827ce5523f
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: '1.3'
+    ref: 6ca72c2f42481a987d40f822b81d2b86b66158b2
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
-    ref: '1.3'
+    ref: 21eede6ffae429f95183a05b9b3e5d3be2a85ccd
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
-    ref: '1.3'
+    ref: a0ab4e48c2b9cdc3e1a17e8b0830f7945b8cc523
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '1.3'
+    ref: c1fc06d691bb07d67ea38712a0498e44a1090605
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
-    ref: '1.3'
+    ref: 3c9ee43de6c8457d7745d171fcd76653c66d9ecf


### PR DESCRIPTION
### Description
Locking the commit from RC build manifest [OS](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.10/7848/linux/x64/tar/dist/opensearch/manifest.yml), [OSD](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.10/6126/linux/x64/tar/builds/opensearch-dashboards/manifest.yml).

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/3331

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
