### PR TITLE
Change password based on version in integtest health check

### DIFF
--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -40,7 +40,7 @@ class ServiceOpenSearch(Service):
         self.dist = Distributions.get_distribution("opensearch", distribution, version, work_dir)
         self.dependency_installer = dependency_installer
         self.install_dir = self.dist.install_dir
-        self.password = 'myStrongPassword123!' if float('.'.join("3.0.0".split('.')[:2])) >= 2.12 else 'admin'
+        self.password = 'myStrongPassword123!' if float('.'.join(self.version.split('.')[:2])) >= 2.12 else 'admin'
 
     def start(self) -> None:
         self.dist.install(self.download())

--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -40,6 +40,7 @@ class ServiceOpenSearch(Service):
         self.dist = Distributions.get_distribution("opensearch", distribution, version, work_dir)
         self.dependency_installer = dependency_installer
         self.install_dir = self.dist.install_dir
+        self.password = 'myStrongPassword123!' if float('.'.join("3.0.0".split('.')[:2])) >= 2.12 else 'admin'
 
     def start(self) -> None:
         self.dist.install(self.download())
@@ -65,7 +66,7 @@ class ServiceOpenSearch(Service):
     def get_service_response(self) -> Response:
         url = self.url("/_cluster/health")
         logging.info(f"Pinging {url}")
-        return requests.get(url, verify=False, auth=("admin", "admin"))
+        return requests.get(url, verify=False, auth=("admin", self.password))
 
     def __add_plugin_specific_config(self, additional_config: dict) -> None:
         with open(self.opensearch_yml_path, "a") as yamlfile:

--- a/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/src/test_workflow/perf_test/perf_test_cluster.py
@@ -113,9 +113,6 @@ class PerfTestCluster(TestCluster):
         if self.manifest:
             if semver.compare(self.manifest.build.version, '2.12.0') != -1:
                 password = 'myStrongPassword123!'
-        else:
-            if semver.compare(self.args.distribution_version, '2.12.0') != -1:
-                password = 'myStrongPassword123!'
 
         # Should be invoked only if the endpoint is public.
         assert self.is_endpoint_public, "wait_for_processing should be invoked only when cluster is public"

--- a/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/src/test_workflow/perf_test/perf_test_cluster.py
@@ -119,7 +119,7 @@ class PerfTestCluster(TestCluster):
 
         # Should be invoked only if the endpoint is public.
         assert self.is_endpoint_public, "wait_for_processing should be invoked only when cluster is public"
-        logging.info(f"Waiting for domain at {self.endpoint} to be up")
+        logging.info("Waiting for domain to be up")
         url = "".join([self.endpoint_with_port, "/_cluster/health"])
         retry_call(requests.get, fkwargs={"url": url, "auth": HTTPBasicAuth('admin', password), "verify": False},
                    tries=tries, delay=delay, backoff=backoff)

--- a/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/src/test_workflow/perf_test/perf_test_cluster.py
@@ -117,9 +117,10 @@ class PerfTestCluster(TestCluster):
             if semver.compare(self.args.distribution_version, '2.12.0') != -1:
                 password = 'myStrongPassword123!'
 
+        # Should be invoked only if the endpoint is public.
+        assert self.is_endpoint_public, "wait_for_processing should be invoked only when cluster is public"
         logging.info(f"Waiting for domain at {self.endpoint} to be up")
-        protocol = "http://" if self.args.insecure else "https://"
-        url = "".join([protocol, self.endpoint, "/_cluster/health"])
+        url = "".join([self.endpoint_with_port, "/_cluster/health"])
         retry_call(requests.get, fkwargs={"url": url, "auth": HTTPBasicAuth('admin', password), "verify": False},
                    tries=tries, delay=delay, backoff=backoff)
 

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/data/bundle_manifest.yml
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/data/bundle_manifest.yml
@@ -5,7 +5,7 @@ build:
   id: 41d5ae25183d4e699e92debfbe3f83bd
   location: https://artifacts.opensearch.org/bundles/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/opensearch-1.0.0-linux-x64.tar.gz
   name: OpenSearch
