### PR TITLE
Add support for signing jar and taco files using jar_signer

### DIFF
--- a/src/sign_workflow/sign_args.py
+++ b/src/sign_workflow/sign_args.py
@@ -13,7 +13,7 @@ from typing import List
 
 class SignArgs:
     ACCEPTED_SIGNATURE_FILE_TYPES = [".sig", ".asc"]
-    ACCEPTED_PLATFORM = ["linux", "windows", "mac"]
+    ACCEPTED_PLATFORM = ["linux", "windows", "mac", "jar_signer"]
 
     target: Path
     components: List[str]

--- a/src/sign_workflow/signer_jar.py
+++ b/src/sign_workflow/signer_jar.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import os
+from pathlib import Path
+
+from sign_workflow.signer import Signer
+
+"""
+This class is responsible for signing jar and taco files using the OpenSearch-signer-client and verifying its signature.
+"""
+
+
+class SignerJar(Signer):
+    ACCEPTED_FILE_TYPES = [".jar", ".taco"]
+
+    def generate_signature_and_verify(self, artifact: str, basepath: Path, signature_type: str) -> None:
+        filename = os.path.join(basepath, artifact)
+        signed_filename = filename if self.overwrite else os.path.join(basepath, "signed_" + artifact)
+        self.sign(artifact, basepath, signature_type)
+        self.verify(signed_filename)
+
+    def is_valid_file_type(self, file_name: str) -> bool:
+        return any(
+            file_name.endswith(x) for x in SignerJar.ACCEPTED_FILE_TYPES
+        )
+
+    def sign(self, artifact: str, basepath: Path, signature_type: str) -> None:
+        filename = os.path.join(basepath, artifact)
+        signed_filename = filename if self.overwrite else os.path.join(basepath, "signed_" + artifact)
+        signing_cmd = [
+            "./opensearch-signer-client",
+            "-i",
+            filename,
+            "-o",
+            signed_filename,
+            "-p",
+            "jar_signer",
+            "-r",
+            str(self.overwrite)
+        ]
+        self.git_repo.execute(" ".join(signing_cmd))
+
+    def verify(self, filename: str) -> None:
+        verify_cmd = ["jarsigner", "-verify", filename, "-verbose", "-certs", "-strict"]
+        signature = self.git_repo.output(" ".join(verify_cmd))
+        if signature.find('jar verified') == -1:
+            raise ValueError(f"Cannot verify the signature for {filename}")

--- a/src/sign_workflow/signers.py
+++ b/src/sign_workflow/signers.py
@@ -8,6 +8,7 @@
 
 
 from sign_workflow.signer import Signer
+from sign_workflow.signer_jar import SignerJar
 from sign_workflow.signer_mac import SignerMac
 from sign_workflow.signer_pgp import SignerPGP
 from sign_workflow.signer_windows import SignerWindows
@@ -18,6 +19,7 @@ class Signers:
         "windows": SignerWindows,
         "linux": SignerPGP,
         "mac": SignerMac,
+        "jar_signer": SignerJar
     }
 
     @classmethod

--- a/tests/tests_sign_workflow/test_signer_jar.py
+++ b/tests/tests_sign_workflow/test_signer_jar.py
@@ -1,0 +1,61 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, call, patch
+
+from sign_workflow.signer_jar import SignerJar
+
+
+class TestSignerJar(unittest.TestCase):
+
+    @patch("sign_workflow.signer.GitRepository")
+    def test_accepted_file_types(self, git_repo: Mock) -> None:
+        artifacts = [
+            "the-msi.msi",
+            "the-zip.zip",
+            "the-jar.jar",
+            "the-taco.taco",
+            "the-sys.sys",
+            "something-1.0.0.0.jar",
+        ]
+        expected = [
+            call("the-jar.jar", Path("path"), 'null'),
+            call("the-taco.taco", Path("path"), 'null'),
+            call("something-1.0.0.0.jar", Path("path"), 'null')
+        ]
+        signer = SignerJar(True)
+        signer.sign = MagicMock()  # type: ignore
+        signer.sign_artifacts(artifacts, Path("path"), 'null')
+        self.assertEqual(signer.sign.call_args_list, expected)
+
+    @patch("sign_workflow.signer.GitRepository")
+    @patch('os.rename')
+    @patch('os.mkdir')
+    def test_signer_sign(self, mock_os_mkdir: Mock, mock_os_rename: Mock, mock_repo: Mock) -> None:
+        signer = SignerJar(False)
+        signer.sign("the-jar.jar", Path("/path/"), "null")
+        command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"), 'the-jar.jar') + " -o " + os.path.join(Path("/path/"), 'signed_the-jar.jar') + " -p jar_signer -r False"
+        mock_repo.assert_has_calls(
+            [call().execute(command)])
+
+    @patch("sign_workflow.signer.GitRepository")
+    def test_sign_command_for_overwrite(self, mock_repo: Mock) -> None:
+        signer = SignerJar(True)
+        signer.sign("the-taco.taco", Path("/path/"), 'null')
+        command = "./opensearch-signer-client -i " + os.path.join(Path("/path/"), 'the-taco.taco') + " -o " + os.path.join(Path("/path/"), 'the-taco.taco') + " -p jar_signer" + " -r True"
+        mock_repo.assert_has_calls(
+            [call().execute(command)])
+
+    @patch("sign_workflow.signer.GitRepository")
+    def test_signer_verify(self, mock_repo: Mock) -> None:
+        signer = SignerJar(True)
+        signer.verify('/path/the-jar.jar')
+        mock_repo.assert_has_calls([call().output("jarsigner -verify /path/the-jar.jar -verbose -certs -strict")])

