### PR TITLE
BUNDLE_MANIFEST env var bug-fix in benchmark jenkinsfile

### DIFF
--- a/jenkins/opensearch/benchmark-test.jenkinsfile
+++ b/jenkins/opensearch/benchmark-test.jenkinsfile
@@ -232,6 +232,7 @@ pipeline {
                         currentBuild.description = "Running benchmark test for build number: ${BUILD_ID} Manifest: ${BUNDLE_MANIFEST_URL}"
                     }
                     else {
+                        BUNDLE_MANIFEST = ''
                         env.HAS_SECURITY = "false"
                         env.ARCHITECTURE = "x64"
                         echo "HAS_SECURITY: ${env.HAS_SECURITY}"


### PR DESCRIPTION
### Description
BUNDLE_MANIFEST env variable has been hard-coded to `bundle-mainfest.yml` filename, even when the user doesn't pass the BUNDLE_MANIFEST_URL param, the placeholder filename value is passed to groovy script, the groovy script then fails with `file not found error`. 
This PR overrides the env variable to an empty string if BUNDLE_MANIFEST_URL param is not passed. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
