### PR TITLE
Allow opensearch-dashboard user to read its config

### DIFF
--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
@@ -37,6 +37,7 @@ echo "### You can start opensearch-dashboards service by executing"
 echo " sudo systemctl start opensearch-dashboards.service"
 
 # Set ownership and permissions
+chown -R root.opensearch-dashboards ${config_dir}
 chmod -R u=rwX,g=rX,o= ${config_dir}
 
 chown -R opensearch-dashboards.adm ${log_dir}

--- a/scripts/pkg/build_templates/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
@@ -76,6 +76,7 @@ exit 0
 
 %post
 set -e
+chown -R root.%{name} %{config_dir}
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then
     systemctl daemon-reload


### PR DESCRIPTION
In  #3952, the permissions where changed to fix some inconsistencies in
the .deb and .rpm packaging.

This change restricted access to the configuration files (which where
previously readable by all users) but failed to adjust the files
ownership so that the service can access these files.

Ensure the configuration directory and files belong to the root user and
the opensearch-dashboards group

Signed-off-by: Romain Tartière <romain@blogreen.org>
