### PR TITLE
Fix broken manifest workflow

### DIFF
--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -16,7 +16,7 @@ on:
           - warning
           - debug
 jobs:
-  osd-plugin-version-increment:
+  plugin-version-increment-sync:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -7,7 +7,6 @@
 
 import os
 import unittest
-from typing import Any
 from unittest.mock import MagicMock, call, mock_open, patch
 
 from manifests_workflow.input_manifests import InputManifests
@@ -129,17 +128,25 @@ class TestInputManifests(unittest.TestCase):
             f"TARGET_JOB_NAME=distribution-build-test;BUILD_PLATFORM=linux;BUILD_DISTRIBUTION=tar\n"
         )
 
-    def test_versionincrement_workflow(self) -> None:
+    def test_os_versionincrement_workflow(self) -> None:
         self.assertEqual(
-            InputManifests.versionincrement_workflow(),
-            os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", ".github", "workflows", "increment-plugin-versions.yml"))
+            InputManifests.os_versionincrement_workflow(),
+            os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", ".github", "workflows", "os-increment-plugin-versions.yml"))
         )
+        self.assertTrue(os.path.exists(InputManifests.os_versionincrement_workflow()))
 
-    @patch("builtins.open", new_callable=mock_open)
+    def test_osd_versionincrement_workflow(self) -> None:
+        self.assertEqual(
+            InputManifests.osd_versionincrement_workflow(),
+            os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", ".github", "workflows", "osd-increment-plugin-versions.yml"))
+        )
+        self.assertTrue(os.path.exists(InputManifests.osd_versionincrement_workflow()))
+
     @patch("manifests_workflow.input_manifests.InputManifests.add_to_versionincrement_workflow")
-    def test_add_to_versionincrement_workflow(self, *mocks: Any) -> None:
+    def test_add_to_versionincrement_workflow(self, mock_add_to_versionincrement_workflow: MagicMock) -> None:
         input_manifests = InputManifests("test")
-        input_manifests.add_to_versionincrement_workflow('0.1.2')
+        input_manifests.add_to_versionincrement_workflow('1.0.0')
+        mock_add_to_versionincrement_workflow.assert_called_with("1.0.0")
 
     def test_create_manifest_with_components(self) -> None:
         pass


### PR DESCRIPTION
### Description
Fix broken manifest workflow: https://build.ci.opensearch.org/job/manifest-update/49/console
and modify the code to update the `osd-increment-plugin-versions.yml` workflow with new branch entry.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3610

### Test on local
Updated the workflow files
```

Adding 2.9 to /usr/share/opensearch/git/opensearch-build/.github/workflows/os-increment-plugin-versions.yml
2023-06-08 21:48:16 INFO     Added new version to the version increment workflow
Adding 2.9 to /usr/share/opensearch/git/opensearch-build/.github/workflows/osd-increment-plugin-versions.yml
2023-06-08 21:48:16 INFO     Added new version to the version increment workflow
```

git status: Added new manifests
```

# On branch main
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#
#	modified:   .github/workflows/os-increment-plugin-versions.yml
#	modified:   .github/workflows/osd-increment-plugin-versions.yml
#	modified:   jenkins/check-for-build.jenkinsfile
#
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#	manifests/2.8.1/
#	manifests/2.9.0/

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
