### PR TITLE
Support new distribution-validations and add few enhancements to validation workflow

### DIFF
--- a/src/validation_workflow/deb/__init__.py
+++ b/src/validation_workflow/deb/__init__.py
@@ -1,0 +1,8 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/src/validation_workflow/deb/validation_deb.py
+++ b/src/validation_workflow/deb/validation_deb.py
@@ -42,7 +42,8 @@ class ValidateDeb(Validation, DownloadUtils):
 
     def validation(self) -> bool:
         if self.check_cluster_readiness():
-            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch")) if not self.args.force_https else True)  # noqa: E501
+            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects,
+                                                            self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch")) if self.args.allow_http else True)
             if (test_result):
                 logging.info(f'All tests Pass : {counter}')
                 return True

--- a/src/validation_workflow/docker/inspect_docker_image.py
+++ b/src/validation_workflow/docker/inspect_docker_image.py
@@ -27,7 +27,7 @@ class InspectDockerImage:
         self.image_id = image_id
         self.image_name = image_name
         self.prod_image_tag = prod_image_tag
-        self.image_tag = ValidationArgs().stg_tag('opensearch_dashboards').replace(" ", "") if ("dashboards" in self.image_name) else ValidationArgs().stg_tag('opensearch').replace(" ", "")
+        self.image_tag = ValidationArgs().stg_tag('opensearch-dashboards').replace(" ", "") if ("dashboards" in self.image_name) else ValidationArgs().stg_tag('opensearch').replace(" ", "")
         self.auth_token_url = "https://auth.docker.io/token?"
         self.auth_service_scope = "service=registry.docker.io&scope=repository:"
         self.registry_url = "https://index.docker.io/v2/"

--- a/src/validation_workflow/docker/validation_docker.py
+++ b/src/validation_workflow/docker/validation_docker.py
@@ -9,14 +9,10 @@ import logging
 import os
 import shutil
 import subprocess
-import time
 from subprocess import PIPE
 from typing import Any
 
-import requests
-
-from system.temporary_directory import TemporaryDirectory
-from validation_workflow.api_request import ApiTest
+from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.docker.inspect_docker_image import InspectDockerImage
 from validation_workflow.validation import Validation
@@ -61,7 +57,7 @@ class ValidateDocker(Validation):
     def validation(self) -> bool:
         # STEP 2 . inspect image digest between opensearchproject(downloaded/local) and opensearchstaging(dockerHub)
         if not self.args.using_staging_artifact_only:
-            self.image_names_list = [self.args.OS_image, self.args.OSD_image]
+            self.image_names_list = ['opensearchproject/' + project for project in self.args.projects]
             self.image_names_list = [x for x in self.image_names_list if (os.path.basename(x) in self.args.projects)]
             self.image_digests = list(map(lambda x: self.inspect_docker_image(x[0], x[1]), zip(self.image_ids.values(), self.image_names_list)))  # type: ignore
             if all(self.image_digests):
@@ -79,7 +75,7 @@ class ValidateDocker(Validation):
                 self.args.version
             )
             if return_code:
-                logging.info('Checking if cluster is ready for API test in every 10 seconds\n\n')
+                logging.info('Checking if cluster is ready for API test in every 5 seconds\n\n')
 
                 if self.check_cluster_readiness():
                     # STEP 4 . OS, OSD API validation
@@ -94,8 +90,8 @@ class ValidateDocker(Validation):
                         raise Exception(f'Not all tests Pass : {_counter}')
                 else:
                     raise Exception("Cluster is not ready for API test.")
-        else:
-            raise Exception('The container failed to start. Exiting the validation.')
+            else:
+                raise Exception('The container failed to start. Exiting the validation.')
 
         return True
 
@@ -128,36 +124,6 @@ class ValidateDocker(Validation):
             logging.error("Error: %s - %s." % (e.filename, e.strerror))
 
         return('returncode=0' in (str(result)))
-
-    def check_http_request(self) -> bool:
-        self.test_readiness_urls = {
-            'https://localhost:9200/': 'opensearch cluster API',
-            'http://localhost:5601/api/status': 'opensearch-dashboards API',
-        }
-
-        for url, name in self.test_readiness_urls.items():
-            try:
-                status_code, response_text = ApiTest(url, self.args.version).api_get()
-                if status_code != 200:
-                    logging.error(f'Error connecting to {name} ({url}): status code {status_code}')
-                    return False
-            except (requests.exceptions.ConnectionError, requests.exceptions.ConnectTimeout) as e:
-                logging.error(f'Error connecting to {name} ({url}): {e}')
-                return False
-        return True
-
-    def check_cluster_readiness(self) -> bool:
-        max_retry = 20
-        retry_count = 0
-        while retry_count < max_retry:
-            logging.info(f'sleeping 10sec for retry {retry_count + 1}/{max_retry}')
-            time.sleep(10)
-            if self.check_http_request():
-                logging.info('\n\ncluster is now ready for API test\n\n')
-                return True
-            retry_count += 1
-        logging.error(f"Maximum number of retries ({max_retry}) reached. Cluster is not ready for API test.")
-        return False
 
     def get_artifact_image_name(self, artifact: str, using_staging_artifact_only: str) -> Any:
         self.image_names = {
@@ -241,7 +207,6 @@ class ValidateDocker(Validation):
             '2': 'docker-compose-2.x.yml'
         }
 
-        self.tmp_dir = TemporaryDirectory()
         self.target_yml_file = os.path.join(self.tmp_dir.name, 'docker-compose.yml')
 
         self.major_version_number = version[0]
@@ -252,8 +217,9 @@ class ValidateDocker(Validation):
         self.replacements = [(f'opensearchproject/{key}:{self.major_version_number}', value) for key, value in image_ids.items()]
 
         list(map(lambda r: self.inplace_change(self.target_yml_file, r[0], r[1]), self.replacements))
-
+        os.environ["OPENSEARCH_INITIAL_ADMIN_PASSWORD"] = get_password(str(version))
         # spin up containers
-        self.docker_compose_up = f'docker-compose -f {self.target_yml_file} up -d'
+        services = "opensearch-node1 opensearch-node2" if "opensearch-dashboards" not in self.args.projects else ""
+        self.docker_compose_up = f'docker-compose -f {self.target_yml_file} up -d {services}'
         result = subprocess.run(self.docker_compose_up, shell=True, stdout=PIPE, stderr=PIPE, universal_newlines=True)
         return ('returncode=0' in (str(result)), self.target_yml_file)

--- a/src/validation_workflow/docker/validation_docker.py
+++ b/src/validation_workflow/docker/validation_docker.py
@@ -58,7 +58,6 @@ class ValidateDocker(Validation):
         # STEP 2 . inspect image digest between opensearchproject(downloaded/local) and opensearchstaging(dockerHub)
         if not self.args.using_staging_artifact_only:
             self.image_names_list = ['opensearchproject/' + project for project in self.args.projects]
-            self.image_names_list = [x for x in self.image_names_list if (os.path.basename(x) in self.args.projects)]
             self.image_digests = list(map(lambda x: self.inspect_docker_image(x[0], x[1]), zip(self.image_ids.values(), self.image_names_list)))  # type: ignore
             if all(self.image_digests):
                 logging.info('Image digest is validated.\n\n')

--- a/src/validation_workflow/rpm/validation_rpm.py
+++ b/src/validation_workflow/rpm/validation_rpm.py
@@ -48,7 +48,8 @@ class ValidateRpm(Validation, DownloadUtils):
 
     def validation(self) -> bool:
         if self.check_cluster_readiness():
-            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch")) if not self.args.force_https else True)  # noqa: E501
+            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects,
+                                                            self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch")) if self.args.allow_http else True)
             if (test_result):
                 logging.info(f'All tests Pass : {counter}')
                 return True

--- a/src/validation_workflow/tar/validation_tar.py
+++ b/src/validation_workflow/tar/validation_tar.py
@@ -45,7 +45,8 @@ class ValidateTar(Validation, DownloadUtils):
 
     def validation(self) -> bool:
         if self.check_cluster_readiness():
-            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(self.tmp_dir.path, "opensearch")) if not self.args.force_https else True)  # noqa: E501
+            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects,
+                                                            self.check_for_security_plugin(os.path.join(self.tmp_dir.path, "opensearch")) if self.args.allow_http else True)
             if (test_result):
                 logging.info(f'All tests Pass : {counter}')
                 return True

--- a/src/validation_workflow/validation.py
+++ b/src/validation_workflow/validation.py
@@ -78,8 +78,15 @@ class Validation(ABC):
         file_name_suffix = "tar.gz" if self.args.distribution == "tar" else self.args.distribution
         if self.args.artifact_type == "staging":
             if self.args.distribution == "yum":
-                return f"{self.base_url_staging}{project}/{self.args.version}/{self.args.build_number[project]}/{self.args.platform}/{self.args.arch}/rpm/dist/{project}/{project}-{self.args.version}.staging.repo"  # noqa: E501
-            return f"{self.base_url_staging}{project}/{self.args.version}/{self.args.build_number[project]}/{self.args.platform}/{self.args.arch}/{self.args.distribution}/dist/{project}/{project}-{self.args.version}-{self.args.platform}-{self.args.arch}.{file_name_suffix}"  # noqa: E501
+                return (
+                    f"{self.base_url_staging}{project}/{self.args.version}/{self.args.build_number[project]}/{self.args.platform}/"
+                    f"{self.args.arch}/rpm/dist/{project}/{project}-{self.args.version}.staging.repo"
+                )
+            return (
+                f"{self.base_url_staging}{project}/{self.args.version}/{self.args.build_number[project]}/{self.args.platform}/"
+                f"{self.args.arch}/{self.args.distribution}/dist/{project}/{project}-{self.args.version}-{self.args.platform}-"
+                f"{self.args.arch}.{file_name_suffix}"
+            )
         if self.args.distribution == "yum":
             return f"{self.base_url_production}{project}/{self.args.version[0:1]}.x/{project}-{self.args.version[0:1]}.x.repo"
         return f"{self.base_url_production}{project}/{self.args.version}/{project}-{self.args.version}-{self.args.platform}-{self.args.arch}.{file_name_suffix}"

