### PR TITLE
Add 300sec client timeout to benchmark command

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_test_suite.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite.py
@@ -53,6 +53,8 @@ class BenchmarkTestSuite:
 
     def execute(self) -> None:
         if self.security:
-            self.command += ' --client-options="use_ssl:true,verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'"'
+            self.command += ' --client-options="timeout:300,use_ssl:true,verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'"'
+        else:
+            self.command += ' --client-options="timeout:300"'
         logging.info(f"Executing {self.command}")
         subprocess.check_call(f"{self.command}", cwd=os.getcwd(), shell=True)

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
@@ -30,7 +30,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
             self.assertEqual(mock_check_call.call_count, 1)
             self.assertEqual(self.benchmark_test_suite.command,
                              'docker run --rm opensearchproject/opensearch-benchmark:latest execute-test --workload=nyc_taxis '
-                             '--pipeline=benchmark-only --target-hosts=abc.com')
+                             '--pipeline=benchmark-only --target-hosts=abc.com --client-options="timeout:300"')
 
     def test_execute_security_enabled(self) -> None:
         benchmark_test_suite = BenchmarkTestSuite(endpoint=self.endpoint, security=True, args=self.args)
@@ -40,7 +40,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
             self.assertEqual(benchmark_test_suite.command,
                              'docker run --rm opensearchproject/opensearch-benchmark:latest execute-test '
                              '--workload=nyc_taxis --pipeline=benchmark-only '
-                             '--target-hosts=abc.com --client-options="use_ssl:true,'
+                             '--target-hosts=abc.com --client-options="timeout:300,use_ssl:true,'
                              'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'"')
 
     def test_execute_default_with_optional_args(self) -> None:
@@ -54,4 +54,4 @@ class TestBenchmarkTestSuite(unittest.TestCase):
                                                                 '--workload=nyc_taxis '
                                                                 '--pipeline=benchmark-only --target-hosts=abc.com '
                                                                 '--workload-params "number_of_replicas:1" '
-                                                                '--user-tag="key1:value1,key2:value2" --telemetry node-stats')
+                                                                '--user-tag="key1:value1,key2:value2" --telemetry node-stats --client-options="timeout:300"')


### PR DESCRIPTION
### Description
Add 300sec client timeout to benchmark command. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
