### PR TITLE
Automation component release issue: Fix label add bug

### DIFF
--- a/.github/workflows/os-release-issues.yml
+++ b/.github/workflows/os-release-issues.yml
@@ -107,6 +107,7 @@ jobs:
         with:
           title: '[RELEASE] Release version ${{ matrix.release_version }}'
           content-filepath: ../opensearch-build/.github/ISSUE_TEMPLATE/component_release_template.md
-          labels: 'v${{ matrix.release_version }}'
+          labels: |
+            v${{ matrix.release_version }}
           token: ${{ steps.github_app_token.outputs.token }}
           repository: opensearch-project/${{ matrix.entry.repo }}

--- a/.github/workflows/osd-release-issues.yml
+++ b/.github/workflows/osd-release-issues.yml
@@ -102,6 +102,7 @@ jobs:
         with:
           title: '[RELEASE] Release version ${{ matrix.release_version }}'
           content-filepath: ../opensearch-build/.github/ISSUE_TEMPLATE/component_release_template.md
-          labels: 'v${{ matrix.release_version }}'
+          labels: |
+            v${{ matrix.release_version }}
           token: ${{ steps.github_app_token.outputs.token }}
           repository: opensearch-project/${{ matrix.entry.repo }}


### PR DESCRIPTION
### Description
Coming from main PR https://github.com/opensearch-project/opensearch-build/pull/3708
https://github.com/opensearch-project/opensearch-build/pull/3795
This fixes the bugs fixes the following error
```
Created issue #1519
Applying labels 'v2.10.0'
Error: Resource not accessible by integration
```

Notice the error is thrown to add the label for the created release issue, following the documentation https://github.com/peter-evans/create-issue-from-file the labels should be added as `A comma or newline-separated list of labels`.

### Issues Resolved
Part of:
https://github.com/opensearch-project/opensearch-build/issues/3349
https://github.com/opensearch-project/opensearch-build/issues/3676
https://github.com/opensearch-project/.github/issues/167

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
