### PR TITLE
Treat release notes table branch name as string by adding bracket

### DIFF
--- a/src/release_notes_workflow/release_notes.py
+++ b/src/release_notes_workflow/release_notes.py
@@ -39,7 +39,7 @@ class ReleaseNotes:
         results = []
         with TemporaryDirectory(chdir=True) as work_dir:
             results.append(component.name)
-            results.append(component.ref)
+            results.append(f"[{component.ref}]")
             with GitRepository(
                     component.repository,
                     component.ref,

--- a/tests/tests_release_notes_workflow/test_release_notes.py
+++ b/tests/tests_release_notes_workflow/test_release_notes.py
@@ -31,7 +31,7 @@ class TestReleaseNotes(unittest.TestCase):
     @patch("subprocess.check_output", return_value=''.encode())
     @patch("subprocess.check_call")
     def test_check(self, *mocks: Any) -> None:
-        self.assertEqual(self.release_notes.check(self.component), ['OpenSearch', 'ref', None, None, False])
+        self.assertEqual(self.release_notes.check(self.component), ['OpenSearch', '[ref]', None, None, False])
 
     @patch("subprocess.check_output", return_value=''.encode())
     @patch("subprocess.check_call")
@@ -39,11 +39,11 @@ class TestReleaseNotes(unittest.TestCase):
         component = next(self.manifest_file.components.select())
         if type(component) is InputComponentFromSource:
             self.assertIsInstance(component, InputComponentFromSource)
-            self.assertEqual(self.release_notes.check(component), ['OpenSearch', 'main', None, None, False])
+            self.assertEqual(self.release_notes.check(component), ['OpenSearch', '[main]', None, None, False])
 
-    @patch('release_notes_workflow.release_notes.ReleaseNotes.check', return_value=['OpenSearch', 'main', 'ee26e01', '2022-08-18', False])
+    @patch('release_notes_workflow.release_notes.ReleaseNotes.check', return_value=['OpenSearch', '[main]', 'ee26e01', '2022-08-18', False])
     def test_table(self, *mocks: Any) -> None:
         table_output = self.release_notes.table()
         self.assertEqual(table_output._table_name.strip(), 'OpenSearch CommitID(after 2022-07-26) & Release Notes info')
         self.assertEqual(table_output.headers, ['Repo', 'Branch', 'CommitID', 'Commit Date', 'Release Notes'])
-        self.assertEqual(table_output.value_matrix, [['OpenSearch', 'main', 'ee26e01', '2022-08-18', False]])
+        self.assertEqual(table_output.value_matrix, [['OpenSearch', '[main]', 'ee26e01', '2022-08-18', False]])


### PR DESCRIPTION
### Description
Treat release notes table branch name as string by adding bracket

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/3743
https://github.com/opensearch-project/opensearch-build/issues/3988

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
