### PR TITLE
Add tini to allow termination signal handling

### DIFF
--- a/docker/release/build-image-single-arch.sh
+++ b/docker/release/build-image-single-arch.sh
@@ -123,6 +123,5 @@ else
 fi
 
 # Docker build
-docker build --build-arg VERSION=$VERSION --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` --build-arg NOTES=$NOTES -f $DOCKERFILE $DIR -t opensearchproject/$PRODUCT:$VERSION
-docker tag opensearchproject/$PRODUCT:$VERSION opensearchproject/$PRODUCT:latest
+docker build --build-arg VERSION=$VERSION --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` --build-arg NOTES=$NOTES -f $DOCKERFILE $DIR -t opensearchproject/$PRODUCT:$VERSION --build-arg TARGETARCH=${arch_uname}
 

--- a/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
@@ -98,7 +98,7 @@ function runOpensearch {
     setupPerformanceAnalyzerPlugin
 
     # Start opensearch
-    "$@" "${opensearch_opts[@]}"
+    exec "$@" "${opensearch_opts[@]}"
 
 }
 

--- a/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
@@ -52,11 +52,17 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ARG UID=1000
 ARG GID=1000
 ARG OPENSEARCH_DASHBOARDS_HOME=/usr/share/opensearch-dashboards
+ARG TARGETARCH
+ENV TINI_VERSION=v0.19.0
 
 # Update packages
 # Install the tools we need: tar and gzip to unpack the OpenSearch tarball, and shadow-utils to give us `groupadd` and `useradd`.
 # Install which to allow running of securityadmin.sh
 RUN yum update -y && yum install -y tar gzip shadow-utils which && yum clean all
+
+# Add Tini to use as init (PID1) process.
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /bin/tini
+RUN chmod 755 ./tini
 
 # Install Reporting dependencies
 RUN yum install -y libnss3.so xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc fontconfig freetype && yum clean all
@@ -96,5 +102,5 @@ LABEL org.label-schema.schema-version="1.0" \
   "DOCKERFILE"="https://github.com/opensearch-project/opensearch-build/blob/main/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile"
 
 # CMD to run
-ENTRYPOINT ["./opensearch-dashboards-docker-entrypoint.sh"]
+ENTRYPOINT ["./tini", "--", "./opensearch-dashboards-docker-entrypoint.sh"]
 CMD ["opensearch-dashboards"]

--- a/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
@@ -61,7 +61,7 @@ ENV TINI_VERSION=v0.19.0
 RUN yum update -y && yum install -y tar gzip shadow-utils which && yum clean all
 
 # Add Tini to use as init (PID1) process.
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /bin/tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} ./tini
 RUN chmod 755 ./tini
 
 # Install Reporting dependencies

--- a/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile
@@ -61,8 +61,8 @@ ENV TINI_VERSION=v0.19.0
 RUN yum update -y && yum install -y tar gzip shadow-utils which && yum clean all
 
 # Add Tini to use as init (PID1) process.
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} ./tini
-RUN chmod 755 ./tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /bin/tini
+RUN chmod 755 /bin/tini
 
 # Install Reporting dependencies
 RUN yum install -y libnss3.so xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc fontconfig freetype && yum clean all
@@ -102,5 +102,5 @@ LABEL org.label-schema.schema-version="1.0" \
   "DOCKERFILE"="https://github.com/opensearch-project/opensearch-build/blob/main/docker/release/dockerfiles/opensearch-dashboards.al2.dockerfile"
 
 # CMD to run
-ENTRYPOINT ["./tini", "--", "./opensearch-dashboards-docker-entrypoint.sh"]
+ENTRYPOINT ["/bin/tini", "--", "./opensearch-dashboards-docker-entrypoint.sh"]
 CMD ["opensearch-dashboards"]

--- a/docker/release/dockerfiles/opensearch.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2.dockerfile
@@ -64,7 +64,7 @@ ENV TINI_VERSION=v0.19.0
 RUN yum update -y && yum install -y tar gzip shadow-utils which && yum clean all
 
 # Add Tini to use as init (PID1) process.
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /bin/tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} ./tini
 RUN chmod 755 ./tini
 
 # Create an opensearch user, group
