### PR TITLE
Switch the benchmark agent back to m52xlarge due to network overload

### DIFF
--- a/jenkins/opensearch/benchmark-test.jenkinsfile
+++ b/jenkins/opensearch/benchmark-test.jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     environment {
-        AGENT_LABEL = 'Jenkins-Agent-AL2023-X64-C54xlarge-Benchmark-Test-New-Spec'
+        AGENT_LABEL = 'Jenkins-Agent-AL2023-X64-M52xlarge-Benchmark-Test'
         BUNDLE_MANIFEST = 'bundle-manifest.yml'
         JOB_NAME = 'benchmark-test'
     }


### PR DESCRIPTION
### Description
Switch the benchmark agent back to m52xlarge due to network overload

### Issues Resolved
Partially Revert https://github.com/opensearch-project/opensearch-build/pull/3931


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
