### PR TITLE
Make distribution build of OpenSearch to use 4.3.0 version lib

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.5.4', retriever: modernSCM([
+lib = library(identifier: 'jenkins@4.3.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Make distribution build of OpenSearch to use 4.3.0 version lib

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/8087
https://github.com/opensearch-project/opensearch-build/pull/3657

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
