### PR TITLE
Update openjdk8 to openjdk8-redhat as the former is not supported on scoop

### DIFF
--- a/docker/ci/config/windows-servercore-setup.ps1
+++ b/docker/ci/config/windows-servercore-setup.ps1
@@ -84,7 +84,7 @@ regedit /s $zlibRegFilePath
 # Temurin jdk does not have all the versions supported on scoop, especially version 14, 20, and above
 # As of now we will switch everything to openjdk as it has the most complete lineup on scoop
 # This will also affect the distribution build jenkinsfile as it has dependencies on the names
-$jdkVersionList = "openjdk8 JAVA8_HOME", "openjdk11 JAVA11_HOME", "openjdk14 JAVA14_HOME", "openjdk17 JAVA17_HOME", "openjdk19 JAVA19_HOME", "openjdk20 JAVA20_HOME"
+$jdkVersionList = "openjdk8-redhat JAVA8_HOME", "openjdk11 JAVA11_HOME", "openjdk14 JAVA14_HOME", "openjdk17 JAVA17_HOME", "openjdk19 JAVA19_HOME", "openjdk20 JAVA20_HOME"
 Foreach ($jdkVersion in $jdkVersionList)
 {
     $jdkVersion


### PR DESCRIPTION


### Description
Update openjdk8 to openjdk8-redhat as the former is not supported on scoop

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/281
https://github.com/opensearch-project/opensearch-build/issues/3820

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
