### PR TITLE
Updates rpm and deb distribution to adapt to admin password change

### DIFF
--- a/scripts/components/OpenSearch/install.sh
+++ b/scripts/components/OpenSearch/install.sh
@@ -84,7 +84,9 @@ if [ "$DISTRIBUTION" = "tar" ]; then
 elif [ "$DISTRIBUTION" = "deb" -o "$DISTRIBUTION" = "rpm" ]; then
     cp -va ../../../scripts/pkg/service_templates/opensearch/* "$OUTPUT/../"
     cp -va ../../../scripts/pkg/build_templates/opensearch/$DISTRIBUTION/* "$OUTPUT/../"
-    sed -i "s/CHANGE_VERSION/${VERSION}/g" "$OUTPUT/../debian/preinst"
+    if [ "$DISTRIBUTION" = "deb" ]; then
+      sed -i "s/CHANGE_VERSION/${VERSION}/g" "$OUTPUT/../debian/preinst"
+    fi
 elif [ "$DISTRIBUTION" = "zip" ] && [ "$PLATFORM" = "windows" ]; then
     cp -v ../../../scripts/startup/zip/windows/opensearch-windows-install.bat "$OUTPUT/"
 fi

--- a/scripts/components/OpenSearch/install.sh
+++ b/scripts/components/OpenSearch/install.sh
@@ -84,7 +84,7 @@ if [ "$DISTRIBUTION" = "tar" ]; then
 elif [ "$DISTRIBUTION" = "deb" -o "$DISTRIBUTION" = "rpm" ]; then
     cp -va ../../../scripts/pkg/service_templates/opensearch/* "$OUTPUT/../"
     cp -va ../../../scripts/pkg/build_templates/opensearch/$DISTRIBUTION/* "$OUTPUT/../"
-    sed -i "s/CHANGE_VERSION/${VERSION}" "$OUTPUT/../debian/preinst"
+    sed -i "s/CHANGE_VERSION/${VERSION}/g" "$OUTPUT/../debian/preinst"
 elif [ "$DISTRIBUTION" = "zip" ] && [ "$PLATFORM" = "windows" ]; then
     cp -v ../../../scripts/startup/zip/windows/opensearch-windows-install.bat "$OUTPUT/"
 fi

--- a/scripts/components/OpenSearch/install.sh
+++ b/scripts/components/OpenSearch/install.sh
@@ -84,6 +84,7 @@ if [ "$DISTRIBUTION" = "tar" ]; then
 elif [ "$DISTRIBUTION" = "deb" -o "$DISTRIBUTION" = "rpm" ]; then
     cp -va ../../../scripts/pkg/service_templates/opensearch/* "$OUTPUT/../"
     cp -va ../../../scripts/pkg/build_templates/opensearch/$DISTRIBUTION/* "$OUTPUT/../"
+    sed -i "s/CHANGE_VERSION/${VERSION}" "$OUTPUT/../debian/preinst"
 elif [ "$DISTRIBUTION" = "zip" ] && [ "$PLATFORM" = "windows" ]; then
     cp -v ../../../scripts/startup/zip/windows/opensearch-windows-install.bat "$OUTPUT/"
 fi

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -21,7 +21,7 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s  > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log." && exit 1)
+    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
 fi
 # Apply PerformanceAnalyzer Settings
 chmod a+rw /tmp

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -21,7 +21,7 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s  > ${log_dir}/install_demo_configuration.log 2>&1 || echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log." && exit 1
+    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s  > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log." && exit 1)
 fi
 # Apply PerformanceAnalyzer Settings
 chmod a+rw /tmp

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -21,7 +21,7 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1
+    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || echo "Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log." > ${log_dir}/install_demo_configuration.log 2>&1
 fi
 
 # Apply PerformanceAnalyzer Settings

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -21,9 +21,8 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || echo "Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log." > ${log_dir}/install_demo_configuration.log 2>&1
+    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s  > ${log_dir}/install_demo_configuration.log 2>&1 || echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log." && exit 1
 fi
-
 # Apply PerformanceAnalyzer Settings
 chmod a+rw /tmp
 if ! grep -q '## OpenSearch Performance Analyzer' ${config_dir}/jvm.options; then

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -23,6 +23,17 @@ if command -v systemctl >/dev/null && systemctl is-active opensearch-performance
     systemctl --no-reload stop opensearch-performance-analyzer.service
 fi
 
+# Check if OPENSEARCH_INITIAL_ADMIN_PASSWORD is defined
+# NOTE:
+# 1. This check will need to be modified if there will be a min dist for deb in future (currently there is none)
+# 2. Currently, the demo config setup is defined to run, in postinst, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
+# 3. There is no version check here as it assumes that this change will be present in preinst scripts for deb distribution of OpenSearch 2.12 and later
+if [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
+  echo "Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
+  exit -1
+fi
+
+
 # Create user and group if they do not already exist.
 getent group opensearch > /dev/null 2>&1 || groupadd -r opensearch
 getent passwd opensearch > /dev/null 2>&1 || \

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -32,14 +32,19 @@ fi
 
 # Check if this is an upgrade by checking whether opensearch already exists
 set +e
-dpkg-query -l opensearch | grep ^ii
-OPENSEARCH_INSTALLED=$? # 0 when installed, 1 when installed
+dpkg-query -l opensearch 2>&1 | grep ^ii >/dev/null
+EX_CODE=$?
+if [ $EX_CODE -eq 0 ]; then
+  OPENSEARCH_ALREADY_INSTALLED=yes
+else
+  OPENSEARCH_ALREADY_INSTALLED=no
+fi
 set -e
 
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
 MINIMUM_OF_TWO_VERSIONS=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 
-if [ $OPENSEARCH_INSTALLED = 1 ] && [ $OPENSEARCH_VERSION != CHANGE_VERSION ]; then
+if [ $OPENSEARCH_ALREADY_INSTALLED = no ]; then
   if [ $MINIMUM_OF_TWO_VERSIONS = $OPENSEARCH_REQUIRED_VERSION ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
     echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
     exit 1

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -26,14 +26,21 @@ if command -v systemctl >/dev/null && systemctl is-active opensearch-performance
 fi
 
 # Check if OPENSEARCH_INITIAL_ADMIN_PASSWORD is defined
-# NOTE:
+# TODO:
 # 1. This check will need to be modified if there will be a min dist for deb in future (currently there is none)
 # 2. Currently, the demo config setup is defined to run, in postinst, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
+
+# Check if this is an upgrade by checking whether opensearch already exists
+OPENSEARCH_INSTALLED=$(dpkg -l | grep opensearch)
+
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
 COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
-if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
-  echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
-  exit 1
+
+if [ -n "$OPENSEARCH_INSTALLED" ] && [ $OPENSEARCH_VERSION != CHANGE_VERSION ]; then
+  if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
+    echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
+    exit 1
+  fi
 fi
 
 

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -31,15 +31,11 @@ fi
 # 2. Currently, the demo config setup is defined to run, in postinst, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
 
 # Check if this is an upgrade by checking whether opensearch already exists
-set +e
-dpkg-query -l opensearch 2>&1 | grep ^ii >/dev/null
-EX_CODE=$?
-if [ $EX_CODE -eq 0 ]; then
-  OPENSEARCH_ALREADY_INSTALLED=yes
+if [ -f /lib/systemd/system/opensearch.service ] || [ -f /etc/systemd/system/opensearch.service ]; then
+    OPENSEARCH_ALREADY_INSTALLED=yes
 else
-  OPENSEARCH_ALREADY_INSTALLED=no
+    OPENSEARCH_ALREADY_INSTALLED=no
 fi
-set -e
 
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
 MINIMUM_OF_TWO_VERSIONS=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -31,7 +31,7 @@ fi
 # 2. Currently, the demo config setup is defined to run, in postinst, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
 
 # Check if this is an upgrade by checking whether opensearch already exists
-if [ -f /lib/systemd/system/opensearch.service ] || [ -f /etc/systemd/system/opensearch.service ]; then
+if dpkg-query -W opensearch >/dev/null 2>&1; then
     OPENSEARCH_ALREADY_INSTALLED=yes
 else
     OPENSEARCH_ALREADY_INSTALLED=no

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -32,7 +32,7 @@ fi
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
 COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
-  echo "Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
+  echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
   exit 1
 fi
 

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -31,13 +31,16 @@ fi
 # 2. Currently, the demo config setup is defined to run, in postinst, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
 
 # Check if this is an upgrade by checking whether opensearch already exists
-OPENSEARCH_INSTALLED=$(dpkg -l | grep opensearch)
+set +e
+dpkg -s opensearch
+OPENSEARCH_INSTALLED=$? # 0 when installed, 1 when installed
+set -e
 
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
-COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+MINIMUM_OF_TWO_VERSIONS=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 
-if [ -n "$OPENSEARCH_INSTALLED" ] && [ $OPENSEARCH_VERSION != CHANGE_VERSION ]; then
-  if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
+if [ $OPENSEARCH_INSTALLED = 1 ] && [ $OPENSEARCH_VERSION != CHANGE_VERSION ]; then
+  if [ $MINIMUM_OF_TWO_VERSIONS = $OPENSEARCH_REQUIRED_VERSION ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
     echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
     exit 1
   fi

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -11,6 +11,9 @@
 
 set -e
 
+OPENSEARCH_VERSION=CHANGE_VERSION
+echo $OPENSEARCH_VERSION
+
 echo "Running OpenSearch Pre-Installation Script"
 
 # Stop existing service
@@ -28,7 +31,9 @@ fi
 # 1. This check will need to be modified if there will be a min dist for deb in future (currently there is none)
 # 2. Currently, the demo config setup is defined to run, in postinst, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
 # 3. There is no version check here as it assumes that this change will be present in preinst scripts for deb distribution of OpenSearch 2.12 and later
-if [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
+OPENSEARCH_REQUIRED_VERSION="2.12.0"
+COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
   echo "Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
   exit -1
 fi

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -32,7 +32,7 @@ fi
 
 # Check if this is an upgrade by checking whether opensearch already exists
 set +e
-dpkg -s opensearch
+dpkg-query -l opensearch | grep ^ii
 OPENSEARCH_INSTALLED=$? # 0 when installed, 1 when installed
 set -e
 

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -12,7 +12,6 @@
 set -e
 
 OPENSEARCH_VERSION=CHANGE_VERSION
-echo $OPENSEARCH_VERSION
 
 echo "Running OpenSearch Pre-Installation Script"
 
@@ -30,12 +29,11 @@ fi
 # NOTE:
 # 1. This check will need to be modified if there will be a min dist for deb in future (currently there is none)
 # 2. Currently, the demo config setup is defined to run, in postinst, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
-# 3. There is no version check here as it assumes that this change will be present in preinst scripts for deb distribution of OpenSearch 2.12 and later
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
 COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
   echo "Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
-  exit -1
+  exit 1
 fi
 
 

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -98,7 +98,7 @@ OPENSEARCH_REQUIRED_VERSION="2.12.0"
 OPENSEARCH_VERSION=%{_version}
 COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
-  echo "Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
+  echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
   exit 1
 fi
 
@@ -113,7 +113,7 @@ exit 0
 set -e
 # Apply Security Settings
 if [ -d %{product_dir}/plugins/opensearch-security ]; then
-    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || echo "Something went wrong during demo configuration installation. Please see the logs in %{log_dir}/install_demo_configuration.log." > %{log_dir}/install_demo_configuration.log 2>&1
+    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in %{log_dir}/install_demo_configuration.log." > %{log_dir}/install_demo_configuration.log 2>&1
 fi
 chown -R %{name}.%{name} %{config_dir}
 chown -R %{name}.%{name} %{log_dir}

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -99,7 +99,7 @@ OPENSEARCH_VERSION=%{_version}
 COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
   echo "Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
-  exit -1
+  exit 1
 fi
 
 # Create user and group if they do not already exist.

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -110,6 +110,7 @@ getent passwd %{name} > /dev/null 2>&1 || \
 exit 0
 
 %post
+set -e
 # Apply Security Settings
 if [ -d %{product_dir}/plugins/opensearch-security ]; then
     sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || echo "Something went wrong during demo configuration installation. Please see the logs in %{log_dir}/install_demo_configuration.log." > %{log_dir}/install_demo_configuration.log 2>&1

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -113,7 +113,7 @@ exit 0
 set -e
 # Apply Security Settings
 if [ -d %{product_dir}/plugins/opensearch-security ]; then
-    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in %{log_dir}/install_demo_configuration.log." > %{log_dir}/install_demo_configuration.log 2>&1
+    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s  > %{log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in %{log_dir}/install_demo_configuration.log." && exit 1)
 fi
 chown -R %{name}.%{name} %{config_dir}
 chown -R %{name}.%{name} %{log_dir}

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -97,15 +97,20 @@ fi
 
 # Check if this is an upgrade by checking whether opensearch already exists
 set +e
-rpm -q opensearch || yum list installed opensearch
-OPENSEARCH_INSTALLED=$? # 0 when installed, 1 when installed
+rpm -q opensearch > /dev/null 2>&1 || yum list installed opensearch > /dev/null 2>&1
+EX_CODE=$?
+if [ $EX_CODE -eq 0 ]; then
+  OPENSEARCH_ALREADY_INSTALLED=yes
+else
+  OPENSEARCH_ALREADY_INSTALLED=no
+fi
 set -e
 
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
 OPENSEARCH_VERSION=%{_version}
 MINIMUM_OF_TWO_VERSIONS=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 
-if [ $OPENSEARCH_INSTALLED = 1 ] && [ $OPENSEARCH_VERSION != CHANGE_VERSION ]; then
+if [ $OPENSEARCH_ALREADY_INSTALLED = no ]; then
   if [ $MINIMUM_OF_TWO_VERSIONS = $OPENSEARCH_REQUIRED_VERSION ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
     echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
     exit 1

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -91,15 +91,22 @@ if command -v systemctl >/dev/null && systemctl is-active opensearch-performance
 fi
 
 # Check if OPENSEARCH_INITIAL_ADMIN_PASSWORD is defined
-# NOTE:
-# 1. This check will need to be modified if there will be a min dist for rpm in future (currently there is none)
-# 2. Currently, the demo config setup is defined to run, in postinstall, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
+# TODO:
+# 1. This check will need to be modified if there will be a min dist for deb in future (currently there is none)
+# 2. Currently, the demo config setup is defined to run, in postinst, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
+
+# Check if this is an upgrade by checking whether opensearch already exists
+OPENSEARCH_INSTALLED=$(rpm -qa || yum list installed | grep opensearch)
+
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
 OPENSEARCH_VERSION=%{_version}
 COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
-if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
-  echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
-  exit 1
+
+if [ -n "$OPENSEARCH_INSTALLED" ] && [ $OPENSEARCH_VERSION != CHANGE_VERSION ]; then
+  if [ "$COMPARE_VERSION" == "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
+    echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
+    exit 1
+  fi
 fi
 
 # Create user and group if they do not already exist.
@@ -113,7 +120,7 @@ exit 0
 set -e
 # Apply Security Settings
 if [ -d %{product_dir}/plugins/opensearch-security ]; then
-    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s  > %{log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in %{log_dir}/install_demo_configuration.log." && exit 1)
+    sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > %{log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in %{log_dir}/install_demo_configuration.log" && exit 1)
 fi
 chown -R %{name}.%{name} %{config_dir}
 chown -R %{name}.%{name} %{log_dir}

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -96,15 +96,11 @@ fi
 # 2. Currently, the demo config setup is defined to run, in postinst, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
 
 # Check if this is an upgrade by checking whether opensearch already exists
-set +e
-rpm -q opensearch > /dev/null 2>&1 || yum list installed opensearch > /dev/null 2>&1
-EX_CODE=$?
-if [ $EX_CODE -eq 0 ]; then
-  OPENSEARCH_ALREADY_INSTALLED=yes
+if rpm -q opensearch >/dev/null 2>&1 || yum list installed opensearch >/dev/null 2>&1; then
+    OPENSEARCH_ALREADY_INSTALLED=yes
 else
-  OPENSEARCH_ALREADY_INSTALLED=no
+    OPENSEARCH_ALREADY_INSTALLED=no
 fi
-set -e
 
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
 OPENSEARCH_VERSION=%{_version}


### PR DESCRIPTION
### Description
This PR is an outcome of a design decision proposed here: https://github.com/opensearch-project/security/issues/3916

Since an initial admin password is required starting OpenSearch version 2.12 and later, this PR adds two checks:
- A preinstall check to verify if `OPENSEARCH_INITIAL_ADMIN_PASSWORD` was set. If yes, do nothing. If not print a helpful  message and exit the installation.
- A postinstall check to verify if demo_config threw any errors. If so print a helpful a message and exit the postinstall checlk. (This will require users to re-install with admin password defined but that is not a big task as they can simply re-run installation again without needing to delete any pre-installed folders. I have tested this and it works)

### Issues Resolved
- Related to : https://github.com/opensearch-project/security/issues/3916

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
