### PR TITLE
Mark build stage as unstable if plugins failed to build

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -213,13 +213,19 @@ pipeline {
                         }
                     }
                     post {
+                        success {
+                            script {
+                                if (params.CONTINUE_ON_ERROR) {
+                                    markStageUnstableIfPluginsFailedToBuild()
+                                }
+                            }
+                        }
                         always {
                             script {
                                 lib.jenkins.Messages.new(this).add(
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
-                                markStageUnstableIfPluginsFailedToBuild()
                                 postCleanup()
                             }
                         }
@@ -258,11 +264,15 @@ pipeline {
                                 }
                             }
                             post {
-                                always {
+                                success {
                                     script {
-                                        markStageUnstableIfPluginsFailedToBuild()
-                                        postCleanup()
+                                        if (params.CONTINUE_ON_ERROR) {
+                                            markStageUnstableIfPluginsFailedToBuild()
+                                        }
                                     }
+                                }
+                                always {
+                                    postCleanup()
                                 }
                             }
                         }
@@ -313,7 +323,6 @@ pipeline {
                                             "${STAGE_NAME}",
                                             lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                         )
-
                                         postCleanup()
                                     }
                                 }
@@ -354,11 +363,15 @@ pipeline {
                                 }
                             }
                             post {
-                                always {
-                                    script{
-                                        markStageUnstableIfPluginsFailedToBuild()
-                                        postCleanup()
+                                success {
+                                    script {
+                                        if (params.CONTINUE_ON_ERROR) {
+                                            markStageUnstableIfPluginsFailedToBuild()
+                                        }
                                     }
+                                }
+                                always {
+                                    postCleanup()
                                 }
                             }
                         }
@@ -459,13 +472,19 @@ pipeline {
                         }
                     }
                     post {
+                        success {
+                            script {
+                                if (params.CONTINUE_ON_ERROR) {
+                                    markStageUnstableIfPluginsFailedToBuild()
+                                }
+                            }
+                        }
                         always {
                             script {
                                 lib.jenkins.Messages.new(this).add(
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
-                                markStageUnstableIfPluginsFailedToBuild()
                                 postCleanup()
                             }
                         }
@@ -504,9 +523,15 @@ pipeline {
                                 }
                             }
                             post {
+                                success {
+                                    script {
+                                        if (params.CONTINUE_ON_ERROR) {
+                                            markStageUnstableIfPluginsFailedToBuild()
+                                        }
+                                    }
+                                }
                                 always {
                                     script{
-                                        markStageUnstableIfPluginsFailedToBuild()
                                         postCleanup()
                                     }
                                 }
@@ -559,7 +584,6 @@ pipeline {
                                             "${STAGE_NAME}",
                                             lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                         )
-
                                         postCleanup()
                                     }
                                 }
@@ -600,9 +624,15 @@ pipeline {
                                 }
                             }
                             post {
+                                success {
+                                    script {
+                                        if (params.CONTINUE_ON_ERROR) {
+                                            markStageUnstableIfPluginsFailedToBuild()
+                                        }
+                                    }
+                                }
                                 always {
                                     script {
-                                        markStageUnstableIfPluginsFailedToBuild()
                                         postCleanup()
                                     }
                                 }
@@ -645,7 +675,6 @@ pipeline {
                                             "${STAGE_NAME}",
                                             lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                         )
-
                                         postCleanup()
                                     }
                                 }
@@ -690,13 +719,19 @@ pipeline {
                         }
                     }
                     post {
+                        success {
+                            script {
+                                if (params.CONTINUE_ON_ERROR) {
+                                    markStageUnstableIfPluginsFailedToBuild()
+                                }
+                            }
+                        }
                         always {
                             script {
                                 lib.jenkins.Messages.new(this).add(
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
-                                markStageUnstableIfPluginsFailedToBuild()
                                 postCleanup()
                             }
                         }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -531,9 +531,7 @@ pipeline {
                                     }
                                 }
                                 always {
-                                    script{
-                                        postCleanup()
-                                    }
+                                    postCleanup()
                                 }
                             }
                         }
@@ -632,9 +630,7 @@ pipeline {
                                     }
                                 }
                                 always {
-                                    script {
-                                        postCleanup()
-                                    }
+                                    postCleanup()
                                 }
                             }
                         }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@5.11.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@5.12.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -219,7 +219,7 @@ pipeline {
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
-
+                                markStageUnstableIfPluginsFailedToBuild()
                                 postCleanup()
                             }
                         }
@@ -259,7 +259,10 @@ pipeline {
                             }
                             post {
                                 always {
-                                    postCleanup()
+                                    script {
+                                        markStageUnstableIfPluginsFailedToBuild()
+                                        postCleanup()
+                                    }
                                 }
                             }
                         }
@@ -352,7 +355,10 @@ pipeline {
                             }
                             post {
                                 always {
-                                    postCleanup()
+                                    script{
+                                        markStageUnstableIfPluginsFailedToBuild()
+                                        postCleanup()
+                                    }
                                 }
                             }
                         }
@@ -459,7 +465,7 @@ pipeline {
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
-
+                                markStageUnstableIfPluginsFailedToBuild()
                                 postCleanup()
                             }
                         }
@@ -499,7 +505,10 @@ pipeline {
                             }
                             post {
                                 always {
-                                    postCleanup()
+                                    script{
+                                        markStageUnstableIfPluginsFailedToBuild()
+                                        postCleanup()
+                                    }
                                 }
                             }
                         }
@@ -592,7 +601,10 @@ pipeline {
                             }
                             post {
                                 always {
-                                    postCleanup()
+                                    script {
+                                        markStageUnstableIfPluginsFailedToBuild()
+                                        postCleanup()
+                                    }
                                 }
                             }
                         }
@@ -684,7 +696,7 @@ pipeline {
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
-
+                                markStageUnstableIfPluginsFailedToBuild()
                                 postCleanup()
                             }
                         }
@@ -822,5 +834,12 @@ pipeline {
                 }
             }
         }
+    }
+}
+
+def markStageUnstableIfPluginsFailedToBuild() {
+    def stageLogs = getLogsForStage(stageName: "${STAGE_NAME}")
+    if (stageLogs.any{e -> e.contains('Failed plugins are')}) {
+        unstable('Some plugins failed to build. See the ./build.sh step for logs and more details')
     }
 }


### PR DESCRIPTION
### Description
The `continue-on-error` option does not throw an error or an non-zero exit code. Hence it comes difficult for component owners to parse jenkins build log to find the exactly failure. This PR marks the stage as unstable if plugins failed to build.

### Issues Resolved
resolves #4018 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
