### PR TITLE
Fix integ tests for windows platform

### DIFF
--- a/src/system/execute.py
+++ b/src/system/execute.py
@@ -20,7 +20,7 @@ def execute(command: str, dir: str, capture: bool = True, raise_on_failure: bool
     :returns a tuple containing the exit code, stdout, and stderr.
     """
     logging.info(f'Executing "{command}" in {dir}')
-    result = subprocess.run(command, cwd=dir, shell=True, capture_output=capture, text=True)
+    result = subprocess.run(command, cwd=dir, shell=True, capture_output=capture, text=True, encoding='utf-8')
     if raise_on_failure:
         result.check_returncode()
     return result.returncode, result.stdout, result.stderr

--- a/src/system/process.py
+++ b/src/system/process.py
@@ -26,8 +26,8 @@ class Process:
         if self.started:
             raise ProcessStartedError(self.pid)
 
-        self.stdout = tempfile.NamedTemporaryFile(mode="r+", delete=False)
-        self.stderr = tempfile.NamedTemporaryFile(mode="r+", delete=False)
+        self.stdout = tempfile.NamedTemporaryFile(mode="r+", delete=False, encoding='utf-8')
+        self.stderr = tempfile.NamedTemporaryFile(mode="r+", delete=False, encoding='utf-8')
 
         self.require_sudo = require_sudo
 
@@ -58,15 +58,33 @@ class Process:
         logging.info(f"Process killed with exit code {self.process.returncode}")
 
         if self.stdout:
-            self.__stdout_data__ = open(self.stdout.name, 'r').read()
+            self.stdout.seek(0)
+            self.__stdout_data__ = self.stdout.read()
+            self.stdout.flush()
             self.stdout.close()
-            os.remove(self.stdout.name)
+            for proc in psutil.process_iter():
+                try:
+                    for item in proc.open_files():
+                        if self.stdout.name == item.path:
+                            logging.warning(f"stdout {item} is being used by process with this detail {proc}")
+                except Exception:
+                    pass
+            os.unlink(self.stdout.name)
             self.stdout = None
 
         if self.stderr:
-            self.__stderr_data__ = open(self.stderr.name, 'r').read()
+            self.stderr.seek(0)
+            self.__stderr_data__ = self.stderr.read()
+            self.stderr.flush()
             self.stderr.close()
-            os.remove(self.stderr.name)
+            for proc in psutil.process_iter():
+                try:
+                    for item in proc.open_files():
+                        if self.stderr.name == item.path:
+                            logging.warning(f"stderr {item} is being used by process with this detail {proc}")
+                except Exception:
+                    pass
+            os.unlink(self.stderr.name)
             self.stderr = None
 
         self.return_code = self.process.returncode

--- a/src/system/process.py
+++ b/src/system/process.py
@@ -66,9 +66,9 @@ class Process:
                 try:
                     for item in proc.open_files():
                         if self.stdout.name == item.path:
-                            logging.warning(f"stdout {item} is being used by process with this detail {proc}")
-                except Exception:
-                    pass
+                            raise Exception(f"stdout {item} is being used by process {proc}")
+                except Exception as err:
+                    logging.warning(f"{err.args}")
             os.unlink(self.stdout.name)
             self.stdout = None
 
@@ -81,9 +81,9 @@ class Process:
                 try:
                     for item in proc.open_files():
                         if self.stderr.name == item.path:
-                            logging.warning(f"stderr {item} is being used by process with this detail {proc}")
-                except Exception:
-                    pass
+                            raise Exception(f"stderr {item} is being used by process {proc}")
+                except Exception as err:
+                    logging.warning(f"{err.args}")
             os.unlink(self.stderr.name)
             self.stderr = None
 

--- a/src/system/process.py
+++ b/src/system/process.py
@@ -68,7 +68,7 @@ class Process:
                         if self.stdout.name == item.path:
                             raise Exception(f"stdout {item} is being used by process {proc}")
                 except Exception as err:
-                    logging.warning(f"{err.args}")
+                    logging.error(f"{err.args}")
             os.unlink(self.stdout.name)
             self.stdout = None
 
@@ -83,7 +83,7 @@ class Process:
                         if self.stderr.name == item.path:
                             raise Exception(f"stderr {item} is being used by process {proc}")
                 except Exception as err:
-                    logging.warning(f"{err.args}")
+                    logging.error(f"{err.args}")
             os.unlink(self.stderr.name)
             self.stderr = None
 

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -49,9 +49,9 @@ class TestRecorder:
         return os.path.realpath(dest_directory)
 
     def _generate_std_files(self, stdout: str, stderr: str, output_path: str) -> None:
-        with open(os.path.join(output_path, "stdout.txt"), "w") as stdout_file:
+        with open(os.path.join(output_path, "stdout.txt"), "w", encoding='utf-8') as stdout_file:
             stdout_file.write(stdout)
-        with open(os.path.join(output_path, "stderr.txt"), "w") as stderr_file:
+        with open(os.path.join(output_path, "stderr.txt"), "w", encoding='utf-8') as stderr_file:
             stderr_file.write(stderr)
 
     def _generate_yml(self, test_result_data: TestResultData, output_path: str) -> str:
@@ -68,7 +68,7 @@ class TestRecorder:
             "test_result": "PASS" if (test_result_data.exit_code == 0) else "FAIL",
             "test_result_files": test_result_file
         }
-        with open(os.path.join(output_path, "%s.yml" % test_result_data.component_name), "w") as file:
+        with open(os.path.join(output_path, "%s.yml" % test_result_data.component_name), "w", encoding='utf-8') as file:
             yaml.dump(outcome, file)
         return os.path.realpath("%s.yml" % test_result_data.component_name)
 

--- a/tests/tests_system/test_process.py
+++ b/tests/tests_system/test_process.py
@@ -60,3 +60,14 @@ class TestProcess(unittest.TestCase):
             process_handler.terminate()
 
         self.assertEqual(str(ctx.exception), "Process has not started")
+
+    @patch('psutil.Process')
+    @patch('subprocess.Popen')
+    @patch('psutil.process_iter')
+    def test_terminate_file_not_closed(self, procs: MagicMock, subprocess: MagicMock, process: MagicMock) -> None:
+        process_handler = Process()
+
+        process_handler.start("mock_command", "mock_cwd")
+        process_handler.terminate()
+
+        procs.assert_called

--- a/tests/tests_system/test_process.py
+++ b/tests/tests_system/test_process.py
@@ -42,7 +42,7 @@ class TestProcess(unittest.TestCase):
     def test_file_open_mode(self, mock_tempfile: MagicMock) -> None:
         process_handler = Process()
         process_handler.start("./tests/tests_system/data/wait_for_input.sh", ".")
-        mock_tempfile.assert_has_calls([call(delete=False, mode='r+'), call(delete=False, mode='r+')])
+        mock_tempfile.assert_has_calls([call(delete=False, encoding='utf-8', mode='r+')])
 
     def test_start_twice(self) -> None:
         process_handler = Process()

--- a/tests/tests_test_workflow/test_recorder/test_test_recorder.py
+++ b/tests/tests_test_workflow/test_recorder/test_test_recorder.py
@@ -80,7 +80,7 @@ class TestTestRecorder(unittest.TestCase):
 
         component_yml = test_recorder._generate_yml(mock_test_result_data, "working-directory")
 
-        mock_open.assert_has_calls([call(os.path.join("working-directory", "sql.yml"), 'w')])
+        mock_open.assert_has_calls([call(os.path.join("working-directory", "sql.yml"), 'w', encoding='utf-8')])
         mock_file_path.assert_called_once_with(None, "sql", "with-security")
         mock_list_files.assert_called()
         mock_update_path.assert_called()

--- a/tests/tests_test_workflow/test_recorder/test_test_recorder.py
+++ b/tests/tests_test_workflow/test_recorder/test_test_recorder.py
@@ -114,6 +114,24 @@ class TestTestRecorder(unittest.TestCase):
         list_files = test_recorder._get_list_files("mock_dir")
         self.assertEqual(list_files, ["file1", "file2"])
 
+    @patch("builtins.open", new_callable=mock_open)
+    def test_generate_std_files(self, mock_open: Mock, *mock: Any) -> None:
+        test_recorder = TestRecorder(
+            "1234",
+            "integ-test",
+            "working-directory"
+        )
+        test_recorder._generate_std_files("mock_stdout", "mock_stderr", "mock_path")
+
+        mock_file = MagicMock()
+        mock_open.return_value = mock_file
+
+        mock_open.assert_has_calls([call(os.path.join("mock_path", "stdout.txt"), 'w', encoding='utf-8')])
+        mock_open.assert_has_calls([call(os.path.join("mock_path", "stderr.txt"), 'w', encoding='utf-8')])
+
+        mock_open.assert_has_calls([call().write("mock_stdout")])
+        mock_open.assert_has_calls([call().write("mock_stderr")])
+
 
 class TestLocalClusterLogs(unittest.TestCase):
 


### PR DESCRIPTION
### Description
Fixing the current error of unable to remove temp files when terminating the process and also adding `UTF-8` encoding when executing the process for results record purpose.

According to the [module document](https://docs.python.org/3/library/tempfile.html) for `NamedTemporaryFile`, the temp file is open when we creating it and it may be supported to re-open it again by its name on Unix but not especially on windows platform. 

Also during my testing, the file was still open by python process even after we closed it by the file name. 
`item is popenfile(path='C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\2\\tmp2mlahvrq', fd=-1) and proc is psutil.Process(pid=6168, name='python.exe', status='running', started='23:49:13')`. Adding the for loop to check if it's closed before we remove it from the system will avoid `PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\2\\tmpix2x74us'` which caused the issue before.

When the process completed, our current `test-recorder` is not able to record the `stdout.txt` for the dashboards on windows because it uses `cp1252` for encoding by default and we would get `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 1357: character maps to <undefined>`. I am adding `utf-8` encoding to the subprocess execution to resolve this.

Sample running tests:
Running on dashboards: `./test.sh integ-test ./manifests/2.8.0/opensearch-dashboards-2.8.0-test.yml -p opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/windows/x64/zip opensearch-dashboards=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.8.0/6182/windows/x64/zip --test-run-id 1234 --component alertingDashboards`
```
2023-07-24 23:22:58 INFO     | alertingDashboards   | with-security        | PASS  |
2023-07-24 23:22:58 INFO     | alertingDashboards   | without-security     | PASS  |
```

Running for OpenSearch: `./test.sh integ-test ./manifests/2.8.0/opensearch-2.8.0-test.yml -p opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/windows/x64/zip  --component alerting --test-run-id 123`
```
2023-07-25 00:17:21 INFO     | alerting             | with-security        | PASS  |
2023-07-25 00:17:21 INFO     | alerting             | without-security     | PASS  |
```

I have also run integ tests on our linux docker and the back compatibility of the changes is passing.
`[opensearch@a49844d86db9 opensearch-build]$ ./test.sh integ-test ./manifests/2.8.0/opensearch-dashboards-2.8.0-test.yml -p opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar opensearch-dashboards=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.8.0/6182/linux/x64/tar --test-run-id 1236 --component mlCommonsDashboards`
```
2023-07-25 00:26:58 INFO     | mlCommonsDashboards  | with-security        | PASS  |
2023-07-25 00:26:58 INFO     | mlCommonsDashboards  | without-security     | PASS  |
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3196

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
