### PR TITLE
Default not to create/update issues during integration test runs

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -201,7 +201,8 @@ pipeline {
                                             parameters: [
                                                 string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
                                                 string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'BUILD_MANIFEST_URL_OPENSEARCH', value: buildManifestUrlOpenSearch)
+                                                string(name: 'BUILD_MANIFEST_URL_OPENSEARCH', value: buildManifestUrlOpenSearch),
+                                                booleanParam(name: 'UPDATE_GITHUB_ISSUES', value: true)
                                             ]
                                     }
                                 },
@@ -527,7 +528,8 @@ pipeline {
                                                     parameters: [
                                                         string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
                                                         string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                        string(name: 'BUILD_MANIFEST_URL_OPENSEARCH', value: buildManifestUrlOpenSearch)
+                                                        string(name: 'BUILD_MANIFEST_URL_OPENSEARCH', value: buildManifestUrlOpenSearch),
+                                                        booleanParam(name: 'UPDATE_GITHUB_ISSUES', value: true)
                                                     ]
                                             }
                                         },

--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -67,6 +67,11 @@ pipeline {
             description: 'The build manifest URL OpenSearch, e.g. "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.9.0/8172/linux/x64/tar/builds/opensearch/manifest.yml".',
             trim: true
         )
+        booleanParam(
+            name: 'UPDATE_GITHUB_ISSUES',
+            description: 'If true results will create / update / close github issues',
+            defaultValue: false
+        )
     }
     stages {
         stage('verify-parameters') {
@@ -111,6 +116,7 @@ pipeline {
                     env.artifactPath = buildManifestObj.getArtifactRoot(BUILD_JOB_NAME, buildId)
                     env.artifactPathOpenSearch = buildManifestObjOpenSearch.getArtifactRoot(BUILD_JOB_NAME_OPENSEARCH, buildIdOpenSearch)
                     env.AGENT_LABEL = agent_nodes["${env.platform}_${architecture}"]
+                    env.updateGithubIssues = UPDATE_GITHUB_ISSUES && env.distribution == 'tar'
 
                     echo "Version: ${version}, VersionOpenSearch: ${versionOpenSearch}, Agent: ${AGENT_LABEL}, OSD_BuildId: ${buildId}, OS_BuildId: ${buildIdOpenSearch}, Distribution: ${distribution}"
                     currentBuild.description = "$architecture, $platform, osd-$version-$buildId, os-$versionOpenSearch-$buildIdOpenSearch, $distribution"
@@ -250,7 +256,7 @@ pipeline {
                                                         switchUserNonRoot: "${switch_user_non_root}"
                                                     )
                                                     String closeCommentMessage = "Closing the issue as the Integration Test passed for ${local_component}<br>Version: ${version}<br>Distribution: ${distribution}<br>Architecture: ${architecture}<br>Platform: ${platform}<br><br>Please check the logs: ${RUN_DISPLAY_URL}<br><br> *"
-                                                    if (env.distribution == 'tar') {
+                                                    if (env.updateGithubIssues) {
                                                         closeGithubIssue(
                                                             repoUrl: buildManifestObj.getRepo("${local_component}"),
                                                             issueTitle: "[AUTOCUT] Integration Test failed for ${local_component}: ${version} ${distribution} distribution",
@@ -262,7 +268,7 @@ pipeline {
                                             } catch (e) {
                                                 echo "Error running integtest for component ${local_component}, creating Github issue"
                                                 String issueBodyMessage = "The integration test failed at distribution level for component ${local_component}<br>Version: ${version}<br>Distribution: ${distribution}<br>Architecture: ${architecture}<br>Platform: ${platform}<br><br>Please check the logs: ${RUN_DISPLAY_URL}<br><br> * Test-report manifest:*<br> - https://ci.opensearch.org/ci/dbc/${JOB_NAME}/${version}/${buildId}/${platform}/${architecture}/${distribution}/test-results/${BUILD_NUMBER}/integ-test/test-report.yml <br><br> _Note: Steps to reproduce, additional logs and other files can be found within the above test-report manifest. <br>Instructions of this test-report manifest can be found [here](https://github.com/opensearch-project/opensearch-build/tree/main/src/report_workflow#guide-on-test-report-manifest-from-ci)._"
-                                                if (env.distribution == 'tar') {
+                                                if (env.updateGithubIssues) {
                                                     createGithubIssue(
                                                         repoUrl: buildManifestObj.getRepo("${local_component}"),
                                                         issueTitle: "[AUTOCUT] Integration Test failed for ${local_component}: ${version} ${distribution} distribution",

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -190,7 +190,8 @@ pipeline {
                                             wait: false,
                                             parameters: [
                                                 string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl)
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                booleanParam(name: 'UPDATE_GITHUB_ISSUES', value: true)
                                             ]
                                     }
                                 },
@@ -456,7 +457,8 @@ pipeline {
                                             wait: false,
                                             parameters: [
                                                 string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl)
+                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                                                booleanParam(name: 'UPDATE_GITHUB_ISSUES', value: true)
                                             ]
                                     }
                                 }

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -66,6 +66,11 @@ pipeline {
             description: 'The build manifest URL for OpenSearch, e.g. "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.9.0/8172/linux/x64/tar/builds/opensearch/manifest.yml".',
             trim: true
         )
+        booleanParam(
+            name: 'UPDATE_GITHUB_ISSUES',
+            description: 'If true results will create / update / close github issues',
+            defaultValue: false
+        )
     }
     stages {
         stage('verify-parameters') {
@@ -97,6 +102,7 @@ pipeline {
                     env.platform = buildManifestObj.build.platform
                     env.artifactPath = buildManifestObj.getArtifactRoot(BUILD_JOB_NAME, buildId)
                     env.AGENT_LABEL = agent_nodes["${env.platform}_${architecture}"]
+                    env.updateGithubIssues = UPDATE_GITHUB_ISSUES && env.distribution == 'tar'
 
                     echo "Version: ${version}, Agent: ${AGENT_LABEL}, BuildId: ${buildId}, Distribution: ${distribution}, Components: ${componentList}"
                     currentBuild.description = "$TEST_MANIFEST, $version, $architecture, $platform, $buildId, $distribution, $componentList"
@@ -206,7 +212,7 @@ pipeline {
                                                         switchUserNonRoot: "${switch_user_non_root}"
                                                     )
                                                     String closeCommentMessage = "Closing the issue as the Integration Test passed for ${local_component}<br>Version: ${version}<br>Distribution: ${distribution}<br>Architecture: ${architecture}<br>Platform: ${platform}<br><br>Please check the logs: ${RUN_DISPLAY_URL}<br><br> *"
-                                                    if (env.distribution == 'tar') {
+                                                    if (env.updateGithubIssues) {
                                                         closeGithubIssue(
                                                             repoUrl: buildManifestObj.getRepo("${local_component}"),
                                                             issueTitle: "[AUTOCUT] Integration Test failed for ${local_component}: ${version} ${distribution} distribution",
@@ -218,7 +224,7 @@ pipeline {
                                             } catch (e) {
                                                 echo "Error running integtest for component ${local_component}, creating Github issue"
                                                 String issueBodyMessage = "The integration test failed at distribution level for component ${local_component}<br>Version: ${version}<br>Distribution: ${distribution}<br>Architecture: ${architecture}<br>Platform: ${platform}<br><br>Please check the logs: ${RUN_DISPLAY_URL}<br><br> * Test-report manifest:*<br> - https://ci.opensearch.org/ci/dbc/${JOB_NAME}/${version}/${buildId}/${platform}/${architecture}/${distribution}/test-results/${BUILD_NUMBER}/integ-test/test-report.yml <br><br> _Note: Steps to reproduce, additional logs and other files can be found within the above test-report manifest. <br>Instructions of this test-report manifest can be found [here](https://github.com/opensearch-project/opensearch-build/tree/main/src/report_workflow#guide-on-test-report-manifest-from-ci)._"
-                                                if (env.distribution == 'tar') {
+                                                if (env.updateGithubIssues) {
                                                     createGithubIssue(
                                                         repoUrl: buildManifestObj.getRepo("${local_component}"),
                                                         issueTitle: "[AUTOCUT] Integration Test failed for ${local_component}: ${version} ${distribution} distribution",

--- a/tests/jenkins/TestOpenSearchDashboardsIntegTest.groovy
+++ b/tests/jenkins/TestOpenSearchDashboardsIntegTest.groovy
@@ -68,6 +68,7 @@ class TestOpenSearchDashboardsIntegTest extends BuildPipelineTest {
         binding.setVariable('distribution', 'tar' )
         binding.setVariable('COMPONENT_NAME', '' )
         binding.getVariable('currentBuild').upstreamBuilds = [[fullProjectName: jobName]]
+        binding.setVariable('UPDATE_GITHUB_ISSUES', true)
         def env = binding.getVariable('env')
         env['DOCKER_AGENT'] = [image:'opensearchstaging/opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v2', args:'-e JAVA_HOME=/opt/java/openjdk-11']
         env['PUBLIC_ARTIFACT_URL'] = 'DUMMY_PUBLIC_ARTIFACT_URL'

--- a/tests/jenkins/TestOpenSearchIntegTest.groovy
+++ b/tests/jenkins/TestOpenSearchIntegTest.groovy
@@ -61,6 +61,7 @@ class TestOpenSearchIntegTest extends BuildPipelineTest {
         binding.setVariable('RUN_DISPLAY_URL', 'https://some/url/redirect')
         binding.setVariable('distribution', 'tar' )
         binding.setVariable('COMPONENT_NAME', '' )
+        binding.setVariable('UPDATE_GITHUB_ISSUES', true)
         binding.getVariable('currentBuild').upstreamBuilds = [[fullProjectName: jobName]]
         helper.registerAllowedMethod("s3Download", [Map])
         helper.registerAllowedMethod("withAWS", [Map, Closure], { args, closure ->


### PR DESCRIPTION
### Description
In Security we are getting spammed from the `concurrent-search-test` integration runs.  Since I do not plan on supporting runs on this flavor of build I don't want to get issues in our codebase for it.

Note; I'm happy to have issues filed once they've been root caused and our team is at issue, but non-standard builds are not supported by our project and it creates noise.

### Issues Resolved
- Related https://github.com/opensearch-project/security/issues/3876

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
