### PR TITLE
Change docker build jenkins workflow to use the v2 docker-builder images

### DIFF
--- a/jenkins/docker/docker-build.jenkinsfile
+++ b/jenkins/docker/docker-build.jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
             agent {
                 docker {
                     label 'Jenkins-Agent-Ubuntu2004-X64-M52xlarge-Docker-Builder'
-                    image 'opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk14'
+                    image 'opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2'
                     args '-u root -v /var/run/docker.sock:/var/run/docker.sock'
                     registryUrl 'https://public.ecr.aws/'
                     alwaysPull true

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-build.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-build.jenkinsfile.txt
@@ -5,7 +5,7 @@
          docker-build.stage(Parameters Check, groovy.lang.Closure)
             docker-build.script(groovy.lang.Closure)
          docker-build.stage(docker-build, groovy.lang.Closure)
-            docker-build.echo(Executing on agent [docker:[alwaysPull:true, args:-u root -v /var/run/docker.sock:/var/run/docker.sock, containerPerStageRoot:false, label:Jenkins-Agent-Ubuntu2004-X64-M52xlarge-Docker-Builder, image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk14, reuseNode:false, registryUrl:https://public.ecr.aws/, stages:[:]]])
+            docker-build.echo(Executing on agent [docker:[alwaysPull:true, args:-u root -v /var/run/docker.sock:/var/run/docker.sock, containerPerStageRoot:false, label:Jenkins-Agent-Ubuntu2004-X64-M52xlarge-Docker-Builder, image:opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.6.3-qemu5.0-awscli1.22-jdk11-v2, reuseNode:false, registryUrl:https://public.ecr.aws/, stages:[:]]])
             docker-build.script(groovy.lang.Closure)
                docker-build.echo(The docker-build workflow will only push docker images to staging, please use docker-copy to move the image to other repositories)
                docker-build.checkout({$class=GitSCM, branches=[{name=main}], userRemoteConfigs=[{url=https://github.com/opensearch-project/opensearch-build}]})


### PR DESCRIPTION
### Description
Change docker build jenkins workflow to use the v2 docker-builder images

### Issues Resolved
#3351

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
