### PR TITLE
Removes check to validate presence of `OPENSEARCH_INITIAL_ADMIN_PASSWORD` variable from preinst script of DEB distribution

### DIFF
--- a/scripts/components/OpenSearch/install.sh
+++ b/scripts/components/OpenSearch/install.sh
@@ -84,9 +84,6 @@ if [ "$DISTRIBUTION" = "tar" ]; then
 elif [ "$DISTRIBUTION" = "deb" -o "$DISTRIBUTION" = "rpm" ]; then
     cp -va ../../../scripts/pkg/service_templates/opensearch/* "$OUTPUT/../"
     cp -va ../../../scripts/pkg/build_templates/opensearch/$DISTRIBUTION/* "$OUTPUT/../"
-    if [ "$DISTRIBUTION" = "deb" ]; then
-      sed -i "s/CHANGE_VERSION/${VERSION}/g" "$OUTPUT/../debian/preinst"
-    fi
 elif [ "$DISTRIBUTION" = "zip" ] && [ "$PLATFORM" = "windows" ]; then
     cp -v ../../../scripts/startup/zip/windows/opensearch-windows-install.bat "$OUTPUT/"
 fi

--- a/scripts/pkg/build_templates/opensearch/deb/debian/preinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/preinst
@@ -11,8 +11,6 @@
 
 set -e
 
-OPENSEARCH_VERSION=CHANGE_VERSION
-
 echo "Running OpenSearch Pre-Installation Script"
 
 # Stop existing service
@@ -24,30 +22,6 @@ if command -v systemctl >/dev/null && systemctl is-active opensearch-performance
     echo "Stop existing opensearch-performance-analyzer.service"
     systemctl --no-reload stop opensearch-performance-analyzer.service
 fi
-
-# Check if OPENSEARCH_INITIAL_ADMIN_PASSWORD is defined
-# TODO:
-# 1. This check will need to be modified if there will be a min dist for deb in future (currently there is none)
-# 2. Currently, the demo config setup is defined to run, in postinst, if `opensearch-security` is present. Cannot apply the same check here since the plugins folder is not available yet.
-
-# Check if this is an upgrade by checking whether opensearch already exists
-if dpkg-query -W opensearch >/dev/null 2>&1; then
-    OPENSEARCH_ALREADY_INSTALLED=yes
-else
-    OPENSEARCH_ALREADY_INSTALLED=no
-fi
-
-OPENSEARCH_REQUIRED_VERSION="2.12.0"
-MINIMUM_OF_TWO_VERSIONS=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
-
-if [ $OPENSEARCH_ALREADY_INSTALLED = no ]; then
-  if [ $MINIMUM_OF_TWO_VERSIONS = $OPENSEARCH_REQUIRED_VERSION ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
-    echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
-    echo "For more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/debian/"
-    exit 1
-  fi
-fi
-
 
 # Create user and group if they do not already exist.
 getent group opensearch > /dev/null 2>&1 || groupadd -r opensearch

--- a/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/opensearch/rpm/opensearch.rpm.spec
@@ -97,17 +97,17 @@ fi
 
 # Check if this is an upgrade by checking whether opensearch already exists
 if rpm -q opensearch >/dev/null 2>&1 || yum list installed opensearch >/dev/null 2>&1; then
-    OPENSEARCH_ALREADY_INSTALLED=yes
+    OPENSEARCH_ALREADY_INSTALLED="yes"
 else
-    OPENSEARCH_ALREADY_INSTALLED=no
+    OPENSEARCH_ALREADY_INSTALLED="no"
 fi
 
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
 OPENSEARCH_VERSION=%{_version}
 MINIMUM_OF_TWO_VERSIONS=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
 
-if [ $OPENSEARCH_ALREADY_INSTALLED = no ]; then
-  if [ $MINIMUM_OF_TWO_VERSIONS = $OPENSEARCH_REQUIRED_VERSION ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
+if [ "$OPENSEARCH_ALREADY_INSTALLED" = "no" ]; then
+  if [ "$MINIMUM_OF_TWO_VERSIONS" = "$OPENSEARCH_REQUIRED_VERSION" ] && [ -z "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" ]; then
     echo "ERROR: Opensearch 2.12 and later requires the env variable OPENSEARCH_INITIAL_ADMIN_PASSWORD to be defined to setup the opensearch-security demo configuration"
     echo "For more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/rpm/"
     exit 1


### PR DESCRIPTION
### Description
While testing 2.12 RC it was discovered that the current check to validate whether `OPENSEARCH_INITIAL_ADMIN_PASSWORD` env variable is defined, is flawed and doesn't work always. There were other options considered as well but none satisfy a uniform experience for preinstall script :

1. `dpkg-query -W opensearch` (current): Prematurely evaluates to true as soon as install starts
2. `dpkg -l opensearch` : Works only in upgrade scenarios. For fresh installation `preinst`  doesn't break (which is what is expected). Prematurely evaluates to true as soon as install starts.
3. `dpkg-query -s opensearch | grep -i ("Status: install ok installed")`: fails on upgrade (it shouldn't), works fine for fresh installation

Hence, this PR removes changes from preinstall script for DEB distribution.

Note: RPM is not affected.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
