### PR TITLE
Add input-manifest argument to Github-issue-creation library

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -961,7 +961,8 @@ pipeline {
                     }
                     if (params.CREATE_GITHUB_ISSUE) {
                         createBuildFailureGithubIssue(
-                            message: buildFailureMessage()
+                            message: buildFailureMessage(),
+                            inputManifestPath: "manifests/$INPUT_MANIFEST"
                         )
                     }
 


### PR DESCRIPTION
### Description
To fix the auto-creation of github issue when an OpenSearch plugin fails

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
