### PR TITLE
Disable incremental build for 2.12.0 release

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -27,8 +27,8 @@ pipeline {
             H 1 * * * %INPUT_MANIFEST=1.3.15/opensearch-1.3.15.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=2.13.0/opensearch-dashboards-2.13.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=2.13.0/opensearch-2.13.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H */6 * * * %INPUT_MANIFEST=2.12.0/opensearch-dashboards-2.12.0.yml;TEST_MANIFEST=2.12.0/opensearch-dashboards-2.12.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H */6 * * * %INPUT_MANIFEST=2.12.0/opensearch-2.12.0.yml;TEST_MANIFEST=2.12.0/opensearch-2.12.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
+            H */6 * * * %INPUT_MANIFEST=2.12.0/opensearch-dashboards-2.12.0.yml;TEST_MANIFEST=2.12.0/opensearch-dashboards-2.12.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;INCREMENTAL=false
+            H */6 * * * %INPUT_MANIFEST=2.12.0/opensearch-2.12.0.yml;TEST_MANIFEST=2.12.0/opensearch-2.12.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip;INCREMENTAL=false
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''


### PR DESCRIPTION
### Description
Disable incremental build for 2.12.0 release.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4115

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
