### PR TITLE
Updated license header checker to Deno License Checker

### DIFF
--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Add License Header
-        uses: kt3k/license_checker@v1.0.6
+        run: npx @kt3k/license-checker

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,6 +1,35 @@
-{
-"**/*.{py,groovy,sh,js,ts}":[
-  " Copyright OpenSearch Contributors",
-  " SPDX-License-Identifier: Apache-2.0"
-]
+{ 
+  "**/*.*": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".flake8",
+    ".yml",
+    ".yaml",
+    ".bat",
+    ".json",
+    ".txt",
+    ".config",
+    ".swp",
+    "tests/tests_test_workflow/test_integ_workflow/integ_test/data/artifacts/",
+    "tests/tests_sign_workflow/data/signature/",
+    "tests/tests_assemble_workflow/data/artifacts/",
+    ".png",
+    "settings.gradle",
+    ".git",
+    ".lychee.excludes",
+    ".whitesource",
+    ".shellcheckrc",
+    ".lock",
+    ".gradle",
+    ".cert",
+    ".key",
+    ".jar",
+    ".gz",
+    ".toml",
+    ".ini",
+    "gradle/wrapper"
+  ]
 }


### PR DESCRIPTION
### Description
- Changed License Header Checker to  [Deno License Checker](https://github.com/kt3k/deno_license_checker)

### Issues Resolved
 - https://github.com/opensearch-project/opensearch-build/issues/3079

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
