### PR TITLE
debian package: fix installation issues on systems having systemd installed but not running it as init.

### DIFF
--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
@@ -20,12 +20,12 @@ log_dir=/var/log/opensearch-dashboards
 pid_dir=/var/run/opensearch-dashboards
 
 # Reload systemctl daemon
-if command -v systemctl > /dev/null; then
+if [ -d /run/systemd/system ]; then
     systemctl daemon-reload
 fi
 
 # Reload other configs
-if command -v systemd-tmpfiles > /dev/null; then
+if [ -d /run/systemd/system ]; then
     systemd-tmpfiles --create opensearch-dashboards.conf
 fi
 

--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/preinst
@@ -14,7 +14,7 @@ set -e
 echo "Running OpenSearch-Dashboards Pre-Installation Script"
 
 # Stop existing service
-if command -v systemctl >/dev/null && systemctl is-active opensearch-dashboards.service >/dev/null; then
+if [ -d /run/systemd/system ] && systemctl is-active opensearch-dashboards.service >/dev/null; then
     echo "Stop existing opensearch-dashboards.service"
     systemctl --no-reload stop opensearch-dashboards.service
 fi

--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/prerm
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/prerm
@@ -14,7 +14,7 @@ set -e
 echo "Running OpenSearch-Dashboards Pre-Removal Script"
 
 # Stop existing service
-if command -v systemctl >/dev/null && systemctl is-active opensearch-dashboards.service >/dev/null; then
+if [ -d /run/systemd/system ] >/dev/null && systemctl is-active opensearch-dashboards.service >/dev/null; then
     echo "Stop existing opensearch-dashboards.service"
     systemctl --no-reload stop opensearch-dashboards.service
 fi

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -45,16 +45,16 @@ chown -R opensearch.opensearch ${data_dir}
 chown -R opensearch.opensearch ${pid_dir}
 
 # Reload systemctl daemon
-if command -v systemctl > /dev/null; then
+if [ -d /run/systemd/system ] ; then
     systemctl daemon-reload
 fi
 
 # Reload other configs
-if command -v systemctl > /dev/null; then
+if [ -d /run/systemd/system ] ; then
     systemctl restart systemd-sysctl.service || true
 fi
 
-if command -v systemd-tmpfiles > /dev/null; then
+if [ -d /run/systemd/system ] ; then
     systemd-tmpfiles --create opensearch.conf
 fi
 

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -14,11 +14,11 @@ set -e
 echo "Running OpenSearch Pre-Installation Script"
 
 # Stop existing service
-if command -v systemctl >/dev/null && systemctl is-active opensearch.service >/dev/null; then
+if [ -d /run/systemd/system ] && systemctl is-active opensearch.service >/dev/null; then
     echo "Stop existing opensearch.service"
     systemctl --no-reload stop opensearch.service
 fi
-if command -v systemctl >/dev/null && systemctl is-active opensearch-performance-analyzer.service >/dev/null; then
+if [ -d /run/systemd/system ] && systemctl is-active opensearch-performance-analyzer.service >/dev/null; then
     echo "Stop existing opensearch-performance-analyzer.service"
     systemctl --no-reload stop opensearch-performance-analyzer.service
 fi

--- a/scripts/pkg/build_templates/opensearch/deb/debian/prerm
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/prerm
@@ -14,11 +14,11 @@ set -e
 echo "Running OpenSearch Pre-Removal Script"
 
 # Stop existing service
-if command -v systemctl >/dev/null && systemctl is-active opensearch.service >/dev/null; then
+if [ -d /run/systemd/system ] && systemctl is-active opensearch.service >/dev/null; then
     echo "Stop existing opensearch.service"
     systemctl --no-reload stop opensearch.service
 fi
-if command -v systemctl >/dev/null && systemctl is-active opensearch-performance-analyzer.service >/dev/null; then
+if [ -d /run/systemd/system ] && systemctl is-active opensearch-performance-analyzer.service >/dev/null; then
     echo "Stop existing opensearch-performance-analyzer.service"
     systemctl --no-reload stop opensearch-performance-analyzer.service
 fi


### PR DESCRIPTION
### Description
Instead of checking for the existence of systemd binaries check for actually running systemd, as seen by the reference result when using dh_installsystemd:

```bash
# Automatically added by dh_installsystemd/13.11.4
if [ -z "${DPKG_ROOT:-}" ] && [ "$1" = upgrade ] && [ -d /run/systemd/system ] ; then
	deb-systemd-invoke stop 'opensearch.service' >/dev/null || true
fi
# End automatically added section
```

This is only a fix based on the current implementation. I'm not changing the way systemctl is invoked.

### Issues Resolved
- This use case has not been reported yet exactly this way.

**This PR can be rejected if my upcoming proposal issue is considered** (will post link below as comment once created)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

/dm