### PR TITLE
Ensure that artifact url is valid for Windows dist manifest

### DIFF
--- a/src/assemble_workflow/bundle_url_location.py
+++ b/src/assemble_workflow/bundle_url_location.py
@@ -16,4 +16,8 @@ class BundleUrlLocation(BundleLocation):
 
     def join(self, *args: str) -> str:
         sub_path = "/".join(args)
-        return urljoin(self.path + "/", sub_path)
+
+        # Make sure \ is replaced with / for valid url
+        # We will only make change here as the location can be either local or url
+        # Thus keep \ if it is a local path
+        return urljoin(self.path + "/", sub_path.replace("\\", "/"))

--- a/tests/tests_assemble_workflow/test_bundle_url_location.py
+++ b/tests/tests_assemble_workflow/test_bundle_url_location.py
@@ -49,3 +49,17 @@ class TestBundleUrlLocation(unittest.TestCase):
             location.get_build_location("sql"),
             "https://ci.opensearch.org/ci/dbc/bundle-build/1.3.0/1318/linux/x64/tar/builds/opensearch-dashboards/sql"
         )
+
+    def test_opensearch_windows(self) -> None:
+        location = BundleUrlLocation("https://ci.opensearch.org/ci/dbc/bundle-build/1.3.0/1318/windows/x64", "opensearch", "plugins\zip")
+
+        self.assertEqual(
+            location.get_bundle_location("sql"),
+            "https://ci.opensearch.org/ci/dbc/bundle-build/1.3.0/1318/windows/x64/plugins/zip/dist/opensearch/sql"
+        )
+
+        self.assertEqual(
+            location.get_build_location("sql"),
+            "https://ci.opensearch.org/ci/dbc/bundle-build/1.3.0/1318/windows/x64/plugins/zip/builds/opensearch/sql"
+        )
+

--- a/tests/tests_assemble_workflow/test_bundle_url_location.py
+++ b/tests/tests_assemble_workflow/test_bundle_url_location.py
@@ -51,7 +51,7 @@ class TestBundleUrlLocation(unittest.TestCase):
         )
 
     def test_opensearch_windows(self) -> None:
-        location = BundleUrlLocation("https://ci.opensearch.org/ci/dbc/bundle-build/1.3.0/1318/windows/x64", "opensearch", "plugins\zip")
+        location = BundleUrlLocation("https://ci.opensearch.org/ci/dbc/bundle-build/1.3.0/1318/windows/x64", "opensearch", "plugins\\zip")
 
         self.assertEqual(
             location.get_bundle_location("sql"),
@@ -62,4 +62,3 @@ class TestBundleUrlLocation(unittest.TestCase):
             location.get_build_location("sql"),
             "https://ci.opensearch.org/ci/dbc/bundle-build/1.3.0/1318/windows/x64/plugins/zip/builds/opensearch/sql"
         )
-


### PR DESCRIPTION
### Description
Ensure that artifact url is valid for Windows dist manifest

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/4506

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
