### PR TITLE
Add hybrid search enable param support to neuralsearch integTest

### DIFF
--- a/manifests/2.10.0/opensearch-2.10.0-concurrent-search-test.yml
+++ b/manifests/2.10.0/opensearch-2.10.0-concurrent-search-test.yml
@@ -108,6 +108,7 @@ components:
         opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
+        plugins.neural_search.hybrid_search_enabled: true
 
   - name: opensearch-reports
     integ-test:

--- a/manifests/2.10.0/opensearch-2.10.0-test.yml
+++ b/manifests/2.10.0/opensearch-2.10.0-test.yml
@@ -83,6 +83,8 @@ components:
       test-configs:
         - with-security
         - without-security
+      additional-cluster-configs:
+        plugins.neural_search.hybrid_search_enabled: true
 
   - name: notifications
     working-directory: notifications


### PR DESCRIPTION
### Description
Add hybrid search enable param support to neuralsearch integTest

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3820

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
