### PR TITLE
 Make cypress@9.5.4 install from pre-compiled archive 

### DIFF
--- a/docker/ci/dockerfiles/current/build.ubuntu2004.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.ubuntu2004.opensearch.x64.arm64.dockerfile
@@ -45,7 +45,7 @@ RUN /tmp/jdk-setup.sh && /tmp/yq-setup.sh
 
 # Create user group
 RUN groupadd -g 1000 opensearch && \
-    useradd -u 1000 -g 1000 -d /usr/share/opensearch opensearch && \
+    useradd -u 1000 -g 1000 -d /usr/share/opensearch -m opensearch && \
     mkdir -p /usr/share/opensearch && \
     chown -R 1000:1000 /usr/share/opensearch 
 

--- a/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
@@ -43,6 +43,7 @@ WORKDIR /usr/share/opensearch
 ENV NVM_DIR /usr/share/opensearch/.nvm
 ENV NODE_VERSION 18.16.0
 ENV CYPRESS_VERSION 12.13.0
+ARG CYPRESS_VERSION_LIST="5.6.0 9.5.4 12.13.0"
 ENV CYPRESS_LOCATION /usr/share/opensearch/.cache/Cypress/$CYPRESS_VERSION
 ENV CYPRESS_LOCATION_954 /usr/share/opensearch/.cache/Cypress/9.5.4
 # install nvm
@@ -61,24 +62,18 @@ COPY --chown=1000:1000 config/yarn-version.sh /tmp
 RUN npm install -g yarn@`/tmp/yarn-version.sh main`
 # install cypress last known version that works for all existing opensearch-dashboards plugin integtests
 RUN npm install -g cypress@$CYPRESS_VERSION && npm cache verify
-# Add legacy cypress@9.5.4 for pre-2.8.0 releases
-RUN npm install -g cypress@9.5.4 && npm cache verify
 # Add legacy cypress@5.6.0 for 1.x line
-RUN npm install -g cypress@5.6.0 && npm cache verify
+# Add legacy cypress@9.5.4 for pre-2.8.0 releases
+# Add latest cypress@12.13.0 for post-2.8.0 releases
+RUN for cypress_version in $CYPRESS_VERSION_LIST; do npm install -g cypress@$cypress_version && npm cache verify; done
 
 # Need root to get pass the build due to chrome sandbox needs to own by the root
 USER 0
