### PR TITLE
Enable continue on error for distribution build jobs

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@5.4.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@5.5.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -73,6 +73,11 @@ pipeline {
         booleanParam(
             name: 'CREATE_GITHUB_ISSUE',
             description: 'To create a github issue for failing component or not.',
+            defaultValue: true
+        )
+        booleanParam(
+            name: 'CONTINUE_ON_ERROR',
+            description: 'Continue building the distribution even if a single or few component fails',
             defaultValue: true
         )
     }
@@ -161,7 +166,8 @@ pipeline {
                                 inputManifest: "manifests/${INPUT_MANIFEST}",
                                 platform: 'linux',
                                 architecture: 'x64',
-                                distribution: 'tar'
+                                distribution: 'tar',
+                                continueOnError: ${params.CONTINUE_ON_ERROR}
                             )
                             String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
                             String buildManifestUrlOpenSearch = [buildManifestObj.getArtifactRootUrl(JOB_NAME_OPENSEARCH, "latest"), "builds", "opensearch", "manifest.yml"].join("/")
@@ -735,7 +741,8 @@ pipeline {
                                 inputManifest: "manifests/${INPUT_MANIFEST}",
                                 platform: 'windows',
                                 architecture: 'x64',
-                                distribution: "zip"
+                                distribution: "zip",
+                                continueOnError: ${params.CONTINUE_ON_ERROR}
                             )
                             String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
                             String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
@@ -826,11 +833,21 @@ pipeline {
             node(AGENT_X64) {
                 checkout scm
                 script {
+                    def findFailedPlugins = buildMessage(search: 'Failed plugins')
+                    if (findFailedPlugins != null) {
+                        currentBuild.result = 'UNSTABLE'
+                    }
                     closeBuildSuccessGithubIssue(
                         message: buildMessage(search: 'Successfully built'),
-                        search: "Successfully built",
+                        search: 'Successfully built',
                         inputManifestPath: "manifests/$INPUT_MANIFEST"
                     )
+                    if (params.CREATE_GITHUB_ISSUE) {
+                        createBuildFailureGithubIssue(
+                            message: buildMessage(search: 'Error building'),
+                            inputManifestPath: "manifests/$INPUT_MANIFEST"
+                        )
+                    }
                     postCleanup()
                 }
             }
@@ -887,13 +904,6 @@ pipeline {
                             manifest: "${INPUT_MANIFEST}"
                         )
                     }
-                    if (params.CREATE_GITHUB_ISSUE) {
-                        createBuildFailureGithubIssue(
-                            message: buildMessage(search: 'Error building'),
-                            inputManifestPath: "manifests/$INPUT_MANIFEST"
-                        )
-                    }
-
                     postCleanup()
                 }
             }

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -77,7 +77,7 @@ pipeline {
         )
         booleanParam(
             name: 'CONTINUE_ON_ERROR',
-            description: 'Continue building the distribution even if a single or few component fails',
+            description: 'Continue building the distribution even if a one or more component fails',
             defaultValue: true
         )
     }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
         )
         booleanParam(
             name: 'CONTINUE_ON_ERROR',
-            description: 'Continue building the distribution even if a single or few component fails',
+            description: 'Continue building the distribution even if a one or more component fails',
             defaultValue: true
         )
     }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@5.4.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@5.5.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -66,6 +66,11 @@ pipeline {
         booleanParam(
             name: 'CREATE_GITHUB_ISSUE',
             description: 'To create a github issue for failing component or not.',
+            defaultValue: true
+        )
+        booleanParam(
+            name: 'CONTINUE_ON_ERROR',
+            description: 'Continue building the distribution even if a single or few component fails',
             defaultValue: true
         )
     }
@@ -287,7 +292,8 @@ pipeline {
                                 inputManifest: "manifests/${INPUT_MANIFEST}",
                                 platform: 'linux',
                                 architecture: 'x64',
-                                distribution: "tar"
+                                distribution: "tar",
+                                continueOnError: ${params.CONTINUE_ON_ERROR}
                             )
                             String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
                             String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
@@ -789,7 +795,8 @@ pipeline {
                                 inputManifest: "manifests/${INPUT_MANIFEST}",
                                 platform: 'windows',
                                 architecture: 'x64',
-                                distribution: "zip"
+                                distribution: "zip",
+                                continueOnError: ${params.CONTINUE_ON_ERROR}
                             )
                             String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
                             String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
@@ -878,11 +885,21 @@ pipeline {
             node(AGENT_X64) {
                 checkout scm
                 script {
+                    def findFailedPlugins = buildMessage(search: 'Failed plugins')
+                    if (findFailedPlugins != null) {
+                        currentBuild.result = 'UNSTABLE'
+                    }
                     closeBuildSuccessGithubIssue(
                         message: buildMessage(search: 'Successfully built'),
-                        search: "Successfully built",
+                        search: 'Successfully built',
                         inputManifestPath: "manifests/$INPUT_MANIFEST"
                     )
+                    if (params.CREATE_GITHUB_ISSUE) {
+                        createBuildFailureGithubIssue(
+                            message: buildMessage(search: 'Error building'),
+                            inputManifestPath: "manifests/$INPUT_MANIFEST"
+                        )
+                    }
                     postCleanup()
                 }
             }
@@ -932,13 +949,6 @@ pipeline {
                             manifest: "${INPUT_MANIFEST}"
                         )
                     }
-                    if (params.CREATE_GITHUB_ISSUE) {
-                        createBuildFailureGithubIssue(
-                            message: buildMessage(search: 'Error building'),
-                            inputManifestPath: "manifests/$INPUT_MANIFEST"
-                        )
-                    }
-
                     postCleanup()
                 }
             }


### PR DESCRIPTION
### Description
This change adds below features:
- Enable continue on error for distribution build jobs for OS and OSD
- Mark build as `UNSTABLE` if there are failed plugins in the build
- Always search for build failures and create issues.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
