### PR TITLE
Enable continue on error for all stages

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -256,6 +256,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'x64',
                                         distribution: 'rpm',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-x64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -283,6 +284,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'x64',
                                         distribution: 'rpm',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-x64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -351,6 +353,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'x64',
                                         distribution: 'deb',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-x64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -378,6 +381,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'x64',
                                         distribution: 'deb',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-x64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -438,6 +442,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64',
                                         distribution: 'tar',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-arm64-tar-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -472,6 +477,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64',
                                         distribution: 'tar',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-arm64-tar-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
 
@@ -562,6 +568,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64',
                                         distribution: 'rpm',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-arm64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -595,6 +602,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64',
                                         distribution: 'rpm',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-arm64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -662,6 +670,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64',
                                         distribution: 'deb',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-arm64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -689,6 +698,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64',
                                         distribution: 'deb',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-arm64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -376,6 +376,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'x64',
                                         distribution: 'rpm',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-x64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -403,6 +404,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'x64',
                                         distribution: 'rpm',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-x64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -467,6 +469,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'x64',
                                         distribution: 'deb',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-x64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -494,6 +497,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'x64',
                                         distribution: 'deb',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-x64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -545,7 +549,8 @@ pipeline {
                                 inputManifest: "manifests/${INPUT_MANIFEST}",
                                 platform: 'linux',
                                 architecture: 'arm64',
-                                distribution: "tar"
+                                distribution: "tar",
+                                continueOnError: params.CONTINUE_ON_ERROR
                             )
                             String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
                             String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
@@ -627,6 +632,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64',
                                         distribution: 'rpm',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-arm64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -654,6 +660,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64',
                                         distribution: 'rpm',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-arm64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -718,6 +725,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64',
                                         distribution: 'deb',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-arm64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -745,6 +753,7 @@ pipeline {
                                         platform: 'linux',
                                         architecture: 'arm64',
                                         distribution: 'deb',
+                                        continueOnError: params.CONTINUE_ON_ERROR,
                                         stashName: "build-archive-linux-arm64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)


### PR DESCRIPTION
### Description
Enable continue on error for all stages. The buildArchieve as well as BuildAssembleUpload builds the artifacts as well. Enabling on all stages now.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
