### PR TITLE
Updating jenkinsfile with using update-alternatives to switch JDK version

### DIFF
--- a/jenkins/opensearch/publish-min-snapshots.jenkinsfile
+++ b/jenkins/opensearch/publish-min-snapshots.jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
                     steps {
                         script {
                             echo("Switching to Java ${env.javaVersionNumber} on MacOS")
-                            sh("jenv global ${dockerAgent.javaVersion}")
+                            sh("/usr/local/bin/update-alternatives --set java `/usr/local/bin/update-alternatives --list java | grep openjdk-${env.javaVersionNumber}`")
                             sh("java -version")
                             buildManifest(
                                 componentName: "OpenSearch",

--- a/tests/jenkins/TestPublishMinSnapshots.groovy
+++ b/tests/jenkins/TestPublishMinSnapshots.groovy
@@ -12,7 +12,6 @@ import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.notNullValue
-import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.MatcherAssert.assertThat
 import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
 import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
@@ -100,7 +99,7 @@ class TestPublishMinSnapshots extends BuildPipelineTest {
             return new Yaml().load(('tests/jenkins/data/opensearch-min-3.0.0-snapshot-darwin-build-manifest.yml' as File).text)
         })
         runScript('jenkins/opensearch/publish-min-snapshots.jenkinsfile')
-        assertThat(getCommands('sh', '/usr/local/bin/update-alternatives'), hasItem(containsString('/usr/local/bin/update-alternatives --set java `/usr/local/bin/update-alternatives --list java')))
+        assertThat(getCommands('sh', '/usr/local/bin/update-alternatives'), hasItem('/usr/local/bin/update-alternatives --set java `/usr/local/bin/update-alternatives --list java | grep openjdk-17`'))
         assertThat(getCommands('sh', 'darwin'), hasItem('./build.sh manifests/3.0.0/opensearch-3.0.0.yml -d tar --component OpenSearch -p darwin -a x64 --snapshot'))
         assertThat(getCommands('s3Upload', 'min-3.0.0-SNAPSHOT'), hasItems('{file=/tmp/workspace/zip/builds/opensearch/dist/opensearch-min-3.0.0-SNAPSHOT-darwin-x64-latest.tar.gz, bucket=ARTIFACT_PRODUCTION_BUCKET_NAME, path=snapshots/core/opensearch/3.0.0-SNAPSHOT/opensearch-min-3.0.0-SNAPSHOT-darwin-x64-latest.tar.gz}',
         '{file=/tmp/workspace/zip/builds/opensearch/dist/opensearch-min-3.0.0-SNAPSHOT-darwin-x64-latest.tar.gz.sha512, bucket=ARTIFACT_PRODUCTION_BUCKET_NAME, path=snapshots/core/opensearch/3.0.0-SNAPSHOT/opensearch-min-3.0.0-SNAPSHOT-darwin-x64-latest.tar.gz.sha512}',

--- a/tests/jenkins/TestPublishMinSnapshots.groovy
+++ b/tests/jenkins/TestPublishMinSnapshots.groovy
@@ -12,6 +12,7 @@ import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.CoreMatchers.hasItems
 import static org.hamcrest.CoreMatchers.notNullValue
+import static org.hamcrest.CoreMatchers.containsString
 import static org.hamcrest.MatcherAssert.assertThat
 import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
 import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
@@ -99,6 +100,7 @@ class TestPublishMinSnapshots extends BuildPipelineTest {
             return new Yaml().load(('tests/jenkins/data/opensearch-min-3.0.0-snapshot-darwin-build-manifest.yml' as File).text)
         })
         runScript('jenkins/opensearch/publish-min-snapshots.jenkinsfile')
+        assertThat(getCommands('sh', '/usr/local/bin/update-alternatives'), hasItem(containsString('/usr/local/bin/update-alternatives --set java `/usr/local/bin/update-alternatives --list java')))
         assertThat(getCommands('sh', 'darwin'), hasItem('./build.sh manifests/3.0.0/opensearch-3.0.0.yml -d tar --component OpenSearch -p darwin -a x64 --snapshot'))
         assertThat(getCommands('s3Upload', 'min-3.0.0-SNAPSHOT'), hasItems('{file=/tmp/workspace/zip/builds/opensearch/dist/opensearch-min-3.0.0-SNAPSHOT-darwin-x64-latest.tar.gz, bucket=ARTIFACT_PRODUCTION_BUCKET_NAME, path=snapshots/core/opensearch/3.0.0-SNAPSHOT/opensearch-min-3.0.0-SNAPSHOT-darwin-x64-latest.tar.gz}',
         '{file=/tmp/workspace/zip/builds/opensearch/dist/opensearch-min-3.0.0-SNAPSHOT-darwin-x64-latest.tar.gz.sha512, bucket=ARTIFACT_PRODUCTION_BUCKET_NAME, path=snapshots/core/opensearch/3.0.0-SNAPSHOT/opensearch-min-3.0.0-SNAPSHOT-darwin-x64-latest.tar.gz.sha512}',

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/publish-min-snapshots.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/publish-min-snapshots.jenkinsfile.txt
@@ -90,7 +90,7 @@
             publish-min-snapshots.echo(Executing on agent [label:Jenkins-Agent-MacOS12-X64-Mac1Metal-Multi-Host])
             publish-min-snapshots.script(groovy.lang.Closure)
                publish-min-snapshots.echo(Switching to Java 17 on MacOS)
-               publish-min-snapshots.sh(jenv global openjdk-17)
+               publish-min-snapshots.sh(/usr/local/bin/update-alternatives --set java `/usr/local/bin/update-alternatives --list java | grep openjdk-17`)
                publish-min-snapshots.sh(java -version)
                publish-min-snapshots.buildManifest({componentName=OpenSearch, inputManifest=manifests/3.0.0/opensearch-3.0.0.yml, platform=darwin, architecture=x64, distribution=tar, snapshot=true})
                   buildManifest.sh(./build.sh manifests/3.0.0/opensearch-3.0.0.yml -d tar --component OpenSearch -p darwin -a x64 --snapshot)


### PR DESCRIPTION
### Description
Updating jenkinsfile with using update-alternatives to switch JDK version per the parameter in manifest

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4272

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
