### PR TITLE
Fix the updateGitHubIssue boolean param

### DIFF
--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
                     env.artifactPath = buildManifestObj.getArtifactRoot(BUILD_JOB_NAME, buildId)
                     env.AGENT_LABEL = agent_nodes["${env.platform}_${architecture}"]
                     env.updateGithubIssues = (params.UPDATE_GITHUB_ISSUES && (env.distribution == 'tar'))
-                    echo "GitHub issue update is set to : ${env.updateGithubIssues}"
+                    echo "GitHub issue update is set to : ${env.updateGithubIssues.toBoolean()}"
                 }
             }
             post {
@@ -211,7 +211,7 @@ pipeline {
                                                         switchUserNonRoot: "${switch_user_non_root}"
                                                     )
                                                     String closeCommentMessage = "Closing the issue as the Integration Test passed for ${local_component}<br>Version: ${version}<br>Distribution: ${distribution}<br>Architecture: ${architecture}<br>Platform: ${platform}<br><br>Please check the logs: ${RUN_DISPLAY_URL}<br><br> *"
-                                                    if (env.updateGithubIssues) {
+                                                    if (env.updateGithubIssues.toBoolean()) {
                                                         closeGithubIssue(
                                                             repoUrl: buildManifestObj.getRepo("${local_component}"),
                                                             issueTitle: "[AUTOCUT] Integration Test failed for ${local_component}: ${version} ${distribution} distribution",
@@ -223,7 +223,7 @@ pipeline {
                                             } catch (e) {
                                                 echo "Error running integtest for component ${local_component}, creating Github issue"
                                                 String issueBodyMessage = "The integration test failed at distribution level for component ${local_component}<br>Version: ${version}<br>Distribution: ${distribution}<br>Architecture: ${architecture}<br>Platform: ${platform}<br><br>Please check the logs: ${RUN_DISPLAY_URL}<br><br> * Test-report manifest:*<br> - https://ci.opensearch.org/ci/dbc/${JOB_NAME}/${version}/${buildId}/${platform}/${architecture}/${distribution}/test-results/${BUILD_NUMBER}/integ-test/test-report.yml <br><br> _Note: Steps to reproduce, additional logs and other files can be found within the above test-report manifest. <br>Instructions of this test-report manifest can be found [here](https://github.com/opensearch-project/opensearch-build/tree/main/src/report_workflow#guide-on-test-report-manifest-from-ci)._"
-                                                if (env.updateGithubIssues) {
+                                                if (env.updateGithubIssues.toBoolean()) {
                                                     createGithubIssue(
                                                         repoUrl: buildManifestObj.getRepo("${local_component}"),
                                                         issueTitle: "[AUTOCUT] Integration Test failed for ${local_component}: ${version} ${distribution} distribution",

--- a/tests/jenkins/TestOpenSearchIntegTest.groovy
+++ b/tests/jenkins/TestOpenSearchIntegTest.groovy
@@ -169,9 +169,6 @@ class TestOpenSearchIntegTest extends BuildPipelineTest {
     @Test
     void checkGHIssueDisable() {
         addParam('COMPONENT_NAME', 'k-NN')
-        helper.addShMock("date -d \"3 days ago\" +'%Y-%m-%d'") { script ->
-            return [stdout: "2023-10-24", exitValue: 0]
-        }
         helper.addShMock("""env PATH=\$PATH JAVA_HOME=/opt/java/openjdk-17 ./test.sh integ-test manifests/tests/jenkins/data/opensearch-3.0.0-test.yml --component k-NN --test-run-id 234 --paths opensearch=/tmp/workspace/tar --base-path DUMMY_PUBLIC_ARTIFACT_URL/dummy_job/3.0.0/9010/linux/x64/tar """) { script ->
             return [stdout: "Error running integtest for component k-NN, creating Github issue", exitValue: 1]}
         assertThrows(Exception) {


### PR DESCRIPTION
### Description
Fix the updateGitHubIssue boolean param to actually use boolean passed using jenkins parameter.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
