### PR TITLE
Reset deb rpm permissions to original state

### DIFF
--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
@@ -36,15 +36,11 @@ echo " sudo systemctl enable opensearch-dashboards.service"
 echo "### You can start opensearch-dashboards service by executing"
 echo " sudo systemctl start opensearch-dashboards.service"
 
-# Set ownership and permissions
-chmod -R u=rwX,g=rX,o= ${config_dir}
-
-chown -R opensearch-dashboards.adm ${log_dir}
-chmod 750 ${log_dir}
-
+# Set owner
+chown -R opensearch-dashboards.opensearch-dashboards ${product_dir}
+chown -R opensearch-dashboards.opensearch-dashboards ${config_dir}
+chown -R opensearch-dashboards.opensearch-dashboards ${log_dir}
 chown -R opensearch-dashboards.opensearch-dashboards ${data_dir}
-chmod 750 ${data_dir}
-
 chown -R opensearch-dashboards.opensearch-dashboards ${pid_dir}
 
 exit 0

--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
@@ -37,7 +37,6 @@ echo "### You can start opensearch-dashboards service by executing"
 echo " sudo systemctl start opensearch-dashboards.service"
 
 # Set ownership and permissions
-chown -R root.opensearch-dashboards ${config_dir}
 chmod -R u=rwX,g=rX,o= ${config_dir}
 
 chown -R opensearch-dashboards.adm ${log_dir}

--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debmake_opensearch_dashboards_install.sh
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debmake_opensearch_dashboards_install.sh
@@ -42,7 +42,6 @@ ln -s ${data_dir} ${buildroot}${product_dir}/data
 ln -s ${log_dir}  ${buildroot}${product_dir}/logs
 
 # Change Permissions
