### PR TITLE
Add Insights repos to 2.11 manifest

### DIFF
--- a/manifests/2.11.0/opensearch-2.11.0.yml
+++ b/manifests/2.11.0/opensearch-2.11.0.yml
@@ -20,3 +20,30 @@ components:
     platforms:
       - linux
       - windows
+  - name: opensearch-observability
+    repository: https://github.com/opensearch-project/observability.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: opensearch-reports
+    repository: https://github.com/opensearch-project/reporting.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version
+  - name: sql
+    repository: https://github.com/opensearch-project/sql.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version: opensearch-sql-plugin

--- a/manifests/2.11.0/opensearch-dashboards-2.11.0.yml
+++ b/manifests/2.11.0/opensearch-dashboards-2.11.0.yml
@@ -10,3 +10,20 @@ components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     ref: 2.x
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+    ref: 2.x
+  - name: observabilityDashboards
+    repository: https://github.com/opensearch-project/dashboards-observability.git
+    ref: 2.x
+  - name: reportsDashboards
+    repository: https://github.com/opensearch-project/dashboards-reporting.git
+    ref: 2.x
+  - name: ganttChartDashboards
+    repository: https://github.com/opensearch-project/dashboards-visualizations.git
+    working_directory: gantt-chart
+    ref: 2.x
+  - name: queryWorkbenchDashboards
+    repository: https://github.com/opensearch-project/dashboards-query-workbench.git
+    ref: 2.x
+

--- a/manifests/2.11.0/opensearch-dashboards-2.11.0.yml
+++ b/manifests/2.11.0/opensearch-dashboards-2.11.0.yml
@@ -26,4 +26,3 @@ components:
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
     ref: 2.x
-


### PR DESCRIPTION
### Description
Addds insights repos and security dashboards plugin to 2.11 manifest 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
