### PR TITLE
Add option to validate with/without security  and new password for latest versions

### DIFF
--- a/src/test_workflow/integ_test/utils.py
+++ b/src/test_workflow/integ_test/utils.py
@@ -5,12 +5,16 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import base64
+
 import semver
 
 
-def get_password(version: str) -> str:
+def str_to_base64(value: str) -> str:
+    return base64.b64encode(value.encode("utf-8")).decode("utf-8")
+
+
+def get_password(version: str, convert_to_base64: bool = False) -> str:
     # Starting in 2.12.0, demo configuration setup script requires a strong password
-    if semver.compare(version, '2.12.0') != -1:
-        return "myStrongPassword123!"
-    else:
-        return "admin"
+    password = "myStrongPassword123!" if semver.compare(version, '2.12.0') != -1 else "admin"
+    return str_to_base64(password) if convert_to_base64 else password

--- a/src/validation_workflow/api_request.py
+++ b/src/validation_workflow/api_request.py
@@ -6,12 +6,11 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
-import base64
 from typing import Any
 
 import requests
 
-from test_workflow.integ_test.utils import get_password
+from test_workflow.integ_test.utils import get_password, str_to_base64
 
 """
 This class is to run API test againt on local OpenSearch API URL with default port 9200.
@@ -23,8 +22,7 @@ class ApiTest:
 
     def __init__(self, request_url: str, version: str) -> None:
         self.request_url = request_url
-        self.password = base64.b64encode(f"admin:{get_password(version)}".encode("utf-8")).decode("utf-8")
-        self.apiHeaders_auth = {"Authorization": f'Basic {self.password}'}  # user/pass "admin/pass" in Base64 format fetched from get_password() method
+        self.apiHeaders_auth = {"Authorization": f'Basic {str_to_base64("admin:" + get_password(version))}'}  # user/pass "admin/pass" in Base64 format fetched from get_password() method
         self.apiHeaders_accept = {"Accept": "*/*"}
         self.apiHeaders_content_type = {"Content-Type": "application/json"}
         self.apiHeaders = {}

--- a/src/validation_workflow/api_request.py
+++ b/src/validation_workflow/api_request.py
@@ -6,9 +6,12 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import base64
 from typing import Any
 
 import requests
+
+from test_workflow.integ_test.utils import get_password
 
 """
 This class is to run API test againt on local OpenSearch API URL with default port 9200.
@@ -18,9 +21,10 @@ It returns response status code and the response content.
 
 class ApiTest:
 
-    def __init__(self, request_url: str) -> None:
+    def __init__(self, request_url: str, version: str) -> None:
         self.request_url = request_url
-        self.apiHeaders_auth = {"Authorization": "Basic YWRtaW46YWRtaW4="}  # default user/pass "admin/admin" in Base64 format
+        self.password = base64.b64encode(f"admin:{get_password(version)}".encode("utf-8")).decode("utf-8")
+        self.apiHeaders_auth = {"Authorization": f'Basic {self.password}'}  # user/pass "admin/pass" in Base64 format fetched from get_password() method
         self.apiHeaders_accept = {"Accept": "*/*"}
         self.apiHeaders_content_type = {"Content-Type": "application/json"}
         self.apiHeaders = {}

--- a/src/validation_workflow/api_test_cases.py
+++ b/src/validation_workflow/api_test_cases.py
@@ -21,7 +21,7 @@ class ApiTestCases:
         pass
 
     @staticmethod
-    def test_apis(version: str, projects: list, allow_with_security: bool = True) -> Any:
+    def test_apis(version: str, projects: list, security_plugin_exists: bool = True) -> Any:
         pass_counter, fail_counter = 0, 0
 
         # the test case parameters are formated as ['<request_url>',<success_status_code>,'<validate_string(optional)>']
@@ -30,7 +30,8 @@ class ApiTestCases:
             ['https://localhost:9200/_cat/plugins?v', 200, ''],
             ['https://localhost:9200/_cat/health?v', 200, 'green'],
         ]
-        if not allow_with_security:
+        # Use http in the request url if the security plugin is absent
+        if not security_plugin_exists:
             for api in test_apis:
                 api[0] = "http" + api[0][5:]  # type: ignore
 

--- a/src/validation_workflow/api_test_cases.py
+++ b/src/validation_workflow/api_test_cases.py
@@ -21,7 +21,7 @@ class ApiTestCases:
         pass
 
     @staticmethod
-    def test_apis(projects: list) -> Any:
+    def test_apis(version: str, projects: list, allow_with_security: bool = True) -> Any:
         pass_counter, fail_counter = 0, 0
 
         # the test case parameters are formated as ['<request_url>',<success_status_code>,'<validate_string(optional)>']
@@ -30,6 +30,10 @@ class ApiTestCases:
             ['https://localhost:9200/_cat/plugins?v', 200, ''],
             ['https://localhost:9200/_cat/health?v', 200, 'green'],
         ]
+        if not allow_with_security:
+            for api in test_apis:
+                api[0] = "http" + api[0][5:]  # type: ignore
+
         if ("opensearch-dashboards" in projects):
             test_apis.append(['http://localhost:5601/api/status', 200, ''])
 
@@ -38,7 +42,7 @@ class ApiTestCases:
             success_status_code = test_api.__getitem__(1)
             validate_string = test_api.__getitem__(2)
 
-            status_code, response_text = ApiTest(str(request_url)).api_get()
+            status_code, response_text = ApiTest(str(request_url), version).api_get()
             logging.info(f"\nRequest_url ->{str(request_url)} \n")
             logging.info(f"\nStatus_code ->{status_code} \nresponse_text ->{response_text}")
 

--- a/src/validation_workflow/api_test_cases.py
+++ b/src/validation_workflow/api_test_cases.py
@@ -23,17 +23,14 @@ class ApiTestCases:
     @staticmethod
     def test_apis(version: str, projects: list, security_plugin_exists: bool = True) -> Any:
         pass_counter, fail_counter = 0, 0
+        protocol_prefix = "https" if security_plugin_exists else "http"
 
         # the test case parameters are formated as ['<request_url>',<success_status_code>,'<validate_string(optional)>']
         test_apis = [
-            ['https://localhost:9200/', 200, ''],
-            ['https://localhost:9200/_cat/plugins?v', 200, ''],
-            ['https://localhost:9200/_cat/health?v', 200, 'green'],
+            [f'{protocol_prefix}://localhost:9200/', 200, ''],
+            [f'{protocol_prefix}://localhost:9200/_cat/plugins?v', 200, ''],
+            [f'{protocol_prefix}://localhost:9200/_cat/health?v', 200, 'green'],
         ]
