### PR TITLE
Switch benchmark agent to newspec runner for testing

### DIFF
--- a/jenkins/cross-cluster-replication/perf-test.jenkinsfile
+++ b/jenkins/cross-cluster-replication/perf-test.jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
         timeout(time: 10, unit: 'HOURS')
     }
     environment {
-        AGENT_LABEL = 'Jenkins-Agent-AL2023-X64-M52xlarge-Docker-Host-Benchmark-Test'
+        AGENT_LABEL = 'Jenkins-Agent-AL2023-X64-M52xlarge-Benchmark-Test'
         AGENT_IMAGE = 'opensearchstaging/ci-runner:ci-runner-centos7-performance-test-v3'
         BUNDLE_MANIFEST = 'bundle-manifest.yml'
         JOB_NAME = 'ccr-perf-test'

--- a/jenkins/legacy/perf-test.jenkinsfile
+++ b/jenkins/legacy/perf-test.jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     environment {
-        AGENT_LABEL = 'Jenkins-Agent-AL2023-X64-M52xlarge-Docker-Host-Benchmark-Test'
+        AGENT_LABEL = 'Jenkins-Agent-AL2023-X64-M52xlarge-Benchmark-Test'
         AGENT_IMAGE = 'opensearchstaging/ci-runner:ci-runner-centos7-performance-test-v3'
         BUNDLE_MANIFEST = 'bundle-manifest.yml'
         JOB_NAME = 'perf-test'

--- a/jenkins/opensearch/benchmark-test.jenkinsfile
+++ b/jenkins/opensearch/benchmark-test.jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     environment {
-        AGENT_LABEL = 'Jenkins-Agent-AL2023-X64-M52xlarge-Docker-Host-Benchmark-Test'
+        AGENT_LABEL = 'Jenkins-Agent-AL2023-X64-C54xlarge-Benchmark-Test-New-Spec'
         BUNDLE_MANIFEST = 'bundle-manifest.yml'
         JOB_NAME = 'benchmark-test'
     }


### PR DESCRIPTION
### Description
Switch benchmark agent to newspec runner for testing

### Issues Resolved
We want to switch to new spec of Benchmarkhost from 2 executors m52xlarge to 4 executors c54xlarge.
This is a trial run to check if that is good enough.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