-  version: 1.0.0
+  version: 3.0.0
 components:
   - commit_id: fb25458f38c30a7ab06de21b0068f1fe3ad56134
     location: https://artifacts.opensearch.org/builds/1.0.0/41d5ae25183d4e699e92debfbe3f83bd/bundle/opensearch-min-1.0.0-linux-x64.tar.gz

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -44,7 +44,7 @@ class TestPerfTestCluster(unittest.TestCase):
         self.perf_test_cluster.is_endpoint_public = True
         self.perf_test_cluster.cluster_endpoint_with_port = ''
         self.perf_test_cluster.wait_for_processing()
-        mock_requests_get.assert_called_with(url='/_cluster/health', verify=False, auth=HTTPBasicAuth('admin', 'admin'))
+        mock_requests_get.assert_called_with(url='/_cluster/health', verify=False, auth=HTTPBasicAuth('admin', 'myStrongPassword123!'))
 
     def test_endpoint(self) -> None:
         self.assertEqual(self.perf_test_cluster.endpoint_with_port, None)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -7,7 +7,8 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, Mock, patch
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 from manifests.bundle_manifest import BundleManifest
 from test_workflow.perf_test.perf_test_cluster import PerfTestCluster
@@ -37,12 +38,12 @@ class TestPerfTestCluster(unittest.TestCase):
                         mock_chdir.assert_called_once_with(os.path.join(self.perf_test_cluster.current_workspace, "test_dir"))
                         self.assertEqual(mock_check_call.call_count, 1)
 
-    def test_wait_for_processing(self, mock_url: Mock, mock_requests_get: Mock) -> None:
-        mock_url_result = MagicMock()
-        mock_url.return_value = mock_url_result
+    @patch("requests.get")
+    @patch("PerfTestCluster.manifest.build.version", return_value='1.0.0')
+    @patch("PerfTestcluster.endpoint_with_port", return_value='')
+    def test_wait_for_processing(self, *mocks: Any) -> None:
         self.perf_test_cluster.wait_for_processing()
-        mock_url.assert_called_once_with("/_cluster/health")
-        mock_requests_get.assert_called_once_with(mock_url_result, verify=False, auth=('admin', 'admin'))
+        self.assert_called_once_with("/_cluster/health")
 
     def test_endpoint(self) -> None:
         self.assertEqual(self.perf_test_cluster.endpoint_with_port, None)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -7,7 +7,7 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from manifests.bundle_manifest import BundleManifest
 from test_workflow.perf_test.perf_test_cluster import PerfTestCluster
@@ -36,6 +36,13 @@ class TestPerfTestCluster(unittest.TestCase):
                         self.perf_test_cluster.start()
                         mock_chdir.assert_called_once_with(os.path.join(self.perf_test_cluster.current_workspace, "test_dir"))
                         self.assertEqual(mock_check_call.call_count, 1)
+
+    def test_wait_for_processing(self, mock_url: Mock, mock_requests_get: Mock) -> None:
+        mock_url_result = MagicMock()
+        mock_url.return_value = mock_url_result
+        self.perf_test_cluster.wait_for_processing()
+        mock_url.assert_called_once_with("/_cluster/health")
+        mock_requests_get.assert_called_once_with(mock_url_result, verify=False, auth=('admin', 'admin'))
 
     def test_endpoint(self) -> None:
         self.assertEqual(self.perf_test_cluster.endpoint_with_port, None)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -38,15 +38,9 @@ class TestPerfTestCluster(unittest.TestCase):
                         self.assertEqual(mock_check_call.call_count, 1)
 
     @patch("requests.get")
-    @patch("PerfTestCluster.manifest.build.version", return_value='1.0.0')
-    @patch("PerfTestCluster.endpoint_with_port", return_value='')
-    def test_wait_for_processing(self, mock_url: Mock, mock_requests_get: Mock) -> None:
-        mock_url_result = MagicMock()
-        mock_url.return_value = mock_url_result
-
+    def test_get_service_response(self, mock_requests_get: Mock) -> None:
         self.perf_test_cluster.wait_for_processing()
-
-        mock_url.assert_called_once_with("/_cluster/health")
+        mock_requests_get.assert_called_once_with('', verify=False, auth=('admin', 'admin'))
 
     def test_endpoint(self) -> None:
         self.assertEqual(self.perf_test_cluster.endpoint_with_port, None)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -39,7 +39,7 @@ class TestPerfTestCluster(unittest.TestCase):
 
     @patch("requests.get")
     @patch("PerfTestCluster.manifest.build.version", return_value='1.0.0')
