### PR TITLE
Update checkout version to v3 as node12 is deprecated now

### DIFF
--- a/.github/workflows/get-ci-image-tag.yml
+++ b/.github/workflows/get-ci-image-tag.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           crane-release: v0.15.2
       - name: Checkout opensearch-build repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'opensearch-project/opensearch-build'
           ref: ${{ inputs.build_ref }}


### PR DESCRIPTION
### Description
Update checkout version to v3 as node12 is deprecated now

### Issues Resolved

Get-CI-Image-Tag / Get-CI-Image-Tag
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