-        # Use http in the request url if the security plugin is absent
-        if not security_plugin_exists:
-            for api in test_apis:
-                api[0] = "http" + api[0][5:]  # type: ignore
 
         if ("opensearch-dashboards" in projects):
             test_apis.append(['http://localhost:5601/api/status', 200, ''])

--- a/src/validation_workflow/docker/validation_docker.py
+++ b/src/validation_workflow/docker/validation_docker.py
@@ -83,7 +83,7 @@ class ValidateDocker(Validation):
 
                 if self.check_cluster_readiness():
                     # STEP 4 . OS, OSD API validation
-                    _test_result, _counter = ApiTestCases().test_apis(self.args.projects)
+                    _test_result, _counter = ApiTestCases().test_apis(self.args.version, self.args.projects, True)
 
                     if _test_result:
                         logging.info(f'All tests Pass : {_counter}')
@@ -137,7 +137,7 @@ class ValidateDocker(Validation):
 
         for url, name in self.test_readiness_urls.items():
             try:
-                status_code, response_text = ApiTest(url).api_get()
+                status_code, response_text = ApiTest(url, self.args.version).api_get()
                 if status_code != 200:
                     logging.error(f'Error connecting to {name} ({url}): status code {status_code}')
                     return False

--- a/src/validation_workflow/rpm/validation_rpm.py
+++ b/src/validation_workflow/rpm/validation_rpm.py
@@ -70,7 +70,7 @@ class ValidateRpm(Validation, DownloadUtils):
         return True
 
     def validation(self) -> bool:
-        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch"), "rpm") if not self.args.force_https_check else True)  # noqa: E501
+        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch")) if not self.args.force_https else True)  # noqa: E501
         if (test_result):
             logging.info(f'All tests Pass : {counter}')
             return True

--- a/src/validation_workflow/rpm/validation_rpm.py
+++ b/src/validation_workflow/rpm/validation_rpm.py
@@ -50,9 +50,6 @@ class ValidateRpm(Validation, DownloadUtils):
                 self.filename = os.path.basename(self.args.file_path.get(project))
                 execute(f'sudo yum remove {project} -y', ".")
                 execute(f'sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD={get_password(str(self.args.version))} rpm -ivh {os.path.join(self.tmp_dir.path, self.filename)}', str(self.tmp_dir.path), True, False)  # noqa: 501
-
-            if self.args.allow_without_security:
-                self.args.allow_without_security = self.test_security_plugin("/usr/")
         except:
             raise Exception('Failed to install Opensearch')
         return True
@@ -73,7 +70,7 @@ class ValidateRpm(Validation, DownloadUtils):
         return True
 
     def validation(self) -> bool:
-        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.args.allow_without_security)
+        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch"), "rpm") if not self.args.force_https_check else True)  # noqa: E501
         if (test_result):
             logging.info(f'All tests Pass : {counter}')
             return True

--- a/src/validation_workflow/rpm/validation_rpm.py
+++ b/src/validation_workflow/rpm/validation_rpm.py
@@ -73,7 +73,7 @@ class ValidateRpm(Validation, DownloadUtils):
 
     def validation(self) -> bool:
         test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.args.allow_without_security)
-        if(test_result):
+        if (test_result):
             logging.info(f'All tests Pass : {counter}')
             return True
         else:

--- a/src/validation_workflow/rpm/validation_rpm.py
+++ b/src/validation_workflow/rpm/validation_rpm.py
@@ -11,6 +11,7 @@ import time
 
 from system.execute import execute
 from system.temporary_directory import TemporaryDirectory
+from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.download_utils import DownloadUtils
 from validation_workflow.validation import Validation
@@ -47,7 +48,10 @@ class ValidateRpm(Validation, DownloadUtils):
             for project in self.args.projects:
                 self.filename = os.path.basename(self.args.file_path.get(project))
                 execute(f'sudo yum remove {project} -y', ".")
-                execute(f'sudo rpm -ivh {os.path.join(self.tmp_dir.path, self.filename)}', str(self.tmp_dir.path), True, False)
+                execute(f'sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD={get_password(str(self.args.version))} rpm -ivh {os.path.join(self.tmp_dir.path, self.filename)}', str(self.tmp_dir.path), True, False)  # noqa: 501
+
+            if self.args.allow_without_security:
+                self.args.allow_without_security = self.test_security_plugin("/usr/")
         except:
             raise Exception('Failed to install Opensearch')
         return True
@@ -57,7 +61,7 @@ class ValidateRpm(Validation, DownloadUtils):
             for project in self.args.projects:
                 execute(f'sudo systemctl start {project}', ".")
                 time.sleep(20)
-                (stdout, stderr, status) = execute(f'sudo systemctl status {project}', ".")
+                (stdout, stderr, status) = execute(f'sudo systemctl status {project}', ".", True, False)
                 if(status == 0):
                     logging.info(stdout)
                 else:
@@ -68,8 +72,8 @@ class ValidateRpm(Validation, DownloadUtils):
         return True
 
     def validation(self) -> bool:
-        test_result, counter = ApiTestCases().test_apis(self.args.projects)
-        if (test_result):
+        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.args.allow_without_security)
+        if(test_result):
             logging.info(f'All tests Pass : {counter}')
             return True
         else:

--- a/src/validation_workflow/rpm/validation_rpm.py
+++ b/src/validation_workflow/rpm/validation_rpm.py
@@ -33,6 +33,7 @@ class ValidateRpm(Validation, DownloadUtils):
                 if ("https:" not in self.args.file_path.get(project)):
                     self.copy_artifact(self.args.file_path.get(project), str(self.tmp_dir.path))
                 else:
+                    self.args.version = self.get_version(self.args.file_path.get(project))
                     self.check_url(self.args.file_path.get(project))
             else:
                 if (self.args.artifact_type == "staging"):
@@ -61,7 +62,7 @@ class ValidateRpm(Validation, DownloadUtils):
             for project in self.args.projects:
                 execute(f'sudo systemctl start {project}', ".")
                 time.sleep(20)
-                (stdout, stderr, status) = execute(f'sudo systemctl status {project}', ".", True, False)
+                (stdout, stderr, status) = execute(f'sudo systemctl status {project}', ".")
                 if(status == 0):
                     logging.info(stdout)
                 else:

--- a/src/validation_workflow/tar/validation_tar.py
+++ b/src/validation_workflow/tar/validation_tar.py
@@ -68,7 +68,7 @@ class ValidateTar(Validation, DownloadUtils):
         return True
 
     def validation(self) -> bool:
