### PR TITLE
Add prefix of registry and repo name to get-ci-images.sh output

### DIFF
--- a/docker/ci/get-ci-images.sh
+++ b/docker/ci/get-ci-images.sh
@@ -69,4 +69,4 @@ if [ -z "$TYPE" ]; then
 fi
 
 # Run script
-crane ls public.ecr.aws/opensearchstaging/ci-runner | grep -Eo '.*v[0-9]' | sort -r | uniq | grep $PLATFORM-$USAGE-$TYPE
+crane ls public.ecr.aws/opensearchstaging/ci-runner | grep -Eo '.*v[0-9]' | sort -r | uniq | grep $PLATFORM-$USAGE-$TYPE | sed 's/^/public.ecr.aws\/opensearchstaging\/ci-runner\:/g'


### PR DESCRIPTION
### Description
Add prefix of registry and repo name to get-ci-images.sh output

### Issues Resolved
Improvement on https://github.com/opensearch-project/opensearch-build/pull/3960

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
