### PR TITLE
Fix the release branch bug in `component_release_template.md`

### DIFF
--- a/.github/ISSUE_TEMPLATE/component_release_template.md
+++ b/.github/ISSUE_TEMPLATE/component_release_template.md
@@ -33,7 +33,7 @@ If including changes in this release, increment the version on `{{RELEASE_VERSIO
 - [ ] Finalize scope and feature set and update [the Public Roadmap](https://github.com/orgs/opensearch-project/projects/1).
 - [ ] All the tasks in this issue have been reviewed by the release owner.
 - [ ] Create, update, triage and label all features and issues targeted for this release with `v{{RELEASE_VERSION}}`.
-- [ ] Finalize the code and create the the release branch `{{RELEASE_VERSION}}` from the `{{RELEASE_VERSION_X}}` branch.
+- [ ] Finalize the code and create the the release branch `{{RELEASE_BRANCH}}` from the `{{RELEASE_VERSION_X}}` branch.
 
 ### CI/CD
 

--- a/.github/workflows/os-release-issues.yml
+++ b/.github/workflows/os-release-issues.yml
@@ -57,6 +57,7 @@ jobs:
           - {repo: security}
           - {repo: security-analytics}
           - {repo: sql}
+          - {repo: flow-framework}
         release_version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
       - name: GitHub App token
@@ -97,6 +98,7 @@ jobs:
           # Read the file contents and replace the placeholders
           file_path="../opensearch-build/.github/ISSUE_TEMPLATE/component_release_template.md"
           RELEASE_VERSION="${{ matrix.release_version }}"
+          RELEASE_BRANCH=$(echo ${{ matrix.release_version }} | cut -d. -f1-2)
           BUILD_REPO_ISSUE_OUTPUT=$(cat <<EOF
           ${{ steps.check_if_build_repo_issue_exists.outputs.issues }}
           EOF
@@ -104,7 +106,7 @@ jobs:
           RELEASE_ISSUE_NUMBER=$(echo $BUILD_REPO_ISSUE_OUTPUT | jq -r '.[0].number')
           RELEASE_ISSUE="https://github.com/opensearch-project/opensearch-build/issues/${RELEASE_ISSUE_NUMBER}"
           RELEASE_VERSION_X=$(echo "${{ matrix.release_version }}" | awk -F'.' '{print $1}').x
-          sed -e "s|{{RELEASE_VERSION}}|${RELEASE_VERSION}|g" -e "s|{{RELEASE_ISSUE}}|${RELEASE_ISSUE}|g" -e "s|{{RELEASE_VERSION_X}}|${RELEASE_VERSION_X}|g" "$file_path" > "$file_path.tmp" && mv "$file_path.tmp" "$file_path"
+          sed -e "s|{{RELEASE_VERSION}}|${RELEASE_VERSION}|g" -e "s|{{RELEASE_ISSUE}}|${RELEASE_ISSUE}|g" -e "s|{{RELEASE_BRANCH}}|${RELEASE_BRANCH}|g" -e "s|{{RELEASE_VERSION_X}}|${RELEASE_VERSION_X}|g" "$file_path" > "$file_path.tmp" && mv "$file_path.tmp" "$file_path"
       - name: Create component release issue from file
         if: steps.check_if_plugin_repo_issue_exists.outputs.issues == '[]'
         uses: peter-evans/create-issue-from-file@v4

--- a/.github/workflows/osd-release-issues.yml
+++ b/.github/workflows/osd-release-issues.yml
@@ -93,6 +93,7 @@ jobs:
           # Read the file contents and replace the placeholders
           file_path="../opensearch-build/.github/ISSUE_TEMPLATE/component_release_template.md"
           RELEASE_VERSION="${{ matrix.release_version }}"
+          RELEASE_BRANCH=$(echo ${{ matrix.release_version }} | cut -d. -f1-2)
           BUILD_REPO_ISSUE_OUTPUT=$(cat <<EOF
           ${{ steps.check_if_build_repo_issue_exists.outputs.issues }}
           EOF
@@ -100,7 +101,7 @@ jobs:
           RELEASE_ISSUE_NUMBER=$(echo $BUILD_REPO_ISSUE_OUTPUT | jq '.[0].number')
           RELEASE_ISSUE="https://github.com/opensearch-project/opensearch-build/issues/${RELEASE_ISSUE_NUMBER}"
           RELEASE_VERSION_X=$(echo "${{ matrix.release_version }}" | awk -F'.' '{print $1}').x
-          sed -e "s|{{RELEASE_VERSION}}|${RELEASE_VERSION}|g" -e "s|{{RELEASE_ISSUE}}|${RELEASE_ISSUE}|g" -e "s|{{RELEASE_VERSION_X}}|${RELEASE_VERSION_X}|g" "$file_path" > "$file_path.tmp" && mv "$file_path.tmp" "$file_path"
+          sed -e "s|{{RELEASE_VERSION}}|${RELEASE_VERSION}|g" -e "s|{{RELEASE_ISSUE}}|${RELEASE_ISSUE}|g" -e "s|{{RELEASE_BRANCH}}|${RELEASE_BRANCH}|g" -e "s|{{RELEASE_VERSION_X}}|${RELEASE_VERSION_X}|g" "$file_path" > "$file_path.tmp" && mv "$file_path.tmp" "$file_path"
       - name: Create component release issue from file
         if: steps.check_if_plugin_repo_issue_exists.outputs.issues == '[]'
         uses: peter-evans/create-issue-from-file@v4


### PR DESCRIPTION
### Description
Fix release branch in `component_release_template.md`, this should tell users to create branch like 2.12, 1.3 etc and not with full release number as:
<img width="637" alt="Screenshot 2024-01-31 at 8 41 11 AM" src="https://github.com/opensearch-project/opensearch-build/assets/28733332/83f4671d-fa84-4000-acaf-69f3c5686491">

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
