### PR TITLE
Update 3.0.0 manifest to use JDK-20

### DIFF
--- a/manifests/3.0.0/opensearch-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-3.0.0-test.yml
@@ -4,7 +4,7 @@ name: OpenSearch
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2
-    args: -e JAVA_HOME=/opt/java/openjdk-17
+    args: -e JAVA_HOME=/opt/java/openjdk-20
 components:
   - name: cross-cluster-replication
     integ-test:

--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -6,7 +6,7 @@ build:
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2
-    args: -e JAVA_HOME=/opt/java/openjdk-17
+    args: -e JAVA_HOME=/opt/java/openjdk-20
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git


### PR DESCRIPTION
### Description
Finally, https://github.com/opensearch-project/OpenSearch/pull/7344 is merged, we could use JDK-20 to build and run OpenSearch 3.x

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/3425

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
