### PR TITLE
Bump peternied/discerning-merger from 2 to 3

### DIFF
--- a/.github/workflows/automatic-merges.yml
+++ b/.github/workflows/automatic-merges.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: peternied/discerning-merger@v2
+      - uses: peternied/discerning-merger@v3
         if: steps.find-triggering-pr.outputs.pr-number != null
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +56,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: peternied/discerning-merger@v2
+      - uses: peternied/discerning-merger@v3
         if: steps.find-triggering-pr.outputs.pr-number != null
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Bumps [peternied/discerning-merger](https://github.com/peternied/discerning-merger) from 2 to 3.
<details>
<summary>Release notes</summary>
<p><em>Sourced from <a href="https://github.com/peternied/discerning-merger/releases">peternied/discerning-merger's releases</a>.</em></p>
<blockquote>
<h2>v3 Release</h2>
<ul>
<li>Allows specifying how the merge is performed, with default of 'squash' method</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/peternied/discerning-merger/commit/07eafb14c195a2c23b291f6b008a686589cfb545"><code>07eafb1</code></a> Support passing merge type</li>
<li>See full diff in <a href="https://github.com/peternied/discerning-merger/compare/v2...v3">compare view</a></li>
</ul>
</details>
<br />


### Issues Resolved
- Fixes a bug preventing https://github.com/opensearch-project/opensearch-build/pull/4135 from working

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
