### PR TITLE
Switch dashboards-search-relevance to pull from 2.10 branch

### DIFF
--- a/manifests/2.10.0/opensearch-dashboards-2.10.0.yml
+++ b/manifests/2.10.0/opensearch-dashboards-2.10.0.yml
@@ -52,4 +52,4 @@ components:
     ref: 2.x
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
-    ref: 2.x
+    ref: 2.10


### PR DESCRIPTION
In preparation for the 2.10 release, the 2.10 branch has been cut and should be used.

### Description
Switches the branch for dashboards-search-relevance plugin to 2.10 (from 2.x). The 2.10 branch is cut and has all commits that we plan to include.

### Issues Resolved
Contributes to completing https://github.com/opensearch-project/dashboards-search-relevance/issues/253

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
