### PR TITLE
Add alerting plugin to 1.3.12 manifest

### DIFF
--- a/manifests/1.3.12/opensearch-1.3.12.yml
+++ b/manifests/1.3.12/opensearch-1.3.12.yml
@@ -32,3 +32,12 @@ components:
     platforms:
       - linux
       - windows
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: '1.3'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting
+    platforms:
+      - linux
+      - windows


### PR DESCRIPTION
### Description
Update alerting plugin in 1.3.12 manifest
### Issues Resolved
Required to publish alerting snapshot of 1.3.12 to Maven

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
