### PR TITLE
Adds doc website link in the message printed for custom admin password requirement

### DIFF
--- a/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
@@ -34,7 +34,7 @@ function setupSecurityPlugin {
         if [ "$DISABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
             echo "Disabling execution of install_demo_configuration.sh for OpenSearch Security Plugin"
         else
-            echo -e "Enabling execution of install_demo_configuration.sh for OpenSearch Security Plugin \nOpenSearch 2.12.0 onwards, the OpenSearch Security Plugin a change that requires an initial password for 'admin' user. \nPlease define an environment variable 'OPENSEARCH_INITIAL_ADMIN_PASSWORD' with a strong password string. \nIf a password is not provided, the setup will quit."
+            echo -e "Enabling execution of install_demo_configuration.sh for OpenSearch Security Plugin \nOpenSearch 2.12.0 onwards, the OpenSearch Security Plugin a change that requires an initial password for 'admin' user. \nPlease define an environment variable 'OPENSEARCH_INITIAL_ADMIN_PASSWORD' with a strong password string. \nIf a password is not provided, the setup will quit. \n For more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/"
             bash $OPENSEARCH_HOME/plugins/$SECURITY_PLUGIN/tools/install_demo_configuration.sh -y -i -s || exit 1
         fi
 

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -43,6 +43,7 @@ MINIMUM_OF_TWO_VERSIONS=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION |
 if [ $OPENSEARCH_ALREADY_INSTALLED = no ]; then
   if [ $MINIMUM_OF_TWO_VERSIONS = $OPENSEARCH_REQUIRED_VERSION ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
     echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
+    echo "For more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/debian/"
     exit 1
   fi
 fi

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -109,6 +109,7 @@ MINIMUM_OF_TWO_VERSIONS=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION |
 if [ $OPENSEARCH_ALREADY_INSTALLED = no ]; then
   if [ $MINIMUM_OF_TWO_VERSIONS = $OPENSEARCH_REQUIRED_VERSION ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
     echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
+    echo "For more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/rpm/"
     exit 1
   fi
 fi

--- a/scripts/startup/tar/linux/opensearch-tar-install.sh
+++ b/scripts/startup/tar/linux/opensearch-tar-install.sh
@@ -10,7 +10,7 @@ cd $OPENSEARCH_HOME
 KNN_LIB_DIR=$OPENSEARCH_HOME/plugins/opensearch-knn/lib
 ##Security Plugin
 if [ -d "$OPENSEARCH_HOME/plugins/opensearch-security" ]; then
-        echo -e "OpenSearch 2.12.0 onwards, the OpenSearch Security Plugin introduces a change that requires an initial password for 'admin' user. \nPlease define an environment variable 'OPENSEARCH_INITIAL_ADMIN_PASSWORD' with a strong password string. \nIf a password is not provided, the setup will quit."
+        echo -e "OpenSearch 2.12.0 onwards, the OpenSearch Security Plugin introduces a change that requires an initial password for 'admin' user. \nPlease define an environment variable 'OPENSEARCH_INITIAL_ADMIN_PASSWORD' with a strong password string. \nIf a password is not provided, the setup will quit. \nFor more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/tar/"
         bash $OPENSEARCH_HOME/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s || exit 1
         echo "done security"
 fi

--- a/scripts/startup/zip/windows/opensearch-windows-install.bat
+++ b/scripts/startup/zip/windows/opensearch-windows-install.bat
@@ -18,6 +18,7 @@ IF EXIST "%OPENSEARCH_HOME%\plugins\opensearch-security" (
     ECHO "OpenSearch 2.12.0 onwards, the OpenSearch Security Plugin a change that requires an initial password for 'admin' user."
     ECHO "Please define an environment variable 'OPENSEARCH_INITIAL_ADMIN_PASSWORD' with a strong password string."
     ECHO "If a password is not provided, the setup will quit."
+    ECHO "For more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/windows/"
     CALL "%OPENSEARCH_HOME%\plugins\opensearch-security\tools\install_demo_configuration.bat" -y -i -s || exit /b 1
 )
 


### PR DESCRIPTION
### Description
Makes the printed messages more useful by redirecting the users to the install and setup documentation for each distribution

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
