### PR TITLE
Change the docker image version for Tar

### DIFF
--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -14,7 +14,7 @@ lib = library(identifier: 'jenkins@5.11.1', retriever: modernSCM([
 ]))
 
 def docker_images = [
-    "tar": "opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v4",
+    "tar": "opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v4.2",
     "rpm": "opensearchstaging/ci-runner:ci-runner-rockylinux8-systemd-base-integtest-v3",
     "deb": "opensearchstaging/ci-runner:ci-runner-ubuntu2004-systemd-base-integtest-v3",
     "zip": "opensearchstaging/ci-runner:ci-runner-windows2019-servercore-opensearch-build-v1",


### PR DESCRIPTION
### Description
Change the docker image version for tarball to 4.2- previous, to fix the integtest component failues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
