### PR TITLE
Add support to sign mac artifacts

### DIFF
--- a/src/sign_workflow/sign_args.py
+++ b/src/sign_workflow/sign_args.py
@@ -13,7 +13,7 @@ from typing import List
 
 class SignArgs:
     ACCEPTED_SIGNATURE_FILE_TYPES = [".sig", ".asc"]
-    ACCEPTED_PLATFORM = ["linux", "windows"]
+    ACCEPTED_PLATFORM = ["linux", "windows", "mac"]
 
     target: Path
     components: List[str]

--- a/src/sign_workflow/signer_mac.py
+++ b/src/sign_workflow/signer_mac.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+import platform
+from pathlib import Path
+
+from sign_workflow.signer import Signer
+
+"""
+This class is responsible for signing macos artifacts using the OpenSearch-signer-client and verifying its signature.
+"""
+
+
+class SignerMac(Signer):
+    ACCEPTED_FILE_TYPES = [".pkg", ".dmg"]
+
+    def generate_signature_and_verify(self, artifact: str, basepath: Path, signature_type: str) -> None:
+        filename = os.path.join(basepath, artifact)
+        signed_filename = filename if self.overwrite else os.path.join(basepath, "signed_" + artifact)
+        self.sign(artifact, basepath, signature_type)
+        self.verify(signed_filename)
+
+    def is_valid_file_type(self, file_name: str) -> bool:
+        return any(
+            file_name.endswith(x) for x in SignerMac.ACCEPTED_FILE_TYPES
+        )
+
+    def sign(self, artifact: str, basepath: Path, signature_type: str) -> None:
+        filename = os.path.join(basepath, artifact)
+        signed_filename = filename if self.overwrite else os.path.join(basepath, "signed_" + artifact)
+        signing_cmd = [
+            "./opensearch-signer-client",
+            "-i",
+            filename,
+            "-o",
+            signed_filename,
+            "-p",
+            "mac"
+            " -r",
+            str(self.overwrite)
+        ]
+        self.git_repo.execute(" ".join(signing_cmd))
+
+    def verify(self, filename: str) -> None:
+        if platform.system() != 'Darwin':
+            raise OSError(f"Cannot verify mac artifacts on non-Darwin system, {platform.system()}")
+        else:
+            verify_cmd = ["pkgutil", "--check-signature", filename]
+            self.git_repo.execute(" ".join(verify_cmd))

--- a/src/sign_workflow/signer_mac.py
+++ b/src/sign_workflow/signer_mac.py
@@ -41,8 +41,8 @@ class SignerMac(Signer):
             "-o",
             signed_filename,
             "-p",
-            "mac"
-            " -r",
+            "mac",
+            "-r",
             str(self.overwrite)
         ]
         self.git_repo.execute(" ".join(signing_cmd))

--- a/src/sign_workflow/signer_windows.py
+++ b/src/sign_workflow/signer_windows.py
@@ -41,8 +41,8 @@ class SignerWindows(Signer):
             "-o",
             signed_filename,
             "-p",
-            "windows"
-            " -r",
+            "windows",
+            "-r",
             str(self.overwrite)
         ]
         self.git_repo.execute(" ".join(signing_cmd))

--- a/src/sign_workflow/signers.py
+++ b/src/sign_workflow/signers.py
@@ -8,6 +8,7 @@
 
 
 from sign_workflow.signer import Signer
+from sign_workflow.signer_mac import SignerMac
 from sign_workflow.signer_pgp import SignerPGP
 from sign_workflow.signer_windows import SignerWindows
 
@@ -16,6 +17,7 @@ class Signers:
     TYPES = {
         "windows": SignerWindows,
         "linux": SignerPGP,
+        "mac": SignerMac,
     }
 
     @classmethod

--- a/tests/tests_sign_workflow/test_signer_mac.py
+++ b/tests/tests_sign_workflow/test_signer_mac.py
@@ -15,9 +15,9 @@ from sign_workflow.signer_mac import SignerMac
 
 
 class TestSignerMac(unittest.TestCase):
