### PR TITLE
Update integ test runner to record each configuration separately

### DIFF
--- a/src/test_workflow/integ_test/integ_test_runner.py
+++ b/src/test_workflow/integ_test/integ_test_runner.py
@@ -45,7 +45,7 @@ class IntegTestRunner(abc.ABC):
                     if test_config.integ_test:
                         test_suite = self.__create_test_suite__(component, test_config, work_dir.path)
                         test_results = test_suite.execute_tests()
-                        # [self.test_recorder.test_results_logs.save_test_result_data(result_data) for result_data in test_suite.result_data]
+                        [self.test_recorder.test_results_logs.generate_component_yml(result_data) for result_data in test_suite.result_data]
                         all_results.append(component.name, test_results)
                     else:
                         logging.info(f"Skipping integ-tests for {component.name}, as it is currently not supported")

--- a/src/test_workflow/integ_test/integ_test_runner.py
+++ b/src/test_workflow/integ_test/integ_test_runner.py
@@ -45,7 +45,7 @@ class IntegTestRunner(abc.ABC):
                     if test_config.integ_test:
                         test_suite = self.__create_test_suite__(component, test_config, work_dir.path)
                         test_results = test_suite.execute_tests()
-                        [self.test_recorder.test_results_logs.save_test_result_data(result_data) for result_data in test_suite.result_data]
+                        # [self.test_recorder.test_results_logs.save_test_result_data(result_data) for result_data in test_suite.result_data]
                         all_results.append(component.name, test_results)
                     else:
                         logging.info(f"Skipping integ-tests for {component.name}, as it is currently not supported")

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -130,6 +130,7 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
                 self.test_artifact_files
             )
             self.save_logs.save_test_result_data(test_result_data)
