### PR TITLE
Run manifest check only aganist the changed manifest

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -26,11 +26,11 @@ jobs:
           json: true
           quotepath: false
           dir_names: false
-        
+
       - name: Set unique changed manifests as matrix
         id: set-matrix
         run: echo "matrix={\"manifest\":${{ steps.list-changed-manifests.outputs.all_changed_files }}}" >> "$GITHUB_OUTPUT"
-    
+
   manifest-checks-jdk11:
     needs: [list-changed-manifests]
     runs-on: ubuntu-latest

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -11,24 +11,20 @@ on:
     - cron: 0 0 * * *
 
 jobs:
-  list-manifests11:
+  list-changed-manifests:
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
-      - id: set-matrix
-        run: echo "::set-output name=matrix::$(ls manifests/**/opensearch*.yml | awk -F/ '{if($2<2)print$0}' | jq -R -s -c 'split("\n")[:-1]')"
-
-  list-manifests17:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: set-matrix
-        run: echo "::set-output name=matrix::$(ls manifests/**/opensearch*.yml | awk -F/ '{if($2>2)print$0}' | jq -R -s -c 'split("\n")[:-1]')"
-
+      - uses: actions/checkout@v2
+      - name: Get changed manifest files
+        uses: tj-actions/changed-files@v5
+        id: changed-files
+        with:
+          filepaths: |
+            manifests/**/*.yml
+            manifests/templates/**/
+      - name: Set unique changed manifests as matrix
+        id: set-matrix
+        run: echo "::set-output name=matrix::${{ steps.changed-files.outputs.files }}"
 
   manifest-checks-jdk11:
     needs: list-manifests11
@@ -38,7 +34,7 @@ jobs:
       JDK_VERSION: 11
     strategy:
       matrix:
-        manifest: ${{ fromJson(needs.list-manifests11.outputs.matrix) }}
+        manifest: ${{ fromJson(needs.list-changed-manifests.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
       - name: Set Up JDK ${{ env.JDK_VERSION }}
@@ -64,7 +60,7 @@ jobs:
       JDK_VERSION: 17
     strategy:
       matrix:
-        manifest: ${{ fromJson(needs.list-manifests17.outputs.matrix) }}
+        manifest: ${{ fromJson(needs.list-changed-manifests.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
       - name: Set Up JDK ${{ env.JDK_VERSION }}

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -14,20 +14,21 @@ jobs:
   list-changed-manifests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Get changed manifest files
-        uses: tj-actions/changed-files@v5
-        id: changed-files
+        uses: tj-actions/changed-files@v39
+        id: list-changed-manifests
         with:
-          filepaths: |
-            manifests/**/*.yml
-            manifests/templates/**/
+          separator: ' '
+        
       - name: Set unique changed manifests as matrix
         id: set-matrix
-        run: echo "::set-output name=matrix::${{ steps.changed-files.outputs.files }}"
-
+        run: |
+          echo "matrix=$(${{ steps.list-changed-manifests.outputs.all_changed_files }} | awk -F/ '{if($2>2)print$0}' | jq -R -s -c 'split(" ")[:-1]') " >> GITHUB_OUTPUT
+            
   manifest-checks-jdk11:
-    needs: list-manifests11
+    needs: list-changed-manifests
     runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: 3.9
@@ -53,7 +54,7 @@ jobs:
           ./ci.sh ${{ matrix.manifest }} --snapshot
 
   manifest-checks-jdk17:
-    needs: list-manifests17
+    needs: list-changed-manifests
     runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: 3.9

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   list-changed-manifests:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -20,22 +22,23 @@ jobs:
         uses: tj-actions/changed-files@v39
         id: list-changed-manifests
         with:
-          separator: ' '
+          files: manifests/**/opensearch*.yml
+          json: true
+          quotepath: false
+          dir_names: false
         
       - name: Set unique changed manifests as matrix
         id: set-matrix
-        run: |
-          echo "matrix=$(${{ steps.list-changed-manifests.outputs.all_changed_files }} | awk -F/ '{if($2>2)print$0}' | jq -R -s -c 'split(" ")[:-1]') " >> GITHUB_OUTPUT
-            
+        run: echo "matrix={\"manifest\":${{ steps.list-changed-manifests.outputs.all_changed_files }}}" >> "$GITHUB_OUTPUT"
+    
   manifest-checks-jdk11:
-    needs: list-changed-manifests
+    needs: [list-changed-manifests]
     runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: 3.9
       JDK_VERSION: 11
     strategy:
-      matrix:
-        manifest: ${{ fromJson(needs.list-changed-manifests.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.list-changed-manifests.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
       - name: Set Up JDK ${{ env.JDK_VERSION }}
@@ -54,14 +57,13 @@ jobs:
           ./ci.sh ${{ matrix.manifest }} --snapshot
 
   manifest-checks-jdk17:
-    needs: list-changed-manifests
+    needs: [list-changed-manifests]
     runs-on: ubuntu-latest
     env:
       PYTHON_VERSION: 3.9
       JDK_VERSION: 17
     strategy:
-      matrix:
-        manifest: ${{ fromJson(needs.list-changed-manifests.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.list-changed-manifests.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
       - name: Set Up JDK ${{ env.JDK_VERSION }}

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -7,8 +7,6 @@ on:
     paths:
       - 'manifests/**/*.yml'
       - '!manifests/templates/**/'
-  schedule:
-    - cron: 0 0 * * *
 
 jobs:
   list-changed-manifests:

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -2,7 +2,6 @@
 name: manifests
 
 on:
-  push:
   pull_request:
     paths:
       - 'manifests/**/*.yml'


### PR DESCRIPTION
### Description
Run manifest check only aganist the changed manifest

### Issues Resolved
closes https://github.com/opensearch-project/opensearch-build/issues/4075

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### Testing Screenshots:
Getting list of changed files in `'manifests/**/*.yml'`
![image](https://github.com/opensearch-project/opensearch-build/assets/56474017/76deb3bf-b511-445a-a87d-3feb3ffd25aa)

Running _manifest-checks-jdk11_  jobs:
![image](https://github.com/opensearch-project/opensearch-build/assets/56474017/04356b2c-0acf-4fb6-aa69-6321eb06aadc)

