### PR TITLE
Bump opensearch-build-library version to 4.2.1

### DIFF
--- a/jenkins/opensearch/benchmark-test.jenkinsfile
+++ b/jenkins/opensearch/benchmark-test.jenkinsfile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@4.2.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@4.2.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Bump opensearch-build-library version to 4.2.1. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
