### PR TITLE
Updates all references to install demo script

### DIFF
--- a/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
@@ -38,7 +38,8 @@ function setupSecurityPlugin {
             echo "OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user."
             echo "Please define an environment variable 'initialAdminPassword' with a password string."
             echo "Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under $OPENSEARCH_PATH_CONF folder."
-            bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || exit 1
+            echo "If no password is provided, a password will be generated for you"
+            bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s -g || exit 1
         fi
 
         if [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then

--- a/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
@@ -35,7 +35,10 @@ function setupSecurityPlugin {
             echo "Disabling execution of install_demo_configuration.sh for OpenSearch Security Plugin"
         else
             echo "Enabling execution of install_demo_configuration.sh for OpenSearch Security Plugin"
-            bash $OPENSEARCH_HOME/plugins/$SECURITY_PLUGIN/tools/install_demo_configuration.sh -y -i -s
+            echo "OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user."
+            echo "Please define an environment variable 'initialAdminPassword' with a password string."
+            echo "Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under $OPENSEARCH_PATH_CONF folder."
+            bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || exit 1
         fi
 
         if [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then

--- a/scripts/opensearch-onetime-setup.sh
+++ b/scripts/opensearch-onetime-setup.sh
@@ -21,7 +21,10 @@ if [ -d "$OPENSEARCH_HOME/plugins/$SECURITY_PLUGIN" ]; then
         echo "Disabling execution of install_demo_configuration.sh for OpenSearch Security Plugin"
     else
         echo "Enabling execution of install_demo_configuration.sh for OpenSearch Security Plugin"
-        bash $OPENSEARCH_HOME/plugins/$SECURITY_PLUGIN/tools/install_demo_configuration.sh -y -i -s
+        echo "OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user."
+        echo "Please define an environment variable 'initialAdminPassword' with a password string."
+        echo "Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under $OPENSEARCH_PATH_CONF folder."
+        bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || exit 1
     fi
 
     if [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then

--- a/scripts/opensearch-onetime-setup.sh
+++ b/scripts/opensearch-onetime-setup.sh
@@ -24,7 +24,8 @@ if [ -d "$OPENSEARCH_HOME/plugins/$SECURITY_PLUGIN" ]; then
         echo "OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user."
         echo "Please define an environment variable 'initialAdminPassword' with a password string."
         echo "Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under $OPENSEARCH_PATH_CONF folder."
-        bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || exit 1
+        echo "If no password is provided, a password will be generated for you"
+        bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s -g || exit 1
     fi
 
     if [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -21,7 +21,10 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1
+    echo "OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user."
+    echo "Please define an environment variable 'initialAdminPassword' with a password string."
+    echo "Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under $OPENSEARCH_PATH_CONF folder."
+    bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || exit 1 > ${log_dir}/install_demo_configuration.log 2>&1
 fi
 
 # Apply PerformanceAnalyzer Settings

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -24,7 +24,8 @@ if [ -d ${product_dir}/plugins/opensearch-security ]; then
     echo "OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user."
     echo "Please define an environment variable 'initialAdminPassword' with a password string."
     echo "Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under $OPENSEARCH_PATH_CONF folder."
-    bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || exit 1 > ${log_dir}/install_demo_configuration.log 2>&1
+    echo "If no password is provided, a password will be generated for you"
+    bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s -g || exit 1 > ${log_dir}/install_demo_configuration.log 2>&1
 fi
 
 # Apply PerformanceAnalyzer Settings

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -93,7 +93,10 @@ exit 0
 set -e
 # Apply Security Settings
 if [ -d %{product_dir}/plugins/opensearch-security ]; then
-    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > %{log_dir}/install_demo_configuration.log 2>&1
+    echo "OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user."
+    echo "Please define an environment variable 'initialAdminPassword' with a password string."
+    echo "Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under $OPENSEARCH_PATH_CONF folder."
+    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || exit 1> %{log_dir}/install_demo_configuration.log 2>&1
 fi
 chown -R %{name}.%{name} %{config_dir}
 chown -R %{name}.%{name} %{log_dir}

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -96,7 +96,8 @@ if [ -d %{product_dir}/plugins/opensearch-security ]; then
     echo "OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user."
     echo "Please define an environment variable 'initialAdminPassword' with a password string."
     echo "Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under $OPENSEARCH_PATH_CONF folder."
-    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || exit 1> %{log_dir}/install_demo_configuration.log 2>&1
+    echo "If no password is provided, a password will be generated for you"
+    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s -g || exit 1> %{log_dir}/install_demo_configuration.log 2>&1
 fi
 chown -R %{name}.%{name} %{config_dir}
 chown -R %{name}.%{name} %{log_dir}

--- a/scripts/startup/tar/linux/opensearch-tar-install.sh
+++ b/scripts/startup/tar/linux/opensearch-tar-install.sh
@@ -10,8 +10,13 @@ cd $OPENSEARCH_HOME
 KNN_LIB_DIR=$OPENSEARCH_HOME/plugins/opensearch-knn/lib
 ##Security Plugin
 if [ -d "$OPENSEARCH_HOME/plugins/opensearch-security" ]; then
-        bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s
-        echo "done security"
+        echo "Enabling execution of install_demo_configuration.sh for OpenSearch Security Plugin"
+        echo "OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user."
+        echo "Please define an environment variable 'initialAdminPassword' with a password string."
+        echo "Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under $OPENSEARCH_PATH_CONF folder."
+        echo "If no password is provided, a password will be generated for you"
+        bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s -g || exit 1
+        echo "Demo security config installed"
 fi
 
 PA_AGENT_JAVA_OPTS="-Dlog4j.configurationFile=$OPENSEARCH_PATH_CONF/opensearch-performance-analyzer/log4j2.xml \

--- a/scripts/startup/zip/windows/opensearch-windows-install.bat
+++ b/scripts/startup/zip/windows/opensearch-windows-install.bat
@@ -15,7 +15,12 @@ ECHO "OPENSEARCH_PATH_CONF: %OPENSEARCH_PATH_CONF%"
 :: Security Plugin Setups
 IF EXIST "%OPENSEARCH_HOME%\plugins\opensearch-security" (
     ECHO "Running Security Plugin Install Demo Configuration"
-    CALL "%OPENSEARCH_HOME%/plugins/opensearch-security/tools/install_demo_configuration.bat" -y -i -s
+    ECHO OpenSearch 2.11.0 onwards, the security plugin introduces a change that requires an initial password for 'admin' user.
+    ECHO Please define an environment variable 'initialAdminPassword' with a password string.
+    ECHO Or create a file 'initialAdminPassword.txt' with a single line that contains the password string and place it under %OPENSEARCH_PATH_CONF% folder.
+    ECHO If no password is provided, a password will be generated for you
+    CALL "%OPENSEARCH_HOME%\plugins\opensearch-security\tools\install_demo_configuration.bat" -y -i -s -g || exit /b 1
+    ECHO "Demo security config installed"
 )
 
 :: k-NN Plugin Setups


### PR DESCRIPTION
Follow-up of https://github.com/opensearch-project/opensearch-build/pull/4105

Related to: https://github.com/opensearch-project/opensearch-build/issues/4094

### Description
Updates the calls to install demo script to spit out a random password, if an initialAdminPassword is not set, by passing an additional flag `-g`.

This PR will be ready once https://github.com/opensearch-project/security/pull/3472 is merged.

As a fast-follow to this, branching strategy will addressed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
