### PR TITLE
Improve ownership and permissions of files in deb and rpm packages

### DIFF
--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -38,7 +38,6 @@ if ! grep -q '## OpenSearch Performance Analyzer' ${config_dir}/jvm.options; the
 fi
 
 # Set owner
-chown -R opensearch.opensearch ${product_dir}
 chown -R opensearch.opensearch ${config_dir}
 chown -R opensearch.opensearch ${log_dir}
 chown -R opensearch.opensearch ${data_dir}

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -40,7 +40,7 @@ fi
 # Set ownership and permissions
 # FIXME: the opensearch service should not have w permission in the config directory
 chown -R opensearch.opensearch ${config_dir}
-chmod -R o-rx ${config_dir}
+chmod -R u=rwX,g=rX,o= ${config_dir}
 
 chown -R opensearch.adm ${log_dir}
 chmod 750 ${log_dir}

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -46,6 +46,8 @@ chown -R opensearch.adm ${log_dir}
 chmod 750 ${log_dir}
 
 chown -R opensearch.opensearch ${data_dir}
+chmod 750 ${data_dir}
+
 chown -R opensearch.opensearch ${pid_dir}
 
 # Reload systemctl daemon

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -42,7 +42,9 @@ fi
 chown -R opensearch.opensearch ${config_dir}
 chmod -R o-rx ${config_dir}
 
-chown -R opensearch.opensearch ${log_dir}
+chown -R opensearch.adm ${log_dir}
+chmod 750 ${log_dir}
+
 chown -R opensearch.opensearch ${data_dir}
 chown -R opensearch.opensearch ${pid_dir}
 

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -37,8 +37,11 @@ if ! grep -q '## OpenSearch Performance Analyzer' ${config_dir}/jvm.options; the
    echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> ${config_dir}/jvm.options
 fi
 
-# Set owner
+# Set ownership and permissions
+# FIXME: the opensearch service should not have w permission in the config directory
 chown -R opensearch.opensearch ${config_dir}
+chmod -R o-rx ${config_dir}
+
 chown -R opensearch.opensearch ${log_dir}
 chown -R opensearch.opensearch ${data_dir}
 chown -R opensearch.opensearch ${pid_dir}

--- a/scripts/pkg/build_templates/opensearch/deb/debmake_opensearch_install.sh
+++ b/scripts/pkg/build_templates/opensearch/deb/debmake_opensearch_install.sh
@@ -41,6 +41,6 @@ ln -s ${data_dir} ${buildroot}${product_dir}/data
 ln -s ${log_dir}  ${buildroot}${product_dir}/logs
 
 # Change Permissions
-chmod -Rf a+rX,u+w,g-w,o-w ${buildroot}/*
+chmod -Rf u=rwX,g=rX,o=rX ${buildroot}/*
 
 exit 0

--- a/scripts/pkg/build_templates/opensearch/deb/debmake_opensearch_install.sh
+++ b/scripts/pkg/build_templates/opensearch/deb/debmake_opensearch_install.sh
@@ -41,6 +41,7 @@ ln -s ${data_dir} ${buildroot}${product_dir}/data
 ln -s ${log_dir}  ${buildroot}${product_dir}/logs
 
 # Change Permissions
+chmod -Rf g-s ${buildroot}/*
 chmod -Rf u=rwX,g=rX,o=rX ${buildroot}/*
 
 exit 0

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -68,7 +68,8 @@ if [ ! -f %{buildroot}%{data_dir}/performance_analyzer_enabled.conf ]; then
     echo 'true' > %{buildroot}%{data_dir}/performance_analyzer_enabled.conf
 fi
 # Change Permissions
-chmod -Rf a+rX,u+w,g-w,o-w %{buildroot}/*
+chmod -Rf g-s %{buildroot}/*
+chmod -Rf u=rwX,g=rX,o= %{buildroot}/etc
 exit 0
 
 %pre
@@ -150,13 +151,6 @@ exit 0
 # Permissions
 %defattr(-, %{name}, %{name})
 
-# Root dirs/docs/licenses
-%dir %{product_dir}
-%doc %{product_dir}/NOTICE.txt
-%doc %{product_dir}/README.md
-%license %{product_dir}/LICENSE.txt
-%{product_dir}/manifest.yml
-
 # Config dirs/files
 %dir %{config_dir}
 %{config_dir}/jvm.options.d
@@ -175,6 +169,20 @@ exit 0
 %attr(0644, root, root) %config(noreplace) %{_prefix}/lib/sysctl.d/%{name}.conf
 %attr(0644, root, root) %config(noreplace) %{_prefix}/lib/tmpfiles.d/%{name}.conf
 
+%dir %attr(750, %{name}, %{name}) %{data_dir}
+%dir %attr(750, %{name}, %{name}) %{log_dir}
+%dir %attr(750, %{name}, %{name}) %{pid_dir}
+
+# Permissions
+%defattr(-, root, root)
+
+# Root dirs/docs/licenses
+%dir %{product_dir}
+%doc %{product_dir}/NOTICE.txt
+%doc %{product_dir}/README.md
+%license %{product_dir}/LICENSE.txt
+%{product_dir}/manifest.yml
+
 # Main dirs
 %{product_dir}/bin
 %{product_dir}/jdk
@@ -182,9 +190,6 @@ exit 0
 %{product_dir}/modules
 %{product_dir}/performance-analyzer-rca
 %{product_dir}/plugins
-%{log_dir}
-%{pid_dir}
-%dir %{data_dir}
 
 # Symlinks
 %{product_dir}/data

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -170,8 +170,8 @@ exit 0
 %attr(0644, root, root) %config(noreplace) %{_prefix}/lib/tmpfiles.d/%{name}.conf
 
 %dir %attr(750, %{name}, %{name}) %{data_dir}
-%dir %attr(750, %{name}, %{name}) %{log_dir}
-%dir %attr(750, %{name}, %{name}) %{pid_dir}
+%attr(750, %{name}, %{name}) %{log_dir}
+%attr(750, %{name}, %{name}) %{pid_dir}
 
 # Permissions
 %defattr(-, root, root)


### PR DESCRIPTION
### Description

When installing OpenSearch from .deb or .rpm packages, the files permissions are unexpectedly relaxed allowing all local users to access all files from the OpenSearch, and allowing OpenSearch itself to update any file installed in the package.

This PR adjust the permissions so that the configuration, logs and data cannot be accessed by random users, and the application code cannot be updated by the opensearch user.

### Issues Resolved

Fixes #3815
