### PR TITLE
Disable multi cluster integtest for CCR

### DIFF
--- a/manifests/2.10.0/opensearch-2.10.0-test.yml
+++ b/manifests/2.10.0/opensearch-2.10.0-test.yml
@@ -36,13 +36,6 @@ components:
 
   - name: cross-cluster-replication
     integ-test:
-      topology:
-        - cluster_name: leader
-          data_nodes: 1
-          cluster_manager_nodes: 0
-        - cluster_name: follower
-          data_nodes: 1
-          cluster_manager_nodes: 0
       test-configs:
         - with-security
         - without-security


### PR DESCRIPTION
Disables multi cluster integration tests for CCR

Currently the logger in test workflow does not support collecting cluster logs for multiple clusters.
This results in entire test failing at the end with 
```
FileExistsError: [Errno 17] File exists: '/var/jenkins/workspace/integ-test@4/test-results/5327/integ-test/cross-cluster-replication/with-security/local-cluster-logs/opensearch-service-logs'
```

Pending https://github.com/opensearch-project/opensearch-build/issues/3448

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
