### PR TITLE
Revert "Revert rpm/deb changes pending decision"

### DIFF
--- a/src/test_workflow/integ_test/distribution_deb.py
+++ b/src/test_workflow/integ_test/distribution_deb.py
@@ -30,7 +30,8 @@ class DistributionDeb(Distribution):
         logging.info("deb installation requires sudo, script will exit if current user does not have sudo access")
         deb_install_cmd = " ".join(
             [
-                'export',
+                'sudo',
+                'env',
                 'OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!',
                 '&&',
                 'sudo',

--- a/src/test_workflow/integ_test/distribution_deb.py
+++ b/src/test_workflow/integ_test/distribution_deb.py
@@ -30,6 +30,9 @@ class DistributionDeb(Distribution):
         logging.info("deb installation requires sudo, script will exit if current user does not have sudo access")
         deb_install_cmd = " ".join(
             [
+                'export',
+                'OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!',
+                '&&',
                 'sudo',
                 'dpkg',
                 '--purge',

--- a/src/test_workflow/integ_test/distribution_rpm.py
+++ b/src/test_workflow/integ_test/distribution_rpm.py
@@ -30,6 +30,9 @@ class DistributionRpm(Distribution):
         logging.info("rpm installation requires sudo, script will exit if current user does not have sudo access")
         rpm_install_cmd = " ".join(
             [
+                'export',
+                'OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!',
+                '&&',
                 'sudo',
                 'yum',
                 'remove',

--- a/src/test_workflow/integ_test/distribution_rpm.py
+++ b/src/test_workflow/integ_test/distribution_rpm.py
@@ -30,7 +30,8 @@ class DistributionRpm(Distribution):
         logging.info("rpm installation requires sudo, script will exit if current user does not have sudo access")
         rpm_install_cmd = " ".join(
             [
-                'export',
+                'sudo',
+                'env',
                 'OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123!',
                 '&&',
                 'sudo',

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
@@ -13,16 +13,14 @@ from test_workflow.integ_test.distribution_deb import DistributionDeb
 
 
 class TestDistributionDeb(unittest.TestCase):
-
     def setUp(self) -> None:
-
         self.work_dir = os.path.join(os.path.dirname(__file__), "data")
         self.distribution_deb = DistributionDeb("opensearch", "1.3.0", self.work_dir)
         self.distribution_deb_dashboards = DistributionDeb("opensearch-dashboards", "1.3.0", self.work_dir)
 
     def test_distribution_deb_vars(self) -> None:
-        self.assertEqual(self.distribution_deb.filename, 'opensearch')
-        self.assertEqual(self.distribution_deb.version, '1.3.0')
+        self.assertEqual(self.distribution_deb.filename, "opensearch")
+        self.assertEqual(self.distribution_deb.version, "1.3.0")
         self.assertEqual(self.distribution_deb.work_dir, self.work_dir)
         self.assertEqual(self.distribution_deb.require_sudo, True)
 
@@ -40,7 +38,15 @@ class TestDistributionDeb(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"sudo dpkg --purge opensearch && sudo dpkg --install opensearch.deb && sudo chmod 0666 {self.distribution_deb.config_path}", args_list[0][0][0])
+        self.assertEqual(
+            (
+                "export OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! && "
+                "sudo dpkg --purge opensearch && "
+                "sudo dpkg --install opensearch.deb && "
+                f"sudo chmod 0666 {self.distribution_deb.config_path}"
+            ),
+            args_list[0][0][0],
+        )
 
     def test_start_cmd(self) -> None:
         self.assertEqual(self.distribution_deb.start_cmd, "sudo systemctl start opensearch")

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
@@ -40,7 +40,7 @@ class TestDistributionDeb(unittest.TestCase):
         self.assertEqual(check_call_mock.call_count, 1)
         self.assertEqual(
             (
-                "export OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! && "
+                "sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! && "
                 "sudo dpkg --purge opensearch && "
                 "sudo dpkg --install opensearch.deb && "
                 f"sudo chmod 0666 {self.distribution_deb.config_path}"

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
@@ -13,16 +13,14 @@ from test_workflow.integ_test.distribution_rpm import DistributionRpm
 
 
 class TestDistributionRpm(unittest.TestCase):
-
     def setUp(self) -> None:
-
         self.work_dir = os.path.join(os.path.dirname(__file__), "data")
         self.distribution_rpm = DistributionRpm("opensearch", "1.3.0", self.work_dir)
         self.distribution_rpm_dashboards = DistributionRpm("opensearch-dashboards", "1.3.0", self.work_dir)
 
     def test_distribution_rpm_vars(self) -> None:
-        self.assertEqual(self.distribution_rpm.filename, 'opensearch')
-        self.assertEqual(self.distribution_rpm.version, '1.3.0')
+        self.assertEqual(self.distribution_rpm.filename, "opensearch")
+        self.assertEqual(self.distribution_rpm.version, "1.3.0")
         self.assertEqual(self.distribution_rpm.work_dir, self.work_dir)
         self.assertEqual(self.distribution_rpm.require_sudo, True)
 
@@ -40,7 +38,15 @@ class TestDistributionRpm(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"sudo yum remove -y opensearch && sudo yum install -y opensearch.rpm && sudo chmod 0666 {self.distribution_rpm.config_path}", args_list[0][0][0])
+        self.assertEqual(
+            (
+                "export OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! && "
+                "sudo yum remove -y opensearch && "
+                "sudo yum install -y opensearch.rpm && "
+                f"sudo chmod 0666 {self.distribution_rpm.config_path}"
+            ),
+            args_list[0][0][0],
+        )
 
     def test_start_cmd(self) -> None:
         self.assertEqual(self.distribution_rpm.start_cmd, "sudo systemctl start opensearch")

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
@@ -40,7 +40,7 @@ class TestDistributionRpm(unittest.TestCase):
         self.assertEqual(check_call_mock.call_count, 1)
         self.assertEqual(
             (
-                "export OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! && "
+                "sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! && "
                 "sudo yum remove -y opensearch && "
                 "sudo yum install -y opensearch.rpm && "
                 f"sudo chmod 0666 {self.distribution_rpm.config_path}"


### PR DESCRIPTION
This reverts commit 00fa11f15bb1ceb8c016c1a3de04b91f52bb0c68.

It was decided to proceed with setting the initial admin password in rpm and deb at install time, and do additional checks later. Thus, integration tests should be installed with the appropriate strong password.

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
