### PR TITLE
Update CI image name to be with v3 on OpenSearch 1.4.0 manifest

### DIFF
--- a/manifests/1.4.0/opensearch-1.4.0.yml
+++ b/manifests/1.4.0/opensearch-1.4.0.yml
@@ -5,7 +5,7 @@ build:
   version: 1.4.0
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-11
 components:
   - name: OpenSearch


### PR DESCRIPTION
### Description
Update CI image name to be with v3 on OpenSearch 1.4.0 manifest

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
