### PR TITLE
Bump jenkins-test-harness version to 2002.v0b_78b_a_d69e5d

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ sourceSets {
 
 sharedLibrary {
     coreVersion = '2.387.1' // https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-core/
-    testHarnessVersion = '1934.v90a_c07cf5b_21' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-test-harness?repo=jenkins-releases
+    testHarnessVersion = '2002.v0b_78b_a_d69e5d' // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-test-harness?repo=jenkins-releases
     pluginDependencies {
         // see https://mvnrepository.com/artifact/org.jenkins-ci.plugins/<name>?repo=jenkins-releases for latest
         workflowCpsGlobalLibraryPluginVersion = '609.vd95673f149b_b'


### PR DESCRIPTION
### Description
Bump jenkins-test-harness version to 2002.v0b_78b_a_d69e5d. 

### Issues Resolved
#3462 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
