### PR TITLE
Add `.mypy_cache/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__
 .pytest_cache
 *.pyc
 
+.mypy_cache/
+
 .coverage
 coverage.xml
 coverage/


### PR DESCRIPTION
### Description

Add `.mypy_cache/` to `.gitignore`

`mypy` uses this folder for some cache-related stuff, we ignore similar folders in this project.

See [documentation](https://mypy.readthedocs.io/en/stable/config_file.html?highlight=mypy_cache#confval-cache_dir).

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
