### PR TITLE
Add unzip and lock pipenv/awscli versions in Windows docker images

### DIFF
--- a/docker/ci/config/windows-servercore-setup.ps1
+++ b/docker/ci/config/windows-servercore-setup.ps1
@@ -202,6 +202,7 @@ cmake --version
 
 # Install zip
 scoop install zip
+scoop install unzip
 
 # Install docker
 scoop install docker
@@ -214,10 +215,10 @@ wget https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
 python get-pip.py
 pip --version
 # Install pipenv
-pip install pipenv
+pip install pipenv==2023.6.12
 pipenv --version
 # Install awscli
-pip install awscli
+pip install awscli==1.22.12
 aws --version
 # Cleanup
 pip cache remove * 


### PR DESCRIPTION
### Description
Add unzip and lock pipenv/awscli versions in Windows docker images

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/281
https://github.com/opensearch-project/opensearch-build/issues/3743

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