-# Build ARM64 Cypress for legacy cypress@9.5.4 versions (cypress 12 has native arm64 binaries)
-COPY --chown=0:0 config/cypress-setup.sh /tmp
-RUN if [ `uname -m` = "aarch64" ]; then echo compile arm64 cypress@9.5.4 && /tmp/cypress-setup.sh 9.5.4; fi
-# Replace default binary with arm64 specific binary
-RUN if [ `uname -m` = "aarch64" ]; then rm -rf $CYPRESS_LOCATION_954/* && \
-    unzip -q /tmp/cypress-9.5.4.zip -d $CYPRESS_LOCATION_954/ && chown 1000:1000 -R $CYPRESS_LOCATION_954; fi && rm -rf /tmp/cypress*
 
-# Add legacy cypress@5.6.0 for ARM64 Architecture
-RUN if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
-    curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-5.6.0-arm64.tar.gz && tar -xzf Cypress-5.6.0-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
-    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/5.6.0 && rm -vf Cypress-5.6.0-arm64.tar.gz; fi
+# Add legacy cypress 5.6.0 / 9.5.4 for ARM64 Architecture
+RUN if [ `uname -m` = "aarch64" ]; then for cypress_version in 5.6.0 9.5.4; do rm -rf /usr/share/opensearch/.cache/Cypress/$cypress_version && \
+    curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-$cypress_version-arm64.tar.gz && tar -xzf Cypress-$cypress_version-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
+    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/$cypress_version && rm -vf Cypress-5.6.0-arm64.tar.gz; done; fi
 
 ########################### Stage 1 ########################
 FROM rockylinux:8

--- a/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
@@ -71,7 +71,7 @@ USER 0
 # Add legacy cypress 5.6.0 / 9.5.4 for ARM64 Architecture
 RUN if [ `uname -m` = "aarch64" ]; then for cypress_version in 5.6.0 9.5.4; do rm -rf /usr/share/opensearch/.cache/Cypress/$cypress_version && \
     curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-$cypress_version-arm64.tar.gz && tar -xzf Cypress-$cypress_version-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
-    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/$cypress_version && rm -vf Cypress-5.6.0-arm64.tar.gz; done; fi
+    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/$cypress_version && rm -vf Cypress-$cypress_version-arm64.tar.gz; done; fi
 
 ########################### Stage 1 ########################
 FROM rockylinux:8

--- a/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
@@ -60,8 +60,6 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 # install yarn
 COPY --chown=1000:1000 config/yarn-version.sh /tmp
 RUN npm install -g yarn@`/tmp/yarn-version.sh main`
-# install cypress last known version that works for all existing opensearch-dashboards plugin integtests
-RUN npm install -g cypress@$CYPRESS_VERSION && npm cache verify
 # Add legacy cypress@5.6.0 for 1.x line
 # Add legacy cypress@9.5.4 for pre-2.8.0 releases
 # Add latest cypress@12.13.0 for post-2.8.0 releases

--- a/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
@@ -48,6 +48,7 @@ WORKDIR /usr/share/opensearch
 ENV NVM_DIR /usr/share/opensearch/.nvm
 ENV NODE_VERSION 18.16.0
 ENV CYPRESS_VERSION 12.13.0
+ARG CYPRESS_VERSION_LIST="5.6.0 9.5.4 12.13.0"
 ENV CYPRESS_LOCATION /usr/share/opensearch/.cache/Cypress/$CYPRESS_VERSION
 ENV CYPRESS_LOCATION_954 /usr/share/opensearch/.cache/Cypress/9.5.4
 # install nvm
@@ -64,26 +65,18 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 # install yarn
 COPY --chown=1000:1000 config/yarn-version.sh /tmp
 RUN npm install -g yarn@`/tmp/yarn-version.sh main`
-# install cypress last known version that works for all existing opensearch-dashboards plugin integtests
-RUN npm install -g cypress@$CYPRESS_VERSION && npm cache verify
-# Add legacy cypress@9.5.4 for pre-2.8.0 releases
-RUN npm install -g cypress@9.5.4 && npm cache verify
 # Add legacy cypress@5.6.0 for 1.x line
-RUN npm install -g cypress@5.6.0 && npm cache verify
+# Add legacy cypress@9.5.4 for pre-2.8.0 releases
+# Add latest cypress@12.13.0 for post-2.8.0 releases
+RUN for cypress_version in $CYPRESS_VERSION_LIST; do npm install -g cypress@$cypress_version && npm cache verify; done
 
 # Need root to get pass the build due to chrome sandbox needs to own by the root
 USER 0
-# Build ARM64 Cypress for legacy cypress@9.5.4 versions (cypress 12 has native arm64 binaries)
-COPY --chown=0:0 config/cypress-setup.sh /tmp
-RUN if [ `uname -m` = "aarch64" ]; then echo compile arm64 cypress@9.5.4 && /tmp/cypress-setup.sh 9.5.4; fi
-# Replace default binary with arm64 specific binary
-RUN if [ `uname -m` = "aarch64" ]; then rm -rf $CYPRESS_LOCATION_954/* && \
-    unzip -q /tmp/cypress-9.5.4.zip -d $CYPRESS_LOCATION_954/ && chown 1000:1000 -R $CYPRESS_LOCATION_954; fi && rm -rf /tmp/cypress*
 
-# Add legacy cypress@5.6.0 for ARM64 Architecture
-RUN if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
-    curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-5.6.0-arm64.tar.gz && tar -xzf Cypress-5.6.0-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
-    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/5.6.0 && rm -vf Cypress-5.6.0-arm64.tar.gz; fi
+# Add legacy cypress 5.6.0 / 9.5.4 for ARM64 Architecture
+RUN if [ `uname -m` = "aarch64" ]; then for cypress_version in 5.6.0 9.5.4; do rm -rf /usr/share/opensearch/.cache/Cypress/$cypress_version && \
+    curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-$cypress_version-arm64.tar.gz && tar -xzf Cypress-$cypress_version-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
+    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/$cypress_version && rm -vf Cypress-5.6.0-arm64.tar.gz; done; fi
 
 ########################### Stage 1 ########################
 FROM rockylinux:8

--- a/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
@@ -76,7 +76,7 @@ USER 0
 # Add legacy cypress 5.6.0 / 9.5.4 for ARM64 Architecture
 RUN if [ `uname -m` = "aarch64" ]; then for cypress_version in 5.6.0 9.5.4; do rm -rf /usr/share/opensearch/.cache/Cypress/$cypress_version && \
     curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-$cypress_version-arm64.tar.gz && tar -xzf Cypress-$cypress_version-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
-    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/$cypress_version && rm -vf Cypress-5.6.0-arm64.tar.gz; done; fi
+    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/$cypress_version && rm -vf Cypress-$cypress_version-arm64.tar.gz; done; fi
 
 ########################### Stage 1 ########################
 FROM rockylinux:8

--- a/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
@@ -46,6 +46,7 @@ WORKDIR /usr/share/opensearch
 ENV NVM_DIR /usr/share/opensearch/.nvm
 ENV NODE_VERSION 18.16.0
 ENV CYPRESS_VERSION 12.13.0
+ARG CYPRESS_VERSION_LIST="5.6.0 9.5.4 12.13.0"
 ENV CYPRESS_LOCATION /usr/share/opensearch/.cache/Cypress/$CYPRESS_VERSION
 ENV CYPRESS_LOCATION_954 /usr/share/opensearch/.cache/Cypress/9.5.4
 # install nvm
@@ -62,26 +63,18 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 # install yarn
 COPY --chown=1000:1000 config/yarn-version.sh /tmp
 RUN npm install -g yarn@`/tmp/yarn-version.sh main`
-# install cypress last known version that works for all existing opensearch-dashboards plugin integtests
-RUN npm install -g cypress@$CYPRESS_VERSION && npm cache verify
-# Add legacy cypress@9.5.4 for pre-2.8.0 releases
-RUN npm install -g cypress@9.5.4 && npm cache verify
 # Add legacy cypress@5.6.0 for 1.x line
-RUN npm install -g cypress@5.6.0 && npm cache verify
+# Add legacy cypress@9.5.4 for pre-2.8.0 releases
+# Add latest cypress@12.13.0 for post-2.8.0 releases
+RUN for cypress_version in $CYPRESS_VERSION_LIST; do npm install -g cypress@$cypress_version && npm cache verify; done
 
 # Need root to get pass the build due to chrome sandbox needs to own by the root
 USER 0
-# Build ARM64 Cypress for legacy cypress@9.5.4 versions (cypress 12 has native arm64 binaries)
-COPY --chown=0:0 config/cypress-setup.sh /tmp
-RUN if [ `uname -m` = "aarch64" ]; then echo compile arm64 cypress@9.5.4 && /tmp/cypress-setup.sh 9.5.4; fi
-# Replace default binary with arm64 specific binary
-RUN if [ `uname -m` = "aarch64" ]; then rm -rf $CYPRESS_LOCATION_954/* && \
-    unzip -q /tmp/cypress-9.5.4.zip -d $CYPRESS_LOCATION_954/ && chown 1000:1000 -R $CYPRESS_LOCATION_954; fi && rm -rf /tmp/cypress*
 
-# Add legacy cypress@5.6.0 for ARM64 Architecture
-RUN if [ `uname -m` = "aarch64" ]; then rm -rf /usr/share/opensearch/.cache/Cypress/5.6.0 && \
-    curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-5.6.0-arm64.tar.gz && tar -xzf Cypress-5.6.0-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
-    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/5.6.0 && rm -vf Cypress-5.6.0-arm64.tar.gz; fi
+# Add legacy cypress 5.6.0 / 9.5.4 for ARM64 Architecture
+RUN if [ `uname -m` = "aarch64" ]; then for cypress_version in 5.6.0 9.5.4; do rm -rf /usr/share/opensearch/.cache/Cypress/$cypress_version && \
+    curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-$cypress_version-arm64.tar.gz && tar -xzf Cypress-$cypress_version-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
+    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/$cypress_version && rm -vf Cypress-5.6.0-arm64.tar.gz; done; fi
 
 ########################### Stage 1 ########################
 FROM ubuntu:20.04

--- a/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
@@ -74,7 +74,7 @@ USER 0
 # Add legacy cypress 5.6.0 / 9.5.4 for ARM64 Architecture
 RUN if [ `uname -m` = "aarch64" ]; then for cypress_version in 5.6.0 9.5.4; do rm -rf /usr/share/opensearch/.cache/Cypress/$cypress_version && \
     curl -SLO https://ci.opensearch.org/ci/dbc/tools/Cypress-$cypress_version-arm64.tar.gz && tar -xzf Cypress-$cypress_version-arm64.tar.gz -C /usr/share/opensearch/.cache/Cypress/ && \
-    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/$cypress_version && rm -vf Cypress-5.6.0-arm64.tar.gz; done; fi
+    chown 1000:1000 -R /usr/share/opensearch/.cache/Cypress/$cypress_version && rm -vf Cypress-$cypress_version-arm64.tar.gz; done; fi
 
 ########################### Stage 1 ########################
 FROM ubuntu:20.04

--- a/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
@@ -33,7 +33,7 @@ RUN /tmp/yq-setup.sh
 
 # Create user group
 RUN groupadd -g 1000 opensearch && \
-    useradd -u 1000 -g 1000 -s /bin/bash -d /usr/share/opensearch opensearch && \
+    useradd -u 1000 -g 1000 -s /bin/bash -d /usr/share/opensearch -m opensearch && \
     mkdir -p /usr/share/opensearch && \
     chown -R 1000:1000 /usr/share/opensearch 
 


### PR DESCRIPTION
### Description
Make cypress@9.5.4 install from pre-compiled archive.
https://build.ci.opensearch.org/job/docker-build/3428/console

With node now using 18 instead of 16, cypress@9.5.4 is not able to compile anymore.
Using the same method as 5.6.0 where a pre-compiled cache package will be downloaded during the image build.

Both 5.6.0 and 9.5.4 are legacy now.

Thanks.

### Issues Resolved
#3434
https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/408

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
