### PR TITLE
Update cron for maven snapshot publish and add two plugins

### DIFF
--- a/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
+++ b/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H 1 * * * %INPUT_MANIFEST=1.3.12/opensearch-1.3.12.yml
+            H 1 * * * %INPUT_MANIFEST=1.3.13/opensearch-1.3.13.yml
         '''
     }
     parameters {

--- a/manifests/1.3.13/opensearch-1.3.13.yml
+++ b/manifests/1.3.13/opensearch-1.3.13.yml
@@ -32,3 +32,21 @@ components:
     platforms:
       - linux
       - windows
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: '1.3'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: alerting
+    platforms:
+      - linux
+      - windows
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: '1.3'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+    platforms:
+      - linux
+      - windows


### PR DESCRIPTION
### Description
Update cron for maven snapshot publish
Add alerting and security plugins to the 1.3.13 input manifest.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/3878

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
