### PR TITLE
Upgrade gcc to 8 with devtoolset-8 for k-NN faiss lib compilation

### DIFF
--- a/docker/ci/dockerfiles/current/build.centos7.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.centos7.opensearch.x64.arm64.dockerfile
@@ -89,6 +89,15 @@ RUN ln -sfn /usr/local/bin/python3.9 /usr/bin/python3 && \
 # Add k-NN Library dependencies
 RUN yum install epel-release -y && yum repolist && yum install openblas-static lapack gcc-gfortran -y
 RUN pip3 install cmake==3.23.3
+# Upgrade gcc8
+# The setup part is partially based on Austin Dewey's article:
+# https://austindewey.com/2019/03/26/enabling-software-collections-binaries-on-a-docker-image/
+RUN yum install -y centos-release-scl && yum install -y devtoolset-8 && yum clean all && \
+    echo "source scl_source enable devtoolset-8" > /etc/profile.d/scl_devtoolset8.sh
+COPY --chown=0:0 config/scl_setup /usr/local/bin/scl_setup
+ENV BASH_ENV="/usr/local/bin/scl_setup"
+ENV ENV="/usr/local/bin/scl_setup"
+ENV PROMPT_COMMAND=". /usr/local/bin/scl_setup"
 
 # Change User
 USER 1000


### PR DESCRIPTION
### Description
Upgrade gcc to 8 with devtoolset-8 for k-NN faiss lib compilation

### Issues Resolved
https://github.com/opensearch-project/k-NN/issues/975

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
