### PR TITLE
Close the created [AUTOCUT] issues : Move the `closeBuildSuccessGithubIssue` to post:always

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -849,6 +849,7 @@ pipeline {
     post {
         always {
             node(AGENT_X64) {
+                checkout scm
                 script {
                     buildInfoYaml(
                         componentName: COMPONENT_NAME,
@@ -857,13 +858,16 @@ pipeline {
                     )
                     unstash "buildInfo_yml"
                     archiveArtifacts artifacts: 'buildInfo.yml'
+                    closeBuildSuccessGithubIssue(
+                        message: buildMessage(search: 'Successfully built'),
+                        inputManifestPath: "manifests/$INPUT_MANIFEST"
+                    )
                     postCleanup()
                 }
             }
         }
         success {
             node(AGENT_X64) {
-                checkout scm
                 script {
                     List<String> stages = []
                     if (params.BUILD_PLATFORM.contains('linux')) {
@@ -898,10 +902,6 @@ pipeline {
                             manifest: "${INPUT_MANIFEST}"
                         )
                     }
-                    closeBuildSuccessGithubIssue(
-                        message: buildMessage(search: 'Successfully built'),
-                        inputManifestPath: "manifests/$INPUT_MANIFEST"
-                    )
                     postCleanup()
                 }
             }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -901,6 +901,7 @@ pipeline {
     post {
         always {
             node(AGENT_X64) {
+                checkout scm
                 script {
                     buildInfoYaml(
                         componentName: COMPONENT_NAME,
@@ -909,13 +910,16 @@ pipeline {
                     )
                     unstash "buildInfo_yml"
                     archiveArtifacts artifacts: 'buildInfo.yml'
+                    closeBuildSuccessGithubIssue(
+                        message: buildMessage(search: 'Successfully built'),
+                        inputManifestPath: "manifests/$INPUT_MANIFEST"
+                    )
                     postCleanup()
                 }
             }
         }
         success {
             node(AGENT_X64) {
-                checkout scm
                 script {
                     List<String> stages = []
                     if (params.BUILD_PLATFORM.contains('linux')) {
@@ -943,11 +947,6 @@ pipeline {
                             manifest: "${INPUT_MANIFEST}"
                         )
                     }
-                    closeBuildSuccessGithubIssue(
-                        message: buildMessage(search: 'Successfully built'),
-                        inputManifestPath: "manifests/$INPUT_MANIFEST"
-                    )
-
                     postCleanup()
                 }
             }


### PR DESCRIPTION
### Description
Close the created [AUTOCUT] issues Move the closeBuildSuccessGithubIssue to post:always.

This change is done to ensure upon every distribution build run the open `[AUTOCUT]` issues are closed. Having the `closeBuildSuccessGithubIssue` in post:failure section will only curate the open `[AUTOCUT]` issues only when the entire build is successful.
With this change moving closeBuildSuccessGithubIssue to post:always will ensure all the successful components `[AUTOCUT]` issues are closed and once which are failed will be handled in post:failure section.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/3809

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
