### PR TITLE
Removed hybrid search feature flag for test clusters

### DIFF
--- a/manifests/2.10.0/opensearch-2.10.0-concurrent-search-test.yml
+++ b/manifests/2.10.0/opensearch-2.10.0-concurrent-search-test.yml
@@ -108,7 +108,6 @@ components:
         opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
-        plugins.neural_search.hybrid_search_enabled: true
 
   - name: opensearch-reports
     integ-test:

--- a/manifests/2.10.0/opensearch-2.10.0-test.yml
+++ b/manifests/2.10.0/opensearch-2.10.0-test.yml
@@ -83,8 +83,6 @@ components:
       test-configs:
         - with-security
         - without-security
-      additional-cluster-configs:
-        plugins.neural_search.hybrid_search_enabled: true
 
   - name: notifications
     working-directory: notifications


### PR DESCRIPTION
### Description
Remove feature flag for hybrid_search from neural-search plugin. Feature flag meaning and name has been changed (https://github.com/opensearch-project/neural-search/pull/275), with existing code cluster may crush on start as feature flag doesn't exit. 

This PR will revert [earlier change](https://github.com/peterzhuamazon), that change is not needed, feature is enabled by default. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3743

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
