### PR TITLE
Release Label creation automation - 2

### DIFF
--- a/.github/workflows/os-increment-plugin-versions.yml
+++ b/.github/workflows/os-increment-plugin-versions.yml
@@ -85,36 +85,36 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
-      - name: Check if label exists
-        id: check_label
+      - name: Check and Create label
+        id: check_create_label
         uses: actions/github-script@v6
         with:
           github-token: ${{ steps.github_app_token.outputs.token }}
           result-encoding: string
           script: |
-            const { data: labels } = await github.rest.issues.listLabelsForRepo({
+            const labelName = "v${{ env.OPENSEARCH_VERSION_NUMBER }}";
+            let labelFound = false;
+            const label = await github.rest.issues.getLabel({
               owner: context.repo.owner,
               repo: "${{ matrix.entry.repo }}",
-              per_page: 100
+              name: labelName
             });
-            const labelFound = labels.some(label => label.name === 'v${{ env.OPENSEARCH_VERSION_NUMBER }}');
+            if (label) {
+              labelFound = true;
+            } else {
+              const randomColor = Math.floor(Math.random() * 16777215).toString(16);
+              const newLabel = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+                color: randomColor,
+                description: labelName
+              };
+              await github.rest.issues.createLabel(newLabel);
+              labelFound = true;
+            }
             console.log(labelFound);
             return labelFound
-      - name: Create label
-        if: ${{ steps.check_label.outputs.result != 'true' }}
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ steps.github_app_token.outputs.token }}
-          script: |
-            const randomColor = Math.floor(Math.random() * 16777215).toString(16);
-            const newLabel = {
-              owner: context.repo.owner,
-              repo: "${{ matrix.entry.repo }}",
-              name: "v${{ env.OPENSEARCH_VERSION_NUMBER }}",
-              color: randomColor,
-              description: "v${{ env.OPENSEARCH_VERSION_NUMBER }}"
-            };
-            await github.rest.issues.createLabel(newLabel);
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -109,29 +109,29 @@ jobs:
           github-token: ${{ steps.github_app_token.outputs.token }}
           result-encoding: string
           script: |
-            const { data: labels } = await github.rest.issues.listLabelsForRepo({
+            const labelName = "v${{ env.DASHBOARD_VERSION }}";
+            let labelFound = false;
+            const label = await github.rest.issues.getLabel({
               owner: context.repo.owner,
               repo: "${{ matrix.entry.repo }}",
-              per_page: 100
+              name: labelName
             });
-            const labelFound = labels.some(label => label.name === 'v${{ env.DASHBOARD_VERSION }}');
+            if (label) {
+              labelFound = true;
+            } else {
+              const randomColor = Math.floor(Math.random() * 16777215).toString(16);
+              const newLabel = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: labelName,
+                color: randomColor,
+                description: labelName
+              };
+              await github.rest.issues.createLabel(newLabel);
+              labelFound = true;
+            }
             console.log(labelFound);
             return labelFound
-      - name: Create label
-        if: ${{ steps.check_label.outputs.result != 'true' }}
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ steps.github_app_token.outputs.token }}
-          script: |
-            const randomColor = Math.floor(Math.random() * 16777215).toString(16);
-            const newLabel = {
-              owner: context.repo.owner,
-              repo: "${{ matrix.entry.repo }}",
-              name: "v${{ env.DASHBOARD_VERSION }}",
-              color: randomColor,
-              description: "v${{ env.DASHBOARD_VERSION }}"
-            };
-            await github.rest.issues.createLabel(newLabel);
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
### Description
Initial merged PR https://github.com/opensearch-project/opensearch-build/pull/3660 does only look for 100 labels in a repo.

This PR looks for only a release specific label and does not iterate all the existing labels.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3661

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
