### PR TITLE
Add build discarder for gradle check job

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -7,6 +7,7 @@ pipeline {
     agent { label AGENT_LABEL }
     options {
         timeout(time: 2, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '180'))
         throttleJobProperty(
             categories: [],
             limitOneJobWithMatchingParams: false,


### PR DESCRIPTION
### Description
Gradle check jobs has reached a build count of 27790. Setting the build discarder to delete builds older than 180 days. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
