### PR TITLE
Switch windows docker jdk back to temurin/openjdk mix

### DIFF
--- a/docker/ci/config/windows-servercore-setup.ps1
+++ b/docker/ci/config/windows-servercore-setup.ps1
@@ -82,9 +82,9 @@ regedit /s $zlibRegFilePath
 
 # Install jdk
 # Temurin jdk does not have all the versions supported on scoop, especially version 14, 20, and above
-# As of now we will switch everything to openjdk as it has the most complete lineup on scoop
-# This will also affect the distribution build jenkinsfile as it has dependencies on the names
-$jdkVersionList = "openjdk8-redhat JAVA8_HOME", "openjdk11 JAVA11_HOME", "openjdk14 JAVA14_HOME", "openjdk17 JAVA17_HOME", "openjdk19 JAVA19_HOME", "openjdk20 JAVA20_HOME"
+# As of now we will mix temurin and openjdk as temurin for production has support policies for fixes and patches
+# We need to make sure we do not mis-install temurin and openjdk with the same version or the distribution build code will have issues
+$jdkVersionList = "temurin8-jdk JAVA8_HOME", "temurin11-jdk JAVA11_HOME", "openjdk14 JAVA14_HOME", "temurin17-jdk JAVA17_HOME", "temurin19-jdk JAVA19_HOME", "openjdk20 JAVA20_HOME"
 Foreach ($jdkVersion in $jdkVersionList)
 {
     $jdkVersion
@@ -97,6 +97,8 @@ Foreach ($jdkVersion in $jdkVersionList)
     [System.Environment]::SetEnvironmentVariable($jdkArray[1], "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)
     java -version
 }
+# Switch to temurin11-jdk as it is the widest supported version to build OpenSearch
+scoop reset temurin11-jdk
 $JAVA_HOME_TEMP = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::User).replace("\", "/")
 $JAVA_HOME_TEMP
 [System.Environment]::SetEnvironmentVariable('JAVA_HOME', "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)


### PR DESCRIPTION
### Description
Switch windows docker jdk back to temurin/openjdk mix

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/281
https://github.com/opensearch-project/opensearch-build/issues/3743

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
