### PR TITLE
Automation component release issue: Workflow update

### DIFF
--- a/.github/workflows/os-release-issues.yml
+++ b/.github/workflows/os-release-issues.yml
@@ -89,7 +89,6 @@ jobs:
           actions: 'find-issues'
           repo: opensearch-project/${{ matrix.entry.repo }}
           token: ${{ steps.github_app_token.outputs.token }}
-          issue-state: 'open'
           title-includes: '[RELEASE] Release version ${{ matrix.release_version }}'
       - name: Replace Placeholders
         if: steps.check_if_plugin_repo_issue_exists.outputs.issues == '[]'

--- a/.github/workflows/osd-release-issues.yml
+++ b/.github/workflows/osd-release-issues.yml
@@ -84,7 +84,6 @@ jobs:
           actions: 'find-issues'
           repo: opensearch-project/${{ matrix.entry.repo }}
           token: ${{ steps.github_app_token.outputs.token }}
-          issue-state: 'open'
           title-includes: '[RELEASE] Release version ${{ matrix.release_version }}'
       - name: Replace Placeholders
         if: steps.check_if_plugin_repo_issue_exists.outputs.issues == '[]'


### PR DESCRIPTION
### Description
Coming from main PR https://github.com/opensearch-project/opensearch-build/pull/3708
https://github.com/opensearch-project/opensearch-build/pull/3795
https://github.com/opensearch-project/opensearch-build/pull/3797

This PR address 2 scenarios:

- Adding label to the component release issue 
Error: https://github.com/opensearch-project/opensearch-build/actions/runs/5591220878/jobs/10222005342#step:8:12
```
Applying labels 'v2.9.0'
Error: Resource not accessible by integration
```
This could be a race condition (where issue creation and add label are invoked at same time) or the permission issue, so removing temporarily adding of release label to the created release issue

- Removing checking the `issue-state: 'open'` as I have noticed sometimes a component release issue is closed by a release manager while the global build repo release issue is still open, so having a check `issue-state: 'open'` is forcing to create a new issue.
Example for `2.9.0` release the global build repo release issue is still open https://github.com/opensearch-project/opensearch-build/issues/3616 the asynchronous-search component repo release issue is closed https://github.com/opensearch-project/asynchronous-search/issues/299 but with `issue-state: 'open'` it recreated a new one https://github.com/opensearch-project/asynchronous-search/issues/319 not honoring the issue that was closed.

### Issues Resolved
Part of:
https://github.com/opensearch-project/opensearch-build/issues/3349
https://github.com/opensearch-project/opensearch-build/issues/3676
https://github.com/opensearch-project/.github/issues/167

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