-        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(self.tmp_dir.path, "opensearch"), "tar") if not self.args.force_https_check else True)  # noqa: E501
+        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(self.tmp_dir.path, "opensearch")) if not self.args.force_https else True)  # noqa: E501
         if (test_result):
             logging.info(f'All tests Pass : {counter}')
         else:

--- a/src/validation_workflow/tar/validation_tar.py
+++ b/src/validation_workflow/tar/validation_tar.py
@@ -51,8 +51,6 @@ class ValidateTar(Validation, DownloadUtils):
             for project in self.args.projects:
                 self.filename = os.path.basename(self.args.file_path.get(project))
                 execute('mkdir ' + os.path.join(self.tmp_dir.path, project) + ' | tar -xzf ' + os.path.join(str(self.tmp_dir.path), self.filename) + ' -C ' + os.path.join(self.tmp_dir.path, project) + ' --strip-components=1', ".", True, False)  # noqa: E501
-            if self.args.allow_without_security:
-                self.args.allow_without_security = self.test_security_plugin(str(self.tmp_dir.path))
         except:
             raise Exception('Failed to install Opensearch')
         return True
@@ -70,8 +68,7 @@ class ValidateTar(Validation, DownloadUtils):
         return True
 
     def validation(self) -> bool:
-
-        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.args.allow_without_security)
+        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(self.tmp_dir.path, "opensearch"), "tar") if not self.args.force_https_check else True)  # noqa: E501
         if (test_result):
             logging.info(f'All tests Pass : {counter}')
         else:

--- a/src/validation_workflow/tar/validation_tar.py
+++ b/src/validation_workflow/tar/validation_tar.py
@@ -36,6 +36,7 @@ class ValidateTar(Validation, DownloadUtils):
                 if ("https:" not in self.args.file_path.get(project)):
                     self.copy_artifact(self.args.file_path.get(project), str(self.tmp_dir.path))
                 else:
+                    self.args.version = self.get_version(self.args.file_path.get(project))
                     self.check_url(self.args.file_path.get(project))
             else:
                 if (self.args.artifact_type == "staging"):

--- a/src/validation_workflow/validation.py
+++ b/src/validation_workflow/validation.py
@@ -40,10 +40,10 @@ class Validation(ABC):
             raise Exception("Provided path for local artifacts does not exist")
 
     def test_security_plugin(self, work_dir: str) -> bool:
-        (_, stdout_1, _) = execute(f'find {work_dir} -type f -iname \'opensearch-plugin\'', ".", True, False)
-        if (stdout_1):
-            (_, stdout_2, _) = execute("./opensearch-plugin list", stdout_1.replace("opensearch-plugin", "").rstrip("\n"), True, False)
-            return "opensearch-security" in stdout_2
+        (_, path, _) = execute(f'find {work_dir} -type f -iname \'opensearch-plugin\'', ".", True, False)
+        if (path):
+            (_, list_plugins, _) = execute("./opensearch-plugin list", path.replace("opensearch-plugin", "").rstrip("\n"), True, False)
+            return "opensearch-security" in list_plugins
         else:
             raise Exception("Couldn't fetch the path to plugin folder")
 

--- a/src/validation_workflow/validation.py
+++ b/src/validation_workflow/validation.py
@@ -11,6 +11,7 @@ import shutil
 from abc import ABC, abstractmethod
 from typing import Any
 
+from system.execute import execute
 from validation_workflow.download_utils import DownloadUtils
 from validation_workflow.validation_args import ValidationArgs
 
@@ -37,6 +38,14 @@ class Validation(ABC):
             return True
         else:
             raise Exception("Provided path for local artifacts does not exist")
+
+    def test_security_plugin(self, work_dir: str) -> bool:
+        (_, stdout_1, _) = execute(f'find {work_dir} -type f -iname \'opensearch-plugin\'', ".", True, False)
+        if (stdout_1):
+            (_, stdout_2, _) = execute("./opensearch-plugin list", stdout_1.replace("opensearch-plugin", "").rstrip("\n"), True, False)
+            return "opensearch-security" in stdout_2
+        else:
+            raise Exception("Couldn't fetch the path to plugin folder")
 
     def run(self) -> Any:
         try:

--- a/src/validation_workflow/validation.py
+++ b/src/validation_workflow/validation.py
@@ -13,7 +13,6 @@ import shutil
 from abc import ABC, abstractmethod
 from typing import Any
 
-from system.execute import execute
 from validation_workflow.download_utils import DownloadUtils
 from validation_workflow.validation_args import ValidationArgs
 
@@ -41,10 +40,9 @@ class Validation(ABC):
         else:
             raise Exception("Provided path for local artifacts does not exist")
 
-    def check_for_security_plugin(self, work_dir: str, distribution: str) -> bool:
-        list_cmd = "dir" if distribution == "zip" else "ls"
-        (_, plugins_list, _) = execute(f"{list_cmd} plugins", work_dir, True, False)
-        return "opensearch-security" in plugins_list
+    def check_for_security_plugin(self, work_dir: str) -> bool:
+        path = os.path.exists(os.path.join(work_dir, "plugins", "opensearch-security"))
+        return path
 
     def get_version(self, project: str) -> str:
         return re.search(r'(\d+\.\d+\.\d+)', os.path.basename(project)).group(1)

--- a/src/validation_workflow/validation.py
+++ b/src/validation_workflow/validation.py
@@ -7,6 +7,8 @@
 
 
 import logging
+import os
+import re
 import shutil
 from abc import ABC, abstractmethod
 from typing import Any
@@ -46,6 +48,9 @@ class Validation(ABC):
             return "opensearch-security" in list_plugins
         else:
             raise Exception("Couldn't fetch the path to plugin folder")
+
+    def get_version(self, project: str) -> str:
+        return re.search(r'(\d+\.\d+\.\d+)', os.path.basename(project)).group(1)
 
     def run(self) -> Any:
         try:

--- a/src/validation_workflow/validation.py
+++ b/src/validation_workflow/validation.py
@@ -41,13 +41,10 @@ class Validation(ABC):
         else:
             raise Exception("Provided path for local artifacts does not exist")
 
