### PR TITLE
Add support for enableRemoteStore parameter in opensearch-cluster-cdk

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.5.4', retriever: modernSCM([
+lib = library(identifier: 'jenkins@4.3.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))

--- a/src/test_workflow/benchmark_test/benchmark_args.py
+++ b/src/test_workflow/benchmark_test/benchmark_args.py
@@ -34,6 +34,7 @@ class BenchmarkArgs:
     jvm_sys_props: str
     additional_config: str
     use_50_percent_heap: bool
+    enable_remote_store: bool
     workload: str
     workload_params: str
     benchmark_config: IO
@@ -77,6 +78,8 @@ class BenchmarkArgs:
                             help="User provided ml-node ebs block storage size defaults to 100Gb")
         parser.add_argument("--data-node-storage", dest="data_node_storage",
                             help="User provided data-node ebs block storage size, defaults to 100Gb")
+        parser.add_argument("--enable-remote-store", dest="enable_remote_store", action="store_true",
+                            help="Enable Remote Store feature in OpenSearch")
         parser.add_argument("--workload", dest="workload", required=True,
                             help="Name of the workload that OpenSearch Benchmark should run")
         parser.add_argument("--benchmark-config", dest="benchmark_config",
@@ -108,6 +111,7 @@ class BenchmarkArgs:
         self.jvm_sys_props = args.jvm_sys_props if args.jvm_sys_props else None
         self.data_node_storage = args.data_node_storage if args.data_node_storage else None
         self.ml_node_storage = args.ml_node_storage if args.ml_node_storage else None
+        self.enable_remote_store = args.enable_remote_store
         self.workload = args.workload
         self.workload_params = args.workload_params if args.workload_params else None
         self.benchmark_config = args.benchmark_config if args.benchmark_config else None

--- a/src/test_workflow/benchmark_test/benchmark_test_cluster.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_cluster.py
@@ -143,7 +143,8 @@ class BenchmarkTestCluster:
             "mlNodeStorage": self.args.ml_node_storage,
             "jvmSysProps": self.args.jvm_sys_props,
             "use50PercentHeap": str(self.args.use_50_percent_heap).lower(),
-            "isInternal": config["Constants"]["isInternal"]
+            "isInternal": config["Constants"]["isInternal"],
+            "enableRemoteStore": str(self.args.enable_remote_store).lower()
         }
 
     @classmethod

--- a/tests/tests_test_workflow/test_benchmark_args.py
+++ b/tests/tests_test_workflow/test_benchmark_args.py
@@ -35,6 +35,7 @@ class TestBenchmarkArgs(unittest.TestCase):
         self.assertFalse(test_args.insecure)
         self.assertFalse(test_args.single_node)
         self.assertFalse(test_args.min_distribution)
+        self.assertFalse(test_args.enable_remote_store)
 
     @patch("argparse._sys.argv",
            [ARGS_PY, "--bundle-manifest", TEST_DIST_MANIFEST_PATH, "--config", TEST_CONFIG_PATH, "--workload", "test",

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_cluster.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_cluster.py
@@ -79,6 +79,7 @@ class TestBenchmarkTestCluster(unittest.TestCase):
     def test_create_multi_node(self, mock_wait_for_processing: Optional[Mock]) -> None:
         self.args.single_node = False
         self.args.use_50_percent_heap = True
+        self.args.enable_remote_store = True
         TestBenchmarkTestCluster.setUp(self, self.args)
         mock_file = MagicMock(side_effect=[{"opensearch-infra-stack-test-suffix-007-x64": {"loadbalancerurl": "www.example.com"}}])
         with patch("subprocess.check_call") as mock_check_call:
@@ -89,3 +90,4 @@ class TestBenchmarkTestCluster(unittest.TestCase):
 
         self.assertTrue("singleNodeCluster=false" in self.benchmark_test_cluster.params)
         self.assertTrue("use50PercentHeap=true" in self.benchmark_test_cluster.params)
+        self.assertTrue("enableRemoteStore=true" in self.benchmark_test_cluster.params)


### PR DESCRIPTION
### Description
This PR adds support for `enableRemoteStore` parameter in opensearch-cluster-cdk. 
This will be used to run nightly benchmarks on remote-store enabled clusters. 

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/8087

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
