### PR TITLE
Fix the infra deployment info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ See [src/manifests_workflow](./src/manifests_workflow) for more information.
 
 ### Deploying Infrastructure
 
-Storage and access roles for the OpenSearch release process are codified in a [CDK project](./deployment/README.md).
+This project uses jenkins as the build infrastruture for building, testing and releasing the artifacts. The infrastruture is deployed using CDK and code can be found in [opensearch-ci](https://github.com/opensearch-project/opensearch-ci/tree/main) repository.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ See [src/manifests_workflow](./src/manifests_workflow) for more information.
 
 ### Deploying Infrastructure
 
-This project uses jenkins as the build infrastruture for building, testing and releasing the artifacts. The infrastruture is deployed using CDK and code can be found in [opensearch-ci](https://github.com/opensearch-project/opensearch-ci/tree/main) repository.
+This project uses jenkins as the build infrastructure for building, testing and releasing the artifacts. The infrastructure is deployed using CDK and code can be found in [opensearch-ci](https://github.com/opensearch-project/opensearch-ci/tree/main) repository.
 
 ## Contributing
 


### PR DESCRIPTION
### Description
Fix the infra deployment info in readme

### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-build/issues/4328

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
