### PR TITLE
Remove ml-commons-dashboards experiment keyword in config file

### DIFF
--- a/config/opensearch_dashboards-2.x.yml
+++ b/config/opensearch_dashboards-2.x.yml
@@ -192,8 +192,8 @@
 # data_source.encryption.wrappingKeyNamespace: 'changeme'
 # data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 
-# 2.6 New ML Commons Dashboards Experimental Feature
-# Set the value of this setting to true to enable the experimental ml commons dashboards
+# 2.6 New ML Commons Dashboards Feature
+# Set the value of this setting to true to enable the ml commons dashboards
 # ml_commons_dashboards.enabled: false
 
 opensearch.hosts: [https://localhost:9200]

--- a/config/opensearch_dashboards-default.x.yml
+++ b/config/opensearch_dashboards-default.x.yml
@@ -192,8 +192,8 @@
 # data_source.encryption.wrappingKeyNamespace: 'changeme'
 # data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
 
-# 2.6 New ML Commons Dashboards Experimental Feature
-# Set the value of this setting to true to enable the experimental ml commons dashboards
+# 2.6 New ML Commons Dashboards Feature
+# Set the value of this setting to true to enable the ml commons dashboards
 # ml_commons_dashboards.enabled: false
 
 opensearch.hosts: [https://localhost:9200]


### PR DESCRIPTION
This reverts commit 1021f6e93ff809416dd0528a03e430b5eb97f880.

### Description
The ml-commons-dashboards will be move to GA in 2.9, this PR will remove experiment keyword in the config files.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
