### PR TITLE
Fix the component issue creation workflow bug

### DIFF
--- a/.github/workflows/os-release-issues.yml
+++ b/.github/workflows/os-release-issues.yml
@@ -97,7 +97,7 @@ jobs:
           # Read the file contents and replace the placeholders
           file_path="../opensearch-build/.github/ISSUE_TEMPLATE/component_release_template.md"
           RELEASE_VERSION="${{ matrix.release_version }}"
-          RELEASE_ISSUE_NUMBER=$(echo '${{ steps.check_if_build_repo_issue_exists.outputs.issues }}' | jq '.[0].number')
+          RELEASE_ISSUE_NUMBER=$(echo '${{ steps.check_if_build_repo_issue_exists.outputs.issueNumbers }}' | jq '.[0]')
           RELEASE_ISSUE="https://github.com/opensearch-project/opensearch-build/issues/${RELEASE_ISSUE_NUMBER}"
           RELEASE_VERSION_X=$(echo "${{ matrix.release_version }}" | awk -F'.' '{print $1}').x
           sed -e "s|{{RELEASE_VERSION}}|${RELEASE_VERSION}|g" -e "s|{{RELEASE_ISSUE}}|${RELEASE_ISSUE}|g" -e "s|{{RELEASE_VERSION_X}}|${RELEASE_VERSION_X}|g" "$file_path" > "$file_path.tmp" && mv "$file_path.tmp" "$file_path"

--- a/.github/workflows/osd-release-issues.yml
+++ b/.github/workflows/osd-release-issues.yml
@@ -92,7 +92,7 @@ jobs:
           # Read the file contents and replace the placeholders
           file_path="../opensearch-build/.github/ISSUE_TEMPLATE/component_release_template.md"
           RELEASE_VERSION="${{ matrix.release_version }}"
-          RELEASE_ISSUE_NUMBER=$(echo '${{ steps.check_if_build_repo_issue_exists.outputs.issues }}' | jq '.[0].number')
+          RELEASE_ISSUE_NUMBER=$(echo '${{ steps.check_if_build_repo_issue_exists.outputs.issueNumbers }}' | jq '.[0]')
           RELEASE_ISSUE="https://github.com/opensearch-project/opensearch-build/issues/${RELEASE_ISSUE_NUMBER}"
           RELEASE_VERSION_X=$(echo "${{ matrix.release_version }}" | awk -F'.' '{print $1}').x
           sed -e "s|{{RELEASE_VERSION}}|${RELEASE_VERSION}|g" -e "s|{{RELEASE_ISSUE}}|${RELEASE_ISSUE}|g" -e "s|{{RELEASE_VERSION_X}}|${RELEASE_VERSION_X}|g" "$file_path" > "$file_path.tmp" && mv "$file_path.tmp" "$file_path"


### PR DESCRIPTION
### Description
Fix the component issue creation workflow bug
The output `${{ steps.check_if_build_repo_issue_exists.outputs.issues }}` is too long to store in a string and not able to parse the issue number, hence changed to `${{ steps.check_if_build_repo_issue_exists.outputs.issueNumbers }}`.

### Issues Resolved
Error: https://github.com/opensearch-project/opensearch-build/actions/runs/6153702599/job/16697978174 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
