### PR TITLE
Enable build failure for job-scheduler and common-utils plugin

### DIFF
--- a/src/run_build.py
+++ b/src/run_build.py
@@ -71,7 +71,7 @@ def main() -> int:
                 logging.info(f"Successfully built {component.name}")
             except:
                 logging.error(f"Error building {component.name}, retry with: {args.component_command(component.name)}")
-                if args.continue_on_error and component.name not in ['OpenSearch', 'OpenSearch-Dashboards']:
+                if args.continue_on_error and component.name not in ['OpenSearch', 'job-scheduler', 'common-utils', 'OpenSearch-Dashboards']:
                     failed_plugins.append(component.name)
                     continue
                 else:

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -181,6 +181,20 @@ class TestRunBuild(unittest.TestCase):
     @patch("run_build.BuildRecorder", return_value=MagicMock())
     @patch("run_build.TemporaryDirectory")
     @patch("run_build.logging.error")
+    def test_common_utils_failure_continue_on_error(self, mock_logging_error: Mock, mock_temp: Mock, mock_recorder: Mock, mock_builder_from: Mock, *mocks: Any) -> None:
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        mock_builder = Mock()
+        mock_builder.build.side_effect = Exception("Error building")
+        mock_builder_from.return_value = mock_builder
+        with pytest.raises(Exception, match="Error building"):
+            main()
+        mock_logging_error.assert_called_with(f"Error building common-utils, retry with: run_build.py {self.NON_OPENSEARCH_MANIFEST} --component common-utils")
+
+    @patch("argparse._sys.argv", ["run_build.py", NON_OPENSEARCH_MANIFEST, "-p", "linux", "--continue-on-error", "--component", "sql" ,"alerting"])
+    @patch("run_build.Builders.builder_from", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.TemporaryDirectory")
+    @patch("run_build.logging.error")
     def test_fail_plugins_continue_on_error(self, mock_logging_error: Mock, mock_temp: Mock, mock_recorder: Mock, mock_builder_from: Mock, *mocks: Any) -> None:
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
         mock_builder = Mock()
@@ -188,7 +202,7 @@ class TestRunBuild(unittest.TestCase):
         mock_builder_from.return_value = mock_builder
 
         main()
-        mock_logging_error.assert_called_with("Failed plugins are ['common-utils', 'job-scheduler', 'sql', 'alerting']")
+        mock_logging_error.assert_called_with("Failed plugins are ['sql', 'alerting']")
 
     @patch("argparse._sys.argv", ["run_build.py", NON_OPENSEARCH_MANIFEST, "-p", "linux"])
     @patch("run_build.Builders.builder_from", return_value=MagicMock())


### PR DESCRIPTION
### Description
Common-utils and job-scheduler plugin act as dependency for large set of plugins. Hence in case of failure of these two components, notifying or engaging downstream components seems irrelevant. 
This change adds these 2 components to hard failure list. Now along with core engines if either of these component fails, the overall build will have a non-zero exit code with or without `--continue-on-error` flag

### Issues Resolved
related 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
