### PR TITLE
Fix opensearch-dashboards-functional-test version increment

### DIFF
--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -92,7 +92,7 @@ jobs:
               cd ${{ matrix.entry.repo }}/
           # tmp `elif` solution for opensearch-dashboards-functional-test (ref: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1801#issuecomment-1545947935)
           elif [ ${{ matrix.entry.repo }} == "opensearch-dashboards-functional-test" ]; then
-                jq --arg DASHBOARD_VERSION "${{ env.DASHBOARD_VERSION }}" '.version = ${{ env.DASHBOARD_VERSION }}' package.json > package-tmp.json
+                jq --arg DASHBOARD_VERSION "${{ env.DASHBOARD_VERSION }}" '.version = $DASHBOARD_VERSION' package.json > package-tmp.json
                 mv package-tmp.json package.json
                 OSD_PLUGIN_VERSION=$(node -p "require('./package.json').version")
                 echo "OSD_PLUGIN_VERSION=$OSD_PLUGIN_VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
### Description

Version increment for opensearch-dashboards-functional-test version started failing recently and looks to me some issue with the `jq` cli.

#### Old Command 
```
jq --arg DASHBOARD_VERSION 2.13.0 '.version = 2.13.0' package.json > package-tmp.json
jq: error: Invalid numeric literal at EOF at line 1, column 6 (while parsing '2.13.0') at <top-level>, line 1:
.version = 2.13.0           
jq: 1 compile error

```

#### New command
 
```
jq --arg DASHBOARD_VERSION "$DASHBOARD_VERSION" '.version = $DASHBOARD_VERSION' package.json > package-tmp.json
```

### Issues Resolved
Failing runs https://github.com/opensearch-project/opensearch-build/actions/runs/8134057241/job/22226466847 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
