### PR TITLE
[Release 2.12.0] Update 2.12.0 build frequency

### DIFF
--- a/.github/workflows/os-increment-plugin-versions.yml
+++ b/.github/workflows/os-increment-plugin-versions.yml
@@ -49,6 +49,7 @@ jobs:
           - {repo: flow-framework}
           - {repo: skills}
         branch:
+          - 1.x
           - '1.3'
           - 2.x
           - '2.8'

--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -41,6 +41,7 @@ jobs:
           - {repo: dashboards-search-relevance}
           - {repo: opensearch-dashboards-functional-test}
         branch:
+          - 1.x
           - '1.3'
           - 2.x
           - '2.8'

--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -26,8 +26,8 @@ pipeline {
             H 1 * * * %INPUT_MANIFEST=1.3.15/opensearch-dashboards-1.3.15.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=1.3.15/opensearch-1.3.15.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.11.2/opensearch-2.11.2.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H 1 * * * %INPUT_MANIFEST=2.12.0/opensearch-dashboards-2.12.0.yml;TEST_MANIFEST=2.12.0/opensearch-dashboards-2.12.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H 1 * * * %INPUT_MANIFEST=2.12.0/opensearch-2.12.0.yml;TEST_MANIFEST=2.12.0/opensearch-2.12.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
+            H */6 * * * %INPUT_MANIFEST=2.12.0/opensearch-dashboards-2.12.0.yml;TEST_MANIFEST=2.12.0/opensearch-dashboards-2.12.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
+            H */6 * * * %INPUT_MANIFEST=2.12.0/opensearch-2.12.0.yml;TEST_MANIFEST=2.12.0/opensearch-2.12.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TEST_MANIFEST=3.0.0/opensearch-3.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TEST_MANIFEST=3.0.0/opensearch-dashboards-3.0.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''


### PR DESCRIPTION
### Description
Update 2.12.0 build frequency to run every 6hrs. 

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4115 

Also pushing a small change to target `1.x` branch version increments, part of https://github.com/opensearch-project/opensearch-build/issues/4392.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