-
+    @patch("platform.system", return_value='Darwin')
     @patch("sign_workflow.signer.GitRepository")
-    def test_accepted_file_types(self, git_repo: Mock) -> None:
+    def test_accepted_file_types(self, git_repo: Mock, platform_moc: Mock) -> None:
         artifacts = [
             "bad-xml.xml",
             "the-dmg.dmg",
@@ -40,9 +40,10 @@ class TestSignerMac(unittest.TestCase):
         self.assertEqual(signer.sign.call_args_list, expected)
 
     @patch("sign_workflow.signer.GitRepository")
+    @patch("platform.system", return_value='Darwin')
     @patch('os.rename')
     @patch('os.mkdir')
-    def test_signer_sign(self, mock_os_mkdir: Mock, mock_os_rename: Mock, mock_repo: Mock) -> None:
+    def test_signer_sign(self, mock_os_mkdir: Mock, mock_os_rename: Mock, platform_moc: Mock, mock_repo: Mock) -> None:
         signer = SignerMac(False)
         signer.sign("the-pkg.pkg", Path("/path/"), "null")
         command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"),
@@ -51,8 +52,9 @@ class TestSignerMac(unittest.TestCase):
         mock_repo.assert_has_calls(
             [call().execute(command)])
 
+    @patch("platform.system", return_value='Darwin')
     @patch("sign_workflow.signer.GitRepository")
-    def test_sign_command_for_overwrite(self, mock_repo: Mock) -> None:
+    def test_sign_command_for_overwrite(self, mock_repo: Mock, platform_moc: Mock) -> None:
         signer = SignerMac(True)
         signer.sign("the-pkg.pkg", Path("/path/"), 'null')
         command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"),
@@ -61,14 +63,16 @@ class TestSignerMac(unittest.TestCase):
         mock_repo.assert_has_calls(
             [call().execute(command)])
 
+    @patch("platform.system", return_value='Darwin')
     @patch("sign_workflow.signer.GitRepository")
-    def test_signer_verify(self, mock_repo: Mock) -> None:
+    def test_signer_verify(self, mock_repo: Mock, platform_moc: Mock) -> None:
         signer = SignerMac(True)
         signer.verify("/path/the-pkg.pkg")
         mock_repo.assert_has_calls([call().execute('pkgutil --check-signature /path/the-pkg.pkg')])
 
     @patch("platform.system", return_value='Linux')
-    def test_signer_invalid_os(self, mock_system: Mock) -> None:
+    @patch("sign_workflow.signer.GitRepository")
+    def test_signer_invalid_os(self, mock_repo: Mock, platform_moc: Mock) -> None:
         with self.assertRaises(OSError) as ctx:
             signer = SignerMac(True)
             signer.verify("/path/the-pkg.pkg")

--- a/tests/tests_sign_workflow/test_signer_mac.py
+++ b/tests/tests_sign_workflow/test_signer_mac.py
@@ -1,0 +1,75 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, call, patch
+
+from sign_workflow.signer_mac import SignerMac
+
+
+class TestSignerMac(unittest.TestCase):
+
+    @patch("sign_workflow.signer.GitRepository")
+    def test_accepted_file_types(self, git_repo: Mock) -> None:
+        artifacts = [
+            "bad-xml.xml",
+            "the-dmg.dmg",
+            "the-exe.exe",
+            "the-dll.dll",
+            "the-sys.sys",
+            "the-pkg.pkg",
+            "the-psm1.psm1",
+            "the-cat.cat",
+            "random-file.txt",
+            "something-1.0.0.0.jar",
+        ]
+        expected = [
+            call("the-dmg.dmg", Path("path"), 'null'),
+            call("the-pkg.pkg", Path("path"), 'null'),
+        ]
+        signer = SignerMac(True)
+        signer.sign = MagicMock()  # type: ignore
+        signer.sign_artifacts(artifacts, Path("path"), 'null')
+        self.assertEqual(signer.sign.call_args_list, expected)
+
+    @patch("sign_workflow.signer.GitRepository")
+    @patch('os.rename')
+    @patch('os.mkdir')
+    def test_signer_sign(self, mock_os_mkdir: Mock, mock_os_rename: Mock, mock_repo: Mock) -> None:
+        signer = SignerMac(False)
+        signer.sign("the-pkg.pkg", Path("/path/"), "null")
+        command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"),
+                                                                  'the-pkg.pkg') + " -o " + os.path.join(Path("/path/"),
+                                                                                                         'signed_the-pkg.pkg') + " -p mac -r False"
+        mock_repo.assert_has_calls(
+            [call().execute(command)])
+
+    @patch("sign_workflow.signer.GitRepository")
+    def test_sign_command_for_overwrite(self, mock_repo: Mock) -> None:
+        signer = SignerMac(True)
+        signer.sign("the-pkg.pkg", Path("/path/"), 'null')
+        command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"),
+                                                                  'the-pkg.pkg') + " -o " + os.path.join(Path("/path/"),
+                                                                                                         'the-pkg.pkg') + " -p mac" + " -r True"
+        mock_repo.assert_has_calls(
+            [call().execute(command)])
+
+    @patch("sign_workflow.signer.GitRepository")
+    def test_signer_verify(self, mock_repo: Mock) -> None:
+        signer = SignerMac(True)
+        signer.verify("/path/the-pkg.pkg")
+        mock_repo.assert_has_calls([call().execute('pkgutil --check-signature /path/the-pkg.pkg')])
+
+    @patch("platform.system", return_value='Linux')
+    def test_signer_invalid_os(self, mock_system: Mock) -> None:
+        with self.assertRaises(OSError) as ctx:
+            signer = SignerMac(True)
+            signer.verify("/path/the-pkg.pkg")
+        self.assertEqual(str(ctx.exception), 'Cannot verify mac artifacts on non-Darwin system, Linux')

