### PR TITLE
Bug fix for docker validation digest mismatch in arm64 

### DIFF
--- a/src/validation_workflow/docker/inspect_docker_image.py
+++ b/src/validation_workflow/docker/inspect_docker_image.py
@@ -57,7 +57,7 @@ class InspectDockerImage:
         logging.info(f'{dockerHub_repo_digest} <-- DockerHub image repon digest {self.image_name.replace("opensearchproject", "opensearchstaging")}:{self.image_tag}')
 
         logging.info('Fetching mainfest from local')
-        local_inspect = f"docker image inspect --format '{{{{json .}}}}' {self.image_id} | jq -r '. | {{RepoDigests: .RepoDigests}}'"      
+        local_inspect = f"docker image inspect --format '{{{{json .}}}}' {self.image_id} | jq -r '. | {{RepoDigests: .RepoDigests}}'"
         result = subprocess.run(local_inspect, shell=True, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         response_dict = json.loads(result.stdout)
         local_image_digests = response_dict['RepoDigests']

--- a/src/validation_workflow/docker/inspect_docker_image.py
+++ b/src/validation_workflow/docker/inspect_docker_image.py
@@ -57,7 +57,7 @@ class InspectDockerImage:
         logging.info(f'{dockerHub_repo_digest} <-- DockerHub image repon digest {self.image_name.replace("opensearchproject", "opensearchstaging")}:{self.image_tag}')
 
         logging.info('Fetching mainfest from local')
-        local_inspect = f"docker image inspect --format '{{{{json .}}}}' {self.image_id} | jq -r '. | {{RepoDigests: .RepoDigests[] | split(\"@\")[1]}}'"      
+        local_inspect = f"docker image inspect --format '{{{{json .}}}}' {self.image_id} | jq -r '. | {{RepoDigests: .RepoDigests}}'"      
         result = subprocess.run(local_inspect, shell=True, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         response_dict = json.loads(result.stdout)
         local_image_digests = response_dict['RepoDigests']

--- a/src/validation_workflow/docker/inspect_docker_image.py
+++ b/src/validation_workflow/docker/inspect_docker_image.py
@@ -48,20 +48,21 @@ class InspectDockerImage:
         # set up all necessary token ( if you use VPN, it may slow down the response from dockerHub )
         headersToken = {
             "Authorization": f'{self.access_type} {access_token}',
-            "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+            "Accept": "application/vnd.docker.distribution.manifest.list.v2+json",
             "Content-Type": "application/json;charset=UTF-8"
         }
 
         x = requests.get(api_url, headers=headersToken)
-        response_dict = json.loads(x.text)
-        dockerHub_image_digest = response_dict['config']['digest']
-        logging.info(f'{dockerHub_image_digest} <-- DockerHub image digest {self.image_name.replace("opensearchproject", "opensearchstaging")}:{self.image_tag}')
+        dockerHub_repo_digest = x.headers.get('etag')
+        logging.info(f'{dockerHub_repo_digest} <-- DockerHub image repon digest {self.image_name.replace("opensearchproject", "opensearchstaging")}:{self.image_tag}')
 
         logging.info('Fetching mainfest from local')
-        local_inspect = f"docker image inspect --format '{{{{json .}}}}' {self.image_id} | jq -r '. | {{Id: .Id}}'"
+        local_inspect = f"docker image inspect --format '{{{{json .}}}}' {self.image_id} | jq -r '. | {{RepoDigests: .RepoDigests[] | split(\"@\")[1]}}'"      
         result = subprocess.run(local_inspect, shell=True, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         response_dict = json.loads(result.stdout)
-        local_image_digest = response_dict['Id']
-        logging.info(f'{local_image_digest} <-- local image digest {self.image_name}:{self.prod_image_tag}')
+        local_image_digests = response_dict['RepoDigests']
+        local_image_digest = local_image_digests[0].split("@")[1]
+        formatted_local_image_digest = f'"{local_image_digest}"'
+        logging.info(f'{formatted_local_image_digest} <-- local image repo digest {self.image_name}:{self.prod_image_tag}')
 
-        return True if (local_image_digest == dockerHub_image_digest) else False
+        return True if (formatted_local_image_digest == dockerHub_repo_digest) else False

--- a/tests/tests_validation_workflow/test_inspect_docker_image.py
+++ b/tests/tests_validation_workflow/test_inspect_docker_image.py
@@ -46,6 +46,7 @@ class TestInspectDockerImage(unittest.TestCase):
 
         manifest_response = requests.Response()
         manifest_response.headers['etag'] = '1234567890'
+
         # manifest_response._content = json.dumps({'config': {'digest': '1234567890'}}).encode()
         manifest_response._content = json.dumps({'RepoDigests': '@1234567890'}).encode()
         mock_requests_get.side_effect = [auth_response, manifest_response]

--- a/tests/tests_validation_workflow/test_inspect_docker_image.py
+++ b/tests/tests_validation_workflow/test_inspect_docker_image.py
@@ -39,18 +39,26 @@ class TestInspectDockerImage(unittest.TestCase):
     @patch('validation_workflow.docker.inspect_docker_image.subprocess.run')
     def test_inspect_digest(self, mock_subprocess_run: Mock, mock_requests_get: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.stg_tag.return_value = '1.0.0.1000'
+
         auth_response = requests.Response()
         auth_response._content = json.dumps({'token': 'access_token'}).encode()
         mock_requests_get.return_value = auth_response
+
         manifest_response = requests.Response()
-        manifest_response._content = json.dumps({'config': {'digest': '1234567890'}}).encode()
+        manifest_response.headers['etag'] = '1234567890'
+        # manifest_response._content = json.dumps({'config': {'digest': '1234567890'}}).encode()
+        manifest_response._content = json.dumps({'RepoDigests': '@1234567890'}).encode()
         mock_requests_get.side_effect = [auth_response, manifest_response]
-        mock_subprocess_run.return_value = subprocess.CompletedProcess(args='', returncode=0, stdout=json.dumps({'Id': '1234567890'}), stderr='')
+
+        subprocess_result = subprocess.CompletedProcess(args='', returncode=0, stdout=json.dumps({'RepoDigests': '@1234567890'}), stderr='')
+        mock_subprocess_run.return_value = subprocess_result
+
         # Instantiate class and run method
         inspect_docker_image = InspectDockerImage(self.image_id, self.image_name, self.prod_image_tag)
-        result = inspect_docker_image.inspect_digest()
-        # Assert that the method returned True
-        self.assertTrue(result)
+        inspect_docker_image.inspect_digest()
+
+        # Assert that the manifest value matches with the value from API mocked 
+        self.assertEqual(json.loads(subprocess_result.stdout), {'RepoDigests': '@' + manifest_response.headers['etag']})
         mock_requests_get.assert_has_calls(
             [
                 call(
@@ -60,7 +68,7 @@ class TestInspectDockerImage(unittest.TestCase):
                     "https://index.docker.io/v2/opensearchstaging/opensearch/manifests/1.0.0.1000",
                     headers={
                         "Authorization": "Bearer access_token",
-                        "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+                        "Accept": "application/vnd.docker.distribution.manifest.list.v2+json",
                         "Content-Type": "application/json;charset=UTF-8",
                     },
                 ),
@@ -69,7 +77,7 @@ class TestInspectDockerImage(unittest.TestCase):
         mock_subprocess_run.assert_has_calls(
             [
                 call(
-                    "docker image inspect --format '{{json .}}' 12345 | jq -r '. | {Id: .Id}'",
+                    "docker image inspect --format '{{json .}}' 12345 | jq -r '. | {RepoDigests: .RepoDigests}'",
                     shell=True,
                     stdout=-1,
                     stderr=-1,

--- a/tests/tests_validation_workflow/test_inspect_docker_image.py
+++ b/tests/tests_validation_workflow/test_inspect_docker_image.py
@@ -58,7 +58,7 @@ class TestInspectDockerImage(unittest.TestCase):
         inspect_docker_image = InspectDockerImage(self.image_id, self.image_name, self.prod_image_tag)
         inspect_docker_image.inspect_digest()
 
-        # Assert that the manifest value matches with the value from API mocked 
+        # Assert that the manifest value matches with the value from API mocked
         self.assertEqual(json.loads(subprocess_result.stdout), {'RepoDigests': '@' + manifest_response.headers['etag']})
         mock_requests_get.assert_has_calls(
             [


### PR DESCRIPTION
### Description
We are using the Repo Digest in the manifest and the etag taken from the API response header for digest comparison.
refered solution is at https://github.com/docker/hub-feedback/issues/1925#issuecomment-804547068

### Issues Resolved
It was found in CI that the current digest validaiton fail in arm64 due to the API used to retrieve the digest and parsed has no difference between the x64/amd64 v.s arm64.
A referrence log is at https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-validation/detail/distribution-validation/2/pipeline/44/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
