### PR TITLE
Lock in commit Id

### DIFF
--- a/manifests/1.3.15/opensearch-1.3.15.yml
+++ b/manifests/1.3.15/opensearch-1.3.15.yml
@@ -10,13 +10,13 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: '1.3'
+    ref: f1842d770471ab4a6e496e5b1e14c14478f059f1
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: '1.3'
+    ref: ede103c546c7cd4843b3c5ef3bc3d66fe1f5496b
     checks:
       - gradle:publish
       - gradle:properties:version
@@ -25,7 +25,7 @@ components:
       - windows
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: '1.3'
+    ref: 3134607457f7813a1a38a728e6bdcc838a4e6f89
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -34,7 +34,7 @@ components:
       - windows
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '1.3'
+    ref: c2247df2cf6138383ea979acbe6ea3d924ac8c85
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -43,7 +43,7 @@ components:
       - windows
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: '1.3'
+    ref: a405f8ae4f2ce379a518225ec9ab7c2853d78bc0
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
@@ -54,7 +54,7 @@ components:
       - common-utils
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: '1.3'
+    ref: b9bcc1e65709c4fa10c7006c4127f20fc28fa33a
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -62,7 +62,7 @@ components:
       - linux
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: '1.3'
+    ref: 59119873187bd7b736a57364a59c55e3aa7ecaec
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
@@ -73,7 +73,7 @@ components:
       - common-utils
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: '1.3'
+    ref: 4546832ed1ad6f4f2c5db2071bba21df4db7900d
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -85,7 +85,7 @@ components:
       - job-scheduler
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '1.3'
+    ref: 696e62410dbb0cc9535ea2b69e51d8c9c30486d5
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -96,7 +96,7 @@ components:
       - common-utils
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: '1.3'
+    ref: 4cf584bde061447713206dd42d0840fbc130c1fd
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -107,7 +107,7 @@ components:
       - common-utils
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: '1.3'
+    ref: a386d3816b5e8fd2550fd1f4bee5c8cf2d12018b
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -119,7 +119,7 @@ components:
       - job-scheduler
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: '1.3'
+    ref: a4c5b5d6fdab6fc788f7ccab2336ae67968d6327
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -130,7 +130,7 @@ components:
       - common-utils
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: '1.3'
+    ref: 51d257ec70bfcf25768d7751602c863194bd956f
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -139,7 +139,7 @@ components:
       - windows
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: '1.3'
+    ref: 5c4590dc62e2abcb68e2f54e19d739f22b64f3e3
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
@@ -150,7 +150,7 @@ components:
       - ml-commons
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: '1.3'
+    ref: 5c77be0de071bc00a60b26b59040dc1e93227548
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/1.3.15/opensearch-dashboards-1.3.15.yml
+++ b/manifests/1.3.15/opensearch-dashboards-1.3.15.yml
@@ -9,31 +9,31 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: '1.3'
+    ref: 54b3e81325a38cf4099220e5c069d7e133502ef0
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '1.3'
+    ref: 22c6937949fe804af4d2889eb38c497eacb345de
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: '1.3'
+    ref: 21a44f83fcd84a7119172decbb72e037869377f8
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
-    ref: '1.3'
+    ref: 20b16a0aab9634fb788bbc385d6c680514dbe50c
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
-    ref: '1.3'
+    ref: 118db7db25b4fbb0332b3ed14176c77b655b111c
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: '1.3'
+    ref: 6418e9f63c8246a77fc1a6da08974434ace29570
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
-    ref: '1.3'
+    ref: 315a98912c504898515f442735553d1772cb85d4
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
-    ref: '1.3'
+    ref: 2a36db35d17c9a5fe679c909ca4cefb8a6af7d69
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '1.3'
+    ref: 81910ea688f0446fec4aa64ba8c5136eabf74f08
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
-    ref: '1.3'
+    ref: 4a6b0faa0907666b6cabcabfc292b997777a4bad


### PR DESCRIPTION
### Description
Freeze commit ids for 1.3.15 manifests

### Issues Resolved
part of [[RELEASE] Release version 1.3.15](https://github.com/opensearch-project/opensearch-build/issues/4294)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
