### PR TITLE
Windows integTest fix for 2.12 with admin:admin security changes

### DIFF
--- a/src/test_workflow/integ_test/distribution_zip.py
+++ b/src/test_workflow/integ_test/distribution_zip.py
@@ -33,7 +33,7 @@ class DistributionZip(Distribution):
     @property
     def start_cmd(self) -> str:
         start_cmd_map = {
-            "opensearch": "set OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! .\\opensearch-windows-install.bat",
+            "opensearch": "env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! .\\opensearch-windows-install.bat",
             "opensearch-dashboards": ".\\opensearch-dashboards.bat",
         }
         return start_cmd_map[self.filename]

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_zip.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_zip.py
@@ -47,7 +47,7 @@ class TestDistributionZipOpenSearch(unittest.TestCase):
             mock_zipfile_extractall.assert_called_with(self.work_dir)
 
     def test_start_cmd(self) -> None:
-        self.assertEqual(self.distribution_zip.start_cmd, "set OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! .\\opensearch-windows-install.bat")
+        self.assertEqual(self.distribution_zip.start_cmd, "env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! .\\opensearch-windows-install.bat")
 
     @patch("subprocess.check_call")
     def test_uninstall(self, check_call_mock: Mock) -> None:


### PR DESCRIPTION
### Description
Windows integTest fix for 2.12 with admin:admin security changes

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/4370

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
