### PR TITLE
Fixes docker release README

### DIFF
--- a/docker/release/README.md
+++ b/docker/release/README.md
@@ -103,7 +103,11 @@ Here are three example scenarios of using above variables:
 #### Scenario 2: No demo certs/configs + disable security on both OpenSearch and OpenSearch-Dashboards:
   * OpenSearch:
      ```
-     $ docker run -it -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "DISABLE_SECURITY_PLUGIN=true" opensearchproject/opensearch:1.1.0
+     docker run -it -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "DISABLE_INSTALL_DEMO_CONFIG=true" -e "DISABLE_SECURITY_PLUGIN=true" opensearchproject/opensearch:1.1.0
+     ```
+    Note: For OpenSearch > 2.11.1 and > 1.3.14, `DISABLE_SECURITY_PLUGIN` when set to true will automatically disable the security demo configuration setup and will no longer require `DISABLE_INSTALL_DEMO_CONFIG` to be explicitly set.
+     ```
+     docker run -it -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" -e "DISABLE_SECURITY_PLUGIN=true" opensearchproject/opensearch:2.12.0
      ```
   * OpenSearch-Dashboards:
      ```


### PR DESCRIPTION
### Description
Updates the README to avoid confusion around `DISABLE_INSTALL_DEMO_CONFIG` and `DISABLE_INSTALL_DEMO_CONFIG` usage for versions < 1.3.15 and < 2.12.0

- Related to #4446 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
