### PR TITLE
Automatic Service Restart (Debian)

### DIFF
--- a/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch-dashboards/deb/debian/postinst
@@ -29,23 +29,32 @@ if command -v systemd-tmpfiles > /dev/null; then
     systemd-tmpfiles --create opensearch-dashboards.conf
 fi
 
-# Messages
-echo "### NOT starting on installation, please execute the following statements to configure opensearch-dashboards service to start automatically using systemd"
-echo " sudo systemctl daemon-reload"
-echo " sudo systemctl enable opensearch-dashboards.service"
-echo "### You can start opensearch-dashboards service by executing"
-echo " sudo systemctl start opensearch-dashboards.service"
+# Restart the service after an upgrade
+if [ "$1" == "configure" ] && [ "$2" != "" ]; then
+    if command -v systemctl >/dev/null && systemctl is-enabled opensearch-dashboards.service >/dev/null; then
+        echo "Restarting opensearch-dashboards.service after upgrade"
+        systemctl start opensearch-dashboards.service
+    fi
+else
+    # Messages
+    echo "### NOT starting on installation, please execute the following statements to configure opensearch-dashboards service to start automatically using systemd"
+    echo " sudo systemctl daemon-reload"
+    echo " sudo systemctl enable opensearch-dashboards.service"
+    echo "### You can start opensearch-dashboards service by executing"
+    echo " sudo systemctl start opensearch-dashboards.service"
+fi
+
 echo "### Upcoming breaking change in packaging"
 echo " In a future release of OpenSearch Dashboards, we plan to change the permissions associated with access to installed files"
 echo " If you are configuring tools that require read access to the OpenSearch Dashboards configuration files, we recommend you add the user that runs these tools to the 'opensearch-dashboards' group"
 echo " For more information, see https://github.com/opensearch-project/opensearch-build/pull/4043"
 
 # Set owner
-chown -R opensearch-dashboards.opensearch-dashboards ${product_dir}
-chown -R opensearch-dashboards.opensearch-dashboards ${config_dir}
-chown -R opensearch-dashboards.opensearch-dashboards ${log_dir}
-chown -R opensearch-dashboards.opensearch-dashboards ${data_dir}
-chown -R opensearch-dashboards.opensearch-dashboards ${pid_dir}
+chown -R opensearch-dashboards:opensearch-dashboards ${product_dir}
+chown -R opensearch-dashboards:opensearch-dashboards ${config_dir}
+chown -R opensearch-dashboards:opensearch-dashboards ${log_dir}
+chown -R opensearch-dashboards:opensearch-dashboards ${data_dir}
+chown -R opensearch-dashboards:opensearch-dashboards ${pid_dir}
 
 exit 0
 

--- a/scripts/pkg/build_templates/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/opensearch/deb/debian/postinst
@@ -37,11 +37,11 @@ if ! grep -q '## OpenSearch Performance Analyzer' ${config_dir}/jvm.options; the
 fi
 
 # Set owner
-chown -R opensearch.opensearch ${product_dir}
-chown -R opensearch.opensearch ${config_dir}
-chown -R opensearch.opensearch ${log_dir}
-chown -R opensearch.opensearch ${data_dir}
-chown -R opensearch.opensearch ${pid_dir}
+chown -R opensearch:opensearch ${product_dir}
+chown -R opensearch:opensearch ${config_dir}
+chown -R opensearch:opensearch ${log_dir}
+chown -R opensearch:opensearch ${data_dir}
+chown -R opensearch:opensearch ${pid_dir}
 
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then
@@ -57,17 +57,30 @@ if command -v systemd-tmpfiles > /dev/null; then
     systemd-tmpfiles --create opensearch.conf
 fi
 
-# Messages
-echo "### NOT starting on installation, please execute the following statements to configure opensearch service to start automatically using systemd"
-echo " sudo systemctl daemon-reload"
-echo " sudo systemctl enable opensearch.service"
-echo "### You can start opensearch service by executing"
-echo " sudo systemctl start opensearch.service"
+# Restart the services after an upgrade
+if [ "$1" == "configure" ] && [ "$2" != "" ]; then
+    if command -v systemctl >/dev/null && systemctl is-enabled opensearch.service >/dev/null; then
+        echo "Restarting opensearch.service after upgrade"
+        systemctl start opensearch.service
+    fi
+    if command -v systemctl >/dev/null && systemctl is-enabled opensearch-performance-analyzer.service >/dev/null; then
+        echo "Restarting opensearch-performance-analyzer.service after upgrade"
+        systemctl start opensearch-performance-analyzer.service
+    fi
+else
+    # Messages
+    echo "### NOT starting on installation, please execute the following statements to configure opensearch service to start automatically using systemd"
+    echo " sudo systemctl daemon-reload"
+    echo " sudo systemctl enable opensearch.service"
+    echo "### You can start opensearch service by executing"
+    echo " sudo systemctl start opensearch.service"
 
-if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    echo "### Create opensearch demo certificates in ${config_dir}/"
-    echo " See demo certs creation log in ${log_dir}/install_demo_configuration.log"
+    if [ -d ${product_dir}/plugins/opensearch-security ]; then
+        echo "### Create opensearch demo certificates in ${config_dir}/"
+        echo " See demo certs creation log in ${log_dir}/install_demo_configuration.log"
+    fi
 fi
+
 echo "### Upcoming breaking change in packaging"
 echo " In a future release of OpenSearch, we plan to change the permissions associated with access to installed files"
 echo " If you are configuring tools that require read access to the OpenSearch configuration files, we recommend you add the user that runs these tools to the 'opensearch' group"


### PR DESCRIPTION
### Description
This change makes it so that the opensearch services are started after upgrades on Debian if they were enabled.
In addition I changed the syntax in the postinst scripts for the chown command from "chown user.group" to "chown user:group" (this changes nothing about the functionality but the former will produce warning messages -> "chown: warning: '.' should be ':'")

### Issues Resolved
#3891 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