+            self.test_result_data.append(test_result_data)
             if stderr:
                 logging.info("Stderr reported for component: " + self.component.name)
                 logging.info(stderr)

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -121,16 +121,15 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
             self.repo_work_dir = os.path.join(
                 self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
             (status, stdout, stderr) = execute(cmd, self.repo_work_dir, True, False)
-            self.test_result_data.append(
-                TestResultData(
-                    self.component.name,
-                    test_config,
-                    status,
-                    stdout,
-                    stderr,
-                    self.test_artifact_files
-                )
+            test_result_data = TestResultData(
+                self.component.name,
+                test_config,
+                status,
+                stdout,
+                stderr,
+                self.test_artifact_files
             )
+            self.save_logs.save_test_result_data(test_result_data)
             if stderr:
                 logging.info("Stderr reported for component: " + self.component.name)
                 logging.info(stderr)

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -121,7 +121,7 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
             self.repo_work_dir = os.path.join(
                 self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
             (status, stdout, stderr) = execute(cmd, self.repo_work_dir, True, False)
-            test_result_data = TestResultData(
+            test_result_data_local = TestResultData(
                 self.component.name,
                 test_config,
                 status,
@@ -129,8 +129,8 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
                 stderr,
                 self.test_artifact_files
             )
-            self.save_logs.save_test_result_data(test_result_data)
-            self.test_result_data.append(test_result_data)
+            self.save_logs.save_test_result_data(test_result_data_local)
+            self.test_result_data.append(test_result_data_local)
             if stderr:
                 logging.info("Stderr reported for component: " + self.component.name)
                 logging.info(stderr)

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
@@ -123,6 +123,7 @@ class IntegTestSuiteOpenSearchDashboards(IntegTestSuite):
                 self.test_artifact_files
             )
             self.save_logs.save_test_result_data(test_result_data)
+            self.test_result_data.append(test_result_data)
             if stderr:
                 logging.info("Stderr reported for component: " + self.component.name)
                 logging.info(stderr)

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
@@ -114,7 +114,7 @@ class IntegTestSuiteOpenSearchDashboards(IntegTestSuite):
             self.repo_work_dir = os.path.join(
                 self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
             (status, stdout, stderr) = execute(cmd, self.repo_work_dir, True, False)
-            test_result_data = TestResultData(
+            test_result_data_local = TestResultData(
                 self.component.name,
                 test_config,
                 status,
@@ -122,8 +122,8 @@ class IntegTestSuiteOpenSearchDashboards(IntegTestSuite):
                 stderr,
                 self.test_artifact_files
             )
-            self.save_logs.save_test_result_data(test_result_data)
-            self.test_result_data.append(test_result_data)
+            self.save_logs.save_test_result_data(test_result_data_local)
+            self.test_result_data.append(test_result_data_local)
             if stderr:
                 logging.info("Stderr reported for component: " + self.component.name)
                 logging.info(stderr)

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
@@ -114,16 +114,15 @@ class IntegTestSuiteOpenSearchDashboards(IntegTestSuite):
             self.repo_work_dir = os.path.join(
                 self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
             (status, stdout, stderr) = execute(cmd, self.repo_work_dir, True, False)
-            self.test_result_data.append(
-                TestResultData(
-                    self.component.name,
-                    test_config,
-                    status,
-                    stdout,
-                    stderr,
-                    self.test_artifact_files
-                )
+            test_result_data = TestResultData(
+                self.component.name,
+                test_config,
+                status,
+                stdout,
+                stderr,
+                self.test_artifact_files
             )
+            self.save_logs.save_test_result_data(test_result_data)
             if stderr:
                 logging.info("Stderr reported for component: " + self.component.name)
                 logging.info(stderr)

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -145,9 +145,9 @@ class TestResultsLogs(LogRecorder):
         self.parent_class._generate_std_files(test_result_data.stdout, test_result_data.stderr, dest_directory)
         self.parent_class._copy_log_files(test_result_data.log_files, dest_directory)
 
-
-    def generate_component_yml(self, test_result_data: TestResultData):
+    def generate_component_yml(self, test_result_data: TestResultData) -> None:
         dest_directory = self.parent_class._create_base_folder_structure(test_result_data.component_name, test_result_data.component_test_config)
         self.parent_class._generate_yml(test_result_data, dest_directory)
+
 
 TestRecorder.__test__ = False  # type:ignore

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -144,7 +144,10 @@ class TestResultsLogs(LogRecorder):
         logging.info(f"Recording component test results for {test_result_data.component_name} at " f"{os.path.realpath(dest_directory)}")
         self.parent_class._generate_std_files(test_result_data.stdout, test_result_data.stderr, dest_directory)
         self.parent_class._copy_log_files(test_result_data.log_files, dest_directory)
-        self.parent_class._generate_yml(test_result_data, dest_directory)
 
+
+    def generate_component_yml(self, test_result_data: TestResultData):
+        dest_directory = self.parent_class._create_base_folder_structure(test_result_data.component_name, test_result_data.component_test_config)
+        self.parent_class._generate_yml(test_result_data, dest_directory)
 
 TestRecorder.__test__ = False  # type:ignore

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_runner_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_runner_opensearch.py
@@ -69,7 +69,7 @@ class TestIntegTestRunnerOpenSearch(unittest.TestCase):
         self.assertEqual(results["sql"], mock_test_results)
 
         mock_suite_object.result_data.__iter__.assert_called()
-        mock_test_recorder_object.test_results_logs.save_test_result_data.assert_called()
+        mock_test_recorder_object.test_results_logs.generate_component_yml.assert_called()
 
         mock_suite.assert_called_once_with(
             mock_properties_object.dependency_installer,

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_runner_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_runner_opensearch_dashboards.py
@@ -76,7 +76,7 @@ class TestIntegTestRunnerOpenSearchDashboards(unittest.TestCase):
         self.assertEqual(results["sql"], mock_test_results)
 
         mock_suite_object.result_data.__iter__.assert_called()
-        mock_test_recorder_object.test_results_logs.save_test_result_data.assert_called()
+        mock_test_recorder_object.test_results_logs.generate_component_yml.assert_called()
 
         mock_suite.assert_called_once_with(
             mock_properties_dependency_object.dependency_installer,

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch.py
@@ -35,9 +35,10 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
         self.work_dir = Path("test_dir")
 
     @patch("os.path.exists", return_value=True)
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch.IntegTestSuiteOpenSearch.multi_execute_integtest_sh")
     @patch("test_workflow.integ_test.integ_test_suite_opensearch.Topology")
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
-    def test_execute_with_multiple_test_configs(self, mock_test_recorder: Mock, mock_topology: Mock, *mock: Any) -> None:
+    def test_execute_with_multiple_test_configs(self, mock_test_recorder: Mock, mock_topology: Mock, mock_multi_execute_integtest_sh: Mock, *mock: Any) -> None:
         test_config, component = self.__get_test_config_and_bundle_component("job-scheduler")
         dependency_installer = MagicMock()
         integ_test_suite = IntegTestSuiteOpenSearch(
@@ -50,8 +51,6 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
             mock_test_recorder
         )
         mock_topology.create().__enter__.return_value = [{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}]
-        mock_multi_execute_integtest_sh = MagicMock()
-        IntegTestSuiteOpenSearch.multi_execute_integtest_sh = mock_multi_execute_integtest_sh  # type: ignore
         mock_multi_execute_integtest_sh.return_value = "success"
 
         test_results = integ_test_suite.execute_tests()
@@ -63,9 +62,10 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
             call([{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}], False, "without-security")
         ])
 
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch.IntegTestSuiteOpenSearch.multi_execute_integtest_sh")
     @patch("test_workflow.integ_test.integ_test_suite_opensearch.Topology")
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
-    def test_execute_with_build_dependencies(self, mock_test_recorder: Mock, mock_topology: Mock, *mock: Any) -> None:
+    def test_execute_with_build_dependencies(self, mock_test_recorder: Mock, mock_topology: Mock, mock_multi_execute_integtest_sh: Mock, *mock: Any) -> None:
         dependency_installer = MagicMock()
         test_config, component = self.__get_test_config_and_bundle_component("index-management")
         integ_test_suite = IntegTestSuiteOpenSearch(
@@ -80,8 +80,6 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
 
         mock_topology.create().__enter__.return_value = [{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}]
 
-        mock_multi_execute_integtest_sh = MagicMock()
-        IntegTestSuiteOpenSearch.multi_execute_integtest_sh = mock_multi_execute_integtest_sh  # type: ignore
         mock_multi_execute_integtest_sh.return_value = "success"
 
         integ_test_suite.execute_tests()
@@ -93,6 +91,7 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
             [{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}], False, "without-security")]
         )
 
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch.IntegTestSuiteOpenSearch.multi_execute_integtest_sh")
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
     @patch("test_workflow.integ_test.integ_test_suite_opensearch.execute")
     def test_execute_without_build_dependencies(self, mock_execute: Mock, *mock: Any) -> None:
@@ -160,9 +159,10 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
 
     @patch("os.path.exists", return_value=True)
     @patch.object(ScriptFinder, "find_integ_test_script")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch.IntegTestSuiteOpenSearch.multi_execute_integtest_sh")
     @patch("test_workflow.integ_test.integ_test_suite_opensearch.Topology")
     @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
-    def test_execute_with_working_directory(self, mock_test_recorder: Mock, mock_topology: Mock, mock_script_finder: Mock, *mock: Any) -> None:
+    def test_execute_with_working_directory(self, mock_test_recorder: Mock, mock_topology: Mock, mock_multi_execute_integtest_sh: Mock, mock_script_finder: Mock, *mock: Any) -> None:
         test_config, component = self.__get_test_config_and_bundle_component("dashboards-reports")
         dependency_installer = MagicMock()
         integ_test_suite = IntegTestSuiteOpenSearch(
@@ -178,8 +178,6 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
         mock_topology.create().__enter__.return_value = [{"cluster_name": "cluster1", "data_nodes": [{"endpoint": "localhost", "port": 9200, "transport": 9300}], "cluster_manager_nodes": []}]
         mock_script_finder.return_value = "integtest.sh"
 
-        mock_multi_execute_integtest_sh = MagicMock()
-        IntegTestSuiteOpenSearch.multi_execute_integtest_sh = mock_multi_execute_integtest_sh  # type: ignore
         mock_multi_execute_integtest_sh.return_value = "success"
 
         integ_test_suite.execute_tests()  # type: ignore
@@ -189,3 +187,60 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
             True,
             "with-security"
         )
+
+    @patch("os.path.exists")
+    @patch("os.makedirs")
+    @patch("test_workflow.test_recorder.test_recorder.TestRecorder")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch.TestResultData")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch.GitRepository.__checkout__")
+    @patch("test_workflow.integ_test.integ_test_suite_opensearch.execute", return_value=True)
+    def test_multi_execute_integtest_sh(self, mock_execute: Mock, mock_git: Mock, mock_test_result_data: Mock,
+                                        mock_test_recorder: Mock, mock_makedirs: Mock, mock_path_exists: Mock, *mock: Any) -> None:
+        mock_find = MagicMock()
+        mock_find.return_value = "./integtest.sh"
+
+        ScriptFinder.find_integ_test_script = mock_find  # type: ignore
+
+        mock_execute.return_value = ("test_status", "test_stdout", "")
+
+        mock_test_result_data_object = MagicMock()
+        mock_test_result_data.return_value = mock_test_result_data_object
+        mock_path_exists.return_value = True
+
+        test_config, component = self.__get_test_config_and_bundle_component("job-scheduler")
+        dependency_installer = MagicMock()
+        integ_test_suite = IntegTestSuiteOpenSearch(
+            dependency_installer,
+            component,
+            test_config,
+            self.bundle_manifest,
+            self.build_manifest,
+            self.work_dir,
+            mock_test_recorder
+        )
+
+        self.assertEqual(integ_test_suite.repo.url, "https://github.com/opensearch-project/job-scheduler.git")
+        self.assertEqual(integ_test_suite.repo.ref, "4504dabfc67dd5628c1451e91e9a1c3c4ca71525")
+        integ_test_suite.repo.dir = "dir"
+
+        # call the test target
+        mock_endpoint = MagicMock()
+        status = integ_test_suite.multi_execute_integtest_sh([mock_endpoint], True, "with-security")
+
+        mock_find.assert_called()
+        self.assertEqual(status, "test_status")
+        mock_execute.assert_called()
+
+        mock_test_result_data.assert_called_once_with(
+            "job-scheduler",
+            "with-security",
+            "test_status",
+            "test_stdout",
+            "",
+            {
+                "opensearch-integ-test": os.path.join("dir", "build", "reports", "tests", "integTest")
+            }
+        )
+
+        assert(mock_test_result_data.return_value in integ_test_suite.result_data)
+        self.assertEqual(integ_test_suite.additional_cluster_config, None)

--- a/tests/tests_test_workflow/test_recorder/test_test_recorder.py
+++ b/tests/tests_test_workflow/test_recorder/test_test_recorder.py
@@ -191,4 +191,7 @@ class TestTestResultsLogs(unittest.TestCase):
         logs.save_test_result_data(mock_test_result_data)
 
         mock_parent_class._copy_log_files.assert_called_once_with(mock_test_result_data.log_files, dest_directory)
+
+        logs.generate_component_yml(mock_test_result_data)
+
         mock_parent_class._generate_yml.assert_called_once_with(mock_test_result_data, dest_directory)


### PR DESCRIPTION
### Description
Change test runner to record test results each time it finished testing with one configuration. 
Generate the component yaml file after both `with-security` and `without-security` tests completed because the local cluster logs will only be generated and recorded after process killed.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4435

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
