### PR TITLE
Using jenv to set Java version on Jenkins Mac agent node

### DIFF
--- a/jenkins/opensearch/publish-min-snapshots.jenkinsfile
+++ b/jenkins/opensearch/publish-min-snapshots.jenkinsfile
@@ -123,11 +123,10 @@ pipeline {
                             label AGENT_MACOS_X64
                         }
                     }
-                    tools {
-                        jdk dockerAgent.javaVersion
-                    }
                     steps {
                         script {
+                            echo("Switching to Java ${env.javaVersionNumber} on Mac Docker Container")
+                            sh("jenv local ${dockerAgent.javaVersion}")
                             buildManifest(
                                 componentName: "OpenSearch",
                                 inputManifest: "manifests/${INPUT_MANIFEST}",

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/publish-min-snapshots.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/publish-min-snapshots.jenkinsfile.txt
@@ -89,6 +89,8 @@
          publish-min-snapshots.stage(macos-x64-tar, groovy.lang.Closure)
             publish-min-snapshots.echo(Executing on agent [label:Jenkins-Agent-MacOS12-X64-Mac1Metal-Multi-Host])
             publish-min-snapshots.script(groovy.lang.Closure)
+               publish-min-snapshots.echo(Switching to Java 17 on Mac Docker Container)
+               publish-min-snapshots.sh(jenv local openjdk-17)
                publish-min-snapshots.buildManifest({componentName=OpenSearch, inputManifest=manifests/3.0.0/opensearch-3.0.0.yml, platform=darwin, architecture=x64, distribution=tar, snapshot=true})
                   buildManifest.sh(./build.sh manifests/3.0.0/opensearch-3.0.0.yml -d tar --component OpenSearch -p darwin -a x64 --snapshot)
                publish-min-snapshots.echo(Uploading darwin min snapshots to S3)


### PR DESCRIPTION
### Description
Using jenv instead of `Jenkins tool `to set Java version on Mac agent nodes

### Issues Resolved
part of https://github.com/opensearch-project/opensearch-build/issues/4272

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
