### PR TITLE
Add test manifests for 2.11.1 and update cron job

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -24,9 +24,7 @@ pipeline {
     triggers {
         parameterizedCron '''
             H 1 * * * %INPUT_MANIFEST=2.10.1/opensearch-dashboards-2.10.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H/60 * * * * %INPUT_MANIFEST=2.11.1/opensearch-dashboards-2.11.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.12.0/opensearch-dashboards-2.12.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H/60 * * * * %INPUT_MANIFEST=2.11.1/opensearch-2.11.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.12.0/opensearch-2.12.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=1.3.14/opensearch-1.3.14.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TEST_MANIFEST=3.0.0/opensearch-3.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip

--- a/manifests/2.11.1/opensearch-2.11.1-test.yml
+++ b/manifests/2.11.1/opensearch-2.11.1-test.yml
@@ -1,0 +1,139 @@
+---
+schema-version: '1.0'
+name: OpenSearch
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
+    args: -e JAVA_HOME=/opt/java/openjdk-17
+components:
+  - name: alerting
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        plugins.destination.host.deny_list: [10.0.0.0/8, 127.0.0.1]
+    bwc-test:
+      test-configs:
+        - with-security
+
+  - name: anomaly-detection
+    integ-test:
+      build-dependencies:
+        - job-scheduler
+      test-configs:
+        - with-security
+        - without-security
+    bwc-test:
+      test-configs:
+        - with-security
+
+  - name: asynchronous-search
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: cross-cluster-replication
+    integ-test:
+      topology:
+        - cluster_name: leader
+          data_nodes: 2
+          cluster_manager_nodes: 0
+        - cluster_name: follower
+          data_nodes: 2
+          cluster_manager_nodes: 0
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: geospatial
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: index-management
+    integ-test:
+      build-dependencies:
+        - job-scheduler
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        path.repo: [/tmp]
+    bwc-test:
+      test-configs:
+        - with-security
+
+  - name: k-NN
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: ml-commons
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: neural-search
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: notifications
+    working-directory: notifications
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+    bwc-test:
+      test-configs:
+        - with-security
+
+  - name: opensearch-observability
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+    bwc-test:
+      test-configs:
+        - with-security
+
+  - name: opensearch-reports
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: security
+    integ-test:
+      test-configs:
+        - with-security
+
+  - name: security-analytics
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
+  - name: sql
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        script.context.field.max_compilations_rate: 1000/1m
+        plugins.query.datasources.encryption.masterkey: 4fc8fee6a3fd7d6ca01772e5
+    bwc-test:
+      test-configs:
+        - with-security
+
+  - name: custom-codecs
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security

--- a/manifests/2.11.1/opensearch-dashboards-2.11.0-test.yml
+++ b/manifests/2.11.1/opensearch-dashboards-2.11.0-test.yml
@@ -1,0 +1,82 @@
+---
+schema-version: '1.0'
+name: OpenSearch Dashboards
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v4
+components:
+  - name: OpenSearch-Dashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        vis_builder.enabled: true
+        data_source.enabled: true
+  - name: alertingDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: anomalyDetectionDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: ganttChartDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: indexManagementDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: observabilityDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: queryWorkbenchDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: reportsDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: securityDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: notificationsDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: customImportMapDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: searchRelevanceDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: securityAnalyticsDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+  - name: mlCommonsDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        ml_commons_dashboards.enabled: true


### PR DESCRIPTION
### Description
Adds test manifests for 2.11.1 and remove 2.11.1 hourly builds from check-for-build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
