### PR TITLE
Add check before triggering tests from distribution build jobs

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -182,8 +182,8 @@ pipeline {
 
                             parallel([
                                 'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '' || buildManifestUrlOpenSearch == '')
+                                    echo "${skipIntegTests ? 'Skipping integration tests as one of the values has empty string: INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl, buildManifestUrlOpenSearch' : 'Running integration tests'}"
                                     if (!skipIntegTests) {
                                         def integTestResults =
                                             build job: INTEG_TEST_JOB_NAME,
@@ -197,8 +197,8 @@ pipeline {
                                     }
                                 },
                                 'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    Boolean skipBwcTests = (BWC_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
+                                    echo "${skipBwcTests ? 'Skipping BWC tests as one of the values has empty string: BWC_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running BWC tests'}"
                                     if (!skipBwcTests) {
                                         def bwcTestResults =
                                             build job: BWC_TEST_JOB_NAME,
@@ -492,8 +492,8 @@ pipeline {
 
                                     parallel([
                                         'integ-test': {
-                                            Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                            echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                            Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == ''|| TEST_MANIFEST == '' || buildManifestUrl == '' || buildManifestUrlOpenSearch == '')
+                                            echo "${skipIntegTests ? 'Skipping integration tests as one of the values has empty string:INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl, buildManifestUrlOpenSearch' : 'Running integration tests'}"
                                             if (!skipIntegTests) {
                                                 def integTestResults =
                                                     build job: INTEG_TEST_JOB_NAME,
@@ -507,8 +507,8 @@ pipeline {
                                             }
                                         },
                                         'bwc-test': {
-                                            Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                            echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                            Boolean skipBwcTests = (BWC_TEST_JOB_NAME == ''|| TEST_MANIFEST == '' || buildManifestUrl == '')
+                                            echo "${skipBwcTests ? 'Skipping BWC tests as one of the values has empty string: BWC_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running BWC tests'}"
                                             if (!skipBwcTests) {
                                                 def bwcTestResults =
                                                     build job: BWC_TEST_JOB_NAME,

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -310,8 +310,8 @@ pipeline {
 
                             parallel([
                                 'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
+                                    echo "${skipIntegTests ? 'Skipping integration tests as one of the values has empty string: INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running integration tests'}"
                                     if (!skipIntegTests) {
                                         def integTestResults =
                                             build job: INTEG_TEST_JOB_NAME,
@@ -324,8 +324,8 @@ pipeline {
                                     }
                                 },
                                 'bwc-test': {
-                                    Boolean skipBwcTests = BWC_TEST_JOB_NAME == ''
-                                    echo "${skipBwcTests ? 'Skipping BWC tests' : 'Running BWC tests'}"
+                                    Boolean skipBwcTests = (BWC_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
+                                    echo "${skipBwcTests ? 'Skipping BWC tests as one of the values has empty string: BWC_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running BWC tests'}"
                                     if (!skipBwcTests) {
                                         def bwcTestResults =
                                             build job: BWC_TEST_JOB_NAME,
@@ -566,8 +566,8 @@ pipeline {
 
                             parallel([
                                 'integ-test': {
-                                    Boolean skipIntegTests = INTEG_TEST_JOB_NAME == ''
-                                    echo "${skipIntegTests ? 'Skipping integration tests' : 'Running integration tests'}"
+                                    Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
+                                    echo "${skipIntegTests ? 'Skipping integration tests as one of the values has empty string: INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running integration tests'}"
                                     if (!skipIntegTests) {
                                         def integTestResults =
                                             build job: INTEG_TEST_JOB_NAME,


### PR DESCRIPTION
### Description
Add check before triggering tests from distribution build jobs. If the any of the parameter is not passed, the workflow starts and aborts the child workflow which is taking up bandwidth. Hence adding a check. Skip if any of the param is missing.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
