### PR TITLE
Upgrade pyyaml to 6.0.1 to support ppc64le

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,8 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pyyaml = "~=5.4"
-types-PyYAML = "~=5.4"
+pyyaml = "~=6.0.1"
+types-PyYAML = "~=6.0.1"
 # TODO: The 'requests' package stays on 2.28 until we deprecate CentOS7.
 #       As newer version requires openssl1.1.1 where CentOS7 only provides openssl1.1.0.
 #       https://github.com/opensearch-project/opensearch-build/issues/3554
@@ -30,7 +30,7 @@ sortedcontainers = "~=2.4.0"
 cerberus = "~=1.3.4"
 psutil = "~=5.8"
 atomicwrites = "~=1.4.1"
-validators = "*"
+validators = "~=0.21.2"
 yamlfix = "~=1.0.1"
 yamllint = "~=1.27.1"
 pytablewriter = "~=0.64.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cd4a2c85dc09d7a50a6942d086774ba390e1b3ec2ba5e3aa571987b54ffcf5b2"
+            "sha256": "c03613ba05c90c679f5832c9f4275d5523890031d2141f6bd2e6916d1a32b10d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,11 +25,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
-                "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
+                "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30",
+                "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==23.1.0"
+            "version": "==23.2.0"
         },
         "cerberus": {
             "hashes": [
@@ -115,7 +115,6 @@
                 "sha256:ff37757e068ae606659c28c3bd0d923f9d29a85de79bf25b2b34b148473b5025"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
             "version": "==4.5.4"
         },
         "dataproperty": {
@@ -143,11 +142,11 @@
         },
         "distro": {
             "hashes": [
-                "sha256:02e111d1dc6a50abb8eed6bf31c3e48ed8b0830d1ea2a1b78c61765c2513fdd8",
-                "sha256:99522ca3e365cac527b44bde033f64c6945d90eb9f769703caaec52b09bbd3ff"
+                "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed",
+                "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.8.0"
+            "version": "==1.9.0"
         },
         "filelock": {
             "hashes": [
@@ -163,7 +162,6 @@
                 "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==3.9.2"
         },
         "identify": {
@@ -188,7 +186,6 @@
                 "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==4.12.0"
         },
         "iniconfig": {
@@ -205,7 +202,6 @@
                 "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.0'",
             "version": "==5.13.2"
         },
         "jproperties": {
@@ -237,7 +233,6 @@
                 "sha256:fc7f93ded930c92394ef2cb6f04a8aabab4117a91449e72dcc8dfa646a508be8"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.0.2"
         },
         "mypy": {
@@ -267,7 +262,6 @@
                 "sha256:f2899a3cbd394da157194f913a931edfd4be5f274a88041c9dc2d9cdcb1c315c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==0.971"
         },
         "mypy-extensions": {
@@ -332,7 +326,6 @@
                 "sha256:a4ed01000afcb484d9eb8d504272e642c4c4099bbad3a6b27e519bd6a3e928a6"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.6.1'",
             "version": "==2.15.0"
         },
         "psutil": {
@@ -355,7 +348,6 @@
                 "sha256:fe8b7f07948f1304497ce4f4684881250cd859b16d06a1dc4d7941eeb6233bfe"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==5.9.7"
         },
         "py": {
@@ -388,7 +380,6 @@
                 "sha256:c46d1ddc40ef4d084213a86f8626cee33b3aa0119535aa8555da64cb5b65e382"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==0.64.2"
         },
         "pytest": {
@@ -397,7 +388,6 @@
                 "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==7.1.3"
         },
         "pytest-cov": {
@@ -406,7 +396,6 @@
                 "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.10.1"
         },
         "python-dateutil": {
@@ -425,39 +414,59 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
-                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
-                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
-                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
-                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
-                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
-                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
-                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
-                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
-                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
-                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
-                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
-                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
-                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
-                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
-                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
-                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
-                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
-                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
-                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
-                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
-                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
-                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
-                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
-                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
-                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
-                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
-                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
-                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+                "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5",
+                "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc",
+                "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df",
+                "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741",
+                "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206",
+                "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27",
+                "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595",
+                "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62",
+                "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98",
+                "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696",
+                "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290",
+                "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9",
+                "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d",
+                "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6",
+                "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867",
+                "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47",
+                "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486",
+                "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6",
+                "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3",
+                "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007",
+                "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938",
+                "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0",
+                "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c",
+                "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735",
+                "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d",
+                "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28",
+                "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4",
+                "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba",
+                "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8",
+                "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5",
+                "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd",
+                "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3",
+                "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0",
+                "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515",
+                "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c",
+                "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c",
+                "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924",
+                "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34",
+                "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43",
+                "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859",
+                "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673",
+                "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54",
+                "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a",
+                "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b",
+                "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab",
+                "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa",
+                "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c",
+                "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585",
+                "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d",
+                "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==5.4.1"
+            "version": "==6.0.1"
         },
         "requests": {
             "hashes": [
@@ -465,7 +474,6 @@
                 "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==2.28.1"
         },
         "retry": {
@@ -482,7 +490,6 @@
                 "sha256:b16b6c3816dff0a93dca12acf5e70afd089fa5acb80604afd1ffa8b465b7722c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3'",
             "version": "==0.17.40"
         },
         "ruamel.yaml.clib": {
@@ -555,16 +562,15 @@
                 "sha256:b1ea4686fe70b981f85359eda33199d60c53964284e0cfb4977d243e37cf4bf4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.0.2"
         },
         "setuptools": {
             "hashes": [
-                "sha256:1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2",
-                "sha256:735896e78a4742605974de002ac60562d286fa8051a7e2299445e8e8fbb01aa6"
+                "sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05",
+                "sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==69.0.2"
+            "version": "==69.0.3"
         },
         "six": {
             "hashes": [
@@ -611,7 +617,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.11'",
             "version": "==2.0.1"
         },
         "typed-ast": {
@@ -659,7 +665,6 @@
                 "sha256:fe58ef6a764de7b4b36edfc8592641f56e69b7163bba9f9c8089838ee596bfb2"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==1.5.5"
         },
         "typepy": {
@@ -675,10 +680,11 @@
         },
         "types-pyyaml": {
             "hashes": [
-                "sha256:3f4daa754357491625ae8c3a39c9e1b0d7cd5632bc4e1c35e7a7f75a64aa124b",
-                "sha256:e06083f85375a5678e4c19452ed6467ce2167b71db222313e1792cb8fc76859a"
+                "sha256:334373d392fde0fdf95af5c3f1661885fa10c52167b14593eb856289e1855062",
+                "sha256:c05bc6c158facb0676674b7f11fe3960db4f389718e19e62bd2b84d6205cfd24"
             ],
-            "version": "==5.4.12"
+            "index": "pypi",
+            "version": "==6.0.12.12"
         },
         "types-requests": {
             "hashes": [
@@ -686,7 +692,6 @@
                 "sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==2.31.0.6"
         },
         "types-urllib3": {
@@ -714,12 +719,11 @@
         },
         "validators": {
             "hashes": [
-                "sha256:61cf7d4a62bbae559f2e54aed3b000cea9ff3e2fdbe463f51179b92c58c9585a",
-                "sha256:77b2689b172eeeb600d9605ab86194641670cdb73b60afd577142a9397873370"
+                "sha256:002ba1552076535176824e43149c18c06f6b611bc8b597ddbcf8770bcf5f9f5c",
+                "sha256:6ad95131005a9d4c734a69dd4ef08cf66961e61222e60da25a9b5137cecd6fd4"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==0.22.0"
+            "version": "==0.21.2"
         },
         "virtualenv": {
             "hashes": [
@@ -735,7 +739,6 @@
                 "sha256:a7e34d1bbd4d29a2b715c7b8b9ba62a766862f3b42489062d520569dd2289e48"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==1.0.1"
         },
         "yamllint": {
@@ -743,7 +746,6 @@
                 "sha256:e688324b58560ab68a1a3cff2c0a474e3fed371dfe8da5d1b9817b7df55039ce"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==1.27.1"
         },
         "zipp": {
@@ -752,7 +754,6 @@
                 "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
             "version": "==3.8.1"
         }
     },

--- a/src/ci_workflow/ci_manifests.py
+++ b/src/ci_workflow/ci_manifests.py
@@ -12,7 +12,6 @@ from io import TextIOWrapper
 from typing import Type, Union
 
 import yaml
-
 from ci_workflow.ci_args import CiArgs
 from ci_workflow.ci_input_manifest import CiInputManifest
 from ci_workflow.ci_test_manifest import CiTestManifest

--- a/src/manifests/manifest.py
+++ b/src/manifests/manifest.py
@@ -12,9 +12,10 @@ from abc import ABC, abstractmethod
 from typing import IO, Any, Dict, Generic, Optional, Type, TypeVar
 
 import validators
-import yaml
 import yamlfix
 from cerberus import Validator
+
+import yaml
 
 T = TypeVar('T', bound='Manifest')
 

--- a/src/report_workflow/test_report_runner.py
+++ b/src/report_workflow/test_report_runner.py
@@ -12,8 +12,8 @@ from typing import Any
 from urllib.error import HTTPError
 
 import validators
-import yaml
 
+import yaml
 from manifests.test_manifest import TestManifest
 from manifests.test_report_manifest import TestReportManifest
 from report_workflow.report_args import ReportArgs

--- a/src/test_workflow/benchmark_test/benchmark_test_runner_opensearch.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_runner_opensearch.py
@@ -9,9 +9,9 @@ import logging
 import os
 from typing import Union
 
-import yaml
 from retry.api import retry_call  # type: ignore
 
+import yaml
 from git.git_repository import GitRepository
 from manifests.build_manifest import BuildManifest
 from manifests.bundle_manifest import BundleManifest

--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -9,9 +9,9 @@ import logging
 import os
 
 import requests
-import yaml
 from requests.models import Response
 
+import yaml
 from test_workflow.dependency_installer import DependencyInstaller
 from test_workflow.integ_test.distribution import Distribution
 from test_workflow.integ_test.distributions import Distributions

--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -10,9 +10,9 @@ import os
 import subprocess
 
 import requests
-import yaml
 from requests.models import Response
 
+import yaml
 from system.os import current_platform
 from test_workflow.dependency_installer import DependencyInstaller
 from test_workflow.integ_test.distribution import Distribution

--- a/src/test_workflow/perf_test/perf_test_runner_opensearch.py
+++ b/src/test_workflow/perf_test/perf_test_runner_opensearch.py
@@ -8,9 +8,9 @@
 import logging
 import os
 
-import yaml
 from retry.api import retry_call  # type: ignore
 
+import yaml
 from git.git_repository import GitRepository
 from manifests.bundle_manifest import BundleManifest
 from system.temporary_directory import TemporaryDirectory

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -11,7 +11,6 @@ import shutil
 from typing import Any
 
 import yaml
-
 from paths.tree_walker import walk
 from test_workflow.test_recorder.log_recorder import LogRecorder
 from test_workflow.test_recorder.test_result_data import TestResultData

--- a/tests/tests_assemble_workflow/test_bundle_recorder.py
+++ b/tests/tests_assemble_workflow/test_bundle_recorder.py
@@ -9,7 +9,6 @@ import os
 import unittest
 
 import yaml
-
 from assemble_workflow.bundle_file_location import BundleFileLocation
 from assemble_workflow.bundle_recorder import BundleRecorder
 from assemble_workflow.bundle_url_location import BundleUrlLocation

--- a/tests/tests_build_workflow/test_build_recorder.py
+++ b/tests/tests_build_workflow/test_build_recorder.py
@@ -10,7 +10,6 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 
 import yaml
-
 from build_workflow.build_recorder import BuildRecorder
 from build_workflow.build_target import BuildTarget
 from build_workflow.opensearch.build_artifact_check_maven import BuildArtifactOpenSearchCheckMaven

--- a/tests/tests_manifests/test_build_manifest.py
+++ b/tests/tests_manifests/test_build_manifest.py
@@ -10,7 +10,6 @@ import unittest
 from unittest.mock import MagicMock, Mock, patch
 
 import yaml
-
 from manifests.build_manifest import BuildComponent, BuildManifest
 
 

--- a/tests/tests_manifests/test_bundle_manifest.py
+++ b/tests/tests_manifests/test_bundle_manifest.py
@@ -9,7 +9,6 @@ import os
 import unittest
 
 import yaml
-
 from manifests.bundle_manifest import BundleManifest
 
 

--- a/tests/tests_manifests/test_input_manifest.py
+++ b/tests/tests_manifests/test_input_manifest.py
@@ -11,7 +11,6 @@ import unittest
 from unittest.mock import Mock, patch
 
 import yaml
-
 from manifests.input.input_manifest_1_0 import Check_1_0, InputComponentFromDist_1_0, InputComponentFromSource_1_0
 from manifests.input_manifest import Check, InputComponent, InputComponentFromDist, InputComponentFromSource, InputManifest
 from system.temporary_directory import TemporaryDirectory

--- a/tests/tests_manifests/test_manifest.py
+++ b/tests/tests_manifests/test_manifest.py
@@ -11,7 +11,6 @@ from typing import Any, Dict
 from unittest.mock import MagicMock, Mock, patch
 
 import yaml
-
 from manifests.manifest import Manifest
 from system.temporary_directory import TemporaryDirectory
 

--- a/tests/tests_manifests/test_test_manifest.py
+++ b/tests/tests_manifests/test_test_manifest.py
@@ -9,7 +9,6 @@ import os
 import unittest
 
 import yaml
-
 from manifests.test_manifest import TestManifest
 
 

--- a/tests/tests_manifests/test_test_run_manifest.py
+++ b/tests/tests_manifests/test_test_run_manifest.py
@@ -9,7 +9,6 @@ import os
 import unittest
 
 import yaml
-
 from manifests.test_report_manifest import TestReportManifest
 
 


### PR DESCRIPTION
### Description
Upgrade pyyaml to 6.0.1 to support ppc64le

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3122

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
