### PR TITLE
Add additional cluster config support in OSD integTest

### DIFF
--- a/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
@@ -80,13 +80,16 @@ class IntegTestSuiteOpenSearchDashboards(IntegTestSuite):
 
     def __setup_cluster_and_execute_test_config(self, config: str) -> int:
         security = self.is_security_enabled(config)
+        if "additional-cluster-configs" in self.test_config.integ_test.keys():
+            self.additional_cluster_config = self.test_config.integ_test.get("additional-cluster-configs")
+            logging.info(f"Additional config found: {self.additional_cluster_config}")
 
         with LocalTestClusterOpenSearchDashboards.create(
             self.dependency_installer,
             self.dependency_installer_opensearch_dashboards,
             self.work_dir,
             self.component.name,
-            {},
+            self.additional_cluster_config,
             self.bundle_manifest,
             self.bundle_manifest_opensearch_dashboards,
             security,

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -50,6 +50,11 @@ class ServiceOpenSearchDashboards(Service):
 
         self.__set_logging_dest()
 
+        # Newer version of NodeJS (16/18) might introduced bug when running test against localhost using cypress
+        # https://github.com/cypress-io/github-action/issues/811
+        # Temporarily set these additional configs to resolve the issue
+        self.additional_config["server.host"] = '0.0.0.0'
+
         if self.additional_config:
             self.__add_plugin_specific_config(self.additional_config)
 

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch_dashboards.py
@@ -29,7 +29,7 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
 
         self.test_config = MagicMock()
         self.test_config.working_directory = "test_working_directory"
-        self.test_config.integ_test = {"test-configs": ['with-security', 'without-security']}
+        self.test_config.integ_test = {"test-configs": ['with-security', 'without-security'], "additional-cluster-configs": {'server.host': '0.0.0.0'}}
 
         self.bundle_manifest_opensearch = MagicMock()
         self.bundle_manifest_opensearch.build.version = "1.2.0"
@@ -93,6 +93,8 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
             call("test_endpoint", 1234, False, "without-security")
         ])
 
+        self.assertEqual(str(suite.additional_cluster_config), "{'server.host': '0.0.0.0'}")
+
     # test base class
 
     @patch("os.path.exists")
@@ -150,6 +152,7 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
             }
         )
         assert(mock_test_result_data.return_value in suite.result_data)
+        self.assertEqual(suite.additional_cluster_config, None)
 
     @patch("os.path.exists")
     @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.TestResultData")
@@ -188,6 +191,8 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
         mock_execute.assert_not_called()
         mock_test_result_data.assert_not_called()
         self.save_logs.assert_not_called()
+        
+        self.assertEqual(suite.additional_cluster_config, None)
 
     @patch("os.path.exists")
     @patch("test_workflow.integ_test.integ_test_suite_opensearch_dashboards.TestResultData")
@@ -225,6 +230,8 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
             suite.is_security_enabled("random-config")
 
         self.assertEqual(str(ctx.exception), "Unsupported test config: random-config")
+
+        self.assertEqual(suite.additional_cluster_config, None)
 
     @patch("test_workflow.integ_test.integ_test_suite.logging")
     @patch("os.path.exists")

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch_dashboards.py
@@ -191,7 +191,6 @@ class TestIntegSuiteOpenSearchDashboards(unittest.TestCase):
         mock_execute.assert_not_called()
         mock_test_result_data.assert_not_called()
         self.save_logs.assert_not_called()
-        
         self.assertEqual(suite.additional_cluster_config, None)
 
     @patch("os.path.exists")

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -67,7 +67,8 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         mock_dump.assert_called_once_with(
             {
                 "script.context.field.max_compilations_rate": "1000/1m",
-                "logging.dest": os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log")
+                "logging.dest": os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log"),
+                "server.host": "0.0.0.0"
             }
         )
         mock_file.return_value.write.assert_called_once_with(mock_dump_result)
@@ -131,7 +132,7 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         )
 
         mock_dump.assert_called_once_with({"logging.dest": os.path.join(
-            self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log")})
+            self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log"), 'server.host': '0.0.0.0'})
 
         mock_file_handler_for_security.close.assert_called_once()
         mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result)
@@ -193,7 +194,7 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         )
 
         mock_dump.assert_called_once_with({"logging.dest": os.path.join(
-            self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log")})
+            self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log"), 'server.host': '0.0.0.0'})
 
         mock_file_handler_for_security.close.assert_called_once()
         mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result)


### PR DESCRIPTION
### Description
Add additional cluster config support in OSD integTest

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3589 partially
#3434

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
