### PR TITLE
Issue 3815

### DIFF
--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -43,6 +43,9 @@ chown -R opensearch.opensearch ${config_dir}
 chown -R opensearch.opensearch ${log_dir}
 chown -R opensearch.opensearch ${data_dir}
 chown -R opensearch.opensearch ${pid_dir}
+chown 640 opensearch.opensearch ${config_dir}/opensearch.yml
+chown 640 opensearch.opensearch ${config_dir}/opensearch-security
+chown 640 opensearch.opensearch ${config_dir}/opensearch-security/*.yml
 
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -69,6 +69,9 @@ if [ ! -f %{buildroot}%{data_dir}/performance_analyzer_enabled.conf ]; then
 fi
 # Change Permissions
 chmod -Rf a+rX,u+w,g-w,o-w %{buildroot}/*
+chown 640 opensearch.opensearch ${config_dir}/opensearch.yml
+chown 640 opensearch.opensearch ${config_dir}/opensearch-security
+chown 640 opensearch.opensearch ${config_dir}/opensearch-security/*.yml
 exit 0
 
 %pre


### PR DESCRIPTION
### Description
The changes proposed in this PR add commands to set permission-bits of OpenSearch configuration files and directories created during installation of OpenSearch via RPM and DEB packages to more secure values.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3815

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
