### PR TITLE
Update readme for the build workflow --continue-on-error parameter

### DIFF
--- a/src/build_workflow/README.md
+++ b/src/build_workflow/README.md
@@ -71,7 +71,7 @@ The following options are available in `build.sh`.
 | -p, --platform          | Specify platform to build, default is platform of build system.                        |
 | --component [name ...]  | Rebuild a subset of components by name, e.g. `--component common-utils job-scheduler`. |
 | --keep                  | Do not delete the temporary working directory on both success or error.                |
-| --continue-on-error     | Do not fail the bundle build on plugin component failure                               |
+| --continue-on-error     | Do not fail the bundle build on plugin component failure.                              |
 | -l, --lock              | Generate a stable reference manifest.                                                  |
 | -v, --verbose           | Show more verbose output.                                                              |
 

--- a/src/build_workflow/README.md
+++ b/src/build_workflow/README.md
@@ -71,6 +71,7 @@ The following options are available in `build.sh`.
 | -p, --platform          | Specify platform to build, default is platform of build system.                        |
 | --component [name ...]  | Rebuild a subset of components by name, e.g. `--component common-utils job-scheduler`. |
 | --keep                  | Do not delete the temporary working directory on both success or error.                |
+| --continue-on-error     | Do not fail the bundle build on plugin component failure                               |
 | -l, --lock              | Generate a stable reference manifest.                                                  |
 | -v, --verbose           | Show more verbose output.                                                              |
 


### PR DESCRIPTION
### Description
Update readme for the build workflow --continue-on-error parameter

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/pull/3834

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
