### PR TITLE
Removing 1.3.15 hourly check-for-build

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -24,8 +24,6 @@ pipeline {
     triggers {
         parameterizedCron '''
             H 1 * * * %INPUT_MANIFEST=2.12.1/opensearch-2.12.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H/60 * * * * %INPUT_MANIFEST=1.3.15/opensearch-dashboards-1.3.15.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H/60 * * * * %INPUT_MANIFEST=1.3.15/opensearch-1.3.15.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=2.13.0/opensearch-dashboards-2.13.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H */6 * * * %INPUT_MANIFEST=2.13.0/opensearch-2.13.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip


### PR DESCRIPTION
### Description
Removing 1.3.15 hourly check-for-build

### Issues Resolved
part of [[RELEASE] Release version 1.3.15](https://github.com/opensearch-project/opensearch-build/issues/4294#top)
#4294

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
