### PR TITLE
Fix path for publish wiki workflow

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -21,3 +21,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          path: docs/


### PR DESCRIPTION
### Description
This change updates the path of the publish-wiki workflow to use the ```docs``` folder correctly.  According to the workflow's [documentation](https://github.com/Andrew-Chen-Wang/github-wiki-action), instead of changing ```paths```, we need to change ```path``` variable, which is an input to the workflow.

Testing:
Adding the ```path``` input allowed me to make changes to the wiki on my [fork](https://github.com/opensearch-project/opensearch-build/wiki) through the publish-wiki workflow.

### Issues Resolved
Closes [#4308]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
