### PR TITLE
Update pyyaml to 6.0 caused by cython 3.0 update

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,8 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pyyaml = "~=5.4"
-types-PyYAML = "~=5.4"
+pyyaml = "~=6.0"
+types-PyYAML = "~=6.0"
 # TODO: The 'requests' package stays on 2.28 until we deprecate CentOS7.
 #       As newer version requires openssl1.1.1 where CentOS7 only provides openssl1.1.0.
 #       https://github.com/opensearch-project/opensearch-build/issues/3554


### PR DESCRIPTION
seems like this was caused by a change from Jul 17 2023 with cython 3.0 [stackoverflow q with similar issue](https://stackoverflow.com/questions/76708329/docker-compose-no-longer-building-image-attributeerror-cython-sources)

### Description
Updates pyyaml

### Issues Resolved
Closes [BUG]:Pyyaml update opensearch-project/opensearch-build#3805

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
