### PR TITLE
[Release 2.9.0] Revert Manifests commit lock

### DIFF
--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -30,12 +30,6 @@ pipeline {
         BUILD_JOB_NAME = "distribution-build-opensearch"
         ARTIFACT_BUCKET_NAME = credentials('jenkins-artifact-bucket-name')
     }
-    triggers {
-        parameterizedCron '''
-            H 3 * * * %TEST_MANIFEST=2.9.0/opensearch-2.9.0-seg-rep-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.9.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
-            H 3 * * * %TEST_MANIFEST=2.9.0/opensearch-2.9.0-seg-rep-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.9.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
-            '''
-    }
     parameters {
         string(
             name: 'COMPONENT_NAME',

--- a/manifests/2.9.0/opensearch-2.9.0.yml
+++ b/manifests/2.9.0/opensearch-2.9.0.yml
@@ -10,13 +10,13 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: cb6d891de16a34704a6513769c2e2c44df9ba1d0
+    ref: '2.9'
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: cdd30e0517dea702497f2584733d71d7b1905455
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -25,7 +25,7 @@ components:
       - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: bf8f0c3803a278926a53a66292637e3faae9f828
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -34,7 +34,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: 591fff664e7ea4068acdcac5d4dd21cd428d2931
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -43,7 +43,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: geospatial
     repository: https://github.com/opensearch-project/geospatial.git
-    ref: f8df9a3d47053e63f1ad0299c56ddeda0839cea9
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -52,13 +52,13 @@ components:
       - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: cc8cce95ce2fe753c21206126133496b6b4e6107
+    ref: '2.9'
     platforms:
       - linux
       - windows
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: 0e405ed7356021076c54cc91ed1562673bfd04bb
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -67,7 +67,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: 51c0ccdd4a4d5f02b81abd52192a1482a9f0a0a9
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -76,7 +76,7 @@ components:
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
   - name: neural-search
     repository: https://github.com/opensearch-project/neural-search.git
-    ref: f9d64d830d98bc829926c846904c783fd7358739
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -85,7 +85,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: notifications-core
     repository: https://github.com/opensearch-project/notifications.git
-    ref: be24fefd88bdab3398cf36def4e43c5e05c3cc05
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -95,7 +95,7 @@ components:
       - gradle:dependencies:opensearch.version: opensearch-notifications-core
   - name: notifications
     repository: https://github.com/opensearch-project/notifications.git
-    ref: be24fefd88bdab3398cf36def4e43c5e05c3cc05
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -105,7 +105,7 @@ components:
       - gradle:dependencies:opensearch.version: notifications
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: a28655eb474c202bb82d2ceaaae528729c3fd195
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -114,7 +114,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: 677be512a5945a93572994357177799cb0ece176
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -123,7 +123,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: 912f99bd32cecc9f470b03f729e98c7d29baf69e
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -132,7 +132,7 @@ components:
       - gradle:dependencies:opensearch.version: opensearch-sql-plugin
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: 68e711089e35b519c667e54ca198978968b003ab
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -141,7 +141,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: 62dd94f6b41a8b836c241be2bdd141e9edf0ab09
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -150,7 +150,7 @@ components:
       - gradle:dependencies:opensearch.version
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: aefb268e0ad073ccff1bd98750b1805a20273056
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -159,7 +159,7 @@ components:
       - gradle:dependencies:opensearch.version: alerting
   - name: security-analytics
     repository: https://github.com/opensearch-project/security-analytics.git
-    ref: 629cfaeebfc5c26241f17b5831b6d970cace6c10
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -167,7 +167,7 @@ components:
       - gradle:properties:version
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: ccd01b1a2b12cf54d7022da412d83a9e5c052970
+    ref: '2.9'
     platforms:
       - linux
       - windows
@@ -175,7 +175,7 @@ components:
       - gradle:properties:version
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: 1f43448a7688645dce4261d798e76706e061adb4
+    ref: '2.9'
     platforms:
       - linux
     checks:

--- a/manifests/2.9.0/opensearch-dashboards-2.9.0.yml
+++ b/manifests/2.9.0/opensearch-dashboards-2.9.0.yml
@@ -9,47 +9,47 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: 23d6f18b7b094e8be41d970a1e56b49226a77752
+    ref: '2.9'
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: 937b60713bf56115b7481f4f6627090b06b371c4
+    ref: '2.9'
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
-    ref: 8c12cba5a5bda17f0b4675db1a84638319a5e3bf
+    ref: '2.9'
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
-    ref: bb5ebdd8856ff3017657236b1c67603188d040cb
+    ref: '2.9'
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
     working_directory: gantt-chart
-    ref: 84c16068db7c7046956fc8fa51cac0db5bbf404a
+    ref: '2.9'
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
-    ref: 6b60135d09e7d775e70fc029bd792bbccb63dbc8
+    ref: '2.9'
   - name: customImportMapDashboards
     repository: https://github.com/opensearch-project/dashboards-maps.git
-    ref: ecff50b08334155acc252684c59f0add26757d48
+    ref: '2.9'
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: f8125c81e11d7279921612e5f1d9ed6bf78c0dde
+    ref: '2.9'
   - name: mlCommonsDashboards
     repository: https://github.com/opensearch-project/ml-commons-dashboards.git
-    ref: f5426490f1fee50deabb66ce72bc2f27e9e5d29f
+    ref: '2.9'
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
-    ref: 6a4582e177809dbd136dbbb7177494b692e5e797
+    ref: '2.9'
   - name: notificationsDashboards
     repository: https://github.com/opensearch-project/dashboards-notifications.git
-    ref: 46c46e405c0cd4528762c05aba59589ef6952bcf
+    ref: '2.9'
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: ba8801db47cbaa3786cc3e4554aed8a8c14eaf42
+    ref: '2.9'
   - name: securityAnalyticsDashboards
     repository: https://github.com/opensearch-project/security-analytics-dashboards-plugin.git
-    ref: e5b2ad85e9073ffc4c8ac7b94a76253b264bc66c
+    ref: '2.9'
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: cf4643412fb26aeddc12b6b8eb189e5f97e236b7
+    ref: '2.9'
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
-    ref: 92d95400327b88cd20a5bde4e10f4156bdf77070
+    ref: '2.9'

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
@@ -5,10 +5,6 @@
          integ-test.credentials(jenkins-artifact-bucket-name)
          integ-test.timeout({time=4, unit=HOURS})
          integ-test.echo(Executing on agent [label:none])
-         integ-test.parameterizedCron(
-            H 3 * * * %TEST_MANIFEST=2.9.0/opensearch-2.9.0-seg-rep-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.9.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
-            H 3 * * * %TEST_MANIFEST=2.9.0/opensearch-2.9.0-seg-rep-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.9.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
-            )
          integ-test.stage(verify-parameters, groovy.lang.Closure)
             integ-test.echo(Executing on agent [label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host])
             integ-test.script(groovy.lang.Closure)


### PR DESCRIPTION
### Description
[Release 2.9.0] Revert Manifests commit lock. Coming from manifest lock PR https://github.com/opensearch-project/opensearch-build/pull/3740 

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/3616

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
