### PR TITLE
OpenSearch Dashboards restrict version increment files

### DIFF
--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -164,6 +164,9 @@ jobs:
           body: |
             - Incremented version to **${{ env.OSD_PLUGIN_VERSION }}**.
           path: 'OpenSearch-Dashboards/plugins/${{ matrix.entry.repo }}'
+          add-paths: |
+              opensearch_dashboards.json
+              package.json
       - name: Check outputs
         run: |-
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
### Description
OpenSearch Dashboards restrict version increment files to `opensearch_dashboards.json` and `package.json`.
This should resolve the issue (https://github.com/opensearch-project/opensearch-build/issues/3856#issue-1841774137) bought up by @noCharger 

### Tests:
(Ref Sample Run:  https://github.com/prudhvigodithi/opensearch-build/actions/runs/7351322887/)
Here is sample dashboards-search-relevance [2.9.0.0 version increment PR](https://github.com/opensearch-project/dashboards-search-relevance/pull/281/commits/2e4e4733d482e372dd8617d2891818052d27bb19) that also adds `yarn.lock` file, but with the change of using `add-paths` notice the sample [github action run](https://github.com/prudhvigodithi/opensearch-build/actions/runs/7351322887/job/20014475111) that does not raise the PR when there is no change in `opensearch_dashboards.json` and `package.json` (ignores all other files).


### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3856

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
