### PR TITLE
Switch OpenSearch Build Image Back to CentOS7

### DIFF
--- a/manifests/2.10.0/opensearch-2.10.0-concurrent-search-test.yml
+++ b/manifests/2.10.0/opensearch-2.10.0-concurrent-search-test.yml
@@ -3,7 +3,7 @@ schema-version: '1.0'
 name: OpenSearch
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-17
 components:
   - name: index-management

--- a/manifests/2.10.0/opensearch-2.10.0-test.yml
+++ b/manifests/2.10.0/opensearch-2.10.0-test.yml
@@ -3,7 +3,7 @@ schema-version: '1.0'
 name: OpenSearch
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-17
 components:
   - name: alerting

--- a/manifests/2.10.0/opensearch-2.10.0.yml
+++ b/manifests/2.10.0/opensearch-2.10.0.yml
@@ -5,7 +5,7 @@ build:
   version: 2.10.0
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-17
 components:
   - name: OpenSearch

--- a/manifests/2.11.0/opensearch-2.11.0.yml
+++ b/manifests/2.11.0/opensearch-2.11.0.yml
@@ -5,7 +5,7 @@ build:
   version: 2.11.0
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-17
 components:
   - name: OpenSearch

--- a/manifests/3.0.0/opensearch-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-3.0.0-test.yml
@@ -3,7 +3,7 @@ schema-version: '1.0'
 name: OpenSearch
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-20
 components:
   - name: alerting

--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -5,7 +5,7 @@ build:
   version: 3.0.0
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-20
 components:
   - name: OpenSearch

--- a/manifests/templates/opensearch/2.x/manifest.yml
+++ b/manifests/templates/opensearch/2.x/manifest.yml
@@ -5,7 +5,7 @@ build:
   version: 'replace'
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-17
 components:
   - name: OpenSearch

--- a/manifests/templates/opensearch/3.x/manifest.yml
+++ b/manifests/templates/opensearch/3.x/manifest.yml
@@ -5,7 +5,7 @@ build:
   version: 'replace'
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-17
 components:
   - name: OpenSearch

--- a/manifests/templates/opensearch/default/manifest.yml
+++ b/manifests/templates/opensearch/default/manifest.yml
@@ -5,7 +5,7 @@ build:
   version: 'replace'
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-17
 components:
   - name: OpenSearch

--- a/tests/jenkins/jenkinsjob-regression-files/release-notes-check/release-notes-check.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-notes-check/release-notes-check.jenkinsfile.txt
@@ -12,7 +12,7 @@
                   detectDockerAgent.library({identifier=jenkins@1.0.4, retriever=null})
                   detectDockerAgent.readYaml({file=manifests/3.0.0/opensearch-3.0.0.yml})
                   InputManifest.asBoolean()
-                  detectDockerAgent.echo(Using Docker image opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4 (-e JAVA_HOME=/opt/java/openjdk-20))
+                  detectDockerAgent.echo(Using Docker image opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3 (-e JAVA_HOME=/opt/java/openjdk-20))
                   detectDockerAgent.echo(Using java version openjdk-20)
          release-notes-check.postCleanup()
             postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -60,7 +60,7 @@ class TestInputManifests(unittest.TestCase):
             {
                 "schema-version": "1.0",
                 "build": {"name": "OpenSearch", "version": "0.2.3"},
-                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-build-v4",
+                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3",
                                  "args": "-e JAVA_HOME=/opt/java/openjdk-17"}},
             },
         )


### PR DESCRIPTION
### Description
Switch OpenSearch Build Image Back to CentOS7

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1563
https://github.com/opensearch-project/opensearch-build/issues/3743

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