-chmod -Rf g-s ${buildroot}/*
-chmod -Rf u=rwX,g=rX,o=rX ${buildroot}/*
+chmod -Rf a+rX,u+w,g-w,o-w ${buildroot}/*
 
 exit 0

--- a/scripts/pkg/build_templates/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
@@ -56,8 +56,7 @@ chmod 0755 %{buildroot}%{product_dir}/bin/*
 ln -s %{data_dir} %{buildroot}%{product_dir}/data
 ln -s %{log_dir}  %{buildroot}%{product_dir}/logs
 # Change Permissions
-chmod -Rf g-s %{buildroot}/*
-chmod -Rf u=rwX,g=rX,o= %{buildroot}/etc
+chmod -Rf a+rX,u+w,g-w,o-w %{buildroot}/*
 exit 0
 
 %pre
@@ -102,7 +101,7 @@ exit 0
 
 %files
 # Permissions
-%defattr(-, root, root)
+%defattr(-, %{name}, %{name})
 
 # Root dirs/docs/licenses
 %dir %{product_dir}
@@ -131,9 +130,9 @@ exit 0
 %{product_dir}/node_modules
 %{product_dir}/plugins
 %{product_dir}/src
-%attr(750, %{name}, %{name}) %{log_dir}
-%attr(750, %{name}, %{name}) %{pid_dir}
-%dir %attr(750, %{name}, %{name}) %{data_dir}
+%{log_dir}
+%{pid_dir}
+%dir %{data_dir}
 
 # Symlinks
 %{product_dir}/data

--- a/scripts/pkg/build_templates/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
@@ -76,7 +76,6 @@ exit 0
 
 %post
 set -e
-chown -R root.%{name} %{config_dir}
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then
     systemctl daemon-reload

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -37,17 +37,11 @@ if ! grep -q '## OpenSearch Performance Analyzer' ${config_dir}/jvm.options; the
    echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> ${config_dir}/jvm.options
 fi
 
-# Set ownership and permissions
-# FIXME: the opensearch service should not have w permission in the config directory
+# Set owner
+chown -R opensearch.opensearch ${product_dir}
 chown -R opensearch.opensearch ${config_dir}
-chmod -R u=rwX,g=rX,o= ${config_dir}
-
-chown -R opensearch.adm ${log_dir}
-chmod 750 ${log_dir}
-
+chown -R opensearch.opensearch ${log_dir}
 chown -R opensearch.opensearch ${data_dir}
-chmod 750 ${data_dir}
-
 chown -R opensearch.opensearch ${pid_dir}
 
 # Reload systemctl daemon

--- a/scripts/pkg/build_templates/opensearch/deb/debmake_opensearch_install.sh
+++ b/scripts/pkg/build_templates/opensearch/deb/debmake_opensearch_install.sh
@@ -41,7 +41,6 @@ ln -s ${data_dir} ${buildroot}${product_dir}/data
 ln -s ${log_dir}  ${buildroot}${product_dir}/logs
 
 # Change Permissions
-chmod -Rf g-s ${buildroot}/*
-chmod -Rf u=rwX,g=rX,o=rX ${buildroot}/*
+chmod -Rf a+rX,u+w,g-w,o-w ${buildroot}/*
 
 exit 0

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -68,8 +68,7 @@ if [ ! -f %{buildroot}%{data_dir}/performance_analyzer_enabled.conf ]; then
     echo 'true' > %{buildroot}%{data_dir}/performance_analyzer_enabled.conf
 fi
 # Change Permissions
-chmod -Rf g-s %{buildroot}/*
-chmod -Rf u=rwX,g=rX,o= %{buildroot}/etc
+chmod -Rf a+rX,u+w,g-w,o-w %{buildroot}/*
 exit 0
 
 %pre
@@ -151,6 +150,13 @@ exit 0
 # Permissions
 %defattr(-, %{name}, %{name})
 
+# Root dirs/docs/licenses
+%dir %{product_dir}
+%doc %{product_dir}/NOTICE.txt
+%doc %{product_dir}/README.md
+%license %{product_dir}/LICENSE.txt
+%{product_dir}/manifest.yml
+
 # Config dirs/files
 %dir %{config_dir}
 %{config_dir}/jvm.options.d
@@ -169,20 +175,6 @@ exit 0
 %attr(0644, root, root) %config(noreplace) %{_prefix}/lib/sysctl.d/%{name}.conf
 %attr(0644, root, root) %config(noreplace) %{_prefix}/lib/tmpfiles.d/%{name}.conf
 
-%dir %attr(750, %{name}, %{name}) %{data_dir}
-%attr(750, %{name}, %{name}) %{log_dir}
-%attr(750, %{name}, %{name}) %{pid_dir}
-
-# Permissions
-%defattr(-, root, root)
-
-# Root dirs/docs/licenses
-%dir %{product_dir}
-%doc %{product_dir}/NOTICE.txt
-%doc %{product_dir}/README.md
-%license %{product_dir}/LICENSE.txt
-%{product_dir}/manifest.yml
-
 # Main dirs
 %{product_dir}/bin
 %{product_dir}/jdk
@@ -190,6 +182,9 @@ exit 0
 %{product_dir}/modules
 %{product_dir}/performance-analyzer-rca
 %{product_dir}/plugins
+%{log_dir}
+%{pid_dir}
+%dir %{data_dir}
 
 # Symlinks
 %{product_dir}/data


### PR DESCRIPTION
### Description
Reset deb rpm permissions to original state

### Issues Resolved
Due to the amount of changes https://github.com/opensearch-project/opensearch-build/issues/3815 make to the deb/rpm packages permissions, and the close timeline of 2.10.0 release/impacting 1.13.13 release. We are resetting to the original permissions for now.

We will try to introduce these changes at a later time with documentation changes, test changes, breaking change notice.

Thanks.

#3898 #3952 #4038

https://github.com/opensearch-project/opensearch-build/issues/3815
https://github.com/opensearch-project/opensearch-build/issues/3743

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
