### PR TITLE
Update ubuntu image chromium installation methods

### DIFF
--- a/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
@@ -85,8 +85,9 @@ USER 0
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install python37 dependencies
-RUN apt-get update -y && apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa -y
+# Install python37 dependencies and chromium dependencies
+RUN apt-get update -y && apt-get install -y software-properties-common && add-apt-repository ppa:deadsnakes/ppa -y && \
+    add-apt-repository ppa:saiarcot895/chromium-beta -y
 
 # Install python37 binaries
 RUN apt-get update -y && apt-get install python3 && \


### PR DESCRIPTION
### Description
Update ubuntu image chromium installation methods.

In Ubuntu snap is required to install chromium correctly, where it is not easy to get running on docker.
Switch to https://github.com/saiarcot895/chromium-ubuntu-build to install non-snap version of chromium.

### Issues Resolved
#3434

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
