### PR TITLE
Trigger manifest check only for mentioned paths

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -3,9 +3,9 @@ name: manifests
 
 on:
   pull_request:
-      - 'manifests/**/*.yml'
-      - '!manifests/templates/**/'
-      - 'legacy-manifests/**/*.yml'
+    - 'manifests/**/*.yml'
+    - '!manifests/templates/**/'
+    - 'legacy-manifests/**/*.yml'
 
 jobs:
   list-changed-manifests:

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -3,6 +3,9 @@ name: manifests
 
 on:
   pull_request:
+      - 'manifests/**/*.yml'
+      - '!manifests/templates/**/'
+      - 'legacy-manifests/**/*.yml'
 
 jobs:
   list-changed-manifests:

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -3,6 +3,7 @@ name: manifests
 
 on:
   pull_request:
+  paths:
     - 'manifests/**/*.yml'
     - '!manifests/templates/**/'
     - 'legacy-manifests/**/*.yml'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![python](https://github.com/opensearch-project/opensearch-build/actions/workflows/python-tests.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/python-tests.yml)
 [![groovy](https://github.com/opensearch-project/opensearch-build/actions/workflows/groovy-tests.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/groovy-tests.yml)
+[![manifests](https://github.com/opensearch-project/opensearch-build/actions/workflows/manifests.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/manifests.yml)
 [![codecov](https://codecov.io/gh/opensearch-project/opensearch-build/branch/main/graph/badge.svg?token=03S5XZ80UI)](https://codecov.io/gh/opensearch-project/opensearch-build)
 
 - [Releasing OpenSearch](#releasing-opensearch)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![python](https://github.com/opensearch-project/opensearch-build/actions/workflows/python-tests.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/python-tests.yml)
 [![groovy](https://github.com/opensearch-project/opensearch-build/actions/workflows/groovy-tests.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/groovy-tests.yml)
-[![manifests](https://github.com/opensearch-project/opensearch-build/actions/workflows/manifests.yml/badge.svg)](https://github.com/opensearch-project/opensearch-build/actions/workflows/manifests.yml)
 [![codecov](https://codecov.io/gh/opensearch-project/opensearch-build/branch/main/graph/badge.svg?token=03S5XZ80UI)](https://codecov.io/gh/opensearch-project/opensearch-build)
 
 - [Releasing OpenSearch](#releasing-opensearch)


### PR DESCRIPTION
### Description
Trigger manifest check only for mentioned paths. Currently they are triggered for all PRs. https://github.com/opensearch-project/opensearch-build/actions/workflows/manifests.yml and aborted later
Also fixes the badge in readme to green once the check are only related to actual run and not aborted ones

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
