### PR TITLE
Bump library version to 5.1.0 for benchmarks

### DIFF
--- a/jenkins/opensearch/benchmark-test.jenkinsfile
+++ b/jenkins/opensearch/benchmark-test.jenkinsfile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@4.3.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@5.1.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/benchmark-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/benchmark-test.jenkinsfile.txt
@@ -1,6 +1,6 @@
    benchmark-test.run()
       benchmark-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
-      benchmark-test.library({identifier=jenkins@4.3.0, retriever=null})
+      benchmark-test.library({identifier=jenkins@5.1.0, retriever=null})
       benchmark-test.pipeline(groovy.lang.Closure)
          benchmark-test.timeout({time=24, unit=HOURS})
          benchmark-test.echo(Executing on agent [label:none])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/secure-benchmark-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/secure-benchmark-test.jenkinsfile.txt
@@ -1,6 +1,6 @@
    benchmark-test.run()
       benchmark-test.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
-      benchmark-test.library({identifier=jenkins@4.3.0, retriever=null})
+      benchmark-test.library({identifier=jenkins@5.1.0, retriever=null})
       benchmark-test.pipeline(groovy.lang.Closure)
          benchmark-test.timeout({time=24, unit=HOURS})
          benchmark-test.echo(Executing on agent [label:none])


### PR DESCRIPTION
### Description
Bump `opensearch-build-libraries` library version to 5.1.0. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
