### PR TITLE
Minor bug fix in repo checkout logic for benchmark workflow

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_test_runner.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_runner.py
@@ -42,7 +42,7 @@ class BenchmarkTestRunner(abc.ABC):
 
     def get_git_ref(self) -> str:
         if self.test_manifest:
-            os_major_version = self.test_manifest.version.split(".")[0]
+            os_major_version = self.test_manifest.build.version.split(".")[0]
             if os_major_version in ['2', '3']:
                 return 'main'
             else:


### PR DESCRIPTION
### Description
Instead of fetching the OS build version the code was fetching the manifest schema version. Fixed it. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
