### PR TITLE
Fix no logs on OS process failure issue

### DIFF
--- a/src/test_workflow/integ_test/service.py
+++ b/src/test_workflow/integ_test/service.py
@@ -112,14 +112,14 @@ class Service(abc.ABC):
         logging.info(f"Downloaded bundle to {os.path.realpath(bundle_name)}")
         return bundle_name
 
-    def wait_for_service(self) -> None:
+    def wait_for_service(self) -> bool:
         logging.info("Waiting for service to become available")
 
         for attempt in range(10):
             try:
                 logging.info(f"Pinging service attempt {attempt}")
                 if self.service_alive():
-                    return
+                    return True
             except requests.exceptions.ConnectionError:
                 logging.info("Service not available, yet")
                 stdout = self.process_handler.stdout_data
@@ -129,7 +129,8 @@ class Service(abc.ABC):
                 if stderr:
                     logging.info("- stderr:\n{stderr}")
             time.sleep(10)
-        raise ClusterCreationException("Cluster is not available after 10 attempts")
+        logging.error("Cluster is not available after 10 attempts")
+        return False
 
     @property
     @abc.abstractmethod

--- a/src/test_workflow/test_cluster.py
+++ b/src/test_workflow/test_cluster.py
@@ -10,7 +10,7 @@ import os
 from contextlib import contextmanager
 from typing import Any, Generator, List, Tuple
 
-from test_workflow.integ_test.service import Service
+from test_workflow.integ_test.service import ClusterCreationException, Service
 from test_workflow.integ_test.service_termination_result import ServiceTerminationResult
 from test_workflow.test_recorder.log_recorder import LogRecorder
 from test_workflow.test_recorder.test_result_data import TestResultData
@@ -31,14 +31,14 @@ class TestCluster(abc.ABC):
     """
 
     def __init__(
-        self,
-        work_dir: str,
-        component_name: str,
-        component_test_config: str,
-        security_enabled: bool,
-        additional_cluster_config: dict,
-        save_logs: LogRecorder,
-        cluster_port: int = 9200
+            self,
+            work_dir: str,
+            component_name: str,
+            component_test_config: str,
+            security_enabled: bool,
+            additional_cluster_config: dict,
+            save_logs: LogRecorder,
+            cluster_port: int = 9200
     ) -> None:
         self.work_dir = os.path.join(work_dir, "local-test-cluster")
         self.component_name = component_name
@@ -78,7 +78,9 @@ class TestCluster(abc.ABC):
             service.start()
 
         for service in self.all_services:
-            service.wait_for_service()
+            if not service.wait_for_service():
+                self.terminate()
+                raise ClusterCreationException("Cluster is not available after 10 attempts")
 
     def terminate(self) -> None:
         if self.service:


### PR DESCRIPTION
### Description
When `integ-tests` workflow fails due to OpenSearch process not coming up there are no logs uploaded to S3 to help debug the cause of the failure and the engineer has to reproduce locally to figure out what went wrong. 
The workflow just fails with raising an Exception and without cleaning up the hung OS process. 

This PR fixes:   
1. No logs for failing `integ-tests` when OpenSearch process fails to start. 
2. Cleaning up the OpenSearch process by gracefully terminating it. 

### Issues Resolved
#3882 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
