### PR TITLE
Move 2.12.0 to use jdk version 21

### DIFF
--- a/manifests/2.12.0/opensearch-2.12.0.yml
+++ b/manifests/2.12.0/opensearch-2.12.0.yml
@@ -6,7 +6,7 @@ build:
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
-    args: -e JAVA_HOME=/opt/java/openjdk-17
+    args: -e JAVA_HOME=/opt/java/openjdk-21
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git


### PR DESCRIPTION
### Description
Move 2.12.0 to use jdk version 21

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/pull/11003

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
