### PR TITLE
Automation for component release issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/component_release_template.md
+++ b/.github/ISSUE_TEMPLATE/component_release_template.md
@@ -1,5 +1,5 @@
-This is a component issue for __{REPLACE_WITH_RELEASE_VERSION}__.
-Coming from [opensearch-build__REPLACE_ISSUE_NUMBER__](https://github.com/opensearch-project/opensearch-build/issues/__REPLACE_ISSUE_NUMBER__). Please follow the following checklist.
+This is a component issue for `{{RELEASE_VERSION}}`.
+Coming from {{RELEASE_ISSUE}}. Please follow the following checklist.
 __Please refer to the DATES in that post__.
 
 <details><summary>How to use this issue</summary>
@@ -22,7 +22,7 @@ Linked at the top of this issue, the overall release issue captures the state of
 
 ## What should I do if my plugin isn't making any changes?
 
-If including changes in this release, increment the version on `__{REPLACE_MAJOR_MINOR_PATCH}__` branch to `__{REPLACE_MAJOR_MINOR_PATCH}__` for Min/Core, and `__{REPLACE_MAJOR_MINOR_PATCH_0}__` for components. Otherwise, keep the version number unchanged for both.
+If including changes in this release, increment the version on `{{RELEASE_VERSION_X}}` branch to `{{RELEASE_VERSION}}` for Min/Core, and `{{RELEASE_VERSION}}.0` for components. Otherwise, keep the version number unchanged for both.
 
 </p>
 </details>
@@ -38,11 +38,11 @@ If including changes in this release, increment the version on `__{REPLACE_MAJOR
 
 - [ ] All code changes for `__{REPLACE_MAJOR_MINOR_PATCH}__` are complete.
 - [ ] Ensure working and passing CI.
-- [ ] Check that this repo is included in the [distribution manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/__REPLACE_MAJOR_MINOR_PATCH__).
+- [ ] Check that this repo is included in the [distribution manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/{{RELEASE_VERSION}}).
 
 ### Pre-Release
 
-- [ ] Update to the `__REPLACE_MAJOR_MINOR__` release branch in the [distribution manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/__REPLACE_MAJOR_MINOR_PATCH__).
+- [ ] Update to the `{{RELEASE_VERSION}}` release branch in the [distribution manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/{{RELEASE_VERSION}}).
 - [ ] Increment the version on the parent branch to the next development iteration.
 - [ ] Gather, review and publish release notes following the [rules](https://github.com/opensearch-project/opensearch-plugins/blob/main/RELEASE_NOTES.md) and back port it to the release branch.[git-release-notes](https://github.com/ariatemplates/git-release-notes) may be used to generate release notes from your commit history.
 - [ ] Confirm that all changes for `__{REPLACE_MAJOR_MINOR_PATCH}__` have been merged.

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -3,6 +3,16 @@ name: releases
 
 on:
   workflow_dispatch:
+    inputs:
+      logLevel:
+        description: Log level
+        required: true
+        default: warning
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
   schedule:
     - cron: 0 0 * * *
 
@@ -13,22 +23,107 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          repository: opensearch-project/opensearch-build
+          ref: main
       - id: set-matrix
         # produces a list of versions, e.g. ["1.0.0","1.0.0","1.0.1","1.1.0","1.2.0","2.0.0"]
         run: echo "::set-output name=matrix::$(ls manifests/**/opensearch*.yml | cut -d'/' -f2 | sort | uniq | jq -R -s -c 'split("\n")[:-1]')"
-  check:
+  component-release-issue:
     needs: list-manifest-versions
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
+        entry:
+          - {repo: OpenSearch}
+          - {repo: alerting}
+          - {repo: anomaly-detection}
+          - {repo: asynchronous-search}
+          - {repo: common-utils}
+          - {repo: cross-cluster-replication}
+          - {repo: geospatial}
+          - {repo: index-management}
+          - {repo: job-scheduler}
+          - {repo: k-NN}
+          - {repo: neural-search}
+          - {repo: ml-commons}
+          - {repo: notifications}
+          - {repo: observability}
+          - {repo: performance-analyzer}
+          - {repo: performance-analyzer-rca}
+          - {repo: reporting}
+          - {repo: security}
+          - {repo: security-analytics}
+          - {repo: sql}
+          - {repo: OpenSearch-Dashboards}
+          - {repo: dashboards-observability}
+          - {repo: dashboards-reporting}
+          - {repo: dashboards-visualizations}
+          - {repo: dashboards-query-workbench}
+          - {repo: dashboards-maps}
+          - {repo: anomaly-detection-dashboards-plugin}
+          - {repo: ml-commons-dashboards}
+          - {repo: index-management-dashboards-plugin}
+          - {repo: dashboards-notifications}
+          - {repo: alerting-dashboards-plugin}
+          - {repo: security-analytics-dashboards-plugin}
+          - {repo: security-dashboards-plugin}
+          - {repo: dashboards-search-relevance}
+          - {repo: opensearch-dashboards-functional-test}
+        release_version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       - uses: dblock/create-a-github-issue@v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ matrix.version }}
+          VERSION: ${{ matrix.release_version }}
+        id: build-repo-release-issue
         with:
           search_existing: all
           update_existing: false
           filename: .github/ISSUE_TEMPLATE/release_template.md
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.6.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+      - name: Check out build repo
+        uses: actions/checkout@v3
+        if: ${{ endsWith(matrix.release_version, '.0') }}
+      - name: Check out plugin repo
+        uses: actions/checkout@v3
+        if: ${{ endsWith(matrix.release_version, '.0') }}
+        with:
+          path: plugin-repo
+          repository: opensearch-project/${{ matrix.entry.repo }}
+      - name: Replace placeholders
+        if: ${{ endsWith(matrix.release_version, '.0') }}
+        run: |
+          # Read the file contents and replace the placeholders
+          file_path="../opensearch-build/.github/ISSUE_TEMPLATE/component_release_template.md"
+          RELEASE_VERSION="${{ matrix.release_version }}"
+          RELEASE_ISSUE="${{ steps.build-repo-release-issue.outputs.url }}"
+          RELEASE_VERSION_X=$(echo "${{ steps.build-repo-release-issue.outputs.url" | awk -F'.' '{print $1}').x
+          sed -e "s|{{RELEASE_VERSION}}|${RELEASE_VERSION}|g" -e "s|{{RELEASE_ISSUE}}|${RELEASE_ISSUE}|g" -e "s|{{RELEASE_VERSION_X}}|${RELEASE_VERSION_X}|g" "$file_path" > "$file_path.tmp" && mv "$file_path.tmp" "$file_path"
+      - name: Check if issue exists
+        if: ${{ endsWith(matrix.release_version, '.0') }}
+        id: check_if_issue_exists
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'find-issues'
+          repo: opensearch-project/${{ matrix.entry.repo }}
+          token: ${{ steps.github_app_token.outputs.token }}
+          title-includes: '[RELEASE] Release version ${{ matrix.release_version }}'
+      - name: Create Issue From File
+        if: steps.check_if_issue_exists.outputs.check-result =='false'
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: '[RELEASE] Release version ${{ matrix.release_version }}'
+          content-filepath: ../opensearch-build/.github/ISSUE_TEMPLATE/component_release_template.md
+          labels: 'v${{ matrix.release_version }}'
+          token: ${{ steps.github_app_token.outputs.token }}
+          repository: opensearch-project/${{ matrix.entry.repo }}


### PR DESCRIPTION
### Description
Automation for component release issue creation

Create a release issue in build repo this logic is same using the action `dblock/create-a-github-issue@v3.0.0`. Using matrix for each repo and version creates an issue in components/plugins repo using `peter-evans/create-issue-from-file@v4`, the action `dblock/create-a-github-issue@v3.0.0` does not support cross repo issue creation. 

Using `actions-cool/issues-helper@v3` to identify if an issue already exists as by default the `peter-evans/create-issue-from-file@v4` does not have this logic (related open issue: https://github.com/peter-evans/create-issue-from-file/issues/298).

The `dblock/create-a-github-issue@v3.0.0` has the logic to avoid creation of duplicate issues (`search_existing: all`) but does not work in creating issues for cross repo.

Hence the combination of all works better in creating a release issue in build repo and component release issue in plugins repo.

The step `Replace placeholders` updates the `component_release_template.md` file with right versions before creating a component release issue.

Note: This creates the main release issue and component release issues but it wont update the component section markdown table of the main release issue.

Sample Testing:
Sample Run: <img width="1263" alt="Screenshot 2023-07-06 at 4 27 18 PM" src="https://github.com/opensearch-project/opensearch-build/assets/28733332/b33db08d-cdbd-4739-be68-6764c168113a">

Sample Component Issue:  https://github.com/prudhvigodithi/job-scheduler/issues/23

Skipping for non major/minor version: (Logic used is to check if the last digit `endsWith` with `.0` )
<img width="880" alt="Screenshot 2023-07-06 at 4 36 34 PM" src="https://github.com/opensearch-project/opensearch-build/assets/28733332/87bded57-2790-4077-9472-50e14d2e1ebb">


### Issues Resolved
Part of: 
https://github.com/opensearch-project/opensearch-build/issues/3349 
https://github.com/opensearch-project/opensearch-build/issues/3676
https://github.com/opensearch-project/.github/issues/167

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
