### PR TITLE
Allow dylib to be signed by macos signing and fix verification command

### DIFF
--- a/src/sign_workflow/signer_mac.py
+++ b/src/sign_workflow/signer_mac.py
@@ -18,7 +18,7 @@ This class is responsible for signing macos artifacts using the OpenSearch-signe
 
 
 class SignerMac(Signer):
-    ACCEPTED_FILE_TYPES = [".pkg", ".dmg"]
+    ACCEPTED_FILE_TYPES = [".pkg", ".dmg", ".dylib"]
 
     def generate_signature_and_verify(self, artifact: str, basepath: Path, signature_type: str) -> None:
         filename = os.path.join(basepath, artifact)
@@ -51,5 +51,8 @@ class SignerMac(Signer):
         if platform.system() != 'Darwin':
             raise OSError(f"Cannot verify mac artifacts on non-Darwin system, {platform.system()}")
         else:
-            verify_cmd = ["pkgutil", "--check-signature", filename]
+            if (filename.endswith('.pkg')):
+                verify_cmd = ["pkgutil", "--check-signature", filename]
+            else:
+                verify_cmd = ["codesign", "--verify", "--deep", "--verbose=4", "--display", filename]
             self.git_repo.execute(" ".join(verify_cmd))

--- a/tests/tests_sign_workflow/test_signer_mac.py
+++ b/tests/tests_sign_workflow/test_signer_mac.py
@@ -29,10 +29,12 @@ class TestSignerMac(unittest.TestCase):
             "the-cat.cat",
             "random-file.txt",
             "something-1.0.0.0.jar",
+            "the-dylib.dylib"
         ]
         expected = [
             call("the-dmg.dmg", Path("path"), 'null'),
             call("the-pkg.pkg", Path("path"), 'null'),
+            call("the-dylib.dylib", Path("path"), 'null')
         ]
         signer = SignerMac(True)
         signer.sign = MagicMock()  # type: ignore
@@ -69,6 +71,13 @@ class TestSignerMac(unittest.TestCase):
         signer = SignerMac(True)
         signer.verify("/path/the-pkg.pkg")
         mock_repo.assert_has_calls([call().execute('pkgutil --check-signature /path/the-pkg.pkg')])
+
+    @patch("platform.system", return_value='Darwin')
+    @patch("sign_workflow.signer.GitRepository")
+    def test_signer_verify_dylib(self, mock_repo: Mock, platform_moc: Mock) -> None:
+        signer = SignerMac(True)
+        signer.verify("/path/the-dylib.dylib")
+        mock_repo.assert_has_calls([call().execute('codesign --verify --deep --verbose=4 --display /path/the-dylib.dylib')])
 
     @patch("platform.system", return_value='Linux')
     @patch("sign_workflow.signer.GitRepository")


### PR DESCRIPTION
### Description
Allow dylib to be signed by macos signing and fix verification command. pkgutil should only be used when the type of pkg signed is a package (.pkg) else use codesign by default.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
