### PR TITLE
[Docker] Fixes security enabled logic to execute demo config only if security plugin is enabled

### DIFF
--- a/docker/release/README.md
+++ b/docker/release/README.md
@@ -91,7 +91,7 @@ Here are three example scenarios of using above variables:
      ```
      $ docker run -it -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" opensearchproject/opensearch:1.1.0
      ```
-     Note: For OpenSearch 2.12 and later, a custom password for the admin user is required to be passed to set-up and utilize demo configuration.
+     Note: For OpenSearch 2.12 and later, a custom password for the admin user is required to be passed to set up and utilize demo configuration.
      ```
      $ docker run -it -p 9200:9200 -p 9600:9600 -e OPENSEARCH_INITIAL_ADMIN_PASSWORD=<strong-password> -e "discovery.type=single-node" opensearchproject/opensearch:2.12.0
      ```
@@ -103,7 +103,7 @@ Here are three example scenarios of using above variables:
 #### Scenario 2: No demo certs/configs + disable security on both OpenSearch and OpenSearch-Dashboards:
   * OpenSearch:
      ```
-     $ docker run -it -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "DISABLE_INSTALL_DEMO_CONFIG=true" -e "DISABLE_SECURITY_PLUGIN=true" opensearchproject/opensearch:1.1.0
+     $ docker run -it -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "DISABLE_SECURITY_PLUGIN=true" opensearchproject/opensearch:1.1.0
      ```
   * OpenSearch-Dashboards:
      ```
@@ -133,7 +133,7 @@ Here are some example scenarios of using above variables:
      ```
      $ docker run -it -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" opensearchproject/opensearch:<TAG>
      ```
-     Note: For OpenSearch 2.12 and later, a custom password for the admin user is required to be passed to set-up and utilize demo configuration.
+     Note: For OpenSearch 2.12 and later, a custom password for the admin user is required to be passed to set up and utilize demo configuration.
      ```
      $ docker run -it -p 9200:9200 -p 9600:9600 -e OPENSEARCH_INITIAL_ADMIN_PASSWORD=<strong-password> -e "discovery.type=single-node" opensearchproject/opensearch:<TAG>
      ```
@@ -143,7 +143,7 @@ Here are some example scenarios of using above variables:
      ```
      $ docker run -it -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI=true" opensearchproject/opensearch:<TAG>
      ```
-     Note: For OpenSearch 2.12 and later, a custom password for the admin user is required to be passed to set-up and utilize demo configuration.
+     Note: For OpenSearch 2.12 and later, a custom password for the admin user is required to be passed to set up and utilize demo configuration.
      ```
      $ docker run -it -p 9200:9200 -p 9600:9600 -e OPENSEARCH_INITIAL_ADMIN_PASSWORD=<strong-password> -e "discovery.type=single-node" -e "DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI=true" opensearchproject/opensearch:<TAG>
      ```

--- a/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint.sh
@@ -31,19 +31,18 @@ function setupSecurityPlugin {
     SECURITY_PLUGIN="opensearch-security"
 
     if [ -d "$OPENSEARCH_HOME/plugins/$SECURITY_PLUGIN" ]; then
-        if [ "$DISABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
-            echo "Disabling execution of install_demo_configuration.sh for OpenSearch Security Plugin"
-        else
-            echo -e "Enabling execution of install_demo_configuration.sh for OpenSearch Security Plugin \nOpenSearch 2.12.0 onwards, the OpenSearch Security Plugin a change that requires an initial password for 'admin' user. \nPlease define an environment variable 'OPENSEARCH_INITIAL_ADMIN_PASSWORD' with a strong password string. \nIf a password is not provided, the setup will quit. \n For more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/"
-            bash $OPENSEARCH_HOME/plugins/$SECURITY_PLUGIN/tools/install_demo_configuration.sh -y -i -s || exit 1
-        fi
-
         if [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
             echo "Disabling OpenSearch Security Plugin"
             opensearch_opt="-Eplugins.security.disabled=true"
             opensearch_opts+=("${opensearch_opt}")
         else
             echo "Enabling OpenSearch Security Plugin"
+            if [ "$DISABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
+                echo "Disabling execution of install_demo_configuration.sh for OpenSearch Security Plugin"
+            else
+                echo -e "Enabling execution of install_demo_configuration.sh for OpenSearch Security Plugin \nOpenSearch 2.12.0 onwards, the OpenSearch Security Plugin a change that requires an initial password for 'admin' user. \nPlease define an environment variable 'OPENSEARCH_INITIAL_ADMIN_PASSWORD' with a strong password string. \nIf a password is not provided, the setup will quit. \n For more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/"
+                bash $OPENSEARCH_HOME/plugins/$SECURITY_PLUGIN/tools/install_demo_configuration.sh -y -i -s || exit 1
+            fi
         fi
     else
         echo "OpenSearch Security Plugin does not exist, disable by default"


### PR DESCRIPTION
### Description
The current docker entrypoint executes the demo security config setup script regardless of whether security plugin is enabled. Then it checks whether security plugin is enabled. I'm not sure why this design was implemented but I feel like this is wrong. This PR restructures the logic to install demo config only if security plugin is enabled.

### Issues Resolved
- Resolves https://github.com/opensearch-project/opensearch-build/issues/4445

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
