### PR TITLE
Update 3.0.0 manifest to use JDK-19

### DIFF
--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -6,7 +6,7 @@ build:
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2
-    args: -e JAVA_HOME=/opt/java/openjdk-20
+    args: -e JAVA_HOME=/opt/java/openjdk-19
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git


### PR DESCRIPTION
### Description
Update 3.0.0 manifest to use JDK-19 (till JDK-20 distribution for Linux/ppc64le become available)

### Issues Resolved
We are still blocked on https://github.com/opensearch-project/OpenSearch/pull/7344, the Linux/ppc64le is still not released and distribution builds fail. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
