### PR TITLE
Remove instructions of updating the release branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/component_release_template.md
+++ b/.github/ISSUE_TEMPLATE/component_release_template.md
@@ -43,7 +43,6 @@ If including changes in this release, increment the version on `{{RELEASE_VERSIO
 
 ### Pre-Release
 
-- [ ] Update to the `{{RELEASE_VERSION}}` release branch in the [distribution manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/{{RELEASE_VERSION}}).
 - [ ] Increment the version on the parent branch to the next development iteration.
 - [ ] Gather, review and publish release notes following the [rules](https://github.com/opensearch-project/opensearch-plugins/blob/main/RELEASE_NOTES.md) and back port it to the release branch.[git-release-notes](https://github.com/ariatemplates/git-release-notes) may be used to generate release notes from your commit history.
 - [ ] Confirm that all changes for `{{RELEASE_VERSION}}` have been merged.


### PR DESCRIPTION


### Description
Since last few releases the developers do not need to  update the release branches in manifest. This task is owned by release manager.

### Issues Resolved
closes #3979 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
