### PR TITLE
Onboard get-ci-image-tag in preparation for other repos

### DIFF
--- a/.github/workflows/get-ci-image-tag.yml
+++ b/.github/workflows/get-ci-image-tag.yml
@@ -1,3 +1,4 @@
+---
 name: Get CI Image Tag
 on:
   workflow_call:
@@ -30,9 +31,9 @@ jobs:
       - name: Checkout opensearch-build repository
         uses: actions/checkout@v2
         with:
-            repository: 'opensearch-project/opensearch-build'
-            ref: ${{ inputs.build_ref }}
-            path: 'opensearch-build'
+          repository: 'opensearch-project/opensearch-build'
+          ref: ${{ inputs.build_ref }}
+          path: 'opensearch-build'
       - name: Get ci image version from opensearch-build repository scripts
         id: step-ci-image-version-linux
         run: |
@@ -40,5 +41,3 @@ jobs:
           CI_IMAGE_VERSION=`opensearch-build/docker/ci/get-ci-images.sh -p ${{ inputs.platform }} -u ${{ inputs.usage }} -t build | head -1`
           echo $CI_IMAGE_VERSION
           echo "ci-image-version-linux=$CI_IMAGE_VERSION" >> $GITHUB_OUTPUT
-
-

--- a/.github/workflows/get-ci-image-tag.yml
+++ b/.github/workflows/get-ci-image-tag.yml
@@ -1,0 +1,44 @@
+name: Get CI Image Tag
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+      usage:
+        required: true
+        type: string
+      build_ref:
+        required: false
+        type: string
+        default: 'main'
+    outputs:
+      ci-image-version-linux:
+        description: The ci image version for linux build
+        value: ${{ jobs.Get-CI-Image-Tag.outputs.output-ci-image-version-linux }}
+
+jobs:
+  Get-CI-Image-Tag:
+    runs-on: ubuntu-latest
+    outputs:
+      output-ci-image-version-linux: ${{ steps.step-ci-image-version-linux.outputs.ci-image-version-linux }}
+    steps:
+      - name: Install crane
+        uses: iarekylew00t/crane-installer@v1
+        with:
+          crane-release: v0.15.2
+      - name: Checkout opensearch-build repository
+        uses: actions/checkout@v2
+        with:
+            repository: 'opensearch-project/opensearch-build'
+            ref: ${{ inputs.build_ref }}
+            path: 'opensearch-build'
+      - name: Get ci image version from opensearch-build repository scripts
+        id: step-ci-image-version-linux
+        run: |
+          crane version
+          CI_IMAGE_VERSION=`opensearch-build/docker/ci/get-ci-images.sh -p ${{ inputs.platform }} -u ${{ inputs.usage }} -t build | head -1`
+          echo $CI_IMAGE_VERSION
+          echo "ci-image-version-linux=$CI_IMAGE_VERSION" >> $GITHUB_OUTPUT
+
+

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -4,11 +4,16 @@ name: python-tests
 on: [push, pull_request]
 
 jobs:
+  Get-CI-Image-Tag:
+    uses: ./.github/workflows/get-ci-image-tag.yml
+    with:
+      platform: centos7
+      usage: opensearch
+
   python-tests:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
           - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
@@ -41,11 +46,16 @@ jobs:
         with:
           files: ./coverage.xml
 
-  python-tests-build-image:
+  python-tests-linux:
+    needs: Get-CI-Image-Tag
     runs-on: ubuntu-latest
     container:
-      image: public.ecr.aws/opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
+      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
+      # this image tag is subject to change as more dependencies and updates will arrive over time
+      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
+      # need to switch to root so that github actions can install runner binary on container without permission issues.
       options: --user root
+
     steps:
       - uses: actions/checkout@v3
       - name: Install Pipenv and Dependencies


### PR DESCRIPTION
### Description
Onboard get-ci-image-tag in preparation for other repos

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3966

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
