### PR TITLE
Add notification plugin to 2.8.0 manifest

### DIFF
--- a/manifests/2.8.0/opensearch-2.8.0.yml
+++ b/manifests/2.8.0/opensearch-2.8.0.yml
@@ -91,3 +91,23 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: notifications-core
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: '2.8'
+    platforms:
+      - linux
+      - windows
+    working_directory: notifications
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: opensearch-notifications-core
+  - name: notifications
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: '2.8'
+    platforms:
+      - linux
+      - windows
+    working_directory: notifications
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: notifications


### PR DESCRIPTION
### Description
Add notification plugin to 2.8.0 manifest.

### Issues Resolved
https://github.com/opensearch-project/notifications/issues/681

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
