### PR TITLE
Tweak the path that get removed by osd plugin cleanups

### DIFF
--- a/scripts/components/ganttChartDashboards/build.sh
+++ b/scripts/components/ganttChartDashboards/build.sh
@@ -15,7 +15,7 @@ SCRIPT_DIR=`dirname $(realpath $0)`
 # For hybrid plugin it actually resides in 'dashboards-visualizations/gantt-chart'
 PLUGIN_FOLDER=$(basename "$PWD")
 PLUGIN_NAME=$(basename $(dirname "$PWD"))
-PLUGIN_PATH="../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER"
+PLUGIN_PATH=`realpath ../../OpenSearch-Dashboards/plugins/$PLUGIN_FOLDER`
 
 function usage() {
     echo "Usage: $0 [args]"

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -13,7 +13,7 @@ set -ex
 SCRIPT_DIR=`dirname $(realpath $0)`
 . $SCRIPT_DIR/../../../lib/shell/file_management.sh
 PLUGIN_NAME=$(basename "$PWD")
-PLUGIN_PATH="../OpenSearch-Dashboards/plugins/$PLUGIN_NAME"
+PLUGIN_PATH=`realpath ../OpenSearch-Dashboards/plugins/$PLUGIN_NAME`
 
 function usage() {
     echo "Usage: $0 [args]"


### PR DESCRIPTION
### Description
Tweak the path that get removed by osd plugin cleanups

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/4350

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