@@ -115,5 +115,5 @@ LABEL org.label-schema.schema-version="1.0" \
   "DOCKERFILE"="https://github.com/opensearch-project/opensearch-build/blob/main/docker/release/dockerfiles/opensearch.al2.dockerfile"
 
 # CMD to run
-ENTRYPOINT ["./opensearch-docker-entrypoint.sh"]
+ENTRYPOINT ["./tini", "--", "./opensearch-docker-entrypoint.sh"]
 CMD ["opensearch"]

--- a/docker/release/dockerfiles/opensearch.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2.dockerfile
@@ -55,11 +55,17 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2
 ARG UID=1000
 ARG GID=1000
 ARG OPENSEARCH_HOME=/usr/share/opensearch
+ARG TARGETARCH
+ENV TINI_VERSION=v0.19.0
 
 # Update packages
 # Install the tools we need: tar and gzip to unpack the OpenSearch tarball, and shadow-utils to give us `groupadd` and `useradd`.
 # Install which to allow running of securityadmin.sh
 RUN yum update -y && yum install -y tar gzip shadow-utils which && yum clean all
+
+# Add Tini to use as init (PID1) process.
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /bin/tini
+RUN chmod 755 ./tini
 
 # Create an opensearch user, group
 RUN groupadd -g $GID opensearch && \

--- a/docker/release/dockerfiles/opensearch.al2.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2.dockerfile
@@ -64,8 +64,8 @@ ENV TINI_VERSION=v0.19.0
 RUN yum update -y && yum install -y tar gzip shadow-utils which && yum clean all
 
 # Add Tini to use as init (PID1) process.
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} ./tini
-RUN chmod 755 ./tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${TARGETARCH} /bin/tini
+RUN chmod 755 /bin/tini
 
 # Create an opensearch user, group
 RUN groupadd -g $GID opensearch && \
@@ -115,5 +115,5 @@ LABEL org.label-schema.schema-version="1.0" \
   "DOCKERFILE"="https://github.com/opensearch-project/opensearch-build/blob/main/docker/release/dockerfiles/opensearch.al2.dockerfile"
 
 # CMD to run
-ENTRYPOINT ["./tini", "--", "./opensearch-docker-entrypoint.sh"]
+ENTRYPOINT ["/bin/tini", "--", "./opensearch-docker-entrypoint.sh"]
 CMD ["opensearch"]


### PR DESCRIPTION
### Description
Adds tini as the PID1 process in opensearch and opensearch-dashboards container to allow for termination signal handling.

### Issues Resolved
closes [[BUG] OpenSearch container does not allow for graceful termination #3229](https://github.com/opensearch-project/opensearch-build/issues/3229)

###Test Plan and results:
1. Build and push opensearch image to dockerhub
`docker run -it -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" chawinphat/opensearch:1.3.9`
2. Test signal handling with new image. See that container is closed after calling "SIGTERM"
```
teddyt@Teddys-MacBook-Pro docker % docker ps
CONTAINER ID   IMAGE                         COMMAND                  CREATED          STATUS          PORTS                                                                NAMES
e7297b7fcbba   chawinphat/opensearch:1.3.9   "/bin/tini -- ./open…"   19 minutes ago   Up 19 minutes   0.0.0.0:9200->9200/tcp, 9300/tcp, 0.0.0.0:9600->9600/tcp, 9650/tcp   vigorous_dewdney
teddyt@Teddys-MacBook-Pro docker % docker kill --signal="SIGTERM" e7297b7fcbba
e7297b7fcbba
teddyt@Teddys-MacBook-Pro docker % docker ps                                  
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES

```3. Opensearch container exits with the following logs
```
[2023-11-15T23:36:53,554][INFO ][o.o.n.Node               ] [e7297b7fcbba] stopped
[2023-11-15T23:36:53,555][INFO ][o.o.n.Node               ] [e7297b7fcbba] closing ...
[2023-11-15T23:36:53,561][INFO ][o.o.s.a.i.AuditLogImpl   ] [e7297b7fcbba] Closing AuditLogImpl
[2023-11-15T23:36:53,568][INFO ][o.o.n.Node               ] [e7297b7fcbba] closed
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
