### PR TITLE
Fix the test manifest paths in cron

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -16,8 +16,8 @@ pipeline {
         parameterizedCron '''
             H 1 * * * %INPUT_MANIFEST=2.11.0/opensearch-dashboards-2.11.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.11.0/opensearch-2.11.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H/60 * * * * %INPUT_MANIFEST=1.3.13/opensearch-dashboards-1.3.13.yml;TEST_MANIFEST=1.3.13/opensearch-1.3.13-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H/60 * * * * %INPUT_MANIFEST=1.3.13/opensearch-1.3.13.yml;TEST_MANIFEST=opensearch-dashboards-1.3.13-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
+            H/60 * * * * %INPUT_MANIFEST=1.3.13/opensearch-dashboards-1.3.13.yml;TEST_MANIFEST=1.3.13/opensearch-dashboards-1.3.13-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
+            H/60 * * * * %INPUT_MANIFEST=1.3.13/opensearch-1.3.13.yml;TEST_MANIFEST=1.3.13/opensearch-1.3.13-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.9.1/opensearch-2.9.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TEST_MANIFEST=3.0.0/opensearch-3.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TEST_MANIFEST=opensearch-dashboards-3.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip


### PR DESCRIPTION
### Description
Update the test manifests in cron to fix the wrong path.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/3878

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