-    def test_security_plugin(self, work_dir: str) -> bool:
-        (_, path, _) = execute(f'find {work_dir} -type f -iname \'opensearch-plugin\'', ".", True, False)
-        if (path):
-            (_, list_plugins, _) = execute("./opensearch-plugin list", path.replace("opensearch-plugin", "").rstrip("\n"), True, False)
-            return "opensearch-security" in list_plugins
-        else:
-            raise Exception("Couldn't fetch the path to plugin folder")
+    def check_for_security_plugin(self, work_dir: str, distribution: str) -> bool:
+        list_cmd = "dir" if distribution == "zip" else "ls"
+        (_, plugins_list, _) = execute(f"{list_cmd} plugins", work_dir, True, False)
+        return "opensearch-security" in plugins_list
 
     def get_version(self, project: str) -> str:
         return re.search(r'(\d+\.\d+\.\d+)', os.path.basename(project)).group(1)

--- a/src/validation_workflow/validation_args.py
+++ b/src/validation_workflow/validation_args.py
@@ -109,7 +109,14 @@ class ValidationArgs:
             help="Enter type of artifacts that needs to be validated",
             choices=["staging", "production"],
             default="production",
-            dest="artifact_type",
+            dest="artifact_type"
+        )
+        parser.add_argument(
+            "-s",
+            "--allow-without-security",
+            action="store_true",
+            default=False,
+            help="Allow Validation without security"
         )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
@@ -136,6 +143,7 @@ class ValidationArgs:
         self.version = args.version
         self.file_path = args.file_path
         self.artifact_type = args.artifact_type
+        self.allow_without_security = args.allow_without_security
         self.logging_level = args.logging_level
         self.distribution = args.distribution
         self.platform = args.platform

--- a/src/validation_workflow/validation_args.py
+++ b/src/validation_workflow/validation_args.py
@@ -112,11 +112,11 @@ class ValidationArgs:
             dest="artifact_type"
         )
         parser.add_argument(
-            "-s",
-            "--allow-without-security",
+            "-f",
+            "--force-https-check",
             action="store_true",
-            default=False,
-            help="Allow Validation without security"
+            default=True,
+            help="If False then check for the existence of security plugin and use http/https as required, else force to check to https"
         )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
@@ -143,7 +143,7 @@ class ValidationArgs:
         self.version = args.version
         self.file_path = args.file_path
         self.artifact_type = args.artifact_type
-        self.allow_without_security = args.allow_without_security
+        self.force_https_check = args.force_https_check
         self.logging_level = args.logging_level
         self.distribution = args.distribution
         self.platform = args.platform

--- a/src/validation_workflow/validation_args.py
+++ b/src/validation_workflow/validation_args.py
@@ -113,10 +113,10 @@ class ValidationArgs:
         )
         parser.add_argument(
             "-f",
-            "--force-https-check",
+            "--force-https",
             action="store_true",
             default=True,
-            help="If False then check for the existence of security plugin and use http/https as required, else force to check to https"
+            help="If False, use http/https to connect based on the existence of security plugin, else always use https, default to True"
         )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
@@ -143,7 +143,7 @@ class ValidationArgs:
         self.version = args.version
         self.file_path = args.file_path
         self.artifact_type = args.artifact_type
-        self.force_https_check = args.force_https_check
+        self.force_https = args.force_https
         self.logging_level = args.logging_level
         self.distribution = args.distribution
         self.platform = args.platform

--- a/src/validation_workflow/yum/validation_yum.py
+++ b/src/validation_workflow/yum/validation_yum.py
@@ -70,7 +70,7 @@ class ValidateYum(Validation, DownloadUtils):
         return True
 
     def validation(self) -> bool:
-        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch"), "yum") if not self.args.force_https_check else True)  # noqa: E501
+        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch")) if not self.args.force_https else True)  # noqa: E501
         if (test_result):
             logging.info(f'All tests Pass : {counter}')
             return True

--- a/src/validation_workflow/yum/validation_yum.py
+++ b/src/validation_workflow/yum/validation_yum.py
@@ -54,8 +54,7 @@ class ValidateYum(Validation, DownloadUtils):
                 urllink = f"{self.args.file_path.get(project)} -o /etc/yum.repos.d/{os.path.basename(self.args.file_path.get(project))}"
                 execute(f'sudo curl -SL {urllink}', ".")
                 execute(f"sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD={get_password(str(self.args.version))} yum install '{project}-{self.args.version}' -y", ".")
-            if self.args.allow_without_security:
-                self.args.allow_without_security = self.test_security_plugin("/usr/")
+
         except:
             raise Exception('Failed to install Opensearch')
         return True
@@ -71,7 +70,7 @@ class ValidateYum(Validation, DownloadUtils):
         return True
 
     def validation(self) -> bool:
-        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.args.allow_without_security)
+        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch"), "yum") if not self.args.force_https_check else True)  # noqa: E501
         if (test_result):
             logging.info(f'All tests Pass : {counter}')
             return True

--- a/src/validation_workflow/yum/validation_yum.py
+++ b/src/validation_workflow/yum/validation_yum.py
@@ -12,6 +12,7 @@ import time
 
 from system.execute import execute
 from system.temporary_directory import TemporaryDirectory
+from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.download_utils import DownloadUtils
 from validation_workflow.validation import Validation
@@ -53,7 +54,9 @@ class ValidateYum(Validation, DownloadUtils):
                 logging.info('Removed previous versions of Opensearch')
                 urllink = f"{self.args.file_path.get(project)} -o /etc/yum.repos.d/{os.path.basename(self.args.file_path.get(project))}"
                 execute(f'sudo curl -SL {urllink}', ".")
-                execute(f"sudo yum install '{project}-{self.args.version}' -y", ".")
+                execute(f"sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD={get_password(str(self.args.version))} yum install '{project}-{self.args.version}' -y", ".")
+            if self.args.allow_without_security:
+                self.args.allow_without_security = self.test_security_plugin("/usr/")
         except:
             raise Exception('Failed to install Opensearch')
         return True
@@ -69,12 +72,12 @@ class ValidateYum(Validation, DownloadUtils):
         return True
 
     def validation(self) -> bool:
-        test_result, counter = ApiTestCases().test_apis(self.args.projects)
+        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.args.allow_without_security)
         if (test_result):
             logging.info(f'All tests Pass : {counter}')
             return True
         else:
-            raise Exception(f'Some test cases failed : {counter}')
+            raise Exception(f'Not all tests Pass : {counter}')
 
     def cleanup(self) -> bool:
         try:

--- a/src/validation_workflow/yum/validation_yum.py
+++ b/src/validation_workflow/yum/validation_yum.py
@@ -7,7 +7,6 @@
 
 import logging
 import os
-import re
 import time
 
 from system.execute import execute
