### PR TITLE
Remove redundant buildInfo.yaml from distribution builds

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -131,31 +131,6 @@ pipeline {
                 }
             }
         }
-        stage('Initialize the job info yaml report') {
-            agent {
-                docker {
-                    label AGENT_X64
-                    image dockerAgent.image
-                    registryUrl 'https://public.ecr.aws/'
-                    alwaysPull true
-                }
-            }
-            steps {
-                script {
-                    buildInfoYaml(
-                        componentName: COMPONENT_NAME,
-                        inputManifest: "manifests/$INPUT_MANIFEST",
-                        status: "NOT_STARTED",
-                        stage: "INITIALIZE_STAGE"
-                    )
-                }
-            }
-            post {
-                always {
-                    postCleanup()
-                }
-            }
-        }
         stage('build') {
             parallel {
                 stage('build-and-test-linux-x64-tar') {
@@ -851,13 +826,6 @@ pipeline {
             node(AGENT_X64) {
                 checkout scm
                 script {
-                    buildInfoYaml(
-                        componentName: COMPONENT_NAME,
-                        status: currentBuild.result,
-                        stage: "FINALIZE_STAGE"
-                    )
-                    unstash "buildInfo_yml"
-                    archiveArtifacts artifacts: 'buildInfo.yml'
                     closeBuildSuccessGithubIssue(
                         message: buildMessage(search: 'Successfully built'),
                         search: "Successfully built",

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -105,31 +105,6 @@ pipeline {
                 }
             }
         }
-        stage('Initialize the job info yaml report') {
-            agent {
-                docker {
-                    label AGENT_X64
-                    image dockerAgent.image
-                    registryUrl 'https://public.ecr.aws/'
-                    alwaysPull true
-                }
-            }
-            steps {
-                script {
-                    buildInfoYaml(
-                        componentName: COMPONENT_NAME,
-                        inputManifest: "manifests/$INPUT_MANIFEST",
-                        status: "NOT_STARTED",
-                        stage: "INITIALIZE_STAGE"
-                    )
-                }
-            }
-            post {
-                always {
-                    postCleanup()
-                }
-            }
-        }
         stage('build') {
             parallel {
                 stage('build-opensearch-snapshot-linux-x64-tar') {
@@ -903,13 +878,6 @@ pipeline {
             node(AGENT_X64) {
                 checkout scm
                 script {
-                    buildInfoYaml(
-                        componentName: COMPONENT_NAME,
-                        status: currentBuild.result,
-                        stage: "FINALIZE_STAGE"
-                    )
-                    unstash "buildInfo_yml"
-                    archiveArtifacts artifacts: 'buildInfo.yml'
                     closeBuildSuccessGithubIssue(
                         message: buildMessage(search: 'Successfully built'),
                         search: "Successfully built",


### PR DESCRIPTION
### Description
The buildInfo.yaml was added to get more insights into build https://github.com/opensearch-project/opensearch-build/pull/2473
However, overtime has become redundant. The underlying library is still in place but removing this from distribution build workflows to avoid unnecessary maintenance.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