--- a/tests/tests_sign_workflow/test_signers.py
+++ b/tests/tests_sign_workflow/test_signers.py
@@ -8,6 +8,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from sign_workflow.signer_mac import SignerMac
 from sign_workflow.signer_pgp import SignerPGP
 from sign_workflow.signer_windows import SignerWindows
 from sign_workflow.signers import Signers
@@ -25,7 +26,12 @@ class TestSigners(unittest.TestCase):
         signer = Signers.create("windows", True)
         self.assertIs(type(signer), SignerWindows)
 
+    @patch("sign_workflow.signer.GitRepository")
+    def test_signer_macos(self, mock_repo: Mock) -> None:
+        signer = Signers.create("mac", True)
+        self.assertIs(type(signer), SignerMac)
+
     def test_signer_invalid(self) -> None:
         with self.assertRaises(ValueError) as ctx:
-            Signers.create("mac", False)
-        self.assertEqual(str(ctx.exception), "Unsupported type of platform for signing: mac")
+            Signers.create("java", False)
+        self.assertEqual(str(ctx.exception), "Unsupported type of platform for signing: java")


### PR DESCRIPTION
### Description
This change allows to sign mac artifacts. Currently just added `.dmg` and `.pkg` as acceptable types.
Also need to add overwrite support to signer client (will take care of it)

<details><summary>Details</summary>
<p>