@@ -34,7 +33,7 @@ class ValidateYum(Validation, DownloadUtils):
                 if ("https:" not in self.args.file_path.get(project)):
                     self.copy_artifact(self.args.file_path.get(project), str(self.tmp_dir.path))
                 else:
-                    self.args.version = re.search(r'(\d+\.\d+\.\d+)', os.path.basename(self.args.file_path.get(project))).group(1)
+                    self.args.version = self.get_version(self.args.file_path.get(project))
                     self.check_url(self.args.file_path.get(project))
 
             else:

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_utils.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_utils.py
@@ -5,12 +5,20 @@
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
 
+import base64
 import unittest
 
-from test_workflow.integ_test.utils import get_password
+from test_workflow.integ_test.utils import get_password, str_to_base64
 
 
 class TestUtils(unittest.TestCase):
     def test_strong_password(self) -> None:
         self.assertEqual("admin", get_password("2.11.1"))
         self.assertEqual("myStrongPassword123!", get_password("3.0.0"))
+        self.assertEqual("YWRtaW4=", get_password("2.11.1", True))
+        self.assertEqual("bXlTdHJvbmdQYXNzd29yZDEyMyE=", get_password("2.12.0", True))
+
+    def test_str_to_base64(self) -> None:
+        value = "admin"
+        result = base64.b64encode(value.encode("utf-8")).decode("utf-8")
+        self.assertEqual(str_to_base64(value), result)

--- a/tests/tests_validation_workflow/test_api_request.py
+++ b/tests/tests_validation_workflow/test_api_request.py
@@ -14,11 +14,22 @@ from validation_workflow.api_request import ApiTest
 class TestApiTest(unittest.TestCase):
 
     @patch('validation_workflow.api_request.requests.get')
+    def test_api_get_new_password(self, mock_get: Mock) -> None:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.text = '{"key": "value"}'
+        request_url = 'https://localhost:9200'
+        api_test = ApiTest(request_url, "2.12.0")
+        status_code, response_text = api_test.api_get()
+        self.assertEqual(status_code, 200)
+        self.assertEqual(response_text, '{"key": "value"}')
+        mock_get.assert_called_once_with(request_url, headers={'Authorization': 'Basic YWRtaW46bXlTdHJvbmdQYXNzd29yZDEyMyE=', 'Accept': '*/*', 'Content-Type': 'application/json'}, verify=False)
+
+    @patch('validation_workflow.api_request.requests.get')
     def test_api_get(self, mock_get: Mock) -> None:
         mock_get.return_value.status_code = 200
         mock_get.return_value.text = '{"key": "value"}'
-        request_url = 'http://localhost:9200'
-        api_test = ApiTest(request_url)
+        request_url = 'https://localhost:9200'
+        api_test = ApiTest(request_url, "2.3.0")
         status_code, response_text = api_test.api_get()
         self.assertEqual(status_code, 200)
         self.assertEqual(response_text, '{"key": "value"}')

--- a/tests/tests_validation_workflow/test_api_test_cases.py
+++ b/tests/tests_validation_workflow/test_api_test_cases.py
@@ -16,7 +16,7 @@ class TestTestCases(unittest.TestCase):
     def test_opensearch(self, mock_api_get: Mock) -> None:
         mock_api_get.return_value = (200, 'green')
         testcases = ApiTestCases()
-        result = testcases.test_apis(['opensearch'])
+        result = testcases.test_apis("1.3.0", ['opensearch'])
 
         self.assertEqual(result[1], 'There are 3/3 test cases Pass')
         self.assertEqual(mock_api_get.call_count, 3)
@@ -25,7 +25,7 @@ class TestTestCases(unittest.TestCase):
     def test_both(self, mock_api_get: Mock) -> None:
         mock_api_get.return_value = (200, 'green')
         testcases = ApiTestCases()
-        result = testcases.test_apis(['opensearch', 'opensearch-dashboards'])
+        result = testcases.test_apis("2.1.1", ['opensearch', 'opensearch-dashboards'])
 
         self.assertEqual(result[1], 'There are 4/4 test cases Pass')
         self.assertEqual(mock_api_get.call_count, 4)

--- a/tests/tests_validation_workflow/test_api_test_cases.py
+++ b/tests/tests_validation_workflow/test_api_test_cases.py
@@ -30,6 +30,15 @@ class TestTestCases(unittest.TestCase):
         self.assertEqual(result[1], 'There are 4/4 test cases Pass')
         self.assertEqual(mock_api_get.call_count, 4)
 
+    @patch('validation_workflow.api_test_cases.ApiTest.api_get')
+    def test_without_security(self, mock_api_get: Mock) -> None:
+        mock_api_get.return_value = (200, 'green')
+        testcases = ApiTestCases()
+        result = testcases.test_apis("1.3.0", ['opensearch'], False)
+
+        self.assertEqual(result[1], 'There are 3/3 test cases Pass')
+        self.assertEqual(mock_api_get.call_count, 3)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests_validation_workflow/test_api_test_cases.py
+++ b/tests/tests_validation_workflow/test_api_test_cases.py
@@ -16,7 +16,7 @@ class TestTestCases(unittest.TestCase):
     def test_opensearch(self, mock_api_get: Mock) -> None:
         mock_api_get.return_value = (200, 'green')
         testcases = ApiTestCases()
-        result = testcases.test_apis("1.3.0", ['opensearch'])
+        result = testcases.test_apis("1.3.0", ['opensearch'], True)
 
         self.assertEqual(result[1], 'There are 3/3 test cases Pass')
         self.assertEqual(mock_api_get.call_count, 3)
@@ -25,7 +25,7 @@ class TestTestCases(unittest.TestCase):
     def test_both(self, mock_api_get: Mock) -> None:
         mock_api_get.return_value = (200, 'green')
         testcases = ApiTestCases()
-        result = testcases.test_apis("2.1.1", ['opensearch', 'opensearch-dashboards'])
+        result = testcases.test_apis("2.1.1", ['opensearch', 'opensearch-dashboards'], True)
 
         self.assertEqual(result[1], 'There are 4/4 test cases Pass')
         self.assertEqual(mock_api_get.call_count, 4)

--- a/tests/tests_validation_workflow/test_validation.py
+++ b/tests/tests_validation_workflow/test_validation.py
@@ -61,3 +61,40 @@ class TestValidation(unittest.TestCase):
 
         result = mock_validation.copy_artifact(url, "tmp/tthcdhfh/")
         self.assertTrue(result)
