### PR TITLE
Remove the concurrent search experimental flags from manifest

### DIFF
--- a/manifests/2.12.0/opensearch-2.12.0-concurrent-search-test.yml
+++ b/manifests/2.12.0/opensearch-2.12.0-concurrent-search-test.yml
@@ -15,7 +15,6 @@ components:
         - without-security
       additional-cluster-configs:
         path.repo: [/tmp]
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
     bwc-test:
@@ -30,7 +29,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
     bwc-test:
@@ -43,7 +41,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
 
@@ -54,7 +51,6 @@ components:
         - without-security
       additional-cluster-configs:
         plugins.destination.host.deny_list: [10.0.0.0/8, 127.0.0.1]
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
     bwc-test:
@@ -68,7 +64,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
     bwc-test:
@@ -83,7 +78,6 @@ components:
       additional-cluster-configs:
         script.context.field.max_compilations_rate: 1000/1m
         plugins.query.datasources.encryption.masterkey: 4fc8fee6a3fd7d6ca01772e5
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
     bwc-test:
@@ -96,7 +90,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
 
@@ -106,7 +99,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
 
@@ -116,7 +108,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
 
@@ -126,7 +117,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
     bwc-test:
@@ -139,7 +129,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
 
@@ -156,7 +145,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
 
@@ -165,7 +153,6 @@ components:
       test-configs:
         - with-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
 
@@ -175,7 +162,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
 
@@ -185,7 +171,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
 
@@ -195,7 +180,6 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2
 
@@ -205,6 +189,5 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
-        opensearch.experimental.feature.concurrent_segment_search.enabled: true
         search.concurrent_segment_search.enabled: true
         search.concurrent.max_slice_count: 2


### PR DESCRIPTION
### Description
There is a concurrent segment search manifest file for 2.12 integ test which is referencing the experimental flag. These flags are deprecated and needs to be removed.
 
### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