-    @patch("PerfTestcluster.endpoint_with_port", return_value='')
+    @patch("PerfTestCluster.endpoint_with_port", return_value='')
     def test_wait_for_processing(self, mock_url: Mock, mock_requests_get: Mock) -> None:
         mock_url_result = MagicMock()
         mock_url.return_value = mock_url_result

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -42,7 +42,7 @@ class TestPerfTestCluster(unittest.TestCase):
         self.perf_test_cluster.is_endpoint_public = True
         self.perf_test_cluster.cluster_endpoint_with_port = ''
         self.perf_test_cluster.wait_for_processing()
-        mock_requests_get.assert_called_once_with('', verify=False, auth=('admin', 'admin'))
+        mock_requests_get.assert_called_with(url='/_cluster/health', verify=False, auth=HTTPBasicAuth('admin', 'admin')))
 
     def test_endpoint(self) -> None:
         self.assertEqual(self.perf_test_cluster.endpoint_with_port, None)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -47,7 +47,6 @@ class TestPerfTestCluster(unittest.TestCase):
         self.perf_test_cluster.wait_for_processing()
 
         mock_url.assert_called_once_with("/_cluster/health")
-        self.perf_test_cluster.wait_for_processing()
 
     def test_endpoint(self) -> None:
         self.assertEqual(self.perf_test_cluster.endpoint_with_port, None)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -9,6 +9,8 @@ import os
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
+from requests.auth import HTTPBasicAuth
+
 from manifests.bundle_manifest import BundleManifest
 from test_workflow.perf_test.perf_test_cluster import PerfTestCluster
 from test_workflow.perf_test.perf_test_cluster_config import PerfTestClusterConfig
@@ -42,7 +44,7 @@ class TestPerfTestCluster(unittest.TestCase):
         self.perf_test_cluster.is_endpoint_public = True
         self.perf_test_cluster.cluster_endpoint_with_port = ''
         self.perf_test_cluster.wait_for_processing()
-        mock_requests_get.assert_called_with(url='/_cluster/health', verify=False, auth=HTTPBasicAuth('admin', 'admin')))
+        mock_requests_get.assert_called_with(url='/_cluster/health', verify=False, auth=HTTPBasicAuth('admin', 'admin'))
 
     def test_endpoint(self) -> None:
         self.assertEqual(self.perf_test_cluster.endpoint_with_port, None)

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -39,6 +39,8 @@ class TestPerfTestCluster(unittest.TestCase):
 
     @patch("requests.get")
     def test_get_service_response(self, mock_requests_get: Mock) -> None:
+        self.perf_test_cluster.is_endpoint_public = True
+        self.perf_test_cluster.cluster_endpoint_with_port = ''
         self.perf_test_cluster.wait_for_processing()
         mock_requests_get.assert_called_once_with('', verify=False, auth=('admin', 'admin'))
 

--- a/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
+++ b/tests/tests_test_workflow/test_perf_workflow/perf_test/test_perf_test_cluster.py
@@ -7,8 +7,7 @@
 
 import os
 import unittest
-from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from manifests.bundle_manifest import BundleManifest
 from test_workflow.perf_test.perf_test_cluster import PerfTestCluster
@@ -41,9 +40,14 @@ class TestPerfTestCluster(unittest.TestCase):
     @patch("requests.get")
     @patch("PerfTestCluster.manifest.build.version", return_value='1.0.0')
     @patch("PerfTestcluster.endpoint_with_port", return_value='')
-    def test_wait_for_processing(self, *mocks: Any) -> None:
+    def test_wait_for_processing(self, mock_url: Mock, mock_requests_get: Mock) -> None:
+        mock_url_result = MagicMock()
+        mock_url.return_value = mock_url_result
+
         self.perf_test_cluster.wait_for_processing()
-        self.assert_called_once_with("/_cluster/health")
+
+        mock_url.assert_called_once_with("/_cluster/health")
+        self.perf_test_cluster.wait_for_processing()
 
     def test_endpoint(self) -> None:
         self.assertEqual(self.perf_test_cluster.endpoint_with_port, None)


### PR DESCRIPTION
### Description
The current cluster health endpoint check is always using "admin:admin", this fails on > 2.12.0 since they are starting to be spun up with "admin:myStrongPassword123!". This PR makes that change in the cluster health endpoint.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
