### PR TITLE
Add opensearch cluster stdout and stderr logs to test results manifest

### DIFF
--- a/src/manifests/test_report_manifest.py
+++ b/src/manifests/test_report_manifest.py
@@ -30,6 +30,10 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
               - name: with-security
                 status: the status of the test run with this config. e.g. pass/fail
                 yml: URL or local path to the component yml file
+                cluster_stdout:
+                  - URL or local path to the OpenSearch cluster logs
+                cluster_stderr:
+                  - URL or local path to the OpenSearch cluster error logs
     """
 
     SCHEMA = {
@@ -61,6 +65,8 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
                                 "name": {"type": "string"},
                                 "status": {"type": "string"},
                                 "yml": {"type": "string"},
+                                "cluster_stdout": {"type": "list"},
+                                "cluster_stderr": {"type": "list"}
                             }
                         },
                     },
@@ -140,12 +146,16 @@ class TestComponent(Component):
                 self.name = data["name"]
                 self.status = data["status"]
                 self.yml = data["yml"]
+                self.cluster_stdout = data["cluster_stdout"]
+                self.cluster_stderr = data["cluster_stderr"]
 
             def __to_dict__(self) -> dict:
                 return {
                     "name": self.name,
                     "status": self.status,
-                    "yml": self.yml
+                    "yml": self.yml,
+                    "cluster_stdout": self.cluster_stdout,
+                    "cluster_stderr": self.cluster_stderr
                 }
 
 

--- a/tests/tests_manifests/data/test-run.yml
+++ b/tests/tests_manifests/data/test-run.yml
@@ -17,9 +17,17 @@ components:
       - name: with-security
         status: FAIL
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/with-security/alerting.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/without-security/alerting.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/without-security/local-cluster-logs/id-0/stderr.txt
   - name: anomaly-detection
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -28,9 +36,17 @@ components:
       - name: with-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/anomaly-detection/with-security/anomaly-detection.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/anomaly-detection/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/anomaly-detection/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/anomaly-detection/without-security/anomaly-detection.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/anomaly-detection/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/anomaly-detection/without-security/local-cluster-logs/id-0/stderr.txt
   - name: asynchronous-search
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -39,9 +55,17 @@ components:
       - name: with-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/asynchronous-search/with-security/asynchronous-search.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/asynchronous-search/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/asynchronous-search/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/asynchronous-search/without-security/asynchronous-search.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/asynchronous-search/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/asynchronous-search/without-security/local-cluster-logs/id-0/stderr.txt
   - name: cross-cluster-replication
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -50,9 +74,17 @@ components:
       - name: with-security
         status: Not Available
         yml: URL not available
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/cross-cluster-replication/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/cross-cluster-replication/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: Not Available
         yml: URL not available
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/cross-cluster-replication/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/cross-cluster-replication/without-security/local-cluster-logs/id-0/stderr.txt
   - name: geospatial
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -61,9 +93,17 @@ components:
       - name: with-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/geospatial/with-security/geospatial.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/geospatial/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/geospatial/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/geospatial/without-security/geospatial.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/geospatial/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/geospatial/without-security/local-cluster-logs/id-0/stderr.txt
   - name: index-management
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -72,9 +112,17 @@ components:
       - name: with-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/index-management/with-security/index-management.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/index-management/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/index-management/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/index-management/without-security/index-management.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/index-management/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/index-management/without-security/local-cluster-logs/id-0/stderr.txt
   - name: k-NN
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -83,9 +131,17 @@ components:
       - name: with-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/k-NN/with-security/k-NN.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/k-NN/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/k-NN/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/k-NN/without-security/k-NN.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/k-NN/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/k-NN/without-security/local-cluster-logs/id-0/stderr.txt
   - name: ml-commons
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -94,9 +150,17 @@ components:
       - name: with-security
         status: FAIL
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/ml-commons/with-security/ml-commons.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/ml-commons/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/ml-commons/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/ml-commons/without-security/ml-commons.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/ml-commons/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/ml-commons/without-security/local-cluster-logs/id-0/stderr.txt
   - name: neural-search
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -105,9 +169,17 @@ components:
       - name: with-security
         status: FAIL
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/neural-search/with-security/neural-search.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/neural-search/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/neural-search/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/neural-search/without-security/neural-search.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/neural-search/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/neural-search/without-security/local-cluster-logs/id-0/stderr.txt
   - name: notifications
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -116,9 +188,17 @@ components:
       - name: with-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/notifications/with-security/notifications.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/notifications/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/notifications/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/notifications/without-security/notifications.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/notifications/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/notifications/without-security/local-cluster-logs/id-0/stderr.txt
   - name: opensearch-observability
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -127,9 +207,17 @@ components:
       - name: with-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-observability/with-security/opensearch-observability.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-observability/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-observability/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-observability/without-security/opensearch-observability.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-observability/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-observability/without-security/local-cluster-logs/id-0/stderr.txt
   - name: opensearch-reports
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -138,9 +226,17 @@ components:
       - name: with-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-reports/with-security/opensearch-reports.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-reports/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-reports/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-reports/without-security/opensearch-reports.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-reports/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/opensearch-reports/without-security/local-cluster-logs/id-0/stderr.txt
   - name: security
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -149,6 +245,10 @@ components:
       - name: with-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/security/with-security/security.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/security/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/security/with-security/local-cluster-logs/id-0/stderr.txt
   - name: security-analytics
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -157,9 +257,17 @@ components:
       - name: with-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/security-analytics/with-security/security-analytics.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/security-analytics/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/security-analytics/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/security-analytics/without-security/security-analytics.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/security-analytics/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/security-analytics/without-security/local-cluster-logs/id-0/stderr.txt
   - name: sql
     command: ./test.sh integ-test manifests/2.8.0/opensearch-2.8.0-test.yml --paths
       opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.8.0/7935/linux/x64/tar
@@ -168,6 +276,14 @@ components:
       - name: with-security
         status: FAIL
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/sql/with-security/sql.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/sql/with-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/sql/with-security/local-cluster-logs/id-0/stderr.txt
       - name: without-security
         status: PASS
         yml: https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/sql/without-security/sql.yml
+        cluster_stdout:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/sql/without-security/local-cluster-logs/id-0/stdout.txt
+        cluster_stderr:
+          - https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/sql/without-security/local-cluster-logs/id-0/stderr.txt

--- a/tests/tests_manifests/test_test_run_manifest.py
+++ b/tests/tests_manifests/test_test_run_manifest.py
@@ -40,10 +40,18 @@ class TestTestReportManifest(unittest.TestCase):
         self.assertEqual(component.configs.configs[0]["status"], "FAIL")
         self.assertEqual(component.configs.configs[0]["yml"],
                          "https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/with-security/alerting.yml")
+        self.assertEqual(component.configs.configs[0]["cluster_stdout"][0],
+                         "https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/with-security/local-cluster-logs/id-0/stdout.txt")
+        self.assertEqual(component.configs.configs[0]["cluster_stderr"][0],
+                         "https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/with-security/local-cluster-logs/id-0/stderr.txt")
         self.assertEqual(component.configs.configs[1]["name"], "without-security")
         self.assertEqual(component.configs.configs[1]["status"], "PASS")
         self.assertEqual(component.configs.configs[1]["yml"],
                          "https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/without-security/alerting.yml")
+        self.assertEqual(component.configs.configs[1]["cluster_stdout"][0],
+                         "https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/without-security/local-cluster-logs/id-0/stdout.txt")
+        self.assertEqual(component.configs.configs[1]["cluster_stderr"][0],
+                         "https://ci.opensearch.org/ci/dbc/integ-test/2.8.0/7935/linux/x64/tar/test-results/5109/integ-test/alerting/without-security/local-cluster-logs/id-0/stderr.txt")
 
     def test_to_dict(self) -> None:
         data = self.manifest.to_dict()

--- a/tests/tests_report_workflow/test_test_report_runner.py
+++ b/tests/tests_report_workflow/test_test_report_runner.py
@@ -19,14 +19,7 @@ class TestTestReportRunner(unittest.TestCase):
     TEST_MANIFEST_PATH = os.path.join(
         os.path.dirname(__file__), "data", "test_manifest.yml"
     )
-
-    TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH = os.path.join(
-        os.path.dirname(__file__), "data", "test-manifest-opensearch-dashboards.yml"
-    )
-
     TEST_MANIFEST = TestManifest.from_path(TEST_MANIFEST_PATH)
-
-    TEST_MANIFEST_OPENSEARCH_DASHBOARDS = TestManifest.from_path(TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH)
 
     @patch("report_workflow.report_args.ReportArgs")
     @patch("manifests.test_manifest.TestManifest")
@@ -46,7 +39,8 @@ class TestTestReportRunner(unittest.TestCase):
     @patch("urllib.request.urlopen")
     @patch("validators.url")
     @patch("report_workflow.report_args.ReportArgs")
-    def test_generate_file(self, report_args_mock: MagicMock, validators_mock: MagicMock, urlopen_mock: MagicMock, yaml_safe_load_mock: MagicMock) -> None:
+    def test_generate_file(self, report_args_mock: MagicMock, validators_mock: MagicMock, urlopen_mock: MagicMock,
+                           yaml_safe_load_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
         report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
         report_args_mock.test_run_id = 123
@@ -67,17 +61,20 @@ class TestTestReportRunner(unittest.TestCase):
 
     @patch("report_workflow.report_args.ReportArgs")
     @patch("manifests.test_manifest.TestManifest")
-    def test_runner_update_test_run_data_local(self, report_args_mock: MagicMock, test_manifest_mock: MagicMock) -> None:
+    def test_runner_update_test_run_data_local(self, report_args_mock: MagicMock,
+                                               test_manifest_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
         report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
         report_args_mock.test_run_id = 123
         report_args_mock.test_type = "integ-test"
 
         test_run_dict = TestReportRunner(report_args_mock, self.TEST_MANIFEST).update_test_run_data()
-        self.assertEqual(test_run_dict.get("Command"), " ".join(["./test.sh", "integ-test", self.TEST_MANIFEST_PATH, "--paths", "opensearch=foo/bar"]))
+        self.assertEqual(test_run_dict.get("Command"), " ".join(
+            ["./test.sh", "integ-test", self.TEST_MANIFEST_PATH, "--paths", "opensearch=foo/bar"]))
         self.assertEqual(test_run_dict.get("TestType"), "integ-test")
         self.assertEqual(test_run_dict.get("TestManifest"), self.TEST_MANIFEST_PATH)
-        self.assertEqual(test_run_dict.get("DistributionManifest"), os.path.join("foo/bar", "dist", "opensearch", "manifest.yml"))
+        self.assertEqual(test_run_dict.get("DistributionManifest"),
+                         os.path.join("foo/bar", "dist", "opensearch", "manifest.yml"))
         self.assertEqual(test_run_dict.get("TestID"), "123")
 
     @patch("report_workflow.report_args.ReportArgs")
@@ -89,17 +86,20 @@ class TestTestReportRunner(unittest.TestCase):
         report_args_mock.test_type = "integ-test"
 
         test_run_dict = TestReportRunner(report_args_mock, self.TEST_MANIFEST).update_test_run_data()
-        self.assertEqual(test_run_dict.get("Command"), " ".join(["./test.sh", "integ-test", self.TEST_MANIFEST_PATH, "--paths", "opensearch=https://foo/bar"]))
+        self.assertEqual(test_run_dict.get("Command"), " ".join(
+            ["./test.sh", "integ-test", self.TEST_MANIFEST_PATH, "--paths", "opensearch=https://foo/bar"]))
         self.assertEqual(test_run_dict.get("TestType"), "integ-test")
         self.assertEqual(test_run_dict.get("TestManifest"), self.TEST_MANIFEST_PATH)
-        self.assertEqual(test_run_dict.get("DistributionManifest"), "/".join(["https://foo/bar", "dist", "opensearch", "manifest.yml"]))
+        self.assertEqual(test_run_dict.get("DistributionManifest"),
+                         "/".join(["https://foo/bar", "dist", "opensearch", "manifest.yml"]))
         self.assertEqual(test_run_dict.get("TestID"), "123")
 
     @patch("yaml.safe_load")
     @patch("urllib.request.urlopen")
     @patch("validators.url")
     @patch("report_workflow.report_args.ReportArgs")
-    def test_runner_component_entry_url(self, report_args_mock: MagicMock, validators_mock: MagicMock, urlopen_mock: MagicMock, yaml_safe_load_mock: MagicMock) -> None:
+    def test_runner_component_entry_url(self, report_args_mock: MagicMock, validators_mock: MagicMock,
+                                        urlopen_mock: MagicMock, yaml_safe_load_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
         report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
         report_args_mock.test_run_id = 123
@@ -111,16 +111,29 @@ class TestTestReportRunner(unittest.TestCase):
         urlopen_mock.return_value = MagicMock()
 
         test_run_component_dict = TestReportRunner(report_args_mock, self.TEST_MANIFEST).component_entry("geospatial")
-        urlopen_mock.assert_has_calls([call('https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml')])
+        urlopen_mock.assert_has_calls([call(
+            'https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml')])
         self.assertEqual(test_run_component_dict.get("configs")[0]["status"], "PASS")
         self.assertEqual(test_run_component_dict.get("configs")[0]["name"], "with-security")
-        self.assertEqual(test_run_component_dict.get("configs")[0]["yml"], "https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["yml"],
+                         "https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stderr"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stderr.txt")
+
+        self.assertEqual(test_run_component_dict.get("configs")[1]["name"], "without-security")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/without-security/local-cluster-logs/id-1/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stderr"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/without-security/local-cluster-logs/id-1/stderr.txt")
 
     @patch("yaml.safe_load")
     @patch("builtins.open", new_callable=mock_open)
     @patch("validators.url")
     @patch("report_workflow.report_args.ReportArgs")
-    def test_runner_component_entry_local(self, report_args_mock: MagicMock, validators_mock: MagicMock, mock_open: MagicMock, yaml_safe_load_mock: MagicMock) -> None:
+    def test_runner_component_entry_local(self, report_args_mock: MagicMock, validators_mock: MagicMock,
+                                          mock_open: MagicMock, yaml_safe_load_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
         report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
         report_args_mock.test_run_id = 123
@@ -132,15 +145,21 @@ class TestTestReportRunner(unittest.TestCase):
         mock_open.return_value = MagicMock()
 
         test_run_component_dict = TestReportRunner(report_args_mock, self.TEST_MANIFEST).component_entry("geospatial")
-        mock_open.assert_has_calls([call('https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml', 'r', encoding='utf8')])
+        mock_open.assert_has_calls([call(
+            'https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml',
+            'r', encoding='utf8')])
         self.assertEqual(test_run_component_dict.get("configs")[0]["status"], "PASS")
         self.assertEqual(test_run_component_dict.get("configs")[0]["name"], "with-security")
-        self.assertEqual(test_run_component_dict.get("configs")[0]["yml"], "https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["yml"],
+                         "https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stdout.txt")
 
     @patch("yaml.safe_load")
     @patch("validators.url")
     @patch("report_workflow.report_args.ReportArgs")
-    def test_runner_component_entry_url_invalid(self, report_args_mock: MagicMock, validators_mock: MagicMock, yaml_safe_load_mock: MagicMock) -> None:
+    def test_runner_component_entry_url_invalid(self, report_args_mock: MagicMock, validators_mock: MagicMock,
+                                                yaml_safe_load_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
         report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
         report_args_mock.test_run_id = 123
@@ -153,12 +172,17 @@ class TestTestReportRunner(unittest.TestCase):
         self.assertEqual(test_run_component_dict.get("configs")[0]["status"], "Not Available")
         self.assertEqual(test_run_component_dict.get("configs")[0]["name"], "with-security")
         self.assertEqual(test_run_component_dict.get("configs")[0]["yml"], "URL not available")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/without-security/local-cluster-logs/id-1/stdout.txt")
 
     @patch("yaml.safe_load")
     @patch("builtins.open", new_callable=mock_open)
     @patch("validators.url")
     @patch("report_workflow.report_args.ReportArgs")
-    def test_runner_component_entry_local_invalid(self, report_args_mock: MagicMock, validators_mock: MagicMock, mock_open: MagicMock, yaml_safe_load_mock: MagicMock) -> None:
+    def test_runner_component_entry_local_invalid(self, report_args_mock: MagicMock, validators_mock: MagicMock,
+                                                  mock_open: MagicMock, yaml_safe_load_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
         report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
         report_args_mock.test_run_id = 123
@@ -170,7 +194,13 @@ class TestTestReportRunner(unittest.TestCase):
         mock_open.side_effect = FileNotFoundError
 
         test_run_component_dict = TestReportRunner(report_args_mock, self.TEST_MANIFEST).component_entry("geospatial")
-        mock_open.assert_has_calls([call('https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml', 'r', encoding='utf8')])
+        mock_open.assert_has_calls([call(
+            'https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml',
+            'r', encoding='utf8')])
         self.assertEqual(test_run_component_dict.get("configs")[0]["status"], "Not Available")
         self.assertEqual(test_run_component_dict.get("configs")[0]["name"], "with-security")
         self.assertEqual(test_run_component_dict.get("configs")[0]["yml"], "URL not available")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/without-security/local-cluster-logs/id-1/stdout.txt")

--- a/tests/tests_report_workflow/test_test_report_runner_dashboards.py
+++ b/tests/tests_report_workflow/test_test_report_runner_dashboards.py
@@ -1,0 +1,105 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+
+import os
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from manifests.test_manifest import TestManifest
+from report_workflow.test_report_runner import TestReportRunner
+from system.temporary_directory import TemporaryDirectory
+
+
+class TestTestReportRunnerDashboards(unittest.TestCase):
+    TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH = os.path.join(
+        os.path.dirname(__file__), "data", "test-manifest-opensearch-dashboards.yml"
+    )
+
+    TEST_MANIFEST_OPENSEARCH_DASHBOARDS = TestManifest.from_path(TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH)
+
+    @patch("report_workflow.report_args.ReportArgs")
+    @patch("manifests.test_manifest.TestManifest")
+    def test_runner_dashboards_init(self, report_args_mock: MagicMock, test_manifest_mock: MagicMock) -> None:
+        report_args_mock.test_manifest_path = self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH
+        report_args_mock.artifact_paths = {"opensearch-dashboards": "foo/bar"}
+        report_args_mock.test_run_id = 123
+        report_args_mock.test_type = "integ-test"
+
+        test_run_runner = TestReportRunner(report_args_mock, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS)
+        self.assertEqual(test_run_runner.name, "opensearch-dashboards")
+        self.assertEqual(test_run_runner.test_run_id, 123)
+        self.assertEqual(test_run_runner.test_type, "integ-test")
+        self.assertEqual(test_run_runner.test_manifest_path, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH)
+
+    @patch("yaml.safe_load")
+    @patch("urllib.request.urlopen")
+    @patch("validators.url")
+    @patch("report_workflow.report_args.ReportArgs")
+    def test_generate_file(self, report_args_mock: MagicMock, validators_mock: MagicMock, urlopen_mock: MagicMock,
+                           yaml_safe_load_mock: MagicMock) -> None:
+        report_args_mock.test_manifest_path = self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH
+        report_args_mock.artifact_paths = {"opensearch-dashboards": "foo/bar"}
+        report_args_mock.test_run_id = 123
+        report_args_mock.base_path = "https://ci.opensearch.org/ci/dbc/mock"
+        report_args_mock.test_type = "integ-test"
+
+        validators_mock.return_value = True
+        yaml_safe_load_mock.return_value = {"test_result": "PASS"}
+        urlopen_mock.return_value = MagicMock()
+
+        test_run_runner = TestReportRunner(report_args_mock, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS)
+        test_run_runner_data = test_run_runner.update_data()
+
+        with TemporaryDirectory() as path:
+            output_path = os.path.join(path.name, "test-report.yml")
+            test_run_runner.generate_report(test_run_runner_data, path.name)
+            self.assertTrue(os.path.isfile(output_path))
+
+    @patch("yaml.safe_load")
+    @patch("urllib.request.urlopen")
+    @patch("validators.url")
+    @patch("report_workflow.report_args.ReportArgs")
+    def test_runner_component_entry_url(self, report_args_mock: MagicMock, validators_mock: MagicMock,
+                                        urlopen_mock: MagicMock, yaml_safe_load_mock: MagicMock) -> None:
+        report_args_mock.test_manifest_path = self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH
+        report_args_mock.artifact_paths = {"opensearch-dashboards": "foo/bar"}
+        report_args_mock.test_run_id = 123
+        report_args_mock.base_path = "https://ci.opensearch.org/ci/dbc/mock"
+        report_args_mock.test_type = "integ-test"
+
+        validators_mock.return_value = True
+        yaml_safe_load_mock.return_value = {"test_result": "PASS"}
+        urlopen_mock.return_value = MagicMock()
+
+        test_run_component_dict = TestReportRunner(report_args_mock,
+                                                   self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS).component_entry(
+            "alertingDashboards")
+        urlopen_mock.assert_has_calls([call(
+            'https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/alertingDashboards/with-security/alertingDashboards.yml')])
+        self.assertEqual(test_run_component_dict.get("configs")[0]["status"], "PASS")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["name"], "with-security")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["yml"],
+                         "https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/alertingDashboards/with-security/alertingDashboards.yml")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/alertingDashboards/with-security/local-cluster-logs/id-0/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][1], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/alertingDashboards/with-security/local-cluster-logs/id-1/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stderr"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/alertingDashboards/with-security/local-cluster-logs/id-0/stderr.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stderr"][1], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/alertingDashboards/with-security/local-cluster-logs/id-1/stderr.txt")
+
+        self.assertEqual(test_run_component_dict.get("configs")[1]["name"], "without-security")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/alertingDashboards/without-security/local-cluster-logs/id-2/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stdout"][1], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/alertingDashboards/without-security/local-cluster-logs/id-3/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stderr"][0], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/alertingDashboards/without-security/local-cluster-logs/id-2/stderr.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stderr"][1], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/alertingDashboards/without-security/local-cluster-logs/id-3/stderr.txt")


### PR DESCRIPTION
### Description
This PR adds opensearch cluster stdout and stderr logs to test results manifest. Now the user will be able to see opensearch cluster logs for their component's integ test run. This will be helpful when the test results show as `N/A` and the users wants to know what went wrong. 

### Issues Resolved
#4335 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
