### PR TITLE
Release Label creation automation - 3

### DIFF
--- a/.github/workflows/os-increment-plugin-versions.yml
+++ b/.github/workflows/os-increment-plugin-versions.yml
@@ -105,7 +105,7 @@ jobs:
               const randomColor = Math.floor(Math.random() * 16777215).toString(16);
               const newLabel = {
                 owner: context.repo.owner,
-                repo: context.repo.repo,
+                repo: "${{ matrix.entry.repo }}",
                 name: labelName,
                 color: randomColor,
                 description: labelName

--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -122,7 +122,7 @@ jobs:
               const randomColor = Math.floor(Math.random() * 16777215).toString(16);
               const newLabel = {
                 owner: context.repo.owner,
-                repo: context.repo.repo,
+                repo: "${{ matrix.entry.repo }}",
                 name: labelName,
                 color: randomColor,
                 description: labelName


### PR DESCRIPTION
### Description
Initial merged PR https://github.com/opensearch-project/opensearch-build/pull/3660 https://github.com/opensearch-project/opensearch-build/pull/3664

The change from  `context.repo.repo` to `"${{ matrix.entry.repo }}"` allows to create a label in external plugin repo. The `context.repo.repo` uses the build repo in which the workflow is running.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3661

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
