### PR TITLE
Update manifests.yml to dynamically define jdk versions based on manifest image jdk export

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -2,9 +2,6 @@
 name: manifests
 
 on:
-  push:
-    branches:
-      - 'manifests-jdks'
   pull_request:
     paths:
       - 'manifests/**/*.yml'

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -2,6 +2,9 @@
 name: manifests
 
 on:
+  push:
+    branches:
+      - 'manifests-jdks'
   pull_request:
     paths:
       - 'manifests/**/*.yml'
@@ -28,45 +31,26 @@ jobs:
         id: set-matrix
         run: echo "matrix={\"manifest\":${{ steps.list-changed-manifests.outputs.all_changed_files }}}" >> "$GITHUB_OUTPUT"
 
-  manifest-checks-jdk11:
+  manifest-checks:
     needs: [list-changed-manifests]
     runs-on: ubuntu-latest
+    fail-fast: false
     env:
       PYTHON_VERSION: 3.9
-      JDK_VERSION: 11
     strategy:
       matrix: ${{ fromJson(needs.list-changed-manifests.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set Up JDK ${{ env.JDK_VERSION }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ env.JDK_VERSION }}
-      - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install Pipenv and Dependencies
+      - name: Check JDK Version
         run: |
-          python -m pip install --upgrade pipenv wheel
-      - name: OpenSearch Manifests
-        run: |-
-          ./ci.sh ${{ matrix.manifest }} --snapshot
-
-  manifest-checks-jdk17:
-    needs: [list-changed-manifests]
-    runs-on: ubuntu-latest
-    env:
-      PYTHON_VERSION: 3.9
-      JDK_VERSION: 17
-    strategy:
-      matrix: ${{ fromJson(needs.list-changed-manifests.outputs.matrix) }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set Up JDK ${{ env.JDK_VERSION }}
+          java_version=`cat ${{ matrix.manifest }} | yq -r .ci.image.args | grep -Eo '[0-9]+' || echo ''`
+          echo $java_version
+          echo "JAVA_VERSION=$java_version" >> "$GITHUB_ENV"
+      - name: Set Up JDK ${{ env.JAVA_VERSION }}
+        if: ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ env.JDK_VERSION }}
+          java-version: ${{ env.JAVA_VERSION }}
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v3
         with:


### PR DESCRIPTION

### Description
Update manifests.yml to dynamically define jdk versions based on manifest image jdk export

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/4227

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
