### PR TITLE
Add build_ref in preparation for build repo branching

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,7 +9,7 @@ jobs:
     with:
       platform: centos7
       usage: opensearch
-      build_ref: main
+      build_ref: ${GITHUB_REF}
 
   python-tests:
     strategy:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,7 +9,7 @@ jobs:
     with:
       platform: centos7
       usage: opensearch
-      build_ref: ${github.ref}
+      build_ref: main
 
   python-tests:
     strategy:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,7 +9,7 @@ jobs:
     with:
       platform: centos7
       usage: opensearch
-      build_ref: ${GITHUB_REF}
+      build_ref: ${github.ref}
 
   python-tests:
     strategy:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,6 +9,7 @@ jobs:
     with:
       platform: centos7
       usage: opensearch
+      build_ref: main
 
   python-tests:
     strategy:


### PR DESCRIPTION
### Description
Add build_ref in preparation for build repo branching

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3966

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
