### PR TITLE
feat: remove useless config

### DIFF
--- a/config/opensearch_dashboards-2.x.yml
+++ b/config/opensearch_dashboards-2.x.yml
@@ -199,8 +199,6 @@
 # 2.12 New experimental Assistant Dashboards Feature
 # Set the value of this setting to true to enable the assistant dashboards
 # assistant.chat.enabled: false
-# Set the value to the root agent name you setup up manually or through flow framework
-# assistant.chat.rootAgentName: "Root agent"
 
 opensearch.hosts: [https://localhost:9200]
 opensearch.ssl.verificationMode: none

--- a/config/opensearch_dashboards-default.x.yml
+++ b/config/opensearch_dashboards-default.x.yml
@@ -199,8 +199,6 @@
 # 2.12 New experimental Assistant Dashboards Feature
 # Set the value of this setting to true to enable the assistant dashboards
 # assistant.chat.enabled: false
-# Set the value to the root agent name you setup up manually or through flow framework
-# assistant.chat.rootAgentName: "Root agent"
 
 opensearch.hosts: [https://localhost:9200]
 opensearch.ssl.verificationMode: none

--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-2.x.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-2.x.sh
@@ -167,7 +167,6 @@ opensearch_dashboards_vars=(
     data_source.audit.appender.layout.pattern
     ml_commons_dashboards.enabled
     assistant.chat.enabled
-    assistant.chat.rootAgentName
 )
 
 function setupSecurityDashboardsPlugin {

--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-default.x.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-default.x.sh
@@ -167,7 +167,6 @@ opensearch_dashboards_vars=(
     data_source.audit.appender.layout.pattern
     ml_commons_dashboards.enabled
     assistant.chat.enabled
-    assistant.chat.rootAgentName
 )
 
 function setupSecurityDashboardsPlugin {

--- a/manifests/2.12.0/opensearch-dashboards-2.12.0-test.yml
+++ b/manifests/2.12.0/opensearch-dashboards-2.12.0-test.yml
@@ -87,4 +87,3 @@ components:
         - without-security
       additional-cluster-configs:
         assistant.chat.enabled: true
-        assistant.chat.rootAgentName: 'Cypress test agent'

--- a/manifests/2.12.0/opensearch-dashboards-2.12.0-test.yml
+++ b/manifests/2.12.0/opensearch-dashboards-2.12.0-test.yml
@@ -83,7 +83,6 @@ components:
   - name: assistantDashboards
     integ-test:
       test-configs:
-        - with-security
         - without-security
       additional-cluster-configs:
         assistant.chat.enabled: true

--- a/manifests/2.12.0/opensearch-dashboards-2.12.0-test.yml
+++ b/manifests/2.12.0/opensearch-dashboards-2.12.0-test.yml
@@ -83,6 +83,7 @@ components:
   - name: assistantDashboards
     integ-test:
       test-configs:
+        - with-security
         - without-security
       additional-cluster-configs:
         assistant.chat.enabled: true

--- a/manifests/3.0.0/opensearch-dashboards-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-dashboards-3.0.0-test.yml
@@ -87,4 +87,3 @@ components:
         - without-security
       additional-cluster-configs:
         assistant.chat.enabled: true
-        assistant.chat.rootAgentName: 'Cypress test agent'

--- a/manifests/3.0.0/opensearch-dashboards-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-dashboards-3.0.0-test.yml
@@ -83,7 +83,6 @@ components:
   - name: assistantDashboards
     integ-test:
       test-configs:
-        - with-security
         - without-security
       additional-cluster-configs:
         assistant.chat.enabled: true

--- a/manifests/3.0.0/opensearch-dashboards-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-dashboards-3.0.0-test.yml
@@ -83,6 +83,7 @@ components:
   - name: assistantDashboards
     integ-test:
       test-configs:
+        - with-security
         - without-security
       additional-cluster-configs:
         assistant.chat.enabled: true


### PR DESCRIPTION
### Description
- Chatbot and Agent framework changed the implementation of how to retrieve the root agent, so the rootAgentName config is useless, remove that from config and template.
- The root agent is config in a ml system index, and it prevents FTRepo to set agent id into the index when running Cypress test(system index config can only be changed in opensearch.yml file), so move the security test out of the test manifest.

The dashboards-assistant plugin is an experimental plugin and we will address the security test in 2.13.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
