### PR TITLE
Update manifest to point to 2.12 branch for k-NN, geospatial, and neural-search

### DIFF
--- a/manifests/2.12.0/opensearch-2.12.0.yml
+++ b/manifests/2.12.0/opensearch-2.12.0.yml
@@ -31,13 +31,13 @@ components:
       - windows
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: 2.x
+    ref: 2.12
     platforms:
       - linux
       - windows
   - name: geospatial
     repository: https://github.com/opensearch-project/geospatial.git
-    ref: 2.x
+    ref: 2.12
     platforms:
       - linux
       - windows
@@ -61,7 +61,7 @@ components:
       - common-utils
   - name: neural-search
     repository: https://github.com/opensearch-project/neural-search.git
-    ref: 2.x
+    ref: 2.12
     platforms:
       - linux
       - windows


### PR DESCRIPTION
### Description
Updates 2.12 build manifest to point to 2.12 branch for k-NN, geospatial, and neural-search repositories

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
