### PR TITLE
Automation component release issue: Fix the bugs

### DIFF
--- a/.github/workflows/os-release-issues.yml
+++ b/.github/workflows/os-release-issues.yml
@@ -58,17 +58,6 @@ jobs:
           - {repo: sql}
         release_version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: dblock/create-a-github-issue@v3.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ matrix.release_version }}
-        id: build-repo-release-issue
-        with:
-          search_existing: all
-          update_existing: false
-          filename: .github/ISSUE_TEMPLATE/release_template.md
       - name: GitHub App token
         id: github_app_token
         uses: tibdex/github-app-token@v1.6.0
@@ -76,6 +65,17 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: dblock/create-a-github-issue@v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
+          VERSION: ${{ matrix.release_version }}
+        id: build-repo-release-issue
+        with:
+          search_existing: all
+          update_existing: false
+          filename: .github/ISSUE_TEMPLATE/release_template.md
       - name: Check out build repo
         uses: actions/checkout@v3
       - name: Check out plugin repo
@@ -100,7 +100,7 @@ jobs:
           token: ${{ steps.github_app_token.outputs.token }}
           title-includes: '[RELEASE] Release version ${{ matrix.release_version }}'
       - name: Create Issue From File
-        if: steps.check_if_issue_exists.issues == '[]'
+        if: steps.check_if_issue_exists.outputs.issues == '[]'
         uses: peter-evans/create-issue-from-file@v4
         with:
           title: '[RELEASE] Release version ${{ matrix.release_version }}'

--- a/.github/workflows/osd-release-issues.yml
+++ b/.github/workflows/osd-release-issues.yml
@@ -53,17 +53,6 @@ jobs:
           - {repo: opensearch-dashboards-functional-test}
         release_version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: dblock/create-a-github-issue@v3.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ matrix.release_version }}
-        id: build-repo-release-issue
-        with:
-          search_existing: all
-          update_existing: false
-          filename: .github/ISSUE_TEMPLATE/release_template.md
       - name: GitHub App token
         id: github_app_token
         uses: tibdex/github-app-token@v1.6.0
@@ -71,6 +60,17 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: dblock/create-a-github-issue@v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}
+          VERSION: ${{ matrix.release_version }}
+        id: build-repo-release-issue
+        with:
+          search_existing: all
+          update_existing: false
+          filename: .github/ISSUE_TEMPLATE/release_template.md
       - name: Check out build repo
         uses: actions/checkout@v3
       - name: Check out plugin repo
@@ -95,7 +95,7 @@ jobs:
           token: ${{ steps.github_app_token.outputs.token }}
           title-includes: '[RELEASE] Release version ${{ matrix.release_version }}'
       - name: Create Issue From File
-        if: steps.check_if_issue_exists.issues == '[]'
+        if: steps.check_if_issue_exists.outputs.issues == '[]'
         uses: peter-evans/create-issue-from-file@v4
         with:
           title: '[RELEASE] Release version ${{ matrix.release_version }}'


### PR DESCRIPTION
### Description
Coming from main PR https://github.com/opensearch-project/opensearch-build/pull/3708
Test Run: https://github.com/prudhvigodithi/opensearch-build/actions/runs/5565317888/jobs/10165581244 

Having just the `${{ secrets.GITHUB_TOKEN }}` would fail with API limits hence using the app tokens.
Failed run: https://github.com/opensearch-project/opensearch-build/actions/runs/5565126376 

### Issues Resolved
Part of:
https://github.com/opensearch-project/opensearch-build/issues/3349
https://github.com/opensearch-project/opensearch-build/issues/3676
https://github.com/opensearch-project/.github/issues/167


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
