### PR TITLE
Move unstable functional call to post always block

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -230,6 +230,9 @@ pipeline {
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
+                                if (params.CONTINUE_ON_ERROR) {
+                                    markStageUnstableIfPluginsFailedToBuild()
+                                }
                                 postCleanup()
                             }
                         }
@@ -274,7 +277,12 @@ pipeline {
                             }
                             post {
                                 always {
-                                    postCleanup()
+                                    script{
+                                        if (params.CONTINUE_ON_ERROR) {
+                                            markStageUnstableIfPluginsFailedToBuild()
+                                        }
+                                        postCleanup()
+                                    }
                                 }
                             }
                         }
@@ -371,7 +379,12 @@ pipeline {
                             }
                             post {
                                 always {
-                                    postCleanup()
+                                    script{
+                                        if (params.CONTINUE_ON_ERROR) {
+                                            markStageUnstableIfPluginsFailedToBuild()
+                                        }
+                                        postCleanup()
+                                    }
                                 }
                             }
                         }
@@ -465,6 +478,9 @@ pipeline {
                                             "${STAGE_NAME}",
                                             lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                         )
+                                        if (params.CONTINUE_ON_ERROR) {
+                                            markStageUnstableIfPluginsFailedToBuild()
+                                        }
                                         postCleanup()
                                     }
                                 }
@@ -591,6 +607,9 @@ pipeline {
                                             "${STAGE_NAME}",
                                             lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                         )
+                                        if (params.CONTINUE_ON_ERROR) {
+                                            markStageUnstableIfPluginsFailedToBuild()
+                                        }
                                         postCleanup()
                                     }
                                 }
@@ -688,7 +707,12 @@ pipeline {
                             }
                             post {
                                 always {
-                                    postCleanup()
+                                    script {
+                                        if (params.CONTINUE_ON_ERROR) {
+                                            markStageUnstableIfPluginsFailedToBuild()
+                                        }
+                                        postCleanup()
+                                    }
                                 }
                             }
                         }
@@ -785,6 +809,9 @@ pipeline {
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
+                                if (params.CONTINUE_ON_ERROR) {
+                                    markStageUnstableIfPluginsFailedToBuild()
+                                }
                                 postCleanup()
                             }
                         }
@@ -935,3 +962,9 @@ pipeline {
     }
 }
 
+def markStageUnstableIfPluginsFailedToBuild() {
+    def stageLogs = getLogsForStage(stageName: "${STAGE_NAME}")
+    if (stageLogs.any{e -> e.contains('Failed plugins are')}) {
+        unstable('Some plugins failed to build. See the ./build.sh step for logs and more details')
+    }
+}

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -213,19 +213,15 @@ pipeline {
                         }
                     }
                     post {
-                        success {
-                            script {
-                                if (params.CONTINUE_ON_ERROR) {
-                                    markStageUnstableIfPluginsFailedToBuild()
-                                }
-                            }
-                        }
                         always {
                             script {
                                 lib.jenkins.Messages.new(this).add(
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
+                                if (params.CONTINUE_ON_ERROR) {
+                                    markStageUnstableIfPluginsFailedToBuild()
+                                }
                                 postCleanup()
                             }
                         }
@@ -264,15 +260,13 @@ pipeline {
                                 }
                             }
                             post {
-                                success {
+                                always {
                                     script {
                                         if (params.CONTINUE_ON_ERROR) {
                                             markStageUnstableIfPluginsFailedToBuild()
                                         }
+                                        postCleanup()                                      
                                     }
-                                }
-                                always {
-                                    postCleanup()
                                 }
                             }
                         }
@@ -363,15 +357,13 @@ pipeline {
                                 }
                             }
                             post {
-                                success {
+                                always {
                                     script {
                                         if (params.CONTINUE_ON_ERROR) {
                                             markStageUnstableIfPluginsFailedToBuild()
                                         }
+                                        postCleanup()                                      
                                     }
-                                }
-                                always {
-                                    postCleanup()
                                 }
                             }
                         }
@@ -472,19 +464,15 @@ pipeline {
                         }
                     }
                     post {
-                        success {
-                            script {
-                                if (params.CONTINUE_ON_ERROR) {
-                                    markStageUnstableIfPluginsFailedToBuild()
-                                }
-                            }
-                        }
                         always {
                             script {
                                 lib.jenkins.Messages.new(this).add(
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
+                                if (params.CONTINUE_ON_ERROR) {
+                                    markStageUnstableIfPluginsFailedToBuild()
+                                }
                                 postCleanup()
                             }
                         }
@@ -523,15 +511,13 @@ pipeline {
                                 }
                             }
                             post {
-                                success {
+                                always {
                                     script {
                                         if (params.CONTINUE_ON_ERROR) {
                                             markStageUnstableIfPluginsFailedToBuild()
                                         }
+                                        postCleanup()
                                     }
-                                }
-                                always {
-                                    postCleanup()
                                 }
                             }
                         }
@@ -622,15 +608,13 @@ pipeline {
                                 }
                             }
                             post {
-                                success {
+                                always {
                                     script {
                                         if (params.CONTINUE_ON_ERROR) {
                                             markStageUnstableIfPluginsFailedToBuild()
                                         }
+                                        postCleanup()
                                     }
-                                }
-                                always {
-                                    postCleanup()
                                 }
                             }
                         }
@@ -715,19 +699,15 @@ pipeline {
                         }
                     }
                     post {
-                        success {
-                            script {
-                                if (params.CONTINUE_ON_ERROR) {
-                                    markStageUnstableIfPluginsFailedToBuild()
-                                }
-                            }
-                        }
                         always {
                             script {
                                 lib.jenkins.Messages.new(this).add(
                                     "${STAGE_NAME}",
                                     lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"])
                                 )
+                                if (params.CONTINUE_ON_ERROR) {
+                                    markStageUnstableIfPluginsFailedToBuild()
+                                }
                                 postCleanup()
                             }
                         }


### PR DESCRIPTION
### Description
Since the overall build is marked as unstable by whichever stage finishes first, the post “success” stage is never called. Indirectly, unstable function is never called for remaining running stages. Tested this theory and looks right. Hence moving the function call to always stage.
Also enable the same for opensearch dashboards build pipeline. 

### Issues Resolved
Bug fix for https://github.com/opensearch-project/opensearch-build/issues/4018

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
