### PR TITLE
Add opensearch-cluster-cdk 1.x git branch support

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_test_runner.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_runner.py
@@ -29,7 +29,8 @@ class BenchmarkTestRunner(abc.ABC):
         else:
             self.security = False
 
-        self.tests_dir = os.path.join(os.getcwd(), "test-results", "benchmark-test", f"{'with' if self.security else 'without'}-security")
+        self.tests_dir = os.path.join(os.getcwd(), "test-results", "benchmark-test",
+                                      f"{'with' if self.security else 'without'}-security")
         os.makedirs(self.tests_dir, exist_ok=True)
 
     @abc.abstractmethod
@@ -38,3 +39,17 @@ class BenchmarkTestRunner(abc.ABC):
 
     def run(self) -> None:
         self.run_tests()
+
+    def get_git_ref(self) -> str:
+        if self.test_manifest:
+            os_major_version = self.test_manifest.version.split(".")[0]
+            if os_major_version in ['2', '3']:
+                return 'main'
+            else:
+                return '1.x'
+        else:
+            os_major_version = self.args.distribution_version.split(".")[0]
+            if os_major_version in ['2', '3']:
+                return 'main'
+            else:
+                return '1.x'

--- a/src/test_workflow/benchmark_test/benchmark_test_runner_opensearch.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_runner_opensearch.py
@@ -41,7 +41,7 @@ class BenchmarkTestRunnerOpenSearch(BenchmarkTestRunner):
 
         with TemporaryDirectory(keep=self.args.keep, chdir=True) as work_dir:
             current_workspace = os.path.join(work_dir.name, "opensearch-cluster-cdk")
-            with GitRepository(self.get_cluster_repo_url(), "main", current_workspace):
+            with GitRepository(self.get_cluster_repo_url(), self.get_git_ref(), current_workspace):
                 with WorkingDirectory(current_workspace):
                     with BenchmarkTestCluster.create(self.test_manifest, config, self.args, current_workspace) as test_cluster:
                         benchmark_test_suite = BenchmarkTestSuite(test_cluster.endpoint_with_port, self.security, self.args)

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_runner_opensearch.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_runner_opensearch.py
@@ -38,7 +38,7 @@ class TestBenchmarkTestRunnerOpenSearch(unittest.TestCase):
         runner = BenchmarkTestRunners.from_args(benchmark_args, test_manifest)
         runner.run()
 
-        mock_git.assert_called_with("https://github.com/opensearch-project/opensearch-cluster-cdk.git", "main",
+        mock_git.assert_called_with("https://github.com/opensearch-project/opensearch-cluster-cdk.git", "1.x",
                                     os.path.join(tempfile.gettempdir(), "opensearch-cluster-cdk"))
         self.assertEqual(mock_suite.call_count, 1)
         self.assertEqual(mock_cluster.call_count, 1)


### PR DESCRIPTION
### Description
We have a requirement to run benchmarks for OpenSearch 1.x versions. 
Since all the code for 1.x support in opensearch-cluster-cdk resides in `1.x` branch in opensearch-cluster-cdk repo, need to add support to select which branch to check-out during git repo checkout step in the workflow. It was hard-coded to `main` repo. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
