### PR TITLE
Generate new input manifest with previous latest version

### DIFF
--- a/src/manifests_workflow/README.md
+++ b/src/manifests_workflow/README.md
@@ -4,13 +4,16 @@
 
 This workflow reacts to version increments in OpenSearch and its components by extracting Gradle properties from project branches. Currently OpenSearch `main`, and `x.y` branches are checked out one-by-one, published to local maven, and their versions extracted using `./gradlew properties`. When a new version is found, a new input manifest is added to [manifests](../../manifests), and [a pull request is opened](../../.github/workflows/manifests.yml) (e.g. [opensearch-build#491](https://github.com/opensearch-project/opensearch-build/pull/491)).
 
-Show information about existing manifests. 
+### Show information about existing manifests
 
 ```bash
 ./manifests.sh list
 ```
 
-Check for updates and create any new manifests. 
+### Check for updates and create any new manifests
+* If there are no existing manifests in either the `manifests` or `legacy-manifests` folder, use the manifest templates located in `manifests/templates` as a base to generate new manifests.
+* If the requested new manifest version (e.g., 0.10.1) is lower than the lowest existing manifest version (e.g., 1.0.0), again, use the manifest templates located in `manifests/templates` as a base to generate new manifests.
+* In other scenarios, always use the latest existing manifest version that is lower than the requested new manifest version as the base to generate new manifests (e.g., Use 2.12.0 to generate 2.12.1, even if 2.13.0 exists).
 
 ```bash
 ./manifests.sh update

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -120,7 +120,7 @@ class InputManifests(Manifests):
         #       (1.0.0-3.0.0 based on template 1.x-3.x, 4.0.0+ from default.x, previous behavior)
         # Else: Create new manifests based on the latest version before the new version
         #       (2.12.1 from 2.12.0, 2.13.0 from 2.12.1, 3.0.0 from 2.13.0, 4.0.0 from 3.0.0, etc.)
-        if not known_versions or Version(version) < Version(min(known_versions)):
+        if not known_versions or Version(version) < Version(min(known_versions, key=version_parse)):
             logging.info("No previous version exist before {version}, create with templates")
             templates_base_path = os.path.join(self.manifests_path(), "templates")
             template_version_folder = version.split(".")[0] + ".x"

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -13,9 +13,10 @@ from abc import abstractmethod
 from typing import Dict, List, Type, Union
 
 import ruamel.yaml
+from packaging.version import Version
+from packaging.version import parse as version_parse
 
-from manifests.component_manifest import ComponentFromSource
-from manifests.input_manifest import InputComponents, InputManifest
+from manifests.input_manifest import InputManifest
 from manifests.manifests import Manifests
 from manifests_workflow.component_opensearch import ComponentOpenSearch
 from manifests_workflow.component_opensearch_dashboards_min import ComponentOpenSearchDashboardsMin
@@ -84,92 +85,75 @@ class InputManifests(Manifests):
         component_klass: Type[ComponentOpenSearch],
         keep: bool = False,
     ) -> None:
-        known_versions = self.versions
+        known_versions = sorted(self.versions, key=version_parse)
+        branch_versions: Dict = {}
         logging.info(f"Known versions: {known_versions}")
-        main_versions: Dict = {}
         with TemporaryDirectory(keep=keep, chdir=True) as work_dir:
             logging.info(f"Checking out components into {work_dir.name}")
 
             # check out and build #main, 1.x, etc.
-            branches = min_klass.branches()
+            branches = sorted(min_klass.branches())
 
             logging.info(f"Checking {self.name} {branches} branches")
             for branch in branches:
-                c = min_klass.checkout(
+                min_component_klass = min_klass.checkout(
                     path=os.path.join(work_dir.name, self.name.replace(" ", ""), branch),
                     branch=branch,
                 )
 
-                version = c.version
+                version = min_component_klass.version
                 logging.info(f"{self.name}#{branch} is version {version}")
-                if version not in main_versions.keys():
-                    main_versions[version] = [c]
-
-            if component_klass is not None:
-                # components can increment their own version first without incrementing min
-                manifest = self.latest
-                logging.info(f"Examining components in the latest manifest of {manifest.build.name} ({manifest.build.version})")
-                for component in manifest.components.values():
-                    if component.name == self.name:
-                        continue
-
-                    if type(component) is ComponentFromSource:
-                        logging.info(f"Checking out {component.name}#main")
-                        component = component_klass.checkout(
-                            name=component.name,
-                            path=os.path.join(work_dir.name, component.name),
-                            opensearch_version=manifest.build.version,
-                            repo_url=component.repository,
-                            branch="main",
-                        )
-
-                        component_version = component.version
-                        if component_version:
-                            release_version = ".".join(component_version.split(".")[:3])
-                            if release_version not in main_versions.keys():
-                                main_versions[release_version] = []
-                            main_versions[release_version].append(component)
-                            logging.info(f"{component.name}#main is version {release_version} (from {component_version})")
-
-            # summarize
-            logging.info("Found versions on main:")
-            for main_version in main_versions.keys():
-                for component in main_versions[main_version]:
-                    logging.info(f" {component.name}={main_version}")
+                if version not in branch_versions:
+                    branch_versions[version] = branch
 
             # generate new manifests
-            for release_version in sorted(main_versions.keys() - known_versions):
-                self.write_manifest(release_version, main_versions[release_version])
-                self.add_to_cron(release_version)
-                self.add_to_versionincrement_workflow(release_version)
+            new_versions = sorted(branch_versions.keys() - known_versions, key=version_parse)
+            logging.info(f"New Versions: {new_versions}")
+            for new_version_entry in new_versions:
+                self.write_manifest(new_version_entry, branch_versions[new_version_entry], known_versions)
+                self.add_to_cron(new_version_entry)
+                self.add_to_versionincrement_workflow(new_version_entry)
+                known_versions.append(new_version_entry)
 
-    def create_manifest(self, version: str, components: List = []) -> InputManifest:
-        templates_base_path = os.path.join(self.manifests_path(), "templates")
-        template_version_folder = version.split(".")[0] + ".x"
-        template_full_path = os.path.join(templates_base_path, self.prefix, template_version_folder, "manifest.yml")
-        if not os.path.exists(template_full_path):
-            template_full_path = os.path.join(templates_base_path, self.prefix, "default", "manifest.yml")
+    def create_manifest(self, version: str, branch: str, known_versions: List[str]) -> InputManifest:
+        # If  : No known_versions manifests exist or new version smaller than the min(known_versions), create new manifests from the templates
+        #       (1.0.0-3.0.0 based on template 1.x-3.x, 4.0.0+ from default.x, previous behavior)
+        # Else: Create new manifests based on the latest version before the new version
+        #       (2.12.1 from 2.12.0, 2.13.0 from 2.12.1, 3.0.0 from 2.13.0, 4.0.0 from 3.0.0, etc.)
+        if not known_versions or Version(version) < Version(min(known_versions)):
+            logging.info("No previous version exist before {version}, create with templates")
+            templates_base_path = os.path.join(self.manifests_path(), "templates")
+            template_version_folder = version.split(".")[0] + ".x"
+            template_full_path = os.path.join(templates_base_path, self.prefix, template_version_folder, "manifest.yml")
+            if not os.path.exists(template_full_path):
+                template_full_path = os.path.join(templates_base_path, self.prefix, "default", "manifest.yml")
+        else:
+            previous_versions = [v for v in known_versions if Version(v) < Version(version)]
+            base_version = max(previous_versions, key=version_parse)
+            logging.info(f"Base Version: {base_version} is the highest version before {version}")
+            template_full_path = os.path.join(self.manifests_path(), base_version, f"{self.prefix}-{base_version}.yml")
+            if not os.path.exists(template_full_path):
+                template_full_path = os.path.join(self.legacy_manifests_path(), base_version, f"{self.prefix}-{base_version}.yml")
+
+        logging.info(f"Using {template_full_path} as the base manifest")
 
         manifest = InputManifest.from_file(open(template_full_path))
 
         manifest.build.version = version
-        manifests_components = []
 
-        for component in components:
-            logging.info(f" Adding {component.name}")
-            manifests_components.append(component.to_dict())
+        for component in manifest.components.select():
+            component.ref = branch  # type: ignore
 
-        manifest.components = InputComponents(manifests_components)  # type: ignore
         return manifest
 
-    def write_manifest(self, version: str, components: List = []) -> None:
+    def write_manifest(self, version: str, branch: str, known_versions: List[str]) -> None:
         logging.info(f"Creating new version: {version}")
-        manifest = self.create_manifest(version, components)
+        manifest = self.create_manifest(version, branch, known_versions)
         manifest_dir = os.path.join(self.manifests_path(), version)
         os.makedirs(manifest_dir, exist_ok=True)
         manifest_path = os.path.join(manifest_dir, f"{self.prefix}-{version}.yml")
         manifest.to_file(manifest_path)
-        logging.info(f"Wrote {manifest_path}")
+        logging.info(f"Wrote {manifest_path} as the new manifest")
 
     def add_to_cron(self, version: str) -> None:
         logging.info(f"Adding new version to cron: {version}")

--- a/tests/tests_manifests_workflow/data/opensearch-2.12.1000.yml
+++ b/tests/tests_manifests_workflow/data/opensearch-2.12.1000.yml
@@ -1,0 +1,185 @@
+---
+schema-version: '1.1'
+build:
+  name: OpenSearch
+  version: 2.12.1000
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
+    args: -e JAVA_HOME=/opt/java/openjdk-21
+components:
+  - name: OpenSearch
+    repository: https://github.com/opensearch-project/OpenSearch.git
+    ref: '2.12'
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+  - name: k-NN
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+  - name: geospatial
+    repository: https://github.com/opensearch-project/geospatial.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - job-scheduler
+  - name: cross-cluster-replication
+    repository: https://github.com/opensearch-project/cross-cluster-replication.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: ml-commons
+    repository: https://github.com/opensearch-project/ml-commons.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: neural-search
+    repository: https://github.com/opensearch-project/neural-search.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - ml-commons
+      - k-NN
+  - name: notifications-core
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: '2.12'
+    working_directory: notifications
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: notifications
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: '2.12'
+    working_directory: notifications
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: opensearch-observability
+    repository: https://github.com/opensearch-project/observability.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: opensearch-reports
+    repository: https://github.com/opensearch-project/reporting.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+      - job-scheduler
+  - name: sql
+    repository: https://github.com/opensearch-project/sql.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - ml-commons
+  - name: asynchronous-search
+    repository: https://github.com/opensearch-project/asynchronous-search.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: anomaly-detection
+    repository: https://github.com/opensearch-project/anomaly-detection.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+      - job-scheduler
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: security-analytics
+    repository: https://github.com/opensearch-project/security-analytics.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: index-management
+    repository: https://github.com/opensearch-project/index-management.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+      - job-scheduler
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
+    ref: '2.12'
+    platforms:
+      - linux
+  - name: custom-codecs
+    repository: https://github.com/opensearch-project/custom-codecs.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+  - name: flow-framework
+    repository: https://github.com/opensearch-project/flow-framework.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: skills
+    repository: https://github.com/opensearch-project/skills.git
+    ref: '2.12'
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - job-scheduler
+      - anomaly-detection
+      - sql
+      - ml-commons

--- a/tests/tests_manifests_workflow/data/opensearch-dashboards-2.12.1000.yml
+++ b/tests/tests_manifests_workflow/data/opensearch-dashboards-2.12.1000.yml
@@ -1,0 +1,57 @@
+---
+schema-version: '1.1'
+build:
+  name: OpenSearch Dashboards
+  version: 2.12.1000
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-build-v1
+components:
+  - name: OpenSearch-Dashboards
+    repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+    ref: '2.12'
+  - name: functionalTestDashboards
+    repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
+    ref: '2.12'
+  - name: observabilityDashboards
+    repository: https://github.com/opensearch-project/dashboards-observability.git
+    ref: '2.12'
+  - name: reportsDashboards
+    repository: https://github.com/opensearch-project/dashboards-reporting.git
+    ref: '2.12'
+  - name: ganttChartDashboards
+    repository: https://github.com/opensearch-project/dashboards-visualizations.git
+    ref: '2.12'
+  - name: queryWorkbenchDashboards
+    repository: https://github.com/opensearch-project/dashboards-query-workbench.git
+    ref: '2.12'
+  - name: customImportMapDashboards
+    repository: https://github.com/opensearch-project/dashboards-maps.git
+    ref: '2.12'
+  - name: anomalyDetectionDashboards
+    repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
+    ref: '2.12'
+  - name: mlCommonsDashboards
+    repository: https://github.com/opensearch-project/ml-commons-dashboards.git
+    ref: '2.12'
+  - name: indexManagementDashboards
+    repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
+    ref: '2.12'
+  - name: notificationsDashboards
+    repository: https://github.com/opensearch-project/dashboards-notifications.git
+    ref: '2.12'
+  - name: alertingDashboards
+    repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
+    ref: '2.12'
+  - name: securityAnalyticsDashboards
+    repository: https://github.com/opensearch-project/security-analytics-dashboards-plugin.git
+    ref: '2.12'
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+    ref: '2.12'
+  - name: searchRelevanceDashboards
+    repository: https://github.com/opensearch-project/dashboards-search-relevance.git
+    ref: '2.12'
+  - name: assistantDashboards
+    repository: https://github.com/opensearch-project/dashboards-assistant.git
+    ref: '2.12'

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -9,6 +9,7 @@ import os
 import unittest
 from unittest.mock import MagicMock, call, mock_open, patch
 
+from manifests.input_manifest import InputManifest
 from manifests_workflow.input_manifests import InputManifests
 
 
@@ -39,9 +40,9 @@ class TestInputManifests(unittest.TestCase):
         self.assertTrue(os.path.join(InputManifests.manifests_path(), os.path.join("3.0.0", "opensearch-dashboards-3.0.0.yml")) in files)
         self.assertTrue(os.path.join(InputManifests.legacy_manifests_path(), os.path.join("1.2.1", "opensearch-dashboards-1.2.1.yml")) in files)
 
-    def test_create_manifest_opensearch(self) -> None:
+    def test_create_manifest_opensearch_template(self) -> None:
         input_manifests = InputManifests("OpenSearch")
-        input_manifest = input_manifests.create_manifest("1.2.3", [])
+        input_manifest = input_manifests.create_manifest("1.2.3", "1.x", [])
         self.assertEqual(
             input_manifest.to_dict(),
             {
@@ -49,52 +50,81 @@ class TestInputManifests(unittest.TestCase):
                 "build": {"name": "OpenSearch", "version": "1.2.3"},
                 "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3",
                                  "args": "-e JAVA_HOME=/opt/java/openjdk-11"}},
-            },
+                "components": [{"name": "OpenSearch",
+                                "repository": "https://github.com/opensearch-project/OpenSearch.git",
+                                "ref": "1.x",
+                                "checks": ["gradle:publish", "gradle:properties:version"]}]
+            }
         )
 
-    def test_create_manifest_opensearch_from_default(self) -> None:
+    def test_create_manifest_opensearch_default_template(self) -> None:
         input_manifests = InputManifests("OpenSearch")
-        input_manifest = input_manifests.create_manifest("0.2.3", [])
+        input_manifest = input_manifests.create_manifest("0.2.3", "0.x", [])
         self.assertEqual(
             input_manifest.to_dict(),
             {
                 "schema-version": "1.1",
                 "build": {"name": "OpenSearch", "version": "0.2.3"},
                 "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3",
-                                 "args": "-e JAVA_HOME=/opt/java/openjdk-21"}},
-            },
+                       "args": "-e JAVA_HOME=/opt/java/openjdk-21"}},
+                "components": [{"name": "OpenSearch",
+                                "repository": "https://github.com/opensearch-project/OpenSearch.git",
+                                "ref": "0.x",
+                                "checks": ["gradle:publish", "gradle:properties:version"]}]
+            }
         )
 
-    def test_create_manifest_opensearch_dashboards(self) -> None:
+    def test_create_manifest_opensearch_previous_base_version(self) -> None:
+        input_manifests = InputManifests("OpenSearch")
+        input_manifest = input_manifests.create_manifest("2.12.1000", "2.12", ["0.9.2", "1.3.1", "1.3.14", "2.12.0", "2.14.0", "3.0.0"])  # based on 2.12.0
+        manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-2.12.1000.yml")
+        input_manifest_compare = InputManifest.from_file(open(manifest_path))
+        self.assertEqual(input_manifest.to_dict(), input_manifest_compare.to_dict())
+
+    def test_create_manifest_opensearch_dashboards_template(self) -> None:
         input_manifests = InputManifests("OpenSearch Dashboards")
-        input_manifest = input_manifests.create_manifest("1.2.3", [])
+        input_manifest = input_manifests.create_manifest("1.2.3", "1.x", [])
         self.assertEqual(
             input_manifest.to_dict(),
             {
                 "schema-version": "1.0",
                 "build": {"name": "OpenSearch Dashboards", "version": "1.2.3"},
-                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v4", }},
-            },
+                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-centos7-opensearch-dashboards-build-v4"}},
+                "components": [{"name": "OpenSearch-Dashboards",
+                                "repository": "https://github.com/opensearch-project/OpenSearch-Dashboards.git",
+                                "ref": "1.x"}]
+            }
         )
 
-    def test_create_manifest_opensearch_dashboards_from_default(self) -> None:
+    def test_create_manifest_opensearch_dashboards_default_template(self) -> None:
         input_manifests = InputManifests("OpenSearch Dashboards")
-        input_manifest = input_manifests.create_manifest("4.2.3", [])
+        input_manifest = input_manifests.create_manifest("4.2.3", "4.x", [])
         self.assertEqual(
             input_manifest.to_dict(),
             {
                 "schema-version": "1.1",
                 "build": {"name": "OpenSearch Dashboards", "version": "4.2.3"},
-                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-build-v1", }},
-            },
+                "ci": {"image": {"name": "opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-build-v1"}},
+                "components": [{"name": "OpenSearch-Dashboards",
+                                "repository": "https://github.com/opensearch-project/OpenSearch-Dashboards.git",
+                                "ref": "4.x",
+                                "checks": ["npm:package:version"]}]
+            }
         )
+
+    def test_create_manifest_opensearch_dashboards_previous_base_version(self) -> None:
+        input_manifests = InputManifests("OpenSearch-Dashboards")
+        input_manifest = input_manifests.create_manifest("2.12.1000", "2.12", ["0.9.2", "1.3.1", "1.3.14", "2.12.0", "2.14.0", "3.0.0"])  # based on 2.12.0
+        manifest_path = os.path.join(os.path.dirname(__file__), "data", "opensearch-dashboards-2.12.1000.yml")
+        input_manifest_compare = InputManifest.from_file(open(manifest_path))
+        self.assertEqual(input_manifest.to_dict(), input_manifest_compare.to_dict())
 
     @patch("os.makedirs")
     @patch("manifests_workflow.input_manifests.InputManifests.create_manifest")
     def test_write_manifest(self, mock_create_manifest: MagicMock, mock_makedirs: MagicMock) -> None:
         input_manifests = InputManifests("opensearch")
-        input_manifests.write_manifest('0.1.2', [])
-        mock_create_manifest.assert_called_with('0.1.2', [])
+        input_manifests.write_manifest('0.1.2', '0.x', [])
+        mock_create_manifest.assert_called_with('0.1.2', '0.x', [])
         mock_makedirs.assert_called_with(os.path.join(InputManifests.manifests_path(), '0.1.2'), exist_ok=True)
         mock_create_manifest.return_value.to_file.assert_called_with(
             os.path.join(InputManifests.manifests_path(), '0.1.2', 'opensearch-0.1.2.yml')

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
@@ -30,38 +30,33 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
 
     @patch("os.makedirs")
     @patch("os.chdir")
-    @patch("manifests_workflow.input_manifests.InputComponents")
-    @patch("manifests_workflow.input_manifests.InputManifest.from_file")
-    @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
     @patch("manifests_workflow.input_manifests.InputManifests.add_to_versionincrement_workflow")
-    @patch("manifests_workflow.input_manifests.InputManifest.from_path")
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
+    @patch("manifests.manifest.Manifest.to_file")
     @patch("manifests_workflow.input_manifests_opensearch_dashboards.ComponentOpenSearchDashboardsMin")
-    @patch("manifests_workflow.input_manifests.InputManifest")
-    def test_update(self, mock_input_manifest: MagicMock, mock_component_opensearch_min: MagicMock,
-                    mock_input_manifest_from_path: MagicMock, mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock,
-                    mock_input_manifest_from_file: MagicMock, mock_input_manifest_component: MagicMock,
-                    *mocks: MagicMock) -> None:
-        mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch-Dashboards")
-        mock_component_opensearch_min.branches.return_value = ["main", "0.9.0"]
-        mock_component_opensearch_min.checkout.return_value = MagicMock(version="0.9.0")
-        mock_input_manifest_from_path.return_value = MagicMock(components=[])
+    def test_update(self, mock_component_opensearch_dashboards_min: MagicMock, mock_manifest_to_file: MagicMock,
+                    mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock,
+                    mock_os_chdir: MagicMock, mock_os_makedirs: MagicMock) -> None:
+        mock_component_opensearch_dashboards_min.return_value = MagicMock(name="OpenSearch-Dashboards")
+        mock_component_opensearch_dashboards_min.branches.return_value = ["2.12"]
+        mock_component_opensearch_dashboards_min.checkout.return_value = MagicMock(version="2.12.1000")
 
         manifests = InputManifestsOpenSearchDashboards()
         manifests.update()
-        self.assertEqual(mock_input_manifest_from_file().to_file.call_count, 1)
+        self.assertEqual(mock_manifest_to_file.call_count, 1)
         calls = [
             call(
                 os.path.join(
                     InputManifestsOpenSearchDashboards.manifests_path(),
-                    "0.9.0",
-                    "opensearch-dashboards-0.9.0.yml",
+                    "2.12.1000",
+                    "opensearch-dashboards-2.12.1000.yml",
                 )
             )
         ]
-        mock_input_manifest_from_file().to_file.assert_has_calls(calls)
+        mock_manifest_to_file.assert_has_calls(calls)
         mock_add_to_cron.assert_has_calls([
-            call('0.9.0')
+            call('2.12.1000')
         ])
         mock_add_to_versionincrement_workflow.assert_has_calls([
-            call('0.9.0')
+            call('2.12.1000')
         ])


### PR DESCRIPTION
### Description
Generate new input manifest with previous latest version

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/4389

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
