### PR TITLE
[1.3.11] Updateing 1.3.11 maven SNAPSHOT publish

### DIFF
--- a/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
+++ b/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H 1 * * * %INPUT_MANIFEST=1.3.10/opensearch-1.3.10.yml
+            H 1 * * * %INPUT_MANIFEST=1.3.10/opensearch-1.3.11.yml
         '''
     }
     parameters {


### PR DESCRIPTION
### Description
Updatinng the version to 1.3.11 for pushing SNAPSHOT to Maven

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
