### PR TITLE
Make sure WindowsZip/LinuxTar remove correct dir when uninstall

### DIFF
--- a/src/test_workflow/integ_test/distribution_tar.py
+++ b/src/test_workflow/integ_test/distribution_tar.py
@@ -39,5 +39,5 @@ class DistributionTar(Distribution):
         return start_cmd_map[self.filename]
 
     def uninstall(self) -> None:
-        logging.info(f"Cleanup {self.work_dir}/* content after the test")
-        subprocess.check_call(f"rm -rf {self.work_dir}/*", shell=True)
+        logging.info(f"Cleanup {self.install_dir} content after the test")
+        subprocess.check_call(f"rm -rf {self.install_dir}", shell=True)

--- a/src/test_workflow/integ_test/distribution_zip.py
+++ b/src/test_workflow/integ_test/distribution_zip.py
@@ -39,5 +39,5 @@ class DistributionZip(Distribution):
         return start_cmd_map[self.filename]
 
     def uninstall(self) -> None:
-        logging.info(f"Cleanup {self.work_dir}/* content after the test")
-        subprocess.check_call(f"rm -rf {self.work_dir}/*", shell=True)
+        logging.info(f"Cleanup {self.install_dir} content after the test")
+        subprocess.check_call(f"rm -rf {self.install_dir}", shell=True)

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_tar.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_tar.py
@@ -54,4 +54,4 @@ class TestDistributionTar(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"rm -rf {self.work_dir}/opensearch-1.3.0", args_list[0][0][0])
+        self.assertEqual(f"rm -rf {os.path.join(self.work_dir, 'opensearch-1.3.0')}", args_list[0][0][0])

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_tar.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_tar.py
@@ -54,4 +54,4 @@ class TestDistributionTar(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"rm -rf {self.work_dir}/*", args_list[0][0][0])
+        self.assertEqual(f"rm -rf {self.work_dir}/opensearch-1.3.0", args_list[0][0][0])

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_zip.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_zip.py
@@ -55,7 +55,7 @@ class TestDistributionZipOpenSearch(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"rm -rf {self.work_dir}/*", args_list[0][0][0])
+        self.assertEqual(f"rm -rf {self.work_dir}/opensearch-2.4.0", args_list[0][0][0])
 
 
 class TestDistributionZipOpenSearchDashboards(unittest.TestCase):
@@ -97,4 +97,4 @@ class TestDistributionZipOpenSearchDashboards(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"rm -rf {self.work_dir}/*", args_list[0][0][0])
+        self.assertEqual(f"rm -rf {self.work_dir}/opensearch-dashboards-2.4.0", args_list[0][0][0])

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_zip.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_zip.py
@@ -55,7 +55,7 @@ class TestDistributionZipOpenSearch(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"rm -rf {self.work_dir}/opensearch-2.4.0", args_list[0][0][0])
+        self.assertEqual(f"rm -rf {os.path.join(self.work_dir, 'opensearch-2.4.0')}", args_list[0][0][0])
 
 
 class TestDistributionZipOpenSearchDashboards(unittest.TestCase):
@@ -97,4 +97,4 @@ class TestDistributionZipOpenSearchDashboards(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"rm -rf {self.work_dir}/opensearch-dashboards-2.4.0", args_list[0][0][0])
+        self.assertEqual(f"rm -rf {os.path.join(self.work_dir, 'opensearch-dashboards-2.4.0')}", args_list[0][0][0])


### PR DESCRIPTION
### Description
Make sure WindowsZip/LinuxTar remove correct dir when uninstall

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/281
https://github.com/opensearch-project/opensearch-build/issues/3743

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
