### PR TITLE
Refactor and enable triggering integ-test for RPM, debian and windows

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -181,19 +181,7 @@ pipeline {
 
                             parallel([
                                 'integ-test': {
-                                    Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
-                                    echo "${skipIntegTests ? 'Skipping integration tests as one of the values has empty string: INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: false,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                booleanParam(name: 'UPDATE_GITHUB_ISSUES', value: true)
-                                            ]
-                                    }
+                                    triggerIntegrationTests(buildManifestUrl)
                                 },
                                 'bwc-test': {
                                     Boolean skipBwcTests = (BWC_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
@@ -210,7 +198,7 @@ pipeline {
                                             ]
                                     }
                                 }
-                            ])
+                                ])
                         }
                     }
                     post {
@@ -284,7 +272,7 @@ pipeline {
                                         if (params.CONTINUE_ON_ERROR) {
                                             markStageUnstableIfPluginsFailedToBuild()
                                         }
-                                        postCleanup()                                      
+                                        postCleanup()
                                     }
                                 }
                             }
@@ -318,16 +306,14 @@ pipeline {
                                     echo "artifactUrl (linux, x64, rpm): ${artifactUrl}"
 
                                     String bundleManifestUrl = buildManifestObj.getBundleManifestUrl(JOB_NAME, BUILD_NUMBER)
-
-                                    echo "Trigger rpm validation for linux x64 rpm ${bundleManifestUrl}"
-                                    def rpmValidationResults =
-                                        build job: 'rpm-validation',
-                                        propagate: false,
-                                        wait: false,
-                                        parameters: [
-                                            string(name: 'BUNDLE_MANIFEST_URL', value: bundleManifestUrl),
-                                            string(name: 'AGENT_LABEL', value: AGENT_LINUX_X64)
-                                        ]
+                                    parallel([
+                                        'integ-test': {
+                                            triggerIntegrationTests(buildManifestUrl)
+                                        },
+                                        'rpm-validation': {
+                                            triggerRpmValidation(bundleManifestUrl)
+                                        }
+                                    ])
                                 }
                             }
                             post {
@@ -400,7 +386,7 @@ pipeline {
                                         if (params.CONTINUE_ON_ERROR) {
                                             markStageUnstableIfPluginsFailedToBuild()
                                         }
-                                        postCleanup()                                      
+                                        postCleanup()
                                     }
                                 }
                             }
@@ -434,6 +420,7 @@ pipeline {
                                     echo "artifactUrl (linux, x64, deb): ${artifactUrl}"
 
                                     String bundleManifestUrl = buildManifestObj.getBundleManifestUrl(JOB_NAME, BUILD_NUMBER)
+                                    triggerIntegrationTests(buildManifestUrl)
                                 }
                             }
                             post {
@@ -502,24 +489,7 @@ pipeline {
 
                             echo "buildManifestUrl (linux, arm64, tar): ${buildManifestUrl}"
                             echo "artifactUrl (linux, arm64, tar): ${artifactUrl}"
-
-                            parallel([
-                                'integ-test': {
-                                    Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
-                                    echo "${skipIntegTests ? 'Skipping integration tests as one of the values has empty string: INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running integration tests'}"
-                                    if (!skipIntegTests) {
-                                        def integTestResults =
-                                            build job: INTEG_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: false,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                booleanParam(name: 'UPDATE_GITHUB_ISSUES', value: true)
-                                            ]
-                                    }
-                                }
-                            ])
+                            triggerIntegrationTests(buildManifestUrl)
                         }
                     }
                     post {
@@ -627,16 +597,14 @@ pipeline {
                                     echo "artifactUrl (linux, arm64, rpm): ${artifactUrl}"
 
                                     String bundleManifestUrl = buildManifestObj.getBundleManifestUrl(JOB_NAME, BUILD_NUMBER)
-
-                                    echo "Trigger rpm validation for linux arm64 rpm ${bundleManifestUrl}"
-                                    def rpmValidationResults =
-                                        build job: 'rpm-validation',
-                                        propagate: false,
-                                        wait: false,
-                                        parameters: [
-                                            string(name: 'BUNDLE_MANIFEST_URL', value: bundleManifestUrl),
-                                            string(name: 'AGENT_LABEL', value: AGENT_LINUX_ARM64)
-                                        ]
+                                    parallel([
+                                        'integ-test': {
+                                            triggerIntegrationTests(buildManifestUrl)
+                                        },
+                                        'rpm-validation': {
+                                            triggerRpmValidation(bundleManifestUrl)
+                                        }
+                                    ])
                                 }
                             }
                             post {
@@ -743,6 +711,7 @@ pipeline {
                                     echo "artifactUrl (linux, arm64, deb): ${artifactUrl}"
 
                                     String bundleManifestUrl = buildManifestObj.getBundleManifestUrl(JOB_NAME, BUILD_NUMBER)
+                                    triggerIntegrationTests(buildManifestUrl)
                                 }
                             }
                             post {
@@ -811,6 +780,7 @@ pipeline {
 
                             echo "buildManifestUrl (windows, x64, zip): ${buildManifestUrl}"
                             echo "artifactUrl (windows, x64, zip): ${artifactUrl}"
+                            triggerIntegrationTests(buildManifestUrl)
                         }
                     }
                     post {
@@ -959,7 +929,35 @@ pipeline {
 
 def markStageUnstableIfPluginsFailedToBuild() {
     def stageLogs = getLogsForStage(stageName: "${STAGE_NAME}")
-    if (stageLogs.any{e -> e.contains('Failed plugins are')}) {
+    if (stageLogs.any { e -> e.contains('Failed plugins are') }) {
         unstable('Some plugins failed to build. See the ./build.sh step for logs and more details')
+}
     }
+
+def triggerIntegrationTests(String buildManifestUrl) {
+    Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
+    echo "${skipIntegTests ? 'Skipping integration tests as one of the values has empty string: INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running integration tests'}"
+    if (!skipIntegTests) {
+        def integTestResults =
+                build job: INTEG_TEST_JOB_NAME,
+                propagate: false,
+                wait: false,
+                parameters: [
+                    string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                    string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                    booleanParam(name: 'UPDATE_GITHUB_ISSUES', value: true)
+                ]
+    }
+}
+
+def triggerRpmValidation(String bundleManifestUrl) {
+    echo "Triggering RPM validation for ${bundleManifestUrl}"
+    def rpmValidationResults =
+            build job: 'rpm-validation',
+            propagate: false,
+            wait: false,
+            parameters: [
+                string(name: 'BUNDLE_MANIFEST_URL', value: bundleManifestUrl),
+                string(name: 'AGENT_LABEL', value: AGENT_LINUX_X64)
+            ]
 }


### PR DESCRIPTION
### Description
1. Refactors triggering the integ-test and RPM validation workflow by reducing the code duplication
2. Enables integ-test for RPM, debian and Windows

### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-build/issues/2994

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
