### PR TITLE
[Release 2.12.0] RC commit lock

### DIFF
--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -44,12 +44,13 @@ pipeline {
         BUILD_JOB_NAME = 'distribution-build-opensearch'
         ARTIFACT_BUCKET_NAME = credentials('jenkins-artifact-bucket-name')
     }
-    triggers {
+    // Add as follows to enable parameterizedCron trigger for a specific test manifest.
+    /*triggers {
         parameterizedCron '''
             H 1 * * * %TEST_MANIFEST=2.12.0/opensearch-2.12.0-concurrent-search-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.12.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
             H 1 * * * %TEST_MANIFEST=2.12.0/opensearch-2.12.0-concurrent-search-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.12.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
             '''
-    }
+    }*/
     parameters {
         string(
             name: 'COMPONENT_NAME',

--- a/manifests/2.12.0/opensearch-2.12.0.yml
+++ b/manifests/2.12.0/opensearch-2.12.0.yml
@@ -10,34 +10,34 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: '2.12'
+    ref: 2c355ce1a427e4a528778d4054436b5c4b756221
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: '2.12'
+    ref: b10a9dd770b3265c3fc79581b690e3830550ba2d
     platforms:
       - linux
       - windows
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: '2.12'
+    ref: e5e9673585d81ecb5a79207acabc38ed0fb690e8
     platforms:
       - linux
       - windows
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '2.12'
+    ref: a5c3191146f86fe0ec227439a56ee9374c51d91c
     platforms:
       - linux
       - windows
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: '2.12'
+    ref: e7a919221ef37db1e68ae0189c222f282f47217a
     platforms:
       - linux
       - windows
   - name: geospatial
     repository: https://github.com/opensearch-project/geospatial.git
-    ref: '2.12'
+    ref: 0186b99774b31e628b1ac27141ac088eee2ea7c3
     platforms:
       - linux
       - windows
@@ -45,7 +45,7 @@ components:
       - job-scheduler
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '2.12'
+    ref: 91c5fadf1aeab41127929547c0153217899242e9
     platforms:
       - linux
       - windows
@@ -53,7 +53,7 @@ components:
       - common-utils
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: '2.12'
+    ref: 7722020b5e834c6f50d46286d916a68de8cb22f3
     platforms:
       - linux
       - windows
@@ -61,7 +61,7 @@ components:
       - common-utils
   - name: neural-search
     repository: https://github.com/opensearch-project/neural-search.git
-    ref: '2.12'
+    ref: a521f78bb8be00035af2077ffd70eb95bab398ce
     platforms:
       - linux
       - windows
@@ -70,7 +70,7 @@ components:
       - k-NN
   - name: notifications-core
     repository: https://github.com/opensearch-project/notifications.git
-    ref: '2.12'
+    ref: 9df7874d2680369b765fd9fa84f851bd6814a064
     platforms:
       - linux
       - windows
@@ -79,7 +79,7 @@ components:
       - common-utils
   - name: notifications
     repository: https://github.com/opensearch-project/notifications.git
-    ref: '2.12'
+    ref: 9df7874d2680369b765fd9fa84f851bd6814a064
     platforms:
       - linux
       - windows
@@ -88,7 +88,7 @@ components:
       - common-utils
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: '2.12'
+    ref: 7848617064395b766371c5ad09b5c8171219b36e
     platforms:
       - linux
       - windows
@@ -96,7 +96,7 @@ components:
       - common-utils
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: '2.12'
+    ref: b9d9d9975e6affc2574986666489ef5005510d2a
     platforms:
       - linux
       - windows
@@ -105,7 +105,7 @@ components:
       - job-scheduler
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: '2.12'
+    ref: 429f9c807d24def8653565fdda8d67cf3a5b1d4d
     platforms:
       - linux
       - windows
@@ -113,7 +113,7 @@ components:
       - ml-commons
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: '2.12'
+    ref: 169fc306f0f4dc66821d11fdd72ca49d8a393529
     platforms:
       - linux
       - windows
@@ -121,7 +121,7 @@ components:
       - common-utils
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: '2.12'
+    ref: 24c700022c438aa59322f085eea1a5c8c4009389
     platforms:
       - linux
       - windows
@@ -130,7 +130,7 @@ components:
       - job-scheduler
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: '2.12'
+    ref: d4f16758f1c1f165a32a21a94149950c07a7fb00
     platforms:
       - linux
       - windows
@@ -138,7 +138,7 @@ components:
       - common-utils
   - name: security-analytics
     repository: https://github.com/opensearch-project/security-analytics.git
-    ref: '2.12'
+    ref: fca29cfcb8cba9a0219c8825dcd80320a6a9de81
     platforms:
       - linux
       - windows
@@ -146,7 +146,7 @@ components:
       - common-utils
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: '2.12'
+    ref: 97b9c3ac7432aa5d4e34a5fcf887eaad513afdd8
     platforms:
       - linux
       - windows
@@ -155,18 +155,18 @@ components:
       - job-scheduler
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: '2.12'
+    ref: f2d6b0b4a6a8931e2898a53210975d7ed321953c
     platforms:
       - linux
   - name: custom-codecs
     repository: https://github.com/opensearch-project/custom-codecs.git
-    ref: '2.12'
+    ref: 36ad8504605d04735d56c6c864ea1f47c840fe61
     platforms:
       - linux
       - windows
   - name: flow-framework
     repository: https://github.com/opensearch-project/flow-framework.git
-    ref: '2.12'
+    ref: 987b96ff5190d3f0c698968aa2be15131a58afee
     platforms:
       - linux
       - windows
@@ -174,7 +174,7 @@ components:
       - common-utils
   - name: skills
     repository: https://github.com/opensearch-project/skills.git
-    ref: '2.12'
+    ref: 7546f72c432e20b3210e5cc4ef0d15ebb3e6fa1c
     platforms:
       - linux
       - windows

--- a/manifests/2.12.0/opensearch-dashboards-2.12.0.yml
+++ b/manifests/2.12.0/opensearch-dashboards-2.12.0.yml
@@ -9,49 +9,49 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: '2.12'
+    ref: 9ec9a677af5f28e5450926ce07e9d6c3273717a7
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '2.12'
+    ref: f92d151aba63e4598f0e2a3455e0f127e9bf43ca
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
-    ref: '2.12'
+    ref: 63a88069000555a1d8019c69e65207fc1d611b60
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
-    ref: '2.12'
+    ref: c7a4403f708edc1bda472cabfeacbb57afee12f7
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
-    ref: '2.12'
+    ref: 2c345b34e8e43dea33fc406f39b3bfa00eb81108
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
-    ref: '2.12'
+    ref: ac68dedb7a217776ce5d6edee7080cd4245154c8
   - name: customImportMapDashboards
     repository: https://github.com/opensearch-project/dashboards-maps.git
-    ref: '2.12'
+    ref: c3331e1da332691f465caae8a52d28349752ec30
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: '2.12'
+    ref: 0268447d5fd687dd28a067d8b54424df1815eeea
   - name: mlCommonsDashboards
     repository: https://github.com/opensearch-project/ml-commons-dashboards.git
-    ref: '2.12'
+    ref: d28607d0dc67c961774ec6742ac12de167da1679
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
-    ref: '2.12'
+    ref: 1e4bf2d01bc686017e3bb549598f8029b1127f40
   - name: notificationsDashboards
     repository: https://github.com/opensearch-project/dashboards-notifications.git
-    ref: '2.12'
+    ref: ac4b53317300217b420cd54fb545c8194ff13c6e
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: '2.12'
+    ref: 86dfb877ece10ab33dc3532d4018156f5978fbb0
   - name: securityAnalyticsDashboards
     repository: https://github.com/opensearch-project/security-analytics-dashboards-plugin.git
-    ref: '2.12'
+    ref: 5dc511ef0ba0c47f0de8118a15ceac441739c219
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '2.12'
+    ref: d36297f9df01c9a80582fda42ceee981975bc33e
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
-    ref: '2.12'
+    ref: 8838be9312a1d58cbecd17b0ae2cb85fe703ce48
   - name: assistantDashboards
     repository: https://github.com/opensearch-project/dashboards-assistant.git
-    ref: '2.12'
+    ref: bfe6fb9a4b92f53c305d6ba98b637d33268cf248

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
@@ -7,10 +7,6 @@
          integ-test.logRotator({daysToKeepStr=30})
          integ-test.buildDiscarder(null)
          integ-test.echo(Executing on agent [label:none])
-         integ-test.parameterizedCron(
-            H 1 * * * %TEST_MANIFEST=2.12.0/opensearch-2.12.0-concurrent-search-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.12.0/latest/linux/arm64/tar/builds/opensearch/manifest.yml
-            H 1 * * * %TEST_MANIFEST=2.12.0/opensearch-2.12.0-concurrent-search-test.yml;BUILD_MANIFEST_URL=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.12.0/latest/linux/x64/tar/builds/opensearch/manifest.yml
-            )
          integ-test.stage(verify-parameters, groovy.lang.Closure)
             integ-test.echo(Executing on agent [label:Jenkins-Agent-AL2023-X64-C54xlarge-Docker-Host])
             integ-test.script(groovy.lang.Closure)


### PR DESCRIPTION
### Description
[Release 2.12.0] coming from the [RC](https://github.com/opensearch-project/opensearch-build/issues/4115#issuecomment-1953322664). Lock the commits based on the following manifests.
https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.12.0/9445/linux/x64/tar/dist/opensearch/manifest.yml
https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/2.12.0/7326/linux/x64/tar/dist/opensearch-dashboards/manifest.yml

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4115

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
