### PR TITLE
Replace temurin with openjdk in Windows container and tweak docker build better support Windows

### DIFF
--- a/docker/ci/config/windows-servercore-setup.ps1
+++ b/docker/ci/config/windows-servercore-setup.ps1
@@ -81,7 +81,7 @@ $zlibRegFilePath
 regedit /s $zlibRegFilePath
 
 # Install jdk
-# temurin jdk does not have all the versions supported on scoop, especially version 14, 20, and above
+# Temurin jdk does not have all the versions supported on scoop, especially version 14, 20, and above
 # As of now we will switch everything to openjdk as it has the most complete lineup on scoop
 # This will also affect the distribution build jenkinsfile as it has dependencies on the names
 $jdkVersionList = "openjdk8 JAVA8_HOME", "openjdk11 JAVA11_HOME", "openjdk14 JAVA14_HOME", "openjdk17 JAVA17_HOME", "openjdk19 JAVA19_HOME", "openjdk20 JAVA20_HOME"
@@ -97,8 +97,6 @@ Foreach ($jdkVersion in $jdkVersionList)
     [System.Environment]::SetEnvironmentVariable($jdkArray[1], "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)
     java -version
 }
-# Need to reset to jdk11 for Jenkins Agent to start
-scoop reset openjdk11
 $JAVA_HOME_TEMP = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::User).replace("\", "/")
 $JAVA_HOME_TEMP
 [System.Environment]::SetEnvironmentVariable('JAVA_HOME', "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)

--- a/docker/ci/config/windows-servercore-setup.ps1
+++ b/docker/ci/config/windows-servercore-setup.ps1
@@ -81,7 +81,10 @@ $zlibRegFilePath
 regedit /s $zlibRegFilePath
 
 # Install jdk
-$jdkVersionList = "temurin8-jdk JAVA8_HOME", "temurin11-jdk JAVA11_HOME", "temurin17-jdk JAVA17_HOME", "temurin19-jdk JAVA19_HOME", "openjdk20 JAVA20_HOME", "openjdk14 JAVA14_HOME"
+# temurin jdk does not have all the versions supported on scoop, especially version 14, 20, and above
+# As of now we will switch everything to openjdk as it has the most complete lineup on scoop
+# This will also affect the distribution build jenkinsfile as it has dependencies on the names
+$jdkVersionList = "openjdk8 JAVA8_HOME", "openjdk11 JAVA11_HOME", "openjdk14 JAVA14_HOME", "openjdk17 JAVA17_HOME", "openjdk19 JAVA19_HOME", "openjdk20 JAVA20_HOME"
 Foreach ($jdkVersion in $jdkVersionList)
 {
     $jdkVersion
@@ -95,7 +98,7 @@ Foreach ($jdkVersion in $jdkVersionList)
     java -version
 }
 # Need to reset to jdk11 for Jenkins Agent to start
-scoop reset temurin11-jdk
+scoop reset openjdk11
 $JAVA_HOME_TEMP = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::User).replace("\", "/")
 $JAVA_HOME_TEMP
 [System.Environment]::SetEnvironmentVariable('JAVA_HOME', "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)

--- a/jenkins/docker/docker-build.jenkinsfile
+++ b/jenkins/docker/docker-build.jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
                     echo 'The docker-build workflow will only push docker images to staging, please use docker-copy to move the image to other repositories'
                     checkout([$class: 'GitSCM', branches: [[name: "${DOCKER_BUILD_GIT_REPOSITORY_REFERENCE}" ]], userRemoteConfigs: [[url: "${DOCKER_BUILD_GIT_REPOSITORY}" ]]])
                     def CREDENTIAL_ID = "jenkins-staging-dockerhub-credential"
-                    sh "echo Account: $CREDENTIAL_ID"
+                    sh("echo Account: ${CREDENTIAL_ID}")
                     withCredentials([usernamePassword(credentialsId: CREDENTIAL_ID, usernameVariable: 'DOCKER_USERNAME', passwordVariable: 'DOCKER_PASSWORD')]) {
                         sh '''
                             set -e
@@ -83,7 +83,7 @@ pipeline {
                 always {
                     script {
                         cleanWs disableDeferredWipeout: true, deleteDirs: true
-                        sh "docker logout && docker image prune -f --all"
+                        sh("docker logout && docker image prune -f --all")
                     }
                 }
             }


### PR DESCRIPTION


### Description
Replace temurin with openjdk in Windows container and tweak docker build better support Windows

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/281
https://github.com/opensearch-project/opensearch-build/issues/3820

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
