### PR TITLE
Freeze commit ids for 1.3.14 manifests

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -24,10 +24,8 @@ pipeline {
     triggers {
         parameterizedCron '''
             H 1 * * * %INPUT_MANIFEST=2.11.2/opensearch-2.11.2.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H/60 * * * * %INPUT_MANIFEST=1.3.14/opensearch-dashboards-1.3.14.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.12.0/opensearch-dashboards-2.12.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.12.0/opensearch-2.12.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H/60 * * * * %INPUT_MANIFEST=1.3.14/opensearch-1.3.14.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TEST_MANIFEST=3.0.0/opensearch-3.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TEST_MANIFEST=3.0.0/opensearch-dashboards-3.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''

--- a/manifests/1.3.14/opensearch-1.3.14.yml
+++ b/manifests/1.3.14/opensearch-1.3.14.yml
@@ -10,13 +10,13 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: '1.3'
+    ref: cedab0bd232290c2606c28ef7087106fc1a74f9a
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: '1.3'
+    ref: 02d6bfdc3113e2aeb9a52dd108144948dabe81b9
     checks:
       - gradle:publish
       - gradle:properties:version
@@ -25,7 +25,7 @@ components:
       - windows
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: '1.3'
+    ref: ed410027d243b764b623be1c76dd6ded55e6fd19
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -34,7 +34,7 @@ components:
       - windows
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '1.3'
+    ref: b653d56d561171c10049064d5a17861d97aac843
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -43,7 +43,7 @@ components:
       - windows
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: '1.3'
+    ref: 143048f718128e6bc0d0b5413055abadb7721b38
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
@@ -52,7 +52,7 @@ components:
       - windows
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: '1.3'
+    ref: 5ee85f736d0c6dc3ab45e7a0a57c612bf25c2ad4
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -60,7 +60,7 @@ components:
       - linux
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: '1.3'
+    ref: 5f67ea58d9489b8ad9fc06d4f89d347727e5fe9e
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
@@ -69,7 +69,7 @@ components:
       - windows
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: '1.3'
+    ref: e68a5a38240f0f26d34bcad38c1cd0de8c7ada95
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -78,7 +78,7 @@ components:
       - windows
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '1.3'
+    ref: 1294d44e572a250673a30328e8bf0a1ea0c295b5
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -87,7 +87,7 @@ components:
       - windows
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: '1.3'
+    ref: 1e4d12efb7ae37c4dc9b792336322e69dbb2a177
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
@@ -96,7 +96,7 @@ components:
       - windows
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: '1.3'
+    ref: 2740d97374ba559526b0c07df0bb31384f70cb2b
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -105,7 +105,7 @@ components:
       - windows
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: '1.3'
+    ref: a72f824b7e4165765152c4ebd4c47e98d6b8c94e
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -114,7 +114,7 @@ components:
       - windows
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: '1.3'
+    ref: 71db6ce79dcdf1dada24c07303cff5e2aee997e2
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -123,7 +123,7 @@ components:
       - windows
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: '1.3'
+    ref: 97efd1ef35d33f60c2edf6b9dcbf81ce808693e6
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -132,7 +132,7 @@ components:
       - windows
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: '1.3'
+    ref: f4d500419482e0a53cf35a34cd8864e5f0864d96
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/1.3.14/opensearch-dashboards-1.3.14.yml
+++ b/manifests/1.3.14/opensearch-dashboards-1.3.14.yml
@@ -9,32 +9,32 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: '1.3'
+    ref: 39fdcad14c375edbf8e5cd992241084bd2d56871
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '1.3'
+    ref: 9fc625b491f39e1682d9fb67ebd862537b103969
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: '1.3'
+    ref: 4cb5ec5e3d3b234036b1fff1be65186293aefba7
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
+    ref: 99b9779c0c167d41a53add2c1681ac9968c389c2
     working_directory: gantt-chart
-    ref: '1.3'
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
-    ref: '1.3'
+    ref: ba3458981e3f2f08950a774a3e2f27e2cdd04885
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: '1.3'
+    ref: 7937896ee07160cb4e1fffec989ff64c60c64fa6
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
-    ref: '1.3'
+    ref: 762c086503368b5aa26b3c3e7fe9413aaaaec77f
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
-    ref: '1.3'
+    ref: fb6e305fff5893c8820cad97a353465dcfc1edc6
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '1.3'
+    ref: f861f46379a88aab2f9a9c88dd4f2101af1bdfe4
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
-    ref: '1.3'
+    ref: 95231a70357834240b3169491a8ce35c36fff0cf


### PR DESCRIPTION
### Description
Freeze commit ids for 1.3.14 manifests

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4069

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
