### PR TITLE
Add support to accept telemetry parameters

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_args.py
+++ b/src/test_workflow/benchmark_test/benchmark_args.py
@@ -42,6 +42,7 @@ class BenchmarkArgs:
     user_tag: str
     target_hosts: str
     telemetry: list
+    telemetry_params: str
     logging_level: int
 
     def __init__(self) -> None:
@@ -97,6 +98,8 @@ class BenchmarkArgs:
         parser.add_argument("--capture-segment-replication-stat", dest="telemetry", action="append_const",
                             const="segment-replication-stats",
                             help="Enable opensearch-benchmark to segment_replication stat metrics such as replication lag.")
+        parser.add_argument("--telemetry-params", dest="telemetry_params",
+                            help="Allows to set parameters for telemetry devices. Accepts json input.")
         parser.add_argument("-v", "--verbose", help="Show more verbose output.", action="store_const", default=logging.INFO,
                             const=logging.DEBUG, dest="logging_level")
 
@@ -126,4 +129,5 @@ class BenchmarkArgs:
         self.additional_config = json.dumps(args.additional_config) if args.additional_config is not None else None
         self.use_50_percent_heap = args.use_50_percent_heap
         self.telemetry = args.telemetry
+        self.telemetry_params = args.telemetry_params if args.telemetry_params else None
         self.logging_level = args.logging_level

--- a/src/test_workflow/benchmark_test/benchmark_test_suite.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite.py
@@ -35,23 +35,25 @@ class BenchmarkTestSuite:
         self.args = args
         # Pass the cluster endpoints with -t for multi-cluster use cases(e.g. cross-cluster-replication)
         self.command = 'docker run --rm'
-        if args.benchmark_config:
+        if self.args.benchmark_config:
             self.command += f" -v {args.benchmark_config}:/opensearch-benchmark/.benchmark/benchmark.ini"
         self.command += f" opensearchproject/opensearch-benchmark:latest execute-test --workload={self.args.workload} " \
                         f"--pipeline=benchmark-only --target-hosts={endpoint}"
 
-        if args.workload_params:
+        if self.args.workload_params:
             logging.info(f"Workload Params are {args.workload_params}")
             self.command += f" --workload-params '{args.workload_params}'"
 
-        if args.user_tag:
+        if self.args.user_tag:
             user_tag = f"--user-tag=\"{args.user_tag}\""
             self.command += f" {user_tag}"
 
-        if args.telemetry:
+        if self.args.telemetry:
             self.command += " --telemetry "
-            for value in args.telemetry:
+            for value in self.args.telemetry:
                 self.command += f"{value},"
+            if self.args.telemetry_params:
+                self.command += f" --telemetry-params '{self.args.telemetry_params}'"
 
     def execute(self) -> None:
         if self.security:

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
@@ -14,13 +14,14 @@ from test_workflow.benchmark_test.benchmark_test_suite import BenchmarkTestSuite
 
 class TestBenchmarkTestSuite(unittest.TestCase):
     def setUp(self, config: Optional[str] = None, tag: Optional[str] = None,
-              workload_params: Optional[str] = None, telemetry: Optional[list] = None) -> None:
+              workload_params: Optional[str] = None, telemetry: Optional[list] = None, telemetry_params: Optional[str] = None) -> None:
         self.args = Mock()
         self.args.workload = "nyc_taxis"
         self.args.benchmark_config = config
         self.args.user_tag = tag
         self.args.workload_params = workload_params
         self.args.telemetry = telemetry
+        self.args.telemetry_params = telemetry_params
         self.endpoint = "abc.com"
         self.benchmark_test_suite = BenchmarkTestSuite(endpoint=self.endpoint, security=False, args=self.args)
 
@@ -44,6 +45,20 @@ class TestBenchmarkTestSuite(unittest.TestCase):
                              'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'"')
 
     def test_execute_default_with_optional_args(self) -> None:
+        TestBenchmarkTestSuite.setUp(self, "/home/test/benchmark.ini", "key1:value1,key2:value2", "{\"number_of_replicas\":\"1\"}", ['node-stats', 'test'], "{\"example_key\":\"example_value\"}")
+        with patch("subprocess.check_call") as mock_check_call:
+            self.benchmark_test_suite.execute()
+            self.assertEqual(mock_check_call.call_count, 1)
+            self.assertEqual(self.benchmark_test_suite.command, 'docker run --rm -v /home/test/benchmark.ini:'
+                                                                '/opensearch-benchmark/.benchmark/benchmark.ini '
+                                                                'opensearchproject/opensearch-benchmark:latest execute-test '
+                                                                '--workload=nyc_taxis '
+                                                                '--pipeline=benchmark-only --target-hosts=abc.com '
+                                                                '--workload-params \'{"number_of_replicas":"1"}\' '
+                                                                '--user-tag="key1:value1,key2:value2" --telemetry node-stats,test, --telemetry-params \'{"example_key":"example_value"}\' '
+                                                                '--client-options="timeout:300"')
+
+    def test_execute_default_with_no_telemetry_params(self) -> None:
         TestBenchmarkTestSuite.setUp(self, "/home/test/benchmark.ini", "key1:value1,key2:value2", "{\"number_of_replicas\":\"1\"}", ['node-stats', 'test'])
         with patch("subprocess.check_call") as mock_check_call:
             self.benchmark_test_suite.execute()
@@ -54,4 +69,5 @@ class TestBenchmarkTestSuite(unittest.TestCase):
                                                                 '--workload=nyc_taxis '
                                                                 '--pipeline=benchmark-only --target-hosts=abc.com '
                                                                 '--workload-params \'{"number_of_replicas":"1"}\' '
-                                                                '--user-tag="key1:value1,key2:value2" --telemetry node-stats,test, --client-options="timeout:300"')
+                                                                '--user-tag="key1:value1,key2:value2" --telemetry node-stats,test, '
+                                                                '--client-options="timeout:300"')


### PR DESCRIPTION
### Description
This PR adds support to accept additional telemetry parameters to enable non-default settings when using `node-stats` or any other type of telemetry. 
The settings are only applied when any type of telemetry, e.g. `node-stats` is enabled, else it will be ignored. 

### Issues Resolved
#3911 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
