### PR TITLE
Add check if security plugin exists in startup script

### DIFF
--- a/scripts/startup/tar/linux/opensearch-tar-install.sh
+++ b/scripts/startup/tar/linux/opensearch-tar-install.sh
@@ -9,9 +9,11 @@ cd $OPENSEARCH_HOME
 
 KNN_LIB_DIR=$OPENSEARCH_HOME/plugins/opensearch-knn/lib
 ##Security Plugin
-bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s
+if [ -d "$OPENSEARCH_HOME/plugins/opensearch-security" ]; then
+        bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s
+        echo "done security"
+fi
 
-echo "done security"
 PA_AGENT_JAVA_OPTS="-Dlog4j.configurationFile=$OPENSEARCH_PATH_CONF/opensearch-performance-analyzer/log4j2.xml \
               -Xms64M -Xmx64M -XX:+UseSerialGC -XX:CICompilerCount=1 -XX:-TieredCompilation -XX:InitialCodeCacheSize=4096 \
               -XX:MaxRAM=400m"

--- a/scripts/startup/zip/windows/opensearch-windows-install.bat
+++ b/scripts/startup/zip/windows/opensearch-windows-install.bat
@@ -13,8 +13,10 @@ ECHO "OPENSEARCH_HOME: %OPENSEARCH_HOME%"
 ECHO "OPENSEARCH_PATH_CONF: %OPENSEARCH_PATH_CONF%"
 
 :: Security Plugin Setups
-ECHO "Running Security Plugin Install Demo Configuration"
-CALL "%OPENSEARCH_HOME%/plugins/opensearch-security/tools/install_demo_configuration.bat" -y -i -s
+IF EXIST "%OPENSEARCH_HOME%\plugins\opensearch-security" (
+    ECHO "Running Security Plugin Install Demo Configuration"
+    CALL "%OPENSEARCH_HOME%/plugins/opensearch-security/tools/install_demo_configuration.bat" -y -i -s
+)
 
 :: k-NN Plugin Setups
 ECHO "Set KNN Dylib Path for Windows systems"


### PR DESCRIPTION
### Description
There are certain cases when a distribution build is built without security plugin. In that case when `opensearch-tar-install.sh` script is run to start the OS process it fails at this [line](https://github.com/opensearch-project/opensearch-build/blob/main/scripts/startup/tar/linux/opensearch-tar-install.sh#L12) as there is no `opensearch-security` plugin present in the bundle. 
To overcome this adding a simple condition to check whether `opensearch-security` plugin exists in the bundle. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