--- a/src/validation_workflow/validation.py
+++ b/src/validation_workflow/validation.py
@@ -95,10 +95,10 @@ class Validation(ABC):
         max_retry = 20
         retry_count = 0
         while retry_count < max_retry:
-            logging.info(f'sleeping 5sec for retry {retry_count + 1}/{max_retry}')
+            logging.info(f'Sleeping 5sec for retry {retry_count + 1}/{max_retry}')
             time.sleep(5)
             if self.check_http_request():
-                logging.info('\n\ncluster is now ready for API test\n\n')
+                logging.info('\n\nCluster is now ready for API test\n\n')
                 return True
             retry_count += 1
         logging.error(f"Maximum number of retries ({max_retry}) reached. Cluster is not ready for API test.")

--- a/src/validation_workflow/validation.py
+++ b/src/validation_workflow/validation.py
@@ -10,9 +10,14 @@ import logging
 import os
 import re
 import shutil
+import time
 from abc import ABC, abstractmethod
 from typing import Any
 
+import requests
+
+from system.temporary_directory import TemporaryDirectory
+from validation_workflow.api_request import ApiTest
 from validation_workflow.download_utils import DownloadUtils
 from validation_workflow.validation_args import ValidationArgs
 
@@ -23,8 +28,10 @@ class Validation(ABC):
     """
 
     def __init__(self, args: ValidationArgs) -> None:
-        super().__init__()
         self.args = args
+        self.base_url_production = "https://artifacts.opensearch.org/releases/bundle/"
+        self.base_url_staging = "https://ci.opensearch.org/ci/dbc/distribution-build-"
+        self.tmp_dir = TemporaryDirectory()
 
     def check_url(self, url: str) -> bool:
         if DownloadUtils().download(url, self.tmp_dir) and DownloadUtils().is_url_valid(url):  # type: ignore
@@ -53,9 +60,59 @@ class Validation(ABC):
         except Exception as e:
             raise Exception(f'An error occurred while running the validation tests: {str(e)}')
 
-    @abstractmethod
     def download_artifacts(self) -> bool:
-        pass
+        isFilePathEmpty = bool(self.args.file_path)
+        for project in self.args.projects:
+            if (isFilePathEmpty):
+                if ("https:" not in self.args.file_path.get(project)):
+                    self.copy_artifact(self.args.file_path.get(project), str(self.tmp_dir.path))
+                else:
+                    self.args.version = self.get_version(self.args.file_path.get(project))
+                    self.check_url(self.args.file_path.get(project))
+            else:
+                self.args.file_path[project] = self.get_filepath(project)
+                self.check_url(self.args.file_path.get(project))
+        return True
+
+    def get_filepath(self, project: str) -> str:
+        file_name_suffix = "tar.gz" if self.args.distribution == "tar" else self.args.distribution
+        if self.args.artifact_type == "staging":
+            if self.args.distribution == "yum":
+                return f"{self.base_url_staging}{project}/{self.args.version}/{self.args.build_number[project]}/{self.args.platform}/{self.args.arch}/rpm/dist/{project}/{project}-{self.args.version}.staging.repo"  # noqa: E501
+            return f"{self.base_url_staging}{project}/{self.args.version}/{self.args.build_number[project]}/{self.args.platform}/{self.args.arch}/{self.args.distribution}/dist/{project}/{project}-{self.args.version}-{self.args.platform}-{self.args.arch}.{file_name_suffix}"  # noqa: E501
+        if self.args.distribution == "yum":
+            return f"{self.base_url_production}{project}/{self.args.version[0:1]}.x/{project}-{self.args.version[0:1]}.x.repo"
+        return f"{self.base_url_production}{project}/{self.args.version}/{project}-{self.args.version}-{self.args.platform}-{self.args.arch}.{file_name_suffix}"
+
+    def check_cluster_readiness(self) -> bool:
+        max_retry = 20
+        retry_count = 0
+        while retry_count < max_retry:
+            logging.info(f'sleeping 5sec for retry {retry_count + 1}/{max_retry}')
+            time.sleep(5)
+            if self.check_http_request():
+                logging.info('\n\ncluster is now ready for API test\n\n')
+                return True
+            retry_count += 1
+        logging.error(f"Maximum number of retries ({max_retry}) reached. Cluster is not ready for API test.")
+        return False
+
+    def check_http_request(self) -> bool:
+        self.test_readiness_urls = {
+            'https://localhost:9200': 'opensearch cluster API'
+        }
+        if 'opensearch-dashboards' in self.args.projects:
+            self.test_readiness_urls['http://localhost:5601/api/status'] = 'opensearch-dashboards API'
+        for url, name in self.test_readiness_urls.items():
+            try:
+                status_code, response_text = ApiTest(url, self.args.version).api_get()
+                if status_code != 200:
+                    logging.error(f'Error connecting to {name} ({url}): status code {status_code}')
+                    return False
+            except (requests.exceptions.ConnectionError, requests.exceptions.ConnectTimeout) as e:
+                logging.error(f'Error connecting to {name} ({url}): {e}')
+                return False
+        return True
 
     @abstractmethod
     def installation(self) -> bool:

--- a/src/validation_workflow/validation_args.py
+++ b/src/validation_workflow/validation_args.py
@@ -124,13 +124,15 @@ class ValidationArgs:
             action="store_true",
             default=False,
             help="(optional) Validate digest only; will not run docker to test API",
-            dest="validate_digest_only")
+            dest="validate_digest_only"
+        )
         group.add_argument(
             "--using-staging-artifact-only",
             action="store_true",
             default=False,
             help="(optional) Use only staging artifact to run docker and API test, will not validate digest",
-            dest="using_staging_artifact_only")
+            dest="using_staging_artifact_only"
+        )
 
         args = parser.parse_args()
 

--- a/src/validation_workflow/validation_args.py
+++ b/src/validation_workflow/validation_args.py
@@ -113,10 +113,10 @@ class ValidationArgs:
         )
         parser.add_argument(
             "-f",
-            "--force-https",
-            action="store_false",
-            default=True,
-            help="If False, use http/https to connect based on the existence of security plugin, else always use https, default to True"
+            "--allow-http",
+            action="store_true",
+            default=False,
+            help="If True, use http/https to connect based on the existence of security plugin, else always use https, default to False"
         )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
@@ -146,14 +146,14 @@ class ValidationArgs:
 
         if args.distribution == "docker":
             if args.osd_build_number != "latest" and "opensearch-dashboards" not in args.projects:
-                raise Exception("Provide opensearch-dashboards in projects argument to validate OpenSearch-Dashboards")
-            if not(args.validate_digest_only or args.using_staging_artifact_only):
+                raise Exception("osd_build_number argument cannot be provided without specifying opensearch-dashboards in --projects")
+            if not(args.validate_digest_only) and not(args.using_staging_artifact_only):
                 raise Exception("Provide either of --validate-digest-only and --using-staging-artifact-only for Docker Validation")
 
         self.version = args.version
         self.file_path = args.file_path
         self.artifact_type = args.artifact_type
-        self.force_https = args.force_https
+        self.allow_http = args.allow_http
         self.logging_level = args.logging_level
         self.distribution = args.distribution
         self.platform = args.platform

--- a/src/validation_workflow/validation_args.py
+++ b/src/validation_workflow/validation_args.py
@@ -146,7 +146,7 @@ class ValidationArgs:
 
         if args.distribution == "docker":
             if args.osd_build_number != "latest" and "opensearch-dashboards" not in args.projects:
-                raise Exception("osd_build_number argument cannot be provided without specifying opensearch-dashboards in --projects")
+                raise Exception("--osd_build_number argument cannot be provided without specifying opensearch-dashboards in --projects")
             if not(args.validate_digest_only) and not(args.using_staging_artifact_only):
                 raise Exception("Provide either of --validate-digest-only and --using-staging-artifact-only for Docker Validation")
 

--- a/src/validation_workflow/validation_args.py
+++ b/src/validation_workflow/validation_args.py
@@ -13,7 +13,7 @@ from test_workflow.test_kwargs import TestKwargs
 
 
 class ValidationArgs:
-    SUPPORTED_PLATFORMS = ["linux"]
+    SUPPORTED_PLATFORMS = ["linux", "windows"]
     DOCKER_SOURCE = ["dockerhub", "ecr"]
 
     def __init__(self) -> None:
@@ -114,7 +114,7 @@ class ValidationArgs:
         parser.add_argument(
             "-f",
             "--force-https",
-            action="store_true",
+            action="store_false",
             default=True,
             help="If False, use http/https to connect based on the existence of security plugin, else always use https, default to True"
         )
@@ -123,22 +123,30 @@ class ValidationArgs:
             "--validate-digest-only",
             action="store_true",
             default=False,
-            help="(optional) Validate digest only; will not run docker to test API")
+            help="(optional) Validate digest only; will not run docker to test API",
+            dest="validate_digest_only")
         group.add_argument(
             "--using-staging-artifact-only",
             action="store_true",
             default=False,
-            help="(optional) Use only staging artifact to run docker and API test, will not validate digest")
+            help="(optional) Use only staging artifact to run docker and API test, will not validate digest",
+            dest="using_staging_artifact_only")
 
         args = parser.parse_args()
 
         if (not (args.version or args.file_path)):
             raise Exception("Provide either version number or File Path")
-        if(args.file_path):
+        if (args.file_path):
+            if 'opensearch' not in args.file_path.keys() or not set(args.file_path.keys()) <= {'opensearch', 'opensearch-dashboards'}:
+                raise Exception("Missing OpenSearch artifact details! Please provide the valid product names among opensearch and opensearch-dashboards")
             args.distribution = self.get_distribution_type(args.file_path)
             args.projects = args.file_path.keys()
-        if (('opensearch' not in args.projects)):
-            raise Exception("Missing OpenSearch OpenSearch artifact details! Please provide the same along with OpenSearch-Dashboards to validate")
+
+        if args.distribution == "docker":
+            if args.osd_build_number != "latest" and "opensearch-dashboards" not in args.projects:
+                raise Exception("Provide opensearch-dashboards in projects argument to validate OpenSearch-Dashboards")
+            if not(args.validate_digest_only or args.using_staging_artifact_only):
+                raise Exception("Provide either of --validate-digest-only and --using-staging-artifact-only for Docker Validation")
 
         self.version = args.version
         self.file_path = args.file_path
@@ -149,8 +157,6 @@ class ValidationArgs:
         self.platform = args.platform
         self.projects = args.projects
         self.arch = args.arch
-        self.OS_image = 'opensearchproject/opensearch'
-        self.OSD_image = 'opensearchproject/opensearch-dashboards'
         self.build_number = {"opensearch": args.os_build_number, "opensearch-dashboards": args.osd_build_number}
         self.os_build_number = args.os_build_number
         self.osd_build_number = args.osd_build_number
@@ -165,6 +171,10 @@ class ValidationArgs:
             return 'yum'
         elif (any("rpm" in value for value in file_path.values())):
             return 'rpm'
+        elif (any("zip" in value for value in file_path.values())):
+            return 'zip'
+        elif (any("deb" in value for value in file_path.values())):
+            return 'deb'
         else:
             raise Exception("Provided distribution is not supported")
 
@@ -174,8 +184,8 @@ class ValidationArgs:
                 None,
                 [
                     self.version,
-                    "." + self.os_build_number if (self.os_build_number != "") and (image_type == "opensearch") else None,
-                    "." + self.osd_build_number if (self.osd_build_number != "") and (image_type == "opensearch_dashboards") else None,
+                    "." + self.os_build_number if (self.os_build_number != "latest") and (image_type == "opensearch") else None,
+                    "." + self.osd_build_number if (self.osd_build_number != "latest") and (image_type == "opensearch-dashboards") else None,
                 ],
             )
         )

--- a/src/validation_workflow/validation_test_runner.py
+++ b/src/validation_workflow/validation_test_runner.py
@@ -6,12 +6,14 @@
 # compatible open source license.
 # type: ignore
 
+from validation_workflow.deb.validation_deb import ValidateDeb
 from validation_workflow.docker.validation_docker import ValidateDocker
 from validation_workflow.rpm.validation_rpm import ValidateRpm
 from validation_workflow.tar.validation_tar import ValidateTar
 from validation_workflow.validation import Validation
 from validation_workflow.validation_args import ValidationArgs
 from validation_workflow.yum.validation_yum import ValidateYum
+from validation_workflow.zip.validation_zip import ValidateZip
 
 
 class ValidationTestRunner:
@@ -19,7 +21,9 @@ class ValidationTestRunner:
         "docker": ValidateDocker,
         "tar": ValidateTar,
         "rpm": ValidateRpm,
-        "yum": ValidateYum
+        "yum": ValidateYum,
+        "zip": ValidateZip,
+        "deb": ValidateDeb
     }
 
     @classmethod

--- a/src/validation_workflow/yum/validation_yum.py
+++ b/src/validation_workflow/yum/validation_yum.py
@@ -7,10 +7,8 @@
 
 import logging
 import os
-import time
 
 from system.execute import execute
-from system.temporary_directory import TemporaryDirectory
 from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.download_utils import DownloadUtils
@@ -22,28 +20,6 @@ class ValidateYum(Validation, DownloadUtils):
 
     def __init__(self, args: ValidationArgs) -> None:
         super().__init__(args)
-        self.base_url_production = "https://artifacts.opensearch.org/releases/bundle/"
-        self.base_url_staging = "https://ci.opensearch.org/ci/dbc/distribution-build-"
-        self.tmp_dir = TemporaryDirectory()
-
-    def download_artifacts(self) -> bool:
-        isFilePathEmpty = bool(self.args.file_path)
-        for project in self.args.projects:
-            if (isFilePathEmpty):
-                if ("https:" not in self.args.file_path.get(project)):
-                    self.copy_artifact(self.args.file_path.get(project), str(self.tmp_dir.path))
-                else:
-                    self.args.version = self.get_version(self.args.file_path.get(project))
-                    self.check_url(self.args.file_path.get(project))
-
-            else:
-                if (self.args.artifact_type == "staging"):
-                    self.args.file_path[project] = f"{self.base_url_staging}{project}/{self.args.version}/{self.args.build_number[project]}/linux/{self.args.arch}/rpm/dist/{project}/{project}-{self.args.version}.staging.repo"  # noqa: E501
-                else:
-                    self.args.file_path[project] = f"{self.base_url_production}{project}/{self.args.version[0:1]}.x/{project}-{self.args.version[0:1]}.x.repo"
-
-                self.check_url(self.args.file_path.get(project))
-        return True
 
     def installation(self) -> bool:
         try:
@@ -63,19 +39,21 @@ class ValidateYum(Validation, DownloadUtils):
         try:
             for project in self.args.projects:
                 execute(f'sudo systemctl start {project}', ".")
-                time.sleep(20)
                 execute(f'sudo systemctl status {project}', ".")
         except:
             raise Exception('Failed to Start Cluster')
         return True
 
     def validation(self) -> bool:
-        test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch")) if not self.args.force_https else True)  # noqa: E501
-        if (test_result):
-            logging.info(f'All tests Pass : {counter}')
-            return True
+        if self.check_cluster_readiness():
+            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch")) if not self.args.force_https else True)  # noqa: E501
+            if (test_result):
+                logging.info(f'All tests Pass : {counter}')
+                return True
+            else:
+                raise Exception(f'Not all tests Pass : {counter}')
         else:
-            raise Exception(f'Not all tests Pass : {counter}')
+            raise Exception("Cluster is not ready for API test")
 
     def cleanup(self) -> bool:
         try:

--- a/src/validation_workflow/yum/validation_yum.py
+++ b/src/validation_workflow/yum/validation_yum.py
@@ -46,7 +46,8 @@ class ValidateYum(Validation, DownloadUtils):
 
     def validation(self) -> bool:
         if self.check_cluster_readiness():
-            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch")) if not self.args.force_https else True)  # noqa: E501
+            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects,
+                                                            self.check_for_security_plugin(os.path.join(os.sep, "usr", "share", "opensearch")) if self.args.allow_http else True)
             if (test_result):
                 logging.info(f'All tests Pass : {counter}')
                 return True

--- a/src/validation_workflow/zip/__init__.py
+++ b/src/validation_workflow/zip/__init__.py
@@ -1,0 +1,8 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# This page intentionally left blank.

--- a/src/validation_workflow/zip/validation_zip.py
+++ b/src/validation_workflow/zip/validation_zip.py
@@ -34,7 +34,8 @@ class ValidateZip(Validation, DownloadUtils):
 
     def start_cluster(self) -> bool:
         try:
-            self.os_process.start(f"env OPENSEARCH_INITIAL_ADMIN_PASSWORD={get_password(str(self.args.version))} .\\opensearch-windows-install.bat", os.path.join(self.tmp_dir.path, f"opensearch-{self.args.version}"), False)  # noqa: E501
+            self.os_process.start(f"env OPENSEARCH_INITIAL_ADMIN_PASSWORD={get_password(str(self.args.version))} .\\opensearch-windows-install.bat",
+                                  os.path.join(self.tmp_dir.path, f"opensearch-{self.args.version}"), False)
             if "opensearch-dashboards" in self.args.projects:
                 self.osd_process.start(".\\bin\\opensearch-dashboards.bat", os.path.join(self.tmp_dir.path, f"opensearch-dashboards-{self.args.version}"), False)
             logging.info("Starting cluster")
@@ -44,7 +45,8 @@ class ValidateZip(Validation, DownloadUtils):
 
     def validation(self) -> bool:
         if self.check_cluster_readiness():
-            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects, self.check_for_security_plugin(os.path.join(self.tmp_dir.path, "opensearch")) if not self.args.force_https else True)  # noqa: E501
+            test_result, counter = ApiTestCases().test_apis(self.args.version, self.args.projects,
+                                                            self.check_for_security_plugin(os.path.join(self.tmp_dir.path, "opensearch")) if self.args.allow_http else True)
             if (test_result):
                 logging.info(f'All tests Pass : {counter}')
                 return True

--- a/src/validation_workflow/zip/validation_zip.py
+++ b/src/validation_workflow/zip/validation_zip.py
@@ -8,8 +8,8 @@
 import logging
 import os
 
-from system.execute import execute
 from system.process import Process
+from system.zip_file import ZipFile
 from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.download_utils import DownloadUtils
@@ -17,8 +17,7 @@ from validation_workflow.validation import Validation
 from validation_workflow.validation_args import ValidationArgs
 
 
-class ValidateTar(Validation, DownloadUtils):
-
+class ValidateZip(Validation, DownloadUtils):
     def __init__(self, args: ValidationArgs) -> None:
         super().__init__(args)
         self.os_process = Process()
@@ -27,18 +26,18 @@ class ValidateTar(Validation, DownloadUtils):
     def installation(self) -> bool:
         try:
             for project in self.args.projects:
-                self.filename = os.path.basename(self.args.file_path.get(project))
-                execute('mkdir ' + os.path.join(self.tmp_dir.path, project) + ' | tar -xzf ' + os.path.join(str(self.tmp_dir.path), self.filename) + ' -C ' + os.path.join(self.tmp_dir.path, project) + ' --strip-components=1', ".", True, False)  # noqa: E501
+                with ZipFile(os.path.join(self.tmp_dir.path, os.path.basename(self.args.file_path.get(project))), "r") as zip:
+                    zip.extractall(self.tmp_dir.path)
         except:
-            raise Exception('Failed to install Opensearch')
+            raise Exception("Failed to install OpenSearch/OpenSearch-Dashboards")
         return True
 
     def start_cluster(self) -> bool:
         try:
-            self.os_process.start(f'export OPENSEARCH_INITIAL_ADMIN_PASSWORD={get_password(str(self.args.version))} && ./opensearch-tar-install.sh', os.path.join(self.tmp_dir.path, "opensearch"))
-            if ("opensearch-dashboards" in self.args.projects):
-                self.osd_process.start(os.path.join(str(self.tmp_dir.path), "opensearch-dashboards", "bin", "opensearch-dashboards"), ".")
-            logging.info('Started cluster')
+            self.os_process.start(f"env OPENSEARCH_INITIAL_ADMIN_PASSWORD={get_password(str(self.args.version))} .\\opensearch-windows-install.bat", os.path.join(self.tmp_dir.path, f"opensearch-{self.args.version}"), False)  # noqa: E501
+            if "opensearch-dashboards" in self.args.projects:
+                self.osd_process.start(".\\bin\\opensearch-dashboards.bat", os.path.join(self.tmp_dir.path, f"opensearch-dashboards-{self.args.version}"), False)
+            logging.info("Starting cluster")
         except:
             raise Exception('Failed to Start Cluster')
         return True

--- a/tests/tests_validation_workflow/test_inspect_docker_image.py
+++ b/tests/tests_validation_workflow/test_inspect_docker_image.py
@@ -23,13 +23,14 @@ class TestInspectDockerImage(unittest.TestCase):
         self.prod_image_tag = "1.2.3"
         self.os_build_number = "1000"
         self.osd_build_number = "2000"
+        self.projects = ["opensearch", "opensearch-dashboards"]
         self.version = "2.4.0"
         with patch("validation_workflow.docker.inspect_docker_image.ValidationArgs", MagicMock()) as mock_args:
             mock_args.stg_tag.return_value = "stg_tag"
             self.inspector = InspectDockerImage(self.image_id, self.image_name, self.prod_image_tag)
 
     def test_validation_args_stg_arg(self) -> None:
-        result = ValidationArgs.stg_tag(self, 'opensearch_dashboards').replace(" ", "")  # type: ignore
+        result = ValidationArgs.stg_tag(self, 'opensearch-dashboards').replace(" ", "")  # type: ignore
         self.assertEqual(result, "2.4.0.2000")
         result = ValidationArgs.stg_tag(self, 'opensearch').replace(" ", "")  # type: ignore
         self.assertEqual(result, "2.4.0.1000")

--- a/tests/tests_validation_workflow/test_validation.py
+++ b/tests/tests_validation_workflow/test_validation.py
@@ -81,7 +81,7 @@ class TestValidation(unittest.TestCase):
     def test_check_cluster_readiness_error(self, mock_validation_args: Mock, mock_check_http: Mock, mock_sleep: Mock) -> None:
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_check_http.return_value = False
 
@@ -96,7 +96,7 @@ class TestValidation(unittest.TestCase):
     def test_check_http_request(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
         mock_validation_args.return_value.version = '1.3.13'
         mock_validation_args.return_value.validate_digest_only = False
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
         mock_api_get.return_value = (200, "text")
 
@@ -111,7 +111,7 @@ class TestValidation(unittest.TestCase):
     def test_check_http_request_error(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
         mock_validation_args.return_value.version = '1.3.14'
         mock_validation_args.return_value.validate_digest_only = False
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_api_get.return_value = (400, "text")
 
@@ -126,7 +126,7 @@ class TestValidation(unittest.TestCase):
     def test_check_http_request_connection_error(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.validate_digest_only = False
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_api_get.side_effect = requests.exceptions.ConnectionError
 

--- a/tests/tests_validation_workflow/test_validation.py
+++ b/tests/tests_validation_workflow/test_validation.py
@@ -79,7 +79,6 @@ class TestValidation(unittest.TestCase):
     @patch('validation_workflow.validation.Validation.check_http_request')
     @patch('validation_workflow.validation.ValidationArgs')
     def test_check_cluster_readiness_error(self, mock_validation_args: Mock, mock_check_http: Mock, mock_sleep: Mock) -> None:
-        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.force_https = False

--- a/tests/tests_validation_workflow/test_validation.py
+++ b/tests/tests_validation_workflow/test_validation.py
@@ -12,6 +12,7 @@ import requests
 
 from system.temporary_directory import TemporaryDirectory
 from validation_workflow.api_request import ApiTest
+from validation_workflow.docker.validation_docker import ValidateDocker
 from validation_workflow.tar.validation_tar import ValidateTar
 from validation_workflow.validation import Validation
 from validation_workflow.validation_args import ValidationArgs
@@ -94,11 +95,10 @@ class TestValidation(unittest.TestCase):
     @patch('validation_workflow.validation.ValidationArgs')
     @patch.object(ApiTest, "api_get")
     def test_check_http_request(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
-        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
         mock_validation_args.return_value.version = '1.3.13'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.force_https = False
-        mock_validation_args.return_value.projects = ["opensearch"]
+        mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
         mock_api_get.return_value = (200, "text")
 
         validate_docker = ValidateTar(mock_validation_args.return_value)
@@ -110,7 +110,6 @@ class TestValidation(unittest.TestCase):
     @patch('validation_workflow.validation.ValidationArgs')
     @patch.object(ApiTest, "api_get")
     def test_check_http_request_error(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
-        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
         mock_validation_args.return_value.version = '1.3.14'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.force_https = False
@@ -126,31 +125,13 @@ class TestValidation(unittest.TestCase):
     @patch('validation_workflow.validation.ValidationArgs')
     @patch.object(ApiTest, "api_get")
     def test_check_http_request_connection_error(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
-        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.force_https = False
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_api_get.side_effect = requests.exceptions.ConnectionError
 
-        validate_docker = ValidateTar(mock_validation_args.return_value)
-
-        result = validate_docker.check_http_request()
-
-        self.assertFalse(result)
-
-    @patch("time.sleep")
-    @patch('validation_workflow.validation.ValidationArgs')
-    @patch.object(ApiTest, "api_get")
-    def test_check_http_request_connection_timeout(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
-        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
-        mock_validation_args.return_value.version = '1.3.12'
-        mock_validation_args.return_value.validate_digest_only = False
-        mock_validation_args.return_value.force_https = False
-        mock_validation_args.return_value.projects = ["opensearch"]
-        mock_api_get.side_effect = requests.exceptions.ConnectTimeout
-
-        validate_docker = ValidateTar(mock_validation_args.return_value)
+        validate_docker = ValidateDocker(mock_validation_args.return_value)
 
         result = validate_docker.check_http_request()
 

--- a/tests/tests_validation_workflow/test_validation.py
+++ b/tests/tests_validation_workflow/test_validation.py
@@ -8,7 +8,10 @@
 import unittest
 from unittest.mock import Mock, patch
 
+import requests
+
 from system.temporary_directory import TemporaryDirectory
+from validation_workflow.api_request import ApiTest
 from validation_workflow.tar.validation_tar import ValidateTar
 from validation_workflow.validation import Validation
 from validation_workflow.validation_args import ValidationArgs
@@ -18,9 +21,6 @@ class ImplementValidation(Validation):
     def __init__(self, args: ValidationArgs) -> None:
         super().__init__(args)
         self.tmp_dir = TemporaryDirectory()
-
-    def download_artifacts(self) -> None:
-        return None
 
     def installation(self) -> None:
         return None
@@ -73,3 +73,85 @@ class TestValidation(unittest.TestCase):
         result = mock_validation.check_for_security_plugin("/tmp/tmkuiuo/opensearch")
 
         self.assertTrue(result)
+
+    @patch("time.sleep")
+    @patch('validation_workflow.validation.Validation.check_http_request')
+    @patch('validation_workflow.validation.ValidationArgs')
+    def test_check_cluster_readiness_error(self, mock_validation_args: Mock, mock_check_http: Mock, mock_sleep: Mock) -> None:
+        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
+        mock_validation_args.return_value.version = '1.0.0.1000'
+        mock_validation_args.return_value.validate_digest_only = False
+        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.projects = ["opensearch"]
+        mock_check_http.return_value = False
+
+        validate_docker = ValidateTar(mock_validation_args.return_value)
+        result = validate_docker.check_cluster_readiness()
+
+        self.assertFalse(result)
+
+    @patch("time.sleep")
+    @patch('validation_workflow.validation.ValidationArgs')
+    @patch.object(ApiTest, "api_get")
+    def test_check_http_request(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
+        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
+        mock_validation_args.return_value.version = '1.3.13'
+        mock_validation_args.return_value.validate_digest_only = False
+        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.projects = ["opensearch"]
+        mock_api_get.return_value = (200, "text")
+
+        validate_docker = ValidateTar(mock_validation_args.return_value)
+        result = validate_docker.check_http_request()
+
+        self.assertTrue(result)
+
+    @patch("time.sleep")
+    @patch('validation_workflow.validation.ValidationArgs')
+    @patch.object(ApiTest, "api_get")
+    def test_check_http_request_error(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
+        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
+        mock_validation_args.return_value.version = '1.3.14'
+        mock_validation_args.return_value.validate_digest_only = False
+        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.projects = ["opensearch"]
+        mock_api_get.return_value = (400, "text")
+
+        validate_docker = ValidateTar(mock_validation_args.return_value)
+        result = validate_docker.check_http_request()
+
+        self.assertFalse(result)
+
+    @patch("time.sleep")
+    @patch('validation_workflow.validation.ValidationArgs')
+    @patch.object(ApiTest, "api_get")
+    def test_check_http_request_connection_error(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
+        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
+        mock_validation_args.return_value.version = '2.3.0'
+        mock_validation_args.return_value.validate_digest_only = False
+        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.projects = ["opensearch"]
+        mock_api_get.side_effect = requests.exceptions.ConnectionError
+
+        validate_docker = ValidateTar(mock_validation_args.return_value)
+
+        result = validate_docker.check_http_request()
+
+        self.assertFalse(result)
+
+    @patch("time.sleep")
+    @patch('validation_workflow.validation.ValidationArgs')
+    @patch.object(ApiTest, "api_get")
+    def test_check_http_request_connection_timeout(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
+        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
+        mock_validation_args.return_value.version = '1.3.12'
+        mock_validation_args.return_value.validate_digest_only = False
+        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.projects = ["opensearch"]
+        mock_api_get.side_effect = requests.exceptions.ConnectTimeout
+
+        validate_docker = ValidateTar(mock_validation_args.return_value)
+
+        result = validate_docker.check_http_request()
+
+        self.assertFalse(result)

--- a/tests/tests_validation_workflow/test_validation_args.py
+++ b/tests/tests_validation_workflow/test_validation_args.py
@@ -69,6 +69,10 @@ class TestValidationArgs(unittest.TestCase):
 
     @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.6", "--distribution", "rpm", "--artifact-type", "staging", "--os-build-number", "1234", "--osd-build-number", "2312", "--force-https"])  # noqa: E501
     def test_force_https(self) -> None:
+        self.assertEqual(ValidationArgs().force_https, False)
+
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.6", "--distribution", "rpm", "--artifact-type", "staging", "--os-build-number", "1234", "--osd-build-number", "2312"])
+    def test_without_force_https(self) -> None:
         self.assertEqual(ValidationArgs().force_https, True)
 
     @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.0", "--projects", "opensearch"])

--- a/tests/tests_validation_workflow/test_validation_args.py
+++ b/tests/tests_validation_workflow/test_validation_args.py
@@ -67,30 +67,33 @@ class TestValidationArgs(unittest.TestCase):
     def test_artifact_type(self) -> None:
         self.assertNotEqual(ValidationArgs().artifact_type, "production")
 
-    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.6", "--distribution", "rpm", "--artifact-type", "staging", "--os-build-number", "1234", "--osd-build-number", "2312", "--force-https"])  # noqa: E501
-    def test_force_https(self) -> None:
-        self.assertEqual(ValidationArgs().force_https, False)
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.6", "--distribution", "rpm", "--artifact-type", "staging",
+                                  "--os-build-number", "1234", "--osd-build-number", "2312", "--allow-http"])
+    def test_allow_http(self) -> None:
+        self.assertEqual(ValidationArgs().allow_http, True)
 
     @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.6", "--distribution", "rpm", "--artifact-type", "staging", "--os-build-number", "1234", "--osd-build-number", "2312"])
-    def test_without_force_https(self) -> None:
-        self.assertEqual(ValidationArgs().force_https, True)
+    def test_do_not_allow_http(self) -> None:
+        self.assertEqual(ValidationArgs().allow_http, False)
 
     @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "1.3.0", "--projects", "opensearch"])
     def test_set_projects(self) -> None:
         self.assertEqual(ValidationArgs().projects, ["opensearch"])
 
-    @patch('sys.argv', [VALIDATION_PY, "--file-path", "opensearch=https://opensearch.org/releases/opensearch/2.8.0/opensearch-2.8.0-linux-x64.rpm", "opensearch-dashboard=https://opensearch.org/releases/opensearch/2.8.0/opensearch-dashboards-2.8.0-linux-x64.rpm"])  # noqa: E501
+    @patch('sys.argv', [VALIDATION_PY, "--file-path", "opensearch=https://opensearch.org/releases/opensearch/2.8.0/opensearch-2.8.0-linux-x64.rpm",
+                        "opensearch-dashboard=https://opensearch.org/releases/opensearch/2.8.0/opensearch-dashboards-2.8.0-linux-x64.rpm"])
     def test_dashboards_exception(self) -> None:
         with self.assertRaises(Exception) as ctx:
             self.assertEqual(ValidationArgs().distribution, "rpm")
         self.assertEqual(str(ctx.exception), "Missing OpenSearch artifact details! Please provide the valid product names among opensearch and opensearch-dashboards")
 
-    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "2.4.0", "--distribution", "docker", "--os-build-number", "1234", "--osd-build-number", "8393", "--projects", "opensearch", "--using-staging-artifact-only"])  # noqa: E501
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "2.4.0", "--distribution", "docker", "--os-build-number", "1234",
+                                  "--osd-build-number", "8393", "--projects", "opensearch", "--using-staging-artifact-only"])
     def test_docker_exception(self) -> None:
         with self.assertRaises(Exception) as ctx:
             self.assertEqual(ValidationArgs().projects, ["opensearch"])
             self.assertEqual(ValidationArgs().osd_build_number, "1234")
-        self.assertEqual(str(ctx.exception), "Provide opensearch-dashboards in projects argument to validate OpenSearch-Dashboards")
+        self.assertEqual(str(ctx.exception), "osd_build_number argument cannot be provided without specifying opensearch-dashboards in --projects")
 
     @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "2.4.0", "--distribution", "docker", "--os-build-number", "1234", "--projects", "opensearch"])
     def test_docker_arguments_exception(self) -> None:

--- a/tests/tests_validation_workflow/test_validation_args.py
+++ b/tests/tests_validation_workflow/test_validation_args.py
@@ -93,7 +93,7 @@ class TestValidationArgs(unittest.TestCase):
         with self.assertRaises(Exception) as ctx:
             self.assertEqual(ValidationArgs().projects, ["opensearch"])
             self.assertEqual(ValidationArgs().osd_build_number, "1234")
-        self.assertEqual(str(ctx.exception), "osd_build_number argument cannot be provided without specifying opensearch-dashboards in --projects")
+        self.assertEqual(str(ctx.exception), "--osd_build_number argument cannot be provided without specifying opensearch-dashboards in --projects")
 
     @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "2.4.0", "--distribution", "docker", "--os-build-number", "1234", "--projects", "opensearch"])
     def test_docker_arguments_exception(self) -> None:

--- a/tests/tests_validation_workflow/test_validation_args.py
+++ b/tests/tests_validation_workflow/test_validation_args.py
@@ -34,7 +34,7 @@ class TestValidationArgs(unittest.TestCase):
     def test_rpm_distribution(self) -> None:
         self.assertEqual(ValidationArgs().distribution, "rpm")
 
-    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "2.4.0", "--distribution", "docker"])
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "2.4.0", "--distribution", "docker", "--projects", "opensearch", "--using-staging-artifact-only"])
     def test_docker_distribution(self) -> None:
         self.assertEqual(ValidationArgs().distribution, "docker")
         self.assertNotEqual(ValidationArgs().distribution, "yum")
@@ -75,12 +75,32 @@ class TestValidationArgs(unittest.TestCase):
     def test_set_projects(self) -> None:
         self.assertEqual(ValidationArgs().projects, ["opensearch"])
 
+    @patch('sys.argv', [VALIDATION_PY, "--file-path", "opensearch=https://opensearch.org/releases/opensearch/2.8.0/opensearch-2.8.0-linux-x64.rpm", "opensearch-dashboard=https://opensearch.org/releases/opensearch/2.8.0/opensearch-dashboards-2.8.0-linux-x64.rpm"])  # noqa: E501
+    def test_dashboards_exception(self) -> None:
+        with self.assertRaises(Exception) as ctx:
+            self.assertEqual(ValidationArgs().distribution, "rpm")
+        self.assertEqual(str(ctx.exception), "Missing OpenSearch artifact details! Please provide the valid product names among opensearch and opensearch-dashboards")
+
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "2.4.0", "--distribution", "docker", "--os-build-number", "1234", "--osd-build-number", "8393", "--projects", "opensearch", "--using-staging-artifact-only"])  # noqa: E501
+    def test_docker_exception(self) -> None:
+        with self.assertRaises(Exception) as ctx:
+            self.assertEqual(ValidationArgs().projects, ["opensearch"])
+            self.assertEqual(ValidationArgs().osd_build_number, "1234")
+        self.assertEqual(str(ctx.exception), "Provide opensearch-dashboards in projects argument to validate OpenSearch-Dashboards")
+
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--version", "2.4.0", "--distribution", "docker", "--os-build-number", "1234", "--projects", "opensearch"])
+    def test_docker_arguments_exception(self) -> None:
+        with self.assertRaises(Exception) as ctx:
+            self.assertEqual(ValidationArgs().projects, ["opensearch"])
+            self.assertEqual(ValidationArgs().osd_build_number, "1234")
+        self.assertEqual(str(ctx.exception), "Provide either of --validate-digest-only and --using-staging-artifact-only for Docker Validation")
+
     @patch("argparse._sys.argv", [VALIDATION_PY, "--file-path", "opensearch-dashboards=https://opensearch.org/releases/opensearch/2.8.0/opensearch-dashboards-2.8.0-linux-x64.rpm"])
     def test_projects_exception(self) -> None:
         with self.assertRaises(Exception) as ctx:
             self.assertEqual(ValidationArgs().distribution, "rpm")
             self.assertEqual(ValidationArgs().projects, ["opensearch-dashboards"])
-        self.assertEqual(str(ctx.exception), "Missing OpenSearch OpenSearch artifact details! Please provide the same along with OpenSearch-Dashboards to validate")
+        self.assertEqual(str(ctx.exception), "Missing OpenSearch artifact details! Please provide the valid product names among opensearch and opensearch-dashboards")
 
     @patch("argparse._sys.argv", [VALIDATION_PY, "--file-path", "opensearch=https://opensearch.org/releases/opensearch/2.8.0/opensearch-2.8.0-linux-x64.xyz"])
     def test_file_path_distribution_type(self) -> None:
@@ -97,3 +117,13 @@ class TestValidationArgs(unittest.TestCase):
     def test_get_distribution_type_yum(self) -> None:
         result = ValidationArgs().get_distribution_type(ValidationArgs().file_path)
         self.assertEqual(result, "yum")
+
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--file-path", "opensearch=https://opensearch.org/releases/opensearch/2.8.0/opensearch--2.8.0-windows-x64.zip"])
+    def test_get_distribution_type_zip(self) -> None:
+        result = ValidationArgs().get_distribution_type(ValidationArgs().file_path)
+        self.assertEqual(result, "zip")
+
+    @patch("argparse._sys.argv", [VALIDATION_PY, "--file-path", "opensearch=https://opensearch.org/releases/opensearch/2.8.0/opensearch-2.8.0-linux-arm64.deb"])
+    def test_get_distribution_type_deb(self) -> None:
+        result = ValidationArgs().get_distribution_type(ValidationArgs().file_path)
+        self.assertEqual(result, "deb")

--- a/tests/tests_validation_workflow/test_validation_deb.py
+++ b/tests/tests_validation_workflow/test_validation_deb.py
@@ -19,8 +19,6 @@ class TestValidateDeb(unittest.TestCase):
         self.mock_args.projects = ["opensearch"]
         self.mock_args.file_path = {"opensearch": "/src/opensearch/opensearch-1.3.12.staging.deb"}
         self.mock_args.platform = "linux"
-        self.mock_args.force_https_check = True
-        self.mock_args.force_https = True
         self.call_methods = ValidateDeb(self.mock_args)
 
     @patch("validation_workflow.deb.validation_deb.execute")
@@ -94,10 +92,9 @@ class TestValidateDeb(unittest.TestCase):
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_validation_without_force_https_check(self, mock_validation_args: Mock, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock,
-                                                  mock_basename: Mock, mock_test_apis: Mock) -> None:
+    def test_validation_with_allow_http(self, mock_validation_args: Mock, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = True
         validate_deb = ValidateDeb(mock_validation_args.return_value)
         mock_check_cluster.return_value = True
         mock_basename.side_effect = lambda path: "mocked_filename"

--- a/tests/tests_validation_workflow/test_validation_deb.py
+++ b/tests/tests_validation_workflow/test_validation_deb.py
@@ -1,0 +1,163 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from unittest.mock import MagicMock, Mock, call, patch
+
+from validation_workflow.deb.validation_deb import ValidateDeb
+
+
+class TestValidateDeb(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_args = MagicMock()
+        self.mock_args.version = "2.3.0"
+        self.mock_args.arch = "x64"
+        self.mock_args.projects = ["opensearch"]
+        self.mock_args.file_path = {"opensearch": "/src/opensearch/opensearch-1.3.12.staging.deb"}
+        self.mock_args.platform = "linux"
+        self.mock_args.force_https_check = True
+        self.mock_args.force_https = True
+        self.call_methods = ValidateDeb(self.mock_args)
+
+    @patch("validation_workflow.deb.validation_deb.execute")
+    @patch('os.path.basename')
+    @patch("validation_workflow.deb.validation_deb.get_password")
+    def test_installation(self, mock_get_pwd: Mock, mock_basename: Mock, mock_system: Mock) -> None:
+        validate_deb = ValidateDeb(self.mock_args)
+        mock_basename.side_effect = lambda path: "mocked_filename"
+        mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
+        result = validate_deb.installation()
+        self.assertTrue(result)
+        mock_get_pwd.assert_called_with("2.3.0")
+
+    @patch("validation_workflow.deb.validation_deb.execute")
+    @patch("validation_workflow.deb.validation_deb.get_password")
+    def test_installation_exception_os(self, mock_get_pwd: Mock, mock_execute: Mock) -> None:
+        validate_deb = ValidateDeb(self.mock_args)
+        mock_execute.side_effect = Exception("any exception occurred")
+        with self.assertRaises(Exception) as context:
+            validate_deb.installation()
+
+        mock_get_pwd.assert_called_with("2.3.0")
+        self.assertEqual(str(context.exception), "Failed to install OpenSearch/OpenSearch-Dashboards")
+
+    @patch("validation_workflow.deb.validation_deb.execute")
+    @patch("validation_workflow.deb.validation_deb.ValidationArgs")
+    def test_start_cluster(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
+        self.mock_args.projects = ["opensearch", "opensearch-dashboards"]
+
+        validate_deb = ValidateDeb(self.mock_args)
+        result = validate_deb.start_cluster()
+        self.assertTrue(result)
+        mock_execute.assert_has_calls(
+            [
+                call("sudo systemctl enable opensearch", "."),
+                call("sudo systemctl start opensearch", "."),
+                call("sudo systemctl status opensearch", "."),
+                call("sudo systemctl enable opensearch-dashboards", "."),
+                call("sudo systemctl start opensearch-dashboards", "."),
+                call("sudo systemctl status opensearch-dashboards", "."),
+            ]
+        )
+
+    @patch("validation_workflow.deb.validation_deb.execute")
+    def test_start_cluster_exception_os(self, mock_execute: MagicMock) -> None:
+        validate_deb = ValidateDeb(self.mock_args)
+        mock_execute.side_effect = Exception("any exception occurred")
+        with self.assertRaises(Exception) as context:
+            validate_deb.start_cluster()
+
+        self.assertEqual(str(context.exception), "Failed to Start Cluster")
+
+    @patch("validation_workflow.deb.validation_deb.ApiTestCases")
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    def test_validation(self, mock_check_cluster: Mock, mock_test_apis: Mock) -> None:
+        mock_test_apis_instance = mock_test_apis.return_value
+        mock_check_cluster.return_value = True
+        mock_test_apis_instance.test_apis.return_value = (True, 3)
+
+        validate_deb = ValidateDeb(self.mock_args)
+
+        result = validate_deb.validation()
+        self.assertTrue(result)
+
+        mock_test_apis.assert_called_once()
+        mock_check_cluster.assert_called_once()
+
+    @patch('validation_workflow.deb.validation_deb.ApiTestCases')
+    @patch('os.path.basename')
+    @patch('validation_workflow.deb.validation_deb.execute')
+    @patch('validation_workflow.validation.Validation.check_for_security_plugin')
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    def test_validation_without_force_https_check(self, mock_validation_args: Mock, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock,
+                                                  mock_basename: Mock, mock_test_apis: Mock) -> None:
+        mock_validation_args.return_value.version = '2.3.0'
+        mock_validation_args.return_value.force_https = False
+        validate_deb = ValidateDeb(mock_validation_args.return_value)
+        mock_check_cluster.return_value = True
+        mock_basename.side_effect = lambda path: "mocked_filename"
+        mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
+        mock_security.return_value = True
+        mock_test_apis_instance = mock_test_apis.return_value
+        mock_test_apis_instance.test_apis.return_value = (True, 4)
+
+        result = validate_deb.validation()
+        self.assertTrue(result)
+        mock_check_cluster.assert_called_once()
+        mock_security.assert_called_once()
+
+    @patch('validation_workflow.deb.validation_deb.ValidationArgs')
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    def test_cluster_not_ready(self, mock_check_cluster: Mock, mock_validation_args: Mock) -> None:
+        mock_validation_args.return_value.version = '2.3.0'
+        validate_deb = ValidateDeb(mock_validation_args.return_value)
+        mock_check_cluster.return_value = False
+
+        with self.assertRaises(Exception) as context:
+            validate_deb.validation()
+        self.assertEqual(str(context.exception), 'Cluster is not ready for API test')
+        mock_check_cluster.assert_called_once()
+
+    @patch("validation_workflow.deb.validation_deb.ApiTestCases")
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    def test_failed_testcases(self, mock_check_cluster: Mock, mock_test_apis: Mock) -> None:
+        mock_test_apis_instance = mock_test_apis.return_value
+        mock_check_cluster.return_value = True
+        mock_test_apis_instance.test_apis.return_value = (False, 2)
+        validate_deb = ValidateDeb(self.mock_args)
+
+        with self.assertRaises(Exception) as context:
+            validate_deb.validation()
+
+        self.assertEqual(str(context.exception), "Not all tests Pass : 2")
+
+        mock_test_apis.assert_called_once()
+
+    @patch("validation_workflow.deb.validation_deb.execute")
+    def test_cleanup(self, mock_execute: Mock) -> None:
+        self.mock_args.projects = ["opensearch", "opensearch-dashboards"]
+
+        validate_deb = ValidateDeb(self.mock_args)
+        result = validate_deb.cleanup()
+        self.assertTrue(result)
+        mock_execute.assert_has_calls(
+            [call("sudo dpkg --purge opensearch", "."), call("sudo dpkg --purge opensearch-dashboards", ".")]
+        )
+
+    @patch("validation_workflow.deb.validation_deb.execute")
+    def test_cleanup_exception(self, mock_execute: Mock) -> None:
+        self.mock_args.projects = ["opensearch", "opensearch-dashboards"]
+        mock_execute.side_effect = Exception("an exception occurred")
+        validate_deb = ValidateDeb(self.mock_args)
+        with self.assertRaises(Exception) as context:
+            validate_deb.cleanup()
+
+        self.assertEqual(
+            str(context.exception),
+            "Exception occurred either while attempting to stop cluster or removing OpenSearch/OpenSearch-Dashboards. an exception occurred",
+        )

--- a/tests/tests_validation_workflow/test_validation_docker.py
+++ b/tests/tests_validation_workflow/test_validation_docker.py
@@ -47,7 +47,6 @@ class TestValidateDocker(unittest.TestCase):
     @patch('validation_workflow.docker.validation_docker.InspectDockerImage.inspect_digest')
     def test_staging(self, mock_digest: Mock, mock_container: Mock, mock_test: Mock, mock_docker_image: Mock, mock_validation_args: Mock, mock_check_http: Mock) -> None:
         # Set up mock objects
-        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.force_https = False
@@ -78,7 +77,6 @@ class TestValidateDocker(unittest.TestCase):
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.run_container')
     def test_staging_cluster_not_ready(self, mock_container: Mock, mock_validation_args: Mock,
                                        mock_cluster_readiness: Mock) -> None:
-        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.force_https = False
@@ -98,7 +96,6 @@ class TestValidateDocker(unittest.TestCase):
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.run_container')
     def test_container_startup_exception(self, mock_container: Mock, mock_validation_args: Mock) -> None:
-        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.force_https = False
@@ -123,7 +120,6 @@ class TestValidateDocker(unittest.TestCase):
     @patch('validation_workflow.docker.validation_docker.InspectDockerImage.inspect_digest')
     def test_digests(self, mock_digest: Mock, mock_container: Mock, mock_test: Mock, mock_docker_image: Mock, mock_validation_args: Mock, mock_check_http: Mock) -> None:
         # Set up mock objects
-        mock_validation_args.return_value.OS_image = 'opensearchstaging/opensearch-os'
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.using_staging_artifact_only = False
         mock_validation_args.return_value.validate_digest_only = True

--- a/tests/tests_validation_workflow/test_validation_docker.py
+++ b/tests/tests_validation_workflow/test_validation_docker.py
@@ -49,7 +49,7 @@ class TestValidateDocker(unittest.TestCase):
         # Set up mock objects
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_docker_image.return_value = MagicMock()
         mock_container.return_value = (True, 'test_file.yml')
@@ -79,7 +79,7 @@ class TestValidateDocker(unittest.TestCase):
                                        mock_cluster_readiness: Mock) -> None:
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_cluster_readiness.return_value = False
         mock_container.return_value = (True, 'test_file.yml')
@@ -98,7 +98,7 @@ class TestValidateDocker(unittest.TestCase):
     def test_container_startup_exception(self, mock_container: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_container.return_value = (False, 'test_file.yml')
 

--- a/tests/tests_validation_workflow/test_validation_rpm.py
+++ b/tests/tests_validation_workflow/test_validation_rpm.py
@@ -84,7 +84,8 @@ class TestValidationRpm(unittest.TestCase):
             mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
             validate_rpm = ValidateRpm(mock_validation_args.return_value)
             validate_rpm.cleanup()
-        self.assertIn("Exception occurred either while attempting to stop cluster or removing OpenSearch/OpenSearch-Dashboards.", str(e3.exception))  # noqa: E501
+        self.assertIn("Exception occurred either while attempting to stop cluster or removing OpenSearch/OpenSearch-Dashboards.",
+                      str(e3.exception))
 
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
     @patch("validation_workflow.rpm.validation_rpm.execute")
@@ -92,7 +93,7 @@ class TestValidationRpm(unittest.TestCase):
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platform = 'linux'
-        mock_validation_args.return_value.force_https = True
+        mock_validation_args.return_value.allow_http = True
         mock_validation_args.return_value.projects = ["opensearch"]
 
         validate_rpm = ValidateRpm(mock_validation_args.return_value)
@@ -132,11 +133,9 @@ class TestValidationRpm(unittest.TestCase):
     @patch('validation_workflow.rpm.validation_rpm.execute')
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_validation_without_force_https_check(self, mock_check_cluster: Mock, mock_security: Mock,
-                                                  mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock,
-                                                  mock_validation_args: Mock) -> None:
+    def test_validation_with_allow_http_check(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = True
         validate_rpm = ValidateRpm(mock_validation_args.return_value)
         mock_check_cluster.return_value = True
         mock_basename.side_effect = lambda path: "mocked_filename"

--- a/tests/tests_validation_workflow/test_validation_tar.py
+++ b/tests/tests_validation_workflow/test_validation_tar.py
@@ -20,6 +20,7 @@ class TestValidateTar(unittest.TestCase):
     def test_empty_file_path_and_production_artifact_type(self) -> None:
         self.args.projects = ["opensearch"]
         self.args.version = "2.4.0"
+        self.args.distribution = "tar"
         self.args.file_path = {}
         self.args.artifact_type = "production"
 
@@ -42,6 +43,7 @@ class TestValidateTar(unittest.TestCase):
     def test_empty_file_path_and_staging_artifact_type(self, mock_validation_args: Mock) -> None:
         self.args.projects = ["opensearch"]
         self.args.version = "2.4.0"
+        self.args.distribution = "tar"
         self.args.artifact_type = "staging"
         self.args.file_path = {}
         self.args.build_number = {"opensearch": "latest", "opensearch-dashboards": "latest"}
@@ -82,13 +84,12 @@ class TestValidateTar(unittest.TestCase):
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
     @patch.object(Process, 'start')
-    @patch('time.sleep')
     @patch('validation_workflow.tar.validation_tar.get_password')
-    def test_start_cluster(self, mock_password: Mock, mock_sleep: Mock, mock_start: Mock, mock_validation_args: Mock) -> None:
+    def test_start_cluster(self, mock_password: Mock, mock_start: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platforms = 'linux'
-        mock_validation_args.return_value.allow_without_security = True
+        mock_validation_args.return_value.force_https = True
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
         mock_password.return_value = "admin"
 
@@ -102,7 +103,7 @@ class TestValidateTar(unittest.TestCase):
     @patch('src.test_workflow.integ_test.utils.get_password')
     def test_start_cluster_exception_os(self, mock_password: Mock, mock_sleep: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.projects = ["opensearch"]
-        mock_validation_args.return_value.allow_without_security = True
+        mock_validation_args.return_value.force_https = True
 
         validate_tar = ValidateTar(mock_validation_args.return_value)
         validate_tar.os_process.start = MagicMock(side_effect=Exception('Failed to Start Cluster'))  # type: ignore
@@ -113,16 +114,18 @@ class TestValidateTar(unittest.TestCase):
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
     @patch('validation_workflow.tar.validation_tar.ApiTestCases')
-    def test_validation(self, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    def test_validation(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_test_apis_instance = mock_test_apis.return_value
+        mock_check_cluster.return_value = True
         mock_test_apis_instance.test_apis.return_value = (True, 3)
 
         validate_tar = ValidateTar(mock_validation_args.return_value)
 
         result = validate_tar.validation()
         self.assertTrue(result)
-
+        mock_check_cluster.assert_called_once()
         mock_test_apis.assert_called_once()
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
@@ -130,10 +133,13 @@ class TestValidateTar(unittest.TestCase):
     @patch('os.path.basename')
     @patch('validation_workflow.tar.validation_tar.execute')
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
-    def test_validation_without_force_https_check(self, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    def test_validation_without_force_https_check(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock,
+                                                  mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.force_https = False
         validate_tar = ValidateTar(mock_validation_args.return_value)
+        mock_check_cluster.return_value = True
         mock_basename.side_effect = lambda path: "mocked_filename"
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
         mock_security.return_value = True
@@ -142,26 +148,37 @@ class TestValidateTar(unittest.TestCase):
 
         result = validate_tar.validation()
         self.assertTrue(result)
+        mock_check_cluster.assert_called_once()
         mock_security.assert_called_once()
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    def test_cluster_not_ready(self, mock_check_cluster: Mock, mock_validation_args: Mock) -> None:
+        mock_validation_args.return_value.version = '2.3.0'
+        validate_tar = ValidateTar(mock_validation_args.return_value)
+        mock_check_cluster.return_value = False
+
+        with self.assertRaises(Exception) as context:
+            validate_tar.validation()
+        self.assertEqual(str(context.exception), 'Cluster is not ready for API test')
+        mock_check_cluster.assert_called_once()
+
+    @patch('validation_workflow.tar.validation_tar.ValidationArgs')
     @patch('validation_workflow.tar.validation_tar.ApiTestCases')
-    def test_failed_testcases(self, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
-        # Set up mock objects
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    def test_failed_testcases(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_test_apis_instance = mock_test_apis.return_value
+        mock_check_cluster.return_value = True
         mock_test_apis_instance.test_apis.return_value = (False, 1)
 
-        # Create instance of ValidateTar class
         validate_tar = ValidateTar(mock_validation_args.return_value)
 
-        # Call validation method and assert the result
         with self.assertRaises(Exception) as context:
             validate_tar.validation()
 
         self.assertEqual(str(context.exception), 'Not all tests Pass : 1')
 
-        # Assert that the mock methods are called as expected
         mock_test_apis.assert_called_once()
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')

--- a/tests/tests_validation_workflow/test_validation_tar.py
+++ b/tests/tests_validation_workflow/test_validation_tar.py
@@ -73,7 +73,7 @@ class TestValidateTar(unittest.TestCase):
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platform = 'linux'
-        mock_validation_args.return_value.force_https = True
+        mock_validation_args.return_value.allow_http = True
         mock_validation_args.return_value.projects = ["opensearch"]
 
         validate_tar = ValidateTar(mock_validation_args.return_value)
@@ -89,7 +89,7 @@ class TestValidateTar(unittest.TestCase):
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platforms = 'linux'
-        mock_validation_args.return_value.force_https = True
+        mock_validation_args.return_value.allow_http = True
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
         mock_password.return_value = "admin"
 
@@ -103,7 +103,7 @@ class TestValidateTar(unittest.TestCase):
     @patch('src.test_workflow.integ_test.utils.get_password')
     def test_start_cluster_exception_os(self, mock_password: Mock, mock_sleep: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.projects = ["opensearch"]
-        mock_validation_args.return_value.force_https = True
+        mock_validation_args.return_value.allow_http = True
 
         validate_tar = ValidateTar(mock_validation_args.return_value)
         validate_tar.os_process.start = MagicMock(side_effect=Exception('Failed to Start Cluster'))  # type: ignore
@@ -134,10 +134,9 @@ class TestValidateTar(unittest.TestCase):
     @patch('validation_workflow.tar.validation_tar.execute')
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_validation_without_force_https_check(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock,
-                                                  mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_validation_with_allow_http(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = True
         validate_tar = ValidateTar(mock_validation_args.return_value)
         mock_check_cluster.return_value = True
         mock_basename.side_effect = lambda path: "mocked_filename"

--- a/tests/tests_validation_workflow/test_validation_yum.py
+++ b/tests/tests_validation_workflow/test_validation_yum.py
@@ -85,14 +85,15 @@ class TestValidationYum(unittest.TestCase):
             mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
             validate_yum = ValidateYum(mock_validation_args.return_value)
             validate_yum.cleanup()
-        self.assertIn("Exception occurred either while attempting to stop cluster or removing OpenSearch/OpenSearch-Dashboards.", str(e3.exception))  # noqa: E501
+        self.assertIn("Exception occurred either while attempting to stop cluster or removing OpenSearch/OpenSearch-Dashboards.",
+                      str(e3.exception))
 
     @patch("validation_workflow.yum.validation_yum.execute")
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
     def test_installation(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = False
 
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
         mock_execute.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
@@ -133,12 +134,9 @@ class TestValidationYum(unittest.TestCase):
     @patch('validation_workflow.yum.validation_yum.execute')
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_validation_without_force_https_check(self, mock_check_cluster: Mock, mock_security: Mock,
-                                                  mock_system: Mock,
-                                                  mock_basename: Mock, mock_test_apis: Mock,
-                                                  mock_validation_args: Mock) -> None:
+    def test_validation_with_allow_http(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = True
         validate_yum = ValidateYum(mock_validation_args.return_value)
         mock_check_cluster.return_value = True
         mock_basename.side_effect = lambda path: "mocked_filename"

--- a/tests/tests_validation_workflow/test_validation_zip.py
+++ b/tests/tests_validation_workflow/test_validation_zip.py
@@ -20,7 +20,7 @@ class TestValidateZip(unittest.TestCase):
         self.mock_args.arch = "x64"
         self.mock_args.platform = "windows"
         self.mock_args.force_https_check = True
-        self.mock_args.force_https = True
+        self.mock_args.allow_http = True
         self.call_methods = ValidateZip(self.mock_args)
 
     @patch("validation_workflow.zip.validation_zip.ZipFile")
@@ -85,10 +85,9 @@ class TestValidateZip(unittest.TestCase):
     @patch('system.execute.execute')
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_validation_without_force_https_check(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock,
-                                                  mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_validation_with_allow_http(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        mock_validation_args.return_value.force_https = False
+        mock_validation_args.return_value.allow_http = True
         validate_zip = ValidateZip(mock_validation_args.return_value)
         mock_check_cluster.return_value = True
         mock_basename.side_effect = lambda path: "mocked_filename"

--- a/tests/tests_validation_workflow/test_validation_zip.py
+++ b/tests/tests_validation_workflow/test_validation_zip.py
@@ -1,0 +1,147 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from unittest.mock import MagicMock, Mock, call, patch
+
+from system.process import Process
+from validation_workflow.zip.validation_zip import ValidateZip
+
+
+class TestValidateZip(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mock_args = MagicMock()
+        self.mock_args.projects = ["opensearch", "opensearch-dashboards"]
+        self.mock_args.version = "2.11.0"
+        self.mock_args.arch = "x64"
+        self.mock_args.platform = "windows"
+        self.mock_args.force_https_check = True
+        self.mock_args.force_https = True
+        self.call_methods = ValidateZip(self.mock_args)
+
+    @patch("validation_workflow.zip.validation_zip.ZipFile")
+    @patch('os.path.basename')
+    def test_installation(self, mock_basename: Mock, mock_zip_file: MagicMock) -> None:
+        mock_zip_file_instance = mock_zip_file.return_value.__enter__()
+        mock_extractall = MagicMock()
+        mock_zip_file_instance.extractall = mock_extractall
+        mock_basename.side_effect = lambda path: "mocked_filename"
+
+        validate_zip = ValidateZip(self.mock_args)
+        result = validate_zip.installation()
+        self.assertTrue(result)
+
+        expected_calls = [call((validate_zip.tmp_dir.path))] * len(self.mock_args.projects)
+        mock_extractall.assert_has_calls(expected_calls)
+
+    @patch("validation_workflow.zip.validation_zip.ZipFile")
+    @patch('os.path.basename')
+    def test_installation_exception(self, mock_basename: Mock, mock_zip_file: MagicMock) -> None:
+        self.mock_args.projects = None
+        validate_zip = ValidateZip(self.mock_args)
+        mock_basename.side_effect = lambda path: "mocked_filename"
+        with self.assertRaises(Exception) as context:
+            validate_zip.installation()
+        self.assertEqual(str(context.exception), "Failed to install OpenSearch/OpenSearch-Dashboards")
+
+    @patch.object(Process, "start")
+    @patch('validation_workflow.zip.validation_zip.get_password')
+    def test_start_cluster(self, mock_password: Mock, mock_start: Mock) -> None:
+
+        validate_zip = ValidateZip(self.mock_args)
+        mock_password.return_value = "admin"
+        result = validate_zip.start_cluster()
+        self.assertTrue(result)
+        mock_password.assert_called_once()
+
+    @patch.object(Process, "start")
+    def test_start_cluster_exception(self, mock_start: Mock) -> None:
+        mock_start.side_effect = Exception("an exception")
+        validate_zip = ValidateZip(self.mock_args)
+        with self.assertRaises(Exception) as context:
+            validate_zip.start_cluster()
+        self.assertEqual(str(context.exception), "Failed to Start Cluster")
+
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    @patch("validation_workflow.zip.validation_zip.ApiTestCases")
+    def test_validation(self, mock_test_apis: MagicMock, mock_check_cluster: Mock) -> None:
+        mock_test_apis_instance = mock_test_apis.return_value
+        mock_check_cluster.return_value = True
+        mock_test_apis_instance.test_apis.return_value = (True, 3)
+        validate_zip = ValidateZip(self.mock_args)
+        result = validate_zip.validation()
+
+        self.assertTrue(result)
+        mock_check_cluster.assert_called_once()
+        mock_test_apis.assert_called_once()
+
+    @patch('validation_workflow.zip.validation_zip.ValidationArgs')
+    @patch('validation_workflow.zip.validation_zip.ApiTestCases')
+    @patch('os.path.basename')
+    @patch('system.execute.execute')
+    @patch('validation_workflow.validation.Validation.check_for_security_plugin')
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    def test_validation_without_force_https_check(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock,
+                                                  mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+        mock_validation_args.return_value.version = '2.3.0'
+        mock_validation_args.return_value.force_https = False
+        validate_zip = ValidateZip(mock_validation_args.return_value)
+        mock_check_cluster.return_value = True
+        mock_basename.side_effect = lambda path: "mocked_filename"
+        mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
+        mock_security.return_value = True
+        mock_test_apis_instance = mock_test_apis.return_value
+        mock_test_apis_instance.test_apis.return_value = (True, 4)
+
+        result = validate_zip.validation()
+        self.assertTrue(result)
+        mock_check_cluster.assert_called_once()
+        mock_security.assert_called_once()
+
+    @patch('validation_workflow.zip.validation_zip.ValidationArgs')
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    def test_cluster_not_ready(self, mock_check_cluster: Mock, mock_validation_args: Mock) -> None:
+        mock_validation_args.return_value.version = '2.3.0'
+        validate_zip = ValidateZip(mock_validation_args.return_value)
+        mock_check_cluster.return_value = False
+
+        with self.assertRaises(Exception) as context:
+            validate_zip.validation()
+        self.assertEqual(str(context.exception), 'Cluster is not ready for API test')
+        mock_check_cluster.assert_called_once()
+
+    @patch('validation_workflow.zip.validation_zip.ApiTestCases')
+    @patch('validation_workflow.validation.Validation.check_cluster_readiness')
+    def test_failed_testcases(self, mock_check_cluster: Mock, mock_test_apis: Mock) -> None:
+        mock_test_apis_instance = mock_test_apis.return_value
+        mock_check_cluster.return_value = True
+        mock_test_apis_instance.test_apis.return_value = (False, 1)
+
+        validate_zip = ValidateZip(self.mock_args)
+        with self.assertRaises(Exception) as context:
+            validate_zip.validation()
+
+        self.assertEqual(str(context.exception), 'Not all tests Pass : 1')
+        mock_test_apis.assert_called_once()
+
+    @patch.object(Process, "terminate")
+    def test_cleanup(self, mock_process_terminate: MagicMock) -> None:
+        validate_zip = ValidateZip(self.mock_args)
+        result = validate_zip.cleanup()
+        self.assertTrue(result)
+        mock_process_terminate.assert_called()
+
+    @patch.object(Process, "terminate")
+    def test_cleanup_exception(self, mock_process_terminate: MagicMock) -> None:
+        mock_process_terminate.side_effect = Exception("any exception")
+        validate_zip = ValidateZip(self.mock_args)
+        with self.assertRaises(Exception) as context:
+            validate_zip.cleanup()
+        self.assertEqual(
+            str(context.exception),
+            "Failed to terminate the processes that started OpenSearch and OpenSearch-Dashboards",
+        )


### PR DESCRIPTION
### Description
1. Support Zip and Deb validations.
2. Move the download_artifacts method from child classes(except docker) to parent class - validation.py.
3. Changes to validation_args.py to fix the bug https://github.com/opensearch-project/opensearch-build/issues/4441
4. Cluster readiness is checked by requesting the api's instead of adding sleep().
5. Changes to docker-validation:
    1. Add security strong password changes before running the container.
    2. Bring up the services opensearchnode1 and opensearchnode2 only when OS is validated, bringup all the services in 
        compose file when both OS and OSD are provided.
    3. Pull and validate the latest staging docker image in the given version if build number is not provided.
    
Addresses #4424 and #4423

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
