### PR TITLE
Remove opensearch 2.12.0/1.3.15 checks as distribution-build already taken care of issue reporting

### DIFF
--- a/manifests/1.3.15/opensearch-1.3.15.yml
+++ b/manifests/1.3.15/opensearch-1.3.15.yml
@@ -11,12 +11,6 @@ components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
     ref: '1.3'
-    checks:
-      - gradle:publish
-      - gradle:properties:version
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: '1.3'
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version

--- a/manifests/2.12.0/opensearch-2.12.0.yml
+++ b/manifests/2.12.0/opensearch-2.12.0.yml
@@ -11,27 +11,18 @@ components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
     ref: 2.x
-    checks:
-      - gradle:publish
-      - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
     ref: 2.x
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:publish
-      - gradle:properties:version
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
     ref: 2.x
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: security
     repository: https://github.com/opensearch-project/security.git
     ref: 2.x
@@ -44,18 +35,12 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: geospatial
     repository: https://github.com/opensearch-project/geospatial.git
     ref: 2.x
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     depends_on:
       - job-scheduler
   - name: cross-cluster-replication
@@ -64,9 +49,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     depends_on:
       - common-utils
   - name: ml-commons
@@ -75,9 +57,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: opensearch-ml-plugin
     depends_on:
       - common-utils
   - name: neural-search
@@ -86,9 +65,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     depends_on:
       - ml-commons
       - k-NN
@@ -99,9 +75,6 @@ components:
       - linux
       - windows
     working_directory: notifications
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: opensearch-notifications-core
     depends_on:
       - common-utils
   - name: notifications
@@ -111,9 +84,6 @@ components:
       - linux
       - windows
     working_directory: notifications
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: notifications
     depends_on:
       - common-utils
   - name: opensearch-observability
@@ -122,9 +92,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     depends_on:
       - common-utils
   - name: opensearch-reports
@@ -133,9 +100,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     depends_on:
       - common-utils
       - job-scheduler
@@ -145,9 +109,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: opensearch-sql-plugin
     depends_on:
       - ml-commons
   - name: asynchronous-search
@@ -156,9 +117,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     depends_on:
       - common-utils
   - name: anomaly-detection
@@ -167,9 +125,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     depends_on:
       - common-utils
       - job-scheduler
@@ -179,9 +134,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version: alerting
     depends_on:
       - common-utils
   - name: security-analytics
@@ -190,8 +142,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
     depends_on:
       - common-utils
   - name: index-management
@@ -200,8 +150,6 @@ components:
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
     depends_on:
       - common-utils
       - job-scheduler
@@ -210,26 +158,17 @@ components:
     ref: 2.x
     platforms:
       - linux
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: custom-codecs
     repository: https://github.com/opensearch-project/custom-codecs.git
     ref: 2.x
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
   - name: flow-framework
     repository: https://github.com/opensearch-project/flow-framework.git
     ref: 2.x
     platforms:
       - linux
       - windows
-    checks:
-      - gradle:properties:version
-      - gradle:dependencies:opensearch.version
     depends_on:
       - common-utils


### PR DESCRIPTION
### Description
Remove opensearch 2.12.0/1.3.15 checks as distribution-build already taken care of issue reporting

### Issues Resolved
Part of #3707

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
