### PR TITLE
Set build discarder for all test jobs to 30 days

### DIFF
--- a/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/bwc-test.jenkinsfile
@@ -6,6 +6,7 @@ lib = library(identifier: 'jenkins@1.0.4', retriever: modernSCM([
 pipeline {
     options {
         timeout(time: 4, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     agent none
     environment {

--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -23,6 +23,7 @@ def agent_nodes = [
 pipeline {
     options {
         timeout(time: 4, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     agent none
     environment {

--- a/jenkins/opensearch/benchmark-test.jenkinsfile
+++ b/jenkins/opensearch/benchmark-test.jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
     agent none
     options {
         timeout(time: 24, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     environment {
         AGENT_LABEL = 'Jenkins-Agent-AL2023-X64-M52xlarge-Docker-Host-Benchmark-Test'

--- a/jenkins/opensearch/bwc-test.jenkinsfile
+++ b/jenkins/opensearch/bwc-test.jenkinsfile
@@ -6,6 +6,7 @@ lib = library(identifier: 'jenkins@1.0.4', retriever: modernSCM([
 pipeline {
     options {
         timeout(time: 3, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     agent none
     environment {

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -23,6 +23,7 @@ def agent_nodes = [
 pipeline {
     options {
         timeout(time: 4, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     agent none
     environment {

--- a/jenkins/opensearch/perf-test.jenkinsfile
+++ b/jenkins/opensearch/perf-test.jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
     agent none
     options {
         timeout(time: 14, unit: 'DAYS')
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     environment {
         AGENT_LABEL = 'Jenkins-Agent-AL2023-X64-M52xlarge-Docker-Host-Perf-Test'

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/bwc-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/bwc-test.jenkinsfile.txt
@@ -3,6 +3,8 @@
       bwc-test.library({identifier=jenkins@1.0.4, retriever=null})
       bwc-test.pipeline(groovy.lang.Closure)
          bwc-test.timeout({time=4, unit=HOURS})
+         bwc-test.logRotator({daysToKeepStr=30})
+         bwc-test.buildDiscarder(null)
          bwc-test.echo(Executing on agent [label:none])
          bwc-test.stage(verify-parameters, groovy.lang.Closure)
             bwc-test.echo(Executing on agent [label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
@@ -4,6 +4,8 @@
       integ-test.pipeline(groovy.lang.Closure)
          integ-test.credentials(jenkins-artifact-bucket-name)
          integ-test.timeout({time=4, unit=HOURS})
+         integ-test.logRotator({daysToKeepStr=30})
+         integ-test.buildDiscarder(null)
          integ-test.echo(Executing on agent [label:none])
          integ-test.stage(verify-parameters, groovy.lang.Closure)
             integ-test.echo(Executing on agent [label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/benchmark-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/benchmark-test.jenkinsfile.txt
@@ -3,6 +3,8 @@
       benchmark-test.library({identifier=jenkins@5.1.0, retriever=null})
       benchmark-test.pipeline(groovy.lang.Closure)
          benchmark-test.timeout({time=24, unit=HOURS})
+         benchmark-test.logRotator({daysToKeepStr=30})
+         benchmark-test.buildDiscarder(null)
          benchmark-test.echo(Executing on agent [label:none])
          benchmark-test.parameterizedCron(
             H 0 * * * %BUNDLE_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/7771/linux/x64/tar/dist/opensearch/manifest.yml;TEST_WORKLOAD=http_logs;SINGLE_NODE_CLUSTER=false;DATA_NODE_COUNT=3;USE_50_PERCENT_HEAP=true;USER_TAGS=run-type:nightly,segrep:disabled,arch:x64,instance-type:r5.xlarge,major-version:2x,cluster-config:x64-r5.xlarge-3-data-3-shards-1-replica;WORKLOAD_PARAMS={"number_of_replicas":"1","number_of_shards":"3"}

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/bwc-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/bwc-test.jenkinsfile.txt
@@ -3,6 +3,8 @@
       bwc-test.library({identifier=jenkins@1.0.4, retriever=null})
       bwc-test.pipeline(groovy.lang.Closure)
          bwc-test.timeout({time=3, unit=HOURS})
+         bwc-test.logRotator({daysToKeepStr=30})
+         bwc-test.buildDiscarder(null)
          bwc-test.echo(Executing on agent [label:none])
          bwc-test.stage(verify-parameters, groovy.lang.Closure)
             bwc-test.echo(Executing on agent [label:Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
@@ -4,6 +4,8 @@
       integ-test.pipeline(groovy.lang.Closure)
          integ-test.credentials(jenkins-artifact-bucket-name)
          integ-test.timeout({time=4, unit=HOURS})
+         integ-test.logRotator({daysToKeepStr=30})
+         integ-test.buildDiscarder(null)
          integ-test.echo(Executing on agent [label:none])
          integ-test.parameterizedCron(
             H 3 * * * %TEST_MANIFEST=2.10.0/opensearch-2.10.0-concurrent-search-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.10.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/perf-test.jenkinsfile.txt
@@ -3,6 +3,8 @@
       perf-test.library({identifier=jenkins@1.0.4, retriever=null})
       perf-test.pipeline(groovy.lang.Closure)
          perf-test.timeout({time=14, unit=DAYS})
+         perf-test.logRotator({daysToKeepStr=30})
+         perf-test.buildDiscarder(null)
          perf-test.echo(Executing on agent [label:none])
          perf-test.parameterizedCron(
             H 12 * * * %BUNDLE_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.11/8029/linux/arm64/tar/dist/opensearch/manifest.yml;TEST_ITERATIONS=3;WARMUP_ITERATIONS=2

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/secure-benchmark-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/secure-benchmark-test.jenkinsfile.txt
@@ -3,6 +3,8 @@
       benchmark-test.library({identifier=jenkins@5.1.0, retriever=null})
       benchmark-test.pipeline(groovy.lang.Closure)
          benchmark-test.timeout({time=24, unit=HOURS})
+         benchmark-test.logRotator({daysToKeepStr=30})
+         benchmark-test.buildDiscarder(null)
          benchmark-test.echo(Executing on agent [label:none])
          benchmark-test.parameterizedCron(
             H 0 * * * %BUNDLE_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.7.0/7771/linux/x64/tar/dist/opensearch/manifest.yml;TEST_WORKLOAD=http_logs;SINGLE_NODE_CLUSTER=false;DATA_NODE_COUNT=3;USE_50_PERCENT_HEAP=true;USER_TAGS=run-type:nightly,segrep:disabled,arch:x64,instance-type:r5.xlarge,major-version:2x,cluster-config:x64-r5.xlarge-3-data-3-shards-1-replica;WORKLOAD_PARAMS={"number_of_replicas":"1","number_of_shards":"3"}


### PR DESCRIPTION
### Description
With the number of data growing with daily jobs run on build.ci.opensearch.org, this PR enables the build discarder for all test jobs. 
Setting the value to 30 days to start with.

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/168

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