```
./sign.sh /Users/gaiksaya/Downloads/artifacts/mac64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg --platform mac
Installing dependencies in . ...
Installing dependencies from Pipfile.lock (b36c9c)...
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 0/0 — 00:00:00
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Running ./src/run_sign.py /Users/gaiksaya/Downloads/artifacts/mac64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg --platform mac ...
2023-06-23 15:37:30 INFO     Executing "git init" in /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3cxk1ve
2023-06-23 15:37:31 INFO     Executing "git remote add origin https://${GITHUB_TOKEN}@github.com/opensearch-project/opensearch-signer-client.git" in /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3cxk1ve
2023-06-23 15:37:31 INFO     Executing "git fetch --depth 1 origin HEAD" in /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3cxk1ve
2023-06-23 15:37:31 INFO     Executing "git checkout FETCH_HEAD" in /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3cxk1ve
2023-06-23 15:37:31 INFO     Executing "git rev-parse HEAD" in /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3cxk1ve
2023-06-23 15:37:31 INFO     Checked out https://${GITHUB_TOKEN}@github.com/opensearch-project/opensearch-signer-client.git@HEAD into /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3cxk1ve at 2c29e4e9830a4f1747cae72f8b3f3bae05e4e274
2023-06-23 15:37:31 INFO     Executing "./bootstrap" in /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3cxk1ve/src
Collecting boto3>=1.17.105
  Using cached boto3-1.26.160-py3-none-any.whl (135 kB)
Collecting backoff>=1.10.0
  Using cached backoff-2.2.1-py3-none-any.whl (15 kB)
Collecting jmespath<2.0.0,>=0.7.1
  Using cached jmespath-1.0.1-py3-none-any.whl (20 kB)
Collecting botocore<1.30.0,>=1.29.160
  Using cached botocore-1.29.160-py3-none-any.whl (10.9 MB)
Collecting s3transfer<0.7.0,>=0.6.0
  Using cached s3transfer-0.6.1-py3-none-any.whl (79 kB)
Collecting python-dateutil<3.0.0,>=2.1
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting urllib3<1.27,>=1.25.4
  Using cached urllib3-1.26.16-py2.py3-none-any.whl (143 kB)
Collecting six>=1.5
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: jmespath, six, python-dateutil, urllib3, botocore, s3transfer, boto3, backoff
Successfully installed backoff-2.2.1 boto3-1.26.160 botocore-1.29.160 jmespath-1.0.1 python-dateutil-2.8.2 s3transfer-0.6.1 six-1.16.0 urllib3-1.26.16
2023-06-23 15:37:44 INFO     Executing "rm config.cfg" in /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3cxk1ve/src
2023-06-23 15:37:44 INFO     Executing "./opensearch-signer-client -i /Users/gaiksaya/Downloads/artifacts/mac64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg -o /Users/gaiksaya/Downloads/artifacts/mac64-installer/signed_OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg -p mac -r False" in /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3cxk1ve/src
Using environment variable configuration.
Uploading OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg to signer bucket...
OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg  1.40 MB / 1.40 MB  (100%)        Artifact is uploaded.
Initiating signing job...
Successfully submitted signing job (Job Id: 6b965017-36df-49ea-ad7e-0a4fec5a6c69).
Signing job is in progress...
Signing job is done.
Downloading signed artifact...
signed_OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg  1.42 MB / 1.42 MB  (100%)        2023-06-23 15:38:49 INFO     Executing "pkgutil --check-signature /Users/gaiksaya/Downloads/artifacts/mac64-installer/signed_OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg" in /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3cxk1ve/src
Package "signed_OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg":
   Status: signed by a developer certificate issued by Apple for distribution
   Signed with a trusted timestamp on: 2023-06-23 22:38:18 +0000
   Certificate Chain:
    1. Developer ID Installer: AMZN Mobile LLC (94KV3E626L)
       Expires: 2027-06-28 22:57:06 +0000
       SHA256 Fingerprint:
           49 68 39 4A BA 83 3B F0 CC 5E 98 3B E7 C1 72 AC 85 97 65 18 B9 4C
           BA 34 62 BF E9 23 76 98 C5 DA
       ------------------------------------------------------------------------
    2. Developer ID Certification Authority
       Expires: 2031-09-17 00:00:00 +0000
       SHA256 Fingerprint:
           F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F
           D1 44 71 5F 35 06 43 D2 DF 3A
       ------------------------------------------------------------------------
    3. Apple Root CA
       Expires: 2035-02-09 21:40:36 +0000
       SHA256 Fingerprint:
           B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
           68 C5 BE 91 B5 A1 10 01 F0 24

2023-06-23 15:38:49 INFO     Done.
```

</p>
</details> 

### Issues Resolved
part of #3669 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
