### PR TITLE
Temperarily remove windows gradle check as docker is not installed now

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -58,12 +58,6 @@ pipeline {
             printPostContent: false
         )
         parameterizedCron '''
-            H 1 * * * %GIT_REFERENCE=main;AGENT_LABEL=Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host
-            H 4 * * * %GIT_REFERENCE=main;AGENT_LABEL=Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host
-            H 9 * * * %GIT_REFERENCE=1.x;AGENT_LABEL=Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host
-            H 12 * * * %GIT_REFERENCE=1.x;AGENT_LABEL=Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host
-            H 17 * * * %GIT_REFERENCE=2.x;AGENT_LABEL=Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host
-            H 20 * * * %GIT_REFERENCE=2.x;AGENT_LABEL=Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host
             H 3 * * * %GIT_REFERENCE=main;AGENT_LABEL=Jenkins-Agent-Ubuntu2004-X64-M58xlarge-Single-Host
             H 6 * * * %GIT_REFERENCE=1.x;AGENT_LABEL=Jenkins-Agent-Ubuntu2004-X64-M58xlarge-Single-Host
             H 9 * * * %GIT_REFERENCE=2.x;AGENT_LABEL=Jenkins-Agent-Ubuntu2004-X64-M58xlarge-Single-Host


### PR DESCRIPTION
### Description
Temperarily remove windows gradle check as docker is not installed now

### Issues Resolved
Windows pending: https://github.com/opensearch-project/opensearch-ci/issues/281

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
