### PR TITLE
Adds security to 1.3.15 and 1.4.0 manifests

### DIFF
--- a/manifests/1.3.15/opensearch-1.3.15.yml
+++ b/manifests/1.3.15/opensearch-1.3.15.yml
@@ -14,3 +14,9 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: '1.3'
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version

--- a/manifests/1.4.0/opensearch-1.4.0.yml
+++ b/manifests/1.4.0/opensearch-1.4.0.yml
@@ -26,3 +26,9 @@ components:
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: 1.x
+    checks:
+      - gradle:properties:version
+      - gradle:dependencies:opensearch.version


### PR DESCRIPTION
### Description
Security-dashboard's 1.x and 1.3 CI is currently blocked because opensearch-security-1.3.15.0 and opensearch-security-1.4.0.0 artifacts are not yet available.

This PR adds security to the appropriates manifests so that next build-run publishes these changes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
