### PR TITLE
Add single version loose param for building plugins

### DIFF
--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -101,7 +101,7 @@ jobs:
                 OSD_PLUGIN_VERSION=$(node -p "require('./package.json').version")
                 echo "OSD_PLUGIN_VERSION=$OSD_PLUGIN_VERSION" >> $GITHUB_ENV
           else
-              yarn osd bootstrap
+              yarn osd bootstrap --single-version=loose
               node ../../scripts/plugin_helpers version --sync legacy
               OSD_PLUGIN_VERSION=$(node -p "require('./package.json').version")
               echo "OSD_PLUGIN_VERSION=$OSD_PLUGIN_VERSION" >> $GITHUB_ENV

--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           cd OpenSearch-Dashboards/plugins/${{ matrix.entry.repo }}
           if [ ${{ matrix.entry.path }} ]; then
-              yarn osd bootstrap
+              yarn osd bootstrap --single-version=loose
               cp -R ${{ matrix.entry.path }} ../
               cd ../${{ matrix.entry.path }}
               node ../../scripts/plugin_helpers version --sync legacy

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -98,7 +98,7 @@ mkdir -p $OUTPUT/plugins
 cp -r ../$PLUGIN_NAME/ ../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 CURR_DIR=`pwd`
-cd ../OpenSearch-Dashboards; eval $NVM_CMD; yarn osd bootstrap
+cd ../OpenSearch-Dashboards; eval $NVM_CMD; yarn osd bootstrap --single-version=loose
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 cd plugins/$PLUGIN_NAME; yarn $HELPER_STRING build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER
 cd $CURR_DIR

--- a/scripts/default/opensearch-dashboards/build.sh
+++ b/scripts/default/opensearch-dashboards/build.sh
@@ -98,7 +98,7 @@ mkdir -p $OUTPUT/plugins
 cp -r ../$PLUGIN_NAME/ ../OpenSearch-Dashboards/plugins
 echo "BUILD MODULES FOR $PLUGIN_NAME"
 CURR_DIR=`pwd`
-cd ../OpenSearch-Dashboards; eval $NVM_CMD; yarn osd bootstrap --single-version=loose
+cd ../OpenSearch-Dashboards; eval $NVM_CMD; yarn osd bootstrap
 echo "BUILD RELEASE ZIP FOR $PLUGIN_NAME"
 cd plugins/$PLUGIN_NAME; yarn $HELPER_STRING build --opensearch-dashboards-version=$VERSION$QUALIFIER_IDENTIFIER
 cd $CURR_DIR


### PR DESCRIPTION
### Description
Coming from: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5675, this PR adds the flag to have loose single-version dependencies. Ideally this should not be enforced for devDependencies, but should unblock the build. 

### Category
CI fix.

### Why these changes are required?
OSD core added a dependency to cypress 9.5.4 (mismatching with the version in this repo) here: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5725/files#r1494915750, leading to error at bootstrap.

### What is the old behavior before changes and new behavior after changes?
Old behavior is that the bootstrap process would fail. OSD core added a dependency to cypress 9.5.4 in this PR: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5725/files#r1494915750. Since we need cypress 13 in order to run our test suites (including cross-origin support), bootstrapping the plugin with OSD fails since there is a version mismatch. With this new flag, this inconsistency is ignored and the CI is green.

### Issues Resolved
Related to: https://github.com/opensearch-project/security-dashboards-plugin/issues/1786. However that issue is coming from autocuts. We need opensearch-build repo to take in this change to close the autocut. 

### Testing


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).