### PR TITLE
Add a warning info and hard stop for security demo setup

### DIFF
--- a/scripts/startup/tar/linux/opensearch-tar-install.sh
+++ b/scripts/startup/tar/linux/opensearch-tar-install.sh
@@ -10,7 +10,10 @@ cd $OPENSEARCH_HOME
 KNN_LIB_DIR=$OPENSEARCH_HOME/plugins/opensearch-knn/lib
 ##Security Plugin
 if [ -d "$OPENSEARCH_HOME/plugins/opensearch-security" ]; then
-        bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s
+        echo "OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user."
+        echo "Please define an environment variable 'initialAdminPassword' with a password string."
+        echo “Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under $OPENSEARCH_PATH_CONF folder.”
+        bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || exit 1
         echo "done security"
 fi
 


### PR DESCRIPTION
### Description
Add a warning info and hard stop for security demo setup

### Issues Resolved
* Relate https://github.com/opensearch-project/opensearch-build/issues/4094

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
