### PR TITLE
Resolve securityDashboards not correctly removed on DEB/RPM

### DIFF
--- a/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
@@ -98,7 +98,7 @@ RUN dnf install -y sudo && \
     useradd -u 1000 -g 1000 -d /usr/share/opensearch opensearch && \
     mkdir -p /usr/share/opensearch && \
     chown -R 1000:1000 /usr/share/opensearch && \
-    echo "opensearch ALL=(root) NOPASSWD:`which systemctl`, `which dnf`, `which yum`, `which rpm`, `which chmod`, `which kill`, `which curl`" >> /etc/sudoers.d/opensearch
+    echo "opensearch ALL=(root) NOPASSWD:`which systemctl`, `which dnf`, `which yum`, `which rpm`, `which chmod`, `which kill`, `which curl`, /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin" >> /etc/sudoers.d/opensearch
 
 # Copy from Stage0
 COPY --from=linux_stage_0 --chown=1000:1000 /usr/share/opensearch /usr/share/opensearch

--- a/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
@@ -117,7 +117,7 @@ RUN apt-get install -y sudo && \
     useradd -u 1000 -g 1000 -s /bin/bash -d /usr/share/opensearch opensearch && \
     mkdir -p /usr/share/opensearch && \
     chown -R 1000:1000 /usr/share/opensearch && \
-    echo "opensearch ALL=(root) NOPASSWD:`which systemctl`, `which apt`, `which apt-get`, `which apt-key`, `which dpkg`, `which chmod`, `which kill`, `which curl`, `which tee`" >> /etc/sudoers.d/opensearch
+    echo "opensearch ALL=(root) NOPASSWD:`which systemctl`, `which apt`, `which apt-get`, `which apt-key`, `which dpkg`, `which chmod`, `which kill`, `which curl`, `which tee`, /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin" >> /etc/sudoers.d/opensearch
 
 # Copy from Stage0
 COPY --from=linux_stage_0 --chown=1000:1000 /usr/share/opensearch /usr/share/opensearch

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -67,7 +67,9 @@ class ServiceOpenSearchDashboards(Service):
     def __remove_security(self) -> None:
         self.security_plugin_dir = os.path.join(self.install_dir, "plugins", "securityDashboards")
         if os.path.isdir(self.security_plugin_dir):
-            plugin_script = "opensearch-dashboards-plugin.bat" if current_platform() == "windows" else "bash opensearch-dashboards-plugin"
+            plugin_script = "opensearch-dashboards-plugin.bat" if current_platform() == "windows" else "opensearch-dashboards-plugin"
+            plugin_script = os.path.join(self.executable_dir, plugin_script)
+            plugin_script = "sudo " + plugin_script if self.dist.require_sudo is True else plugin_script
             subprocess.check_call(f"{plugin_script} remove --allow-root securityDashboards", cwd=self.executable_dir, shell=True)
 
         with open(self.opensearch_dashboards_yml_path, "w") as yamlfile:

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -120,10 +120,12 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
             [call(os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "config", "opensearch_dashboards.yml"), "a")],
         )
 
-        plugin_script = "opensearch-dashboards-plugin.bat" if current_platform() == "windows" else "bash opensearch-dashboards-plugin"
+        cwd_path = os.path.join("test_work_dir", "opensearch-dashboards-1.1.0", "bin")
+        plugin_script = "opensearch-dashboards-plugin.bat" if current_platform() == "windows" else "opensearch-dashboards-plugin"
+        plugin_script = os.path.join(cwd_path, plugin_script)
         mock_check_call.assert_called_once_with(
             f"{plugin_script} remove --allow-root securityDashboards",
-            cwd=os.path.join("test_work_dir", "opensearch-dashboards-1.1.0", "bin"),
+            cwd=cwd_path,
             shell=True
         )
 

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -123,6 +123,7 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         cwd_path = os.path.join("test_work_dir", "opensearch-dashboards-1.1.0", "bin")
         plugin_script = "opensearch-dashboards-plugin.bat" if current_platform() == "windows" else "opensearch-dashboards-plugin"
         plugin_script = os.path.join(cwd_path, plugin_script)
+        plugin_script = "sudo " + plugin_script if service.dist.require_sudo is True else plugin_script
         mock_check_call.assert_called_once_with(
             f"{plugin_script} remove --allow-root securityDashboards",
             cwd=cwd_path,


### PR DESCRIPTION
### Description
Resolve securityDashboards not correctly removed on DEB/RPM.
If `sudo` is not applied to DEB/RPM plugin removal, the run will still goes to success and return 0, despite the plugin directory is still there.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3331

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
