### PR TITLE
Bump lib version to 5.12.0 and remove previous unstable code

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@5.11.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@5.12.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -884,10 +884,6 @@ pipeline {
             node(AGENT_LINUX_X64) {
                 checkout scm
                 script {
-                    def findFailedPlugins = buildMessage(search: 'Failed plugins')
-                    if (findFailedPlugins != null) {
-                        currentBuild.result = 'UNSTABLE'
-                    }
                     closeBuildSuccessGithubIssue(
                         message: buildMessage(search: 'Successfully built'),
                         search: 'Successfully built',

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -777,10 +777,6 @@ pipeline {
             node(AGENT_LINUX_X64) {
                 checkout scm
                 script {
-                    def findFailedPlugins = buildMessage(search: 'Failed plugins')
-                    if (findFailedPlugins != null) {
-                        currentBuild.result = 'UNSTABLE'
-                    }
                     closeBuildSuccessGithubIssue(
                         message: buildMessage(search: 'Successfully built'),
                         search: 'Successfully built',


### PR DESCRIPTION
### Description
Bumps the build-lib version for opensearch dashboards to 5.12.0 and removes redundant code added previously to mark the build as unstable. 

### Issues Resolved
related https://github.com/opensearch-project/opensearch-build/issues/4018

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
