### PR TITLE
Change publishToMavenLocal to publishPluginToMavenLocal only

### DIFF
--- a/scripts/default/opensearch/build.sh
+++ b/scripts/default/opensearch/build.sh
@@ -80,6 +80,10 @@ mkdir -p $OUTPUT/plugins
 cp ${distributions}/*.zip ./$OUTPUT/plugins
 
 # Publish plugin zips to maven
+<<<<<<< Updated upstream
+=======
+./gradlew publishPluginZipPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+>>>>>>> Stashed changes
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 mkdir -p $OUTPUT/maven/org/opensearch
 cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch

--- a/scripts/default/opensearch/build.sh
+++ b/scripts/default/opensearch/build.sh
@@ -80,10 +80,7 @@ mkdir -p $OUTPUT/plugins
 cp ${distributions}/*.zip ./$OUTPUT/plugins
 
 # Publish plugin zips to maven
-<<<<<<< Updated upstream
-=======
 ./gradlew publishPluginZipPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
->>>>>>> Stashed changes
 ./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 mkdir -p $OUTPUT/maven/org/opensearch
 cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch


### PR DESCRIPTION
### Description
Change publishToMavenLocal to publishPluginToMavenLocal only

### Issues Resolved
After this PR: https://github.com/opensearch-project/opensearch-build/pull/4434 merged, build for geospatial and opensearch-reports failed, this is to fix this issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
