### PR TITLE
Remove windows docker speedup command as it is only available in non-container

### DIFF
--- a/docker/ci/config/windows-servercore-setup.ps1
+++ b/docker/ci/config/windows-servercore-setup.ps1
@@ -224,9 +224,6 @@ Remove-Item 'get-pip.py' -Force
 # Refresh env vars
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
 
-# Speed up docker
-Set-MpPreference -DisableRealtimeMonitoring $true
-
 # Enable Long Path
 set-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem LongPathsEnabled -Type DWORD -Value 1 -Force
 


### PR DESCRIPTION
### Description
Remove windows docker speedup command as it is only available in non-container

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/281
https://github.com/opensearch-project/opensearch-build/issues/3743

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
