### PR TITLE
Remove BROWSER_PATH=electron for Windows so integTest can run chromium114

### DIFF
--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -24,7 +24,7 @@ def docker_args = [
     "tar": "-u 1000 -e BROWSER_PATH=electron",
     "rpm": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host -e BROWSER_PATH=electron",
     "deb": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host -e BROWSER_PATH=electron",
-    "zip": "-u ContainerAdministrator -e BROWSER_PATH=electron",
+    "zip": "-u ContainerAdministrator",
 ]
 
 def agent_nodes = [


### PR DESCRIPTION


### Description
_Describe what this change achieves._

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4115#issuecomment-1947502229

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
