### PR TITLE
Added documentation for Github Wiki Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
 ### How is the Wiki Updated?
-This repository's [Github Wiki](https://github.com/opensearch-project/opensearch-build/wiki) utilizes the [github-wiki-action](https://github.com/Andrew-Chen-Wang/github-wiki-action) action via [publish-wiki.yml](../.github/workflows/publish-wiki.yml) workflow. This workflow mirrors the [docs](../docs) folder within opensearch-build onto the Wiki.
+This repository's [Github Wiki](https://github.com/opensearch-project/opensearch-build/wiki) utilizes the [github-wiki-action](https://github.com/Andrew-Chen-Wang/github-wiki-action) action via [publish-wiki.yml](../.github/workflows/publish-wiki.yml) workflow. This workflow mirrors the [docs](https://github.com/opensearch-project/opensearch-build/tree/main/docs) folder within opensearch-build onto the Wiki.
 
 With this workflow, the documentation within this repository can be organized within the Wiki tab, while maintaining the ability for contributors to submit reviewable documentation updates in the form of pull requests.
 
 ### Submit a change to the Wiki
-To submit a documentation update, update the markdown files within the [docs](../docs) folder accordingly, or create new files using the naming convention specified by the [workflow](https://github.com/Andrew-Chen-Wang/github-wiki-action) .
+To submit a documentation update, update the markdown files within the [docs](https://github.com/opensearch-project/opensearch-build/tree/main/docs) folder accordingly, or create new files using the naming convention specified by the [workflow](https://github.com/Andrew-Chen-Wang/github-wiki-action) .
 
 To test your changes, you can fork this repository. Committing and pushing changes to the docs folder of your fork's main branch will run the workflow and update the fork's Wiki page.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+### How is the Wiki Updated?
+This repository's [Github Wiki](https://github.com/opensearch-project/opensearch-build/wiki) utilizes the [github-wiki-action](https://github.com/Andrew-Chen-Wang/github-wiki-action) action via [publish-wiki.yml](../.github/workflows/publish-wiki.yml) workflow. This workflow mirrors the [docs](../docs) folder within opensearch-build onto the Wiki.
+
+With this workflow, the documentation within this repository can be organized within the Wiki tab, while maintaining the ability for contributors to submit reviewable documentation updates in the form of pull requests.
+
+### Submit a change to the Wiki
+To submit a documentation update, update the markdown files within the [docs](../docs) folder accordingly, or create new files using the naming convention specified by the [workflow](https://github.com/Andrew-Chen-Wang/github-wiki-action) .
+
+To test your changes, you can fork this repository. Committing and pushing changes to the docs folder of your fork's main branch will run the workflow and update the fork's Wiki page.
+
+Finally, create a pull request containing the changes. Adding a link to your fork's Wiki page within the pull request will help reviewers understand your changes.


### PR DESCRIPTION
### Description
Added a README file which is visible on both the Github code and wiki sections.  

This file covers how the workflow mirrors the docs folder and contains links to the workflow documentation. It also provides instructions for how other contributors can add documentation and test their changes on their fork's wiki.

Examples of the documentation updates are on my fork: [Code](https://github.com/chawinphat/opensearch-build/tree/main/docs), [Wiki](https://github.com/chawinphat/opensearch-build/wiki/README). 

I also submitted a [pull request](https://github.com/opensearch-project/opensearch-build/pull/4310) to fix a bug of the publish-wiki workflow. Those changes might need to be added first before this pull request, so the wiki can be updated accordingly.


### Issues Resolved
Closes [#4267]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
