### PR TITLE
 Disable multi cluster integtest for CCR

### DIFF
--- a/manifests/2.10.0/opensearch-2.10.0-concurrent-search-test.yml
+++ b/manifests/2.10.0/opensearch-2.10.0-concurrent-search-test.yml
@@ -145,13 +145,6 @@ components:
 
   - name: cross-cluster-replication
     integ-test:
-      topology:
-        - cluster_name: leader
-          data_nodes: 2
-          cluster_manager_nodes: 0
-        - cluster_name: follower
-          data_nodes: 2
-          cluster_manager_nodes: 0
       test-configs:
         - with-security
         - without-security


### PR DESCRIPTION
Disables multi cluster integration tests for CCR

Currently the logger in test workflow does not support collecting cluster logs for multiple clusters.
This results in entire test failing at the end with 
```
FileExistsError: [Errno 17] File exists: '/var/jenkins/workspace/integ-test@4/test-results/5327/integ-test/cross-cluster-replication/with-security/local-cluster-logs/opensearch-service-logs'
```

Pending https://github.com/opensearch-project/opensearch-build/issues/3448