--- a/tests/tests_sign_workflow/test_signers.py
+++ b/tests/tests_sign_workflow/test_signers.py
@@ -8,6 +8,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from sign_workflow.signer_jar import SignerJar
 from sign_workflow.signer_mac import SignerMac
 from sign_workflow.signer_pgp import SignerPGP
 from sign_workflow.signer_windows import SignerWindows
@@ -30,6 +31,11 @@ class TestSigners(unittest.TestCase):
     def test_signer_macos(self, mock_repo: Mock) -> None:
         signer = Signers.create("mac", True)
         self.assertIs(type(signer), SignerMac)
+
+    @patch("sign_workflow.signer.GitRepository")
+    def test_signer_jar(self, mock_repo: Mock) -> None:
+        signer = Signers.create("jar_signer", True)
+        self.assertIs(type(signer), SignerJar)
 
     def test_signer_invalid(self) -> None:
         with self.assertRaises(ValueError) as ctx:


### PR DESCRIPTION
### Description
Add support for signing jar and taco files using jar_signer. Please note that jarsigner is already present in current dockerfiles used for building.
```
docker run --env JAVA_HOME=/opt/java/openjdk-20 -it opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3 /bin/bash
[opensearch@b90575549a20 ~]$ jarsigner --version
jarsigner 20.0.1
```

<details><summary>See signature validation</summary>
<p>

```
common-utils-2.9.0.0-javadoc.jar  8.63 KB / 8.63 KB  (100%)        2023-08-16 16:29:00 INFO     Executing "jarsigner -verify /Users/gaiksaya/opensearch-project/opensearch-build/common-utils-2.9.0.0-javadoc.jar -verbose -certs -strict" in /private/var/folders/kx/fckh1fzj1nl122p3dch9nclrbnsk_0/T/tmph3u2jyo9/src

s        25 Wed Aug 16 23:28:56 PDT 2023 META-INF/MANIFEST.MF

      >>> Signer
      X.509, CN="Amazon Web Services, Inc.", OU=AWS Search Services, O="Amazon Web Services, Inc.", L=Seattle, ST=Washington, C=US, SERIALNUMBER=4152954, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US
      [certificate is valid from 4/13/23, 5:00 PM to 4/16/24, 4:59 PM]
      X.509, CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1, O="DigiCert, Inc.", C=US
      [certificate is valid from 4/28/21, 5:00 PM to 4/28/36, 4:59 PM]
      X.509, CN=DigiCert Trusted Root G4, OU=www.digicert.com, O=DigiCert Inc, C=US
      [trusted certificate]
      >>> TSA
      X.509, CN=DigiCert Timestamp 2023, O="DigiCert, Inc.", C=US
      [certificate is valid from 7/13/23, 5:00 PM to 10/13/34, 4:59 PM]
      X.509, CN=DigiCert Trusted G4 RSA4096 SHA256 TimeStamping CA, O="DigiCert, Inc.", C=US
      [certificate is valid from 3/22/22, 5:00 PM to 3/22/37, 4:59 PM]
      X.509, CN=DigiCert Trusted Root G4, OU=www.digicert.com, O=DigiCert Inc, C=US
      [certificate is valid from 7/31/22, 5:00 PM to 11/9/31, 3:59 PM]

        226 Wed Aug 16 23:28:56 PDT 2023 META-INF/SIGNER.SF
      11640 Wed Aug 16 23:28:56 PDT 2023 META-INF/SIGNER.RSA
          0 Tue Jul 18 21:30:14 PDT 2023 META-INF/

  s = signature was verified
  m = entry is listed in manifest
  k = at least one certificate was found in keystore

- Signed by "CN="Amazon Web Services, Inc.", OU=AWS Search Services, O="Amazon Web Services, Inc.", L=Seattle, ST=Washington, C=US, SERIALNUMBER=4152954, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US"
    Digest algorithm: SHA-256
    Signature algorithm: SHA256withRSA, 3072-bit key
  Timestamped by "CN=DigiCert Timestamp 2023, O="DigiCert, Inc.", C=US" on Wed Aug 16 23:28:57 UTC 2023
    Timestamp digest algorithm: SHA-256
    Timestamp signature algorithm: SHA256withRSA, 4096-bit key

jar verified.

Warning:
POSIX file permission and/or symlink attributes detected. These attributes are ignored when signing and are not protected by the signature.

The signer certificate will expire on 2024-04-16.
The timestamp will expire on 2031-11-09.
2023-08-16 16:29:00 INFO     Done.
```

</p>
</details> 

### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-build/issues/3895

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
