### PR TITLE
Update cmake to 3.23.3 for k-NN in 2.9.0 in docker images

### DIFF
--- a/docker/ci/dockerfiles/current/build.centos7.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch.x64.arm64.dockerfile
@@ -88,7 +88,7 @@ RUN ln -sfn /usr/local/bin/python3.9 /usr/bin/python3 && \
 
 # Add k-NN Library dependencies
 RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack gcc-gfortran -y
-RUN pip3 install cmake==3.21.3
+RUN pip3 install cmake==3.23.3
 
 # Change User
 USER 1000

--- a/docker/ci/dockerfiles/current/build.rockylinux8.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.rockylinux8.opensearch.x64.arm64.dockerfile
@@ -83,7 +83,7 @@ RUN dnf install epel-release -y && dnf repolist && \
     dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled powertools && \
     dnf install openblas-static lapack gcc-gfortran -y && dnf clean all
-RUN pip3 install cmake==3.21.3
+RUN pip3 install cmake==3.23.3
 
 # Change User
 USER 1000

--- a/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.opensearch-dashboards.x64.arm64.dockerfile
@@ -123,7 +123,7 @@ RUN update-alternatives --set python /usr/bin/python3.9 && \
 
 # Add other dependencies
 RUN yum install -y epel-release && yum clean all && yum install -y chromium jq && yum clean all && rm -rf /var/cache/yum/* && \
-    pip3 install cmake==3.21.3
+    pip3 install cmake==3.23.3
 
 # Change User
 USER 1000

--- a/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.rockylinux8.systemd-base.x64.arm64.dockerfile
@@ -134,7 +134,7 @@ RUN update-alternatives --set python /usr/bin/python3.9 && \
 
 # Add other dependencies
 RUN dnf install -y epel-release && dnf clean all && dnf install -y chromium jq && dnf clean all && \
-    pip3 install cmake==3.21.3
+    pip3 install cmake==3.23.3
 
 # We use the version test to check if packages installed correctly
 # And get added to the PATH

--- a/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.dockerfile
@@ -103,7 +103,7 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y curl git gnupg
 # Install pip packages
 RUN curl -SL https://bootstrap.pypa.io/get-pip.py | python && \
     pip3 install pip==23.1.2 && pip3 install pipenv==2023.6.12 awscli==1.22.12 && \
-    pip3 install cmake==3.21.3
+    pip3 install cmake==3.23.3
 
 # Create user group
 RUN apt-get install -y sudo && \


### PR DESCRIPTION
### Description
Update cmake to 3.23.3 for k-NN in 2.9.0 in docker images

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3706

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
