### PR TITLE
Update promote artifact jenkins workflow to use Python3.9 image

### DIFF
--- a/jenkins/opensearch-maven-release/publish-to-maven.jenkinsfile
+++ b/jenkins/opensearch-maven-release/publish-to-maven.jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     agent {
         docker {
             label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
-            image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211130'
+            image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3'
             registryUrl 'https://public.ecr.aws/'
             alwaysPull true
         }

--- a/jenkins/promotion/promote-artifacts.jenkinsfile
+++ b/jenkins/promotion/promote-artifacts.jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             agent {
                 docker {
                     label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
-                    image 'opensearchstaging/ci-runner:ci-runner-centos7-v1'
+                    image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3'
                     registryUrl 'https://public.ecr.aws/'
                     alwaysPull true
                 }

--- a/jenkins/release-tag/release-tag.jenkinsfile
+++ b/jenkins/release-tag/release-tag.jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     agent {
         docker {
             label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
-            image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211130'
+            image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3'
             registryUrl 'https://public.ecr.aws/'
             alwaysPull true
         }


### PR DESCRIPTION
### Description
Update promote artifact jenkins workflow to use Python3.9 image

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3616

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
