### PR TITLE
Replace Python 3.9.17 to 3.9.7 to resolve compilation inconsistency on CentOS7

### DIFF
--- a/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
@@ -56,7 +56,7 @@ RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - && \
 SHELL ["/bin/bash", "-lc"]
 
 # Install ruby / rpm / fpm related dependencies
-#RUN . /etc/profile.d/rvm.sh && rvm install 2.6.0 && rvm --default use 2.6.0 && yum install -y rpm-build createrepo && yum clean all
+RUN . /etc/profile.d/rvm.sh && rvm install 2.6.0 && rvm --default use 2.6.0 && yum install -y rpm-build createrepo && yum clean all
 
 ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.6.0/bin
 ENV RVM_HOME=/usr/local/rvm/bin

--- a/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
@@ -120,4 +120,4 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN node -v
 RUN npm -v
 RUN yarn -v
-#RUN fpm -v
+RUN fpm -v

--- a/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
@@ -96,7 +96,7 @@ USER 1000
 WORKDIR /usr/share/opensearch
 
 # Install fpm for opensearch dashboards core
-#RUN gem install fpm -v 1.14.2
+RUN gem install fpm -v 1.14.2
 ENV PATH=/usr/share/opensearch/.gem/gems/fpm-1.14.2/bin:$PATH
 
 # Hard code node version and yarn version for now

--- a/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch-dashboards.x64.arm64.dockerfile
@@ -56,7 +56,7 @@ RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - && \
 SHELL ["/bin/bash", "-lc"]
 
 # Install ruby / rpm / fpm related dependencies
-RUN . /etc/profile.d/rvm.sh && rvm install 2.6.0 && rvm --default use 2.6.0 && yum install -y rpm-build createrepo && yum clean all
+#RUN . /etc/profile.d/rvm.sh && rvm install 2.6.0 && rvm --default use 2.6.0 && yum install -y rpm-build createrepo && yum clean all
 
 ENV RUBY_HOME=/usr/local/rvm/rubies/ruby-2.6.0/bin
 ENV RVM_HOME=/usr/local/rvm/bin
@@ -65,8 +65,8 @@ ENV GEM_PATH=$GEM_HOME
 ENV PATH=$RUBY_HOME:$RVM_HOME:$PATH
 
 # Install Python binary
-RUN curl https://www.python.org/ftp/python/3.9.17/Python-3.9.17.tgz | tar xzvf - && \
-    cd Python-3.9.17 && \
+RUN curl https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz | tar xzvf - && \
+    cd Python-3.9.7 && \
     ./configure --enable-optimizations && \
     make altinstall
 
@@ -96,7 +96,7 @@ USER 1000
 WORKDIR /usr/share/opensearch
 
 # Install fpm for opensearch dashboards core
-RUN gem install fpm -v 1.14.2
+#RUN gem install fpm -v 1.14.2
 ENV PATH=/usr/share/opensearch/.gem/gems/fpm-1.14.2/bin:$PATH
 
 # Hard code node version and yarn version for now
@@ -120,4 +120,4 @@ ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN node -v
 RUN npm -v
 RUN yarn -v
-RUN fpm -v
+#RUN fpm -v

--- a/docker/ci/dockerfiles/current/build.centos7.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch.x64.arm64.dockerfile
@@ -74,8 +74,8 @@ ENV GEM_PATH=$GEM_HOME
 ENV PATH=$RUBY_HOME:$RVM_HOME:$PATH
 
 # Install Python binary
-RUN curl https://www.python.org/ftp/python/3.9.17/Python-3.9.17.tgz | tar xzvf - && \
-    cd Python-3.9.17 && \
+RUN curl https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz | tar xzvf - && \
+    cd Python-3.9.7 && \
     ./configure --enable-optimizations && \
     make altinstall
 

--- a/docker/ci/dockerfiles/current/release.centos7.clients.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/release.centos7.clients.x64.arm64.dockerfile
@@ -72,8 +72,8 @@ RUN export MAVEN_URL=`curl -s https://maven.apache.org/download.cgi | grep -Eo '
 RUN chmod -R 777 /dev/shm
 
 # Installing Python binary
-RUN curl https://www.python.org/ftp/python/3.9.17/Python-3.9.17.tgz | tar xzvf - && \
-    cd Python-3.9.17 && \
+RUN curl https://www.python.org/ftp/python/3.9.7/Python-3.9.7.tgz | tar xzvf - && \
+    cd Python-3.9.7 && \
     ./configure --enable-optimizations && \
     make altinstall
 


### PR DESCRIPTION


### Description
Replace Python 3.9.17 to 3.9.7 to resolve compilation inconsistency on CentOS7

### Issues Resolved
#3351

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