+
+    @patch('validation_workflow.validation.execute')
+    @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    def test_is_allow_with_security_true(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
+        mock_execute.return_value = (0, "opensearch-security", "")
+
+        mock_validation_args.projects.return_value = ["opensearch"]
+        mock_validation = ValidateTar(mock_validation_args.return_value)
+
+        result = mock_validation.test_security_plugin("/bin/opensearch")
+
+        self.assertTrue(result)
+
+    @patch('validation_workflow.validation.execute')
+    @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    def test_is_allow_with_security_false(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
+        mock_execute.return_value = (0, "opensearch", "")
+
+        mock_validation_args.projects.return_value = ["opensearch"]
+        mock_validation = ValidateTar(mock_validation_args.return_value)
+
+        result = mock_validation.test_security_plugin("/bin/opensearch")
+
+        self.assertFalse(result)
+
+    @patch('validation_workflow.validation.execute')
+    @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    def test_is_allow_with_security_exception(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
+        mock_execute.return_value = (0, "", "error")
+
+        mock_validation_args.projects.return_value = ["opensearch"]
+        mock_validation = ValidateTar(mock_validation_args.return_value)
+
+        with self.assertRaises(Exception) as context:
+            mock_validation.test_security_plugin("/bin/opensearch")
+
+        self.assertEqual(str(context.exception), "Couldn't fetch the path to plugin folder")

--- a/tests/tests_validation_workflow/test_validation.py
+++ b/tests/tests_validation_workflow/test_validation.py
@@ -64,37 +64,24 @@ class TestValidation(unittest.TestCase):
 
     @patch('validation_workflow.validation.execute')
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_is_allow_with_security_true(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
+    def test_check_for_security_plugin_true(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
         mock_execute.return_value = (0, "opensearch-security", "")
 
         mock_validation_args.projects.return_value = ["opensearch"]
         mock_validation = ValidateTar(mock_validation_args.return_value)
 
-        result = mock_validation.test_security_plugin("/bin/opensearch")
+        result = mock_validation.check_for_security_plugin("/tmp/tmkuiuo/opensearch", "tar")
 
         self.assertTrue(result)
 
     @patch('validation_workflow.validation.execute')
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_is_allow_with_security_false(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
+    def test_check_for_security_plugin_false(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
         mock_execute.return_value = (0, "opensearch", "")
 
         mock_validation_args.projects.return_value = ["opensearch"]
         mock_validation = ValidateTar(mock_validation_args.return_value)
 
-        result = mock_validation.test_security_plugin("/bin/opensearch")
+        result = mock_validation.check_for_security_plugin("/bin/opensearch", "tar")
 
         self.assertFalse(result)
-
-    @patch('validation_workflow.validation.execute')
-    @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_is_allow_with_security_exception(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
-        mock_execute.return_value = (0, "", "error")
-
-        mock_validation_args.projects.return_value = ["opensearch"]
-        mock_validation = ValidateTar(mock_validation_args.return_value)
-
-        with self.assertRaises(Exception) as context:
-            mock_validation.test_security_plugin("/bin/opensearch")
-
-        self.assertEqual(str(context.exception), "Couldn't fetch the path to plugin folder")

--- a/tests/tests_validation_workflow/test_validation.py
+++ b/tests/tests_validation_workflow/test_validation.py
@@ -62,26 +62,14 @@ class TestValidation(unittest.TestCase):
         result = mock_validation.copy_artifact(url, "tmp/tthcdhfh/")
         self.assertTrue(result)
 
-    @patch('validation_workflow.validation.execute')
+    @patch('os.path.exists')
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_check_for_security_plugin_true(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
-        mock_execute.return_value = (0, "opensearch-security", "")
+    def test_check_for_security_plugin(self, mock_validation_args: Mock, mock_path_exists: Mock) -> None:
+        mock_path_exists.return_value = True
 
         mock_validation_args.projects.return_value = ["opensearch"]
         mock_validation = ValidateTar(mock_validation_args.return_value)
 
-        result = mock_validation.check_for_security_plugin("/tmp/tmkuiuo/opensearch", "tar")
+        result = mock_validation.check_for_security_plugin("/tmp/tmkuiuo/opensearch")
 
         self.assertTrue(result)
-
-    @patch('validation_workflow.validation.execute')
-    @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_check_for_security_plugin_false(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
-        mock_execute.return_value = (0, "opensearch", "")
-
-        mock_validation_args.projects.return_value = ["opensearch"]
-        mock_validation = ValidateTar(mock_validation_args.return_value)
-
-        result = mock_validation.check_for_security_plugin("/bin/opensearch", "tar")
-
-        self.assertFalse(result)

--- a/tests/tests_validation_workflow/test_validation_args.py
+++ b/tests/tests_validation_workflow/test_validation_args.py
@@ -67,6 +67,10 @@ class TestValidationArgs(unittest.TestCase):
     def test_artifact_type(self) -> None:
         self.assertNotEqual(ValidationArgs().artifact_type, "production")
 
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.6", "--distribution", "rpm", "--artifact-type", "staging", "--os-build-number", "1234", "--osd-build-number", "2312", "--allow-without-security"])  # noqa: E501
+    def test_allow_without_security(self) -> None:
+        self.assertEqual(ValidationArgs().allow_without_security, True)
+
     @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.0", "--projects", "opensearch"])
     def test_set_projects(self) -> None:
         self.assertEqual(ValidationArgs().projects, ["opensearch"])

--- a/tests/tests_validation_workflow/test_validation_args.py
+++ b/tests/tests_validation_workflow/test_validation_args.py
@@ -67,9 +67,9 @@ class TestValidationArgs(unittest.TestCase):
     def test_artifact_type(self) -> None:
         self.assertNotEqual(ValidationArgs().artifact_type, "production")
 
-    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.6", "--distribution", "rpm", "--artifact-type", "staging", "--os-build-number", "1234", "--osd-build-number", "2312", "--allow-without-security"])  # noqa: E501
-    def test_allow_without_security(self) -> None:
-        self.assertEqual(ValidationArgs().allow_without_security, True)
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.6", "--distribution", "rpm", "--artifact-type", "staging", "--os-build-number", "1234", "--osd-build-number", "2312", "--force-https-check"])  # noqa: E501
+    def test_force_https_check(self) -> None:
+        self.assertEqual(ValidationArgs().force_https_check, True)
 
     @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.0", "--projects", "opensearch"])
     def test_set_projects(self) -> None:
@@ -82,7 +82,7 @@ class TestValidationArgs(unittest.TestCase):
             self.assertEqual(ValidationArgs().projects, ["opensearch-dashboards"])
         self.assertEqual(str(ctx.exception), "Missing OpenSearch OpenSearch artifact details! Please provide the same along with OpenSearch-Dashboards to validate")
 
-    @patch("argparse._sys.argv", [VALIDATION_PY, "--file-path", "opensearch=https://opensearch.org/releases/opensearch/2.8.0/opensearch-2.8.0-linux-x64.zip"])
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--file-path", "opensearch=https://opensearch.org/releases/opensearch/2.8.0/opensearch-2.8.0-linux-x64.xyz"])
     def test_file_path_distribution_type(self) -> None:
         with self.assertRaises(Exception) as ctx:
             self.assertEqual(ValidationArgs().projects, ["opensearch"])

--- a/tests/tests_validation_workflow/test_validation_args.py
+++ b/tests/tests_validation_workflow/test_validation_args.py
@@ -67,9 +67,9 @@ class TestValidationArgs(unittest.TestCase):
     def test_artifact_type(self) -> None:
         self.assertNotEqual(ValidationArgs().artifact_type, "production")
 
-    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.6", "--distribution", "rpm", "--artifact-type", "staging", "--os-build-number", "1234", "--osd-build-number", "2312", "--force-https-check"])  # noqa: E501
-    def test_force_https_check(self) -> None:
-        self.assertEqual(ValidationArgs().force_https_check, True)
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.6", "--distribution", "rpm", "--artifact-type", "staging", "--os-build-number", "1234", "--osd-build-number", "2312", "--force-https"])  # noqa: E501
+    def test_force_https(self) -> None:
+        self.assertEqual(ValidationArgs().force_https, True)
 
     @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.0", "--projects", "opensearch"])
     def test_set_projects(self) -> None:

--- a/tests/tests_validation_workflow/test_validation_docker.py
+++ b/tests/tests_validation_workflow/test_validation_docker.py
@@ -168,6 +168,47 @@ class TestValidateDocker(unittest.TestCase):
         self.assertTrue(urllib.request.urlopen(docker_compose_file_v1_url).getcode() == 200)
         self.assertTrue(urllib.request.urlopen(docker_compose_file_v2_url).getcode() == 200)
 
+    # @patch('validation_workflow.docker.validation_docker.ValidateDocker.check_http_request')
+    @patch('validation_workflow.docker.validation_docker.ValidationArgs')
+    @patch('validation_workflow.docker.validation_docker.ApiTest.api_get')
+    def test_check_http_request_success(self, mock_api_test: MagicMock, mock_validation_args: MagicMock) -> None:
+        mock_validation_args.return_value.test_readiness_urls = {
+            'https://localhost:9200/': 'opensearch cluster API',
+            'http://localhost:5601/api/status': 'opensearch-dashboards API',
+        }
+        mock_validation_args.return_value.version = '1.0.0'
+
+        mock_api_test.return_value = (200, "response")
+
+        validate_docker = ValidateDocker(mock_validation_args.return_value)
+
+        validate_docker.args.docker_source = 'dockerhub'
+
+        result = validate_docker.check_http_request()
+
+        self.assertEqual(result, True)
+        mock_api_test.assert_called()
+
+    @patch('validation_workflow.docker.validation_docker.ValidationArgs')
+    @patch('validation_workflow.docker.validation_docker.ApiTest.api_get')
+    def test_check_http_request_failure(self, mock_api_test: MagicMock, mock_validation_args: MagicMock) -> None:
+        mock_validation_args.return_value.test_readiness_urls = {
+            'https://localhost:9200/': 'opensearch cluster API',
+            'http://localhost:5601/api/status': 'opensearch-dashboards API',
+        }
+        mock_validation_args.return_value.version = '1.0.0'
+
+        mock_api_test.return_value = (400, "response")
+
+        validate_docker = ValidateDocker(mock_validation_args.return_value)
+
+        validate_docker.args.docker_source = 'dockerhub'
+
+        result = validate_docker.check_http_request()
+
+        self.assertEqual(result, False)
+        mock_api_test.assert_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tests_validation_workflow/test_validation_docker.py
+++ b/tests/tests_validation_workflow/test_validation_docker.py
@@ -49,6 +49,7 @@ class TestValidateDocker(unittest.TestCase):
         mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
+        mock_validation_args.return_value.allow_without_security = False
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_docker_image.return_value = MagicMock()
         mock_container.return_value = (True, 'test_file.yml')
@@ -69,7 +70,7 @@ class TestValidateDocker(unittest.TestCase):
         # Assert that the mock methods are called as expected
         mock_container.assert_called_once()
         mock_test.assert_called_once()
-        mock_test.assert_has_calls([call(), call().test_apis(['opensearch'])])
+        mock_test.assert_has_calls([call(), call().test_apis("1.0.0", ['opensearch'], True)])
 
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.check_http_request')
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')

--- a/tests/tests_validation_workflow/test_validation_docker.py
+++ b/tests/tests_validation_workflow/test_validation_docker.py
@@ -70,7 +70,7 @@ class TestValidateDocker(unittest.TestCase):
         # Assert that the mock methods are called as expected
         mock_container.assert_called_once()
         mock_test.assert_called_once()
-        mock_test.assert_has_calls([call(), call().test_apis("1.0.0", ['opensearch'], True)])
+        mock_test.assert_has_calls([call(), call().test_apis("1.0.0.1000", ['opensearch'], True)])
 
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.check_http_request')
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')

--- a/tests/tests_validation_workflow/test_validation_rpm.py
+++ b/tests/tests_validation_workflow/test_validation_rpm.py
@@ -90,12 +90,29 @@ class TestValidationRpm(unittest.TestCase):
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platform = 'linux'
+        mock_validation_args.return_value.allow_without_security = False
         mock_validation_args.return_value.projects = ["opensearch"]
 
         validate_rpm = ValidateRpm(mock_validation_args.return_value)
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
         result = validate_rpm.installation()
         self.assertTrue(result)
+
+    @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
+    @patch('os.path.basename')
+    @patch('validation_workflow.rpm.validation_rpm.execute')
+    @patch('validation_workflow.validation.Validation.test_security_plugin')
+    def test_installation_with_security_parameter(self, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_validation_args: Mock) -> None:
+        mock_validation_args.return_value.version = '2.3.0'
+        mock_validation_args.return_value.allow_without_security = True
+        validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        mock_basename.side_effect = lambda path: "mocked_filename"
+        mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
+        mock_security.return_value = True
+
+        result = validate_rpm.installation()
+        self.assertTrue(result)
+        mock_security.assert_called_once()
 
     @patch("validation_workflow.rpm.validation_rpm.execute", return_value=True)
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
@@ -116,15 +133,10 @@ class TestValidationRpm(unittest.TestCase):
         mock_test_apis_instance = mock_test_apis.return_value
         mock_test_apis_instance.test_apis.return_value = (True, 4)
 
-        # Create instance of ValidateRpm class
         validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        validate_rpm.validation()
 
-        # Call validation method and assert the result
-        result = validate_rpm.validation()
-        self.assertTrue(result)
-
-        # Assert that the mock methods are called as expected
-        mock_test_apis.assert_called_once()
+        self.assertEqual(mock_test_apis.call_count, 1)
 
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
     @patch('validation_workflow.rpm.validation_rpm.ApiTestCases')
@@ -132,16 +144,14 @@ class TestValidationRpm(unittest.TestCase):
         # Set up mock objects
         mock_validation_args.return_value.version = '2.3.0'
         mock_test_apis_instance = mock_test_apis.return_value
-        mock_test_apis_instance.test_apis.return_value = (True, 1)
+        mock_test_apis_instance.test_apis.return_value = (False, 1)
 
-        # Create instance of ValidateRpm class
         validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        with self.assertRaises(Exception) as context:
+            validate_rpm.validation()
 
-        # Call validation method and assert the result
-        validate_rpm.validation()
-        self.assertRaises(Exception, "Not all tests Pass : 1")
+        self.assertEqual(str(context.exception), 'Not all tests Pass : 1')
 
-        # Assert that the mock methods are called as expected
         mock_test_apis.assert_called_once()
 
     @patch("validation_workflow.rpm.validation_rpm.execute", return_value=True)

--- a/tests/tests_validation_workflow/test_validation_rpm.py
+++ b/tests/tests_validation_workflow/test_validation_rpm.py
@@ -90,7 +90,7 @@ class TestValidationRpm(unittest.TestCase):
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platform = 'linux'
-        mock_validation_args.return_value.force_https_check = True
+        mock_validation_args.return_value.force_https = True
         mock_validation_args.return_value.projects = ["opensearch"]
 
         validate_rpm = ValidateRpm(mock_validation_args.return_value)
@@ -129,7 +129,7 @@ class TestValidationRpm(unittest.TestCase):
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     def test_validation_with_security_parameter(self, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        mock_validation_args.return_value.force_https_check = False
+        mock_validation_args.return_value.force_https = False
         validate_rpm = ValidateRpm(mock_validation_args.return_value)
         mock_basename.side_effect = lambda path: "mocked_filename"
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")

--- a/tests/tests_validation_workflow/test_validation_rpm.py
+++ b/tests/tests_validation_workflow/test_validation_rpm.py
@@ -90,29 +90,13 @@ class TestValidationRpm(unittest.TestCase):
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platform = 'linux'
-        mock_validation_args.return_value.allow_without_security = False
+        mock_validation_args.return_value.force_https_check = True
         mock_validation_args.return_value.projects = ["opensearch"]
 
         validate_rpm = ValidateRpm(mock_validation_args.return_value)
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
         result = validate_rpm.installation()
         self.assertTrue(result)
-
-    @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
-    @patch('os.path.basename')
-    @patch('validation_workflow.rpm.validation_rpm.execute')
-    @patch('validation_workflow.validation.Validation.test_security_plugin')
-    def test_installation_with_security_parameter(self, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_validation_args: Mock) -> None:
-        mock_validation_args.return_value.version = '2.3.0'
-        mock_validation_args.return_value.allow_without_security = True
-        validate_rpm = ValidateRpm(mock_validation_args.return_value)
-        mock_basename.side_effect = lambda path: "mocked_filename"
-        mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
-        mock_security.return_value = True
-
-        result = validate_rpm.installation()
-        self.assertTrue(result)
-        mock_security.assert_called_once()
 
     @patch("validation_workflow.rpm.validation_rpm.execute", return_value=True)
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
@@ -137,6 +121,25 @@ class TestValidationRpm(unittest.TestCase):
         validate_rpm.validation()
 
         self.assertEqual(mock_test_apis.call_count, 1)
+
+    @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
+    @patch('validation_workflow.rpm.validation_rpm.ApiTestCases')
+    @patch('os.path.basename')
+    @patch('validation_workflow.rpm.validation_rpm.execute')
+    @patch('validation_workflow.validation.Validation.check_for_security_plugin')
+    def test_validation_with_security_parameter(self, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+        mock_validation_args.return_value.version = '2.3.0'
+        mock_validation_args.return_value.force_https_check = False
+        validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        mock_basename.side_effect = lambda path: "mocked_filename"
+        mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
+        mock_security.return_value = True
+        mock_test_apis_instance = mock_test_apis.return_value
+        mock_test_apis_instance.test_apis.return_value = (True, 4)
+
+        result = validate_rpm.validation()
+        self.assertTrue(result)
+        mock_security.assert_called_once()
 
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
     @patch('validation_workflow.rpm.validation_rpm.ApiTestCases')

--- a/tests/tests_validation_workflow/test_validation_tar.py
+++ b/tests/tests_validation_workflow/test_validation_tar.py
@@ -71,7 +71,7 @@ class TestValidateTar(unittest.TestCase):
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platform = 'linux'
-        mock_validation_args.return_value.force_https_check = True
+        mock_validation_args.return_value.force_https = True
         mock_validation_args.return_value.projects = ["opensearch"]
 
         validate_tar = ValidateTar(mock_validation_args.return_value)
@@ -132,7 +132,7 @@ class TestValidateTar(unittest.TestCase):
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     def test_validation_without_force_https_check(self, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        mock_validation_args.return_value.force_https_check = False
+        mock_validation_args.return_value.force_https = False
         validate_tar = ValidateTar(mock_validation_args.return_value)
         mock_basename.side_effect = lambda path: "mocked_filename"
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")

--- a/tests/tests_validation_workflow/test_validation_yum.py
+++ b/tests/tests_validation_workflow/test_validation_yum.py
@@ -131,7 +131,7 @@ class TestValidationYum(unittest.TestCase):
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     def test_validation_without_force_https_check(self, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        mock_validation_args.return_value.force_https_check = False
+        mock_validation_args.return_value.force_https = False
         validate_yum = ValidateYum(mock_validation_args.return_value)
         mock_basename.side_effect = lambda path: "mocked_filename"
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")


### PR DESCRIPTION
### Description
Changes to existing validation workflow
1. Checks for the existence of security plugin in OS artifacts and send https/http requests as required.
2. Use latest password for validating all the version >=2.12.0
 
### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
