### PR TITLE
remove subdirectory for gantt-chart in 1.13.15

### DIFF
--- a/manifests/1.3.15/opensearch-dashboards-1.3.15.yml
+++ b/manifests/1.3.15/opensearch-dashboards-1.3.15.yml
@@ -18,7 +18,6 @@ components:
     ref: '1.3'
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
-    working_directory: gantt-chart
     ref: '1.3'
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git


### PR DESCRIPTION
### Description
Gantt chart build is failing due to https://github.com/opensearch-project/opensearch-build/pull/4375. This was called out in the original PR
> In all future release versions (>=3.0.0, >=2.12.0, >=1.3.15), the manifest file should not include working_directory: gantt-chart

as well as confirmed in this issue https://github.com/opensearch-project/dashboards-visualizations/issues/327#issuecomment-1928037969, but somehow still missed in the new 1.3.15 manifest

### Issues Resolved
https://github.com/opensearch-project/dashboards-visualizations/issues/349

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
