### PR TITLE
Updating Gradle_check API retry frequency

### DIFF
--- a/scripts/gradle/gradle-check.sh
+++ b/scripts/gradle/gradle-check.sh
@@ -41,7 +41,7 @@ perform_curl_and_process_with_jq() {
         fi
 
         count=$((count+1))
-        sleep 5
+        sleep 10
     done
 
     if [ "$success" != "true" ]; then
@@ -80,7 +80,7 @@ if [ -z "$QUEUE_URL" ] || [ "$QUEUE_URL" != "null" ]; then
             echo "Jenkins Workflow Url: $WORKFLOW_URL"
             TIMEPASS=$(( TIMEPASS + 30 )) && echo time pass: $TIMEPASS
             sleep 30
-            RUNNING=$(perform_curl_and_process_with_jq "$WORKFLOW_URL" ".building" 5)
+            RUNNING=$(perform_curl_and_process_with_jq "$WORKFLOW_URL" ".building" 10)
             echo "Workflow running status :$RUNNING"
         done
 


### PR DESCRIPTION
### Description
Updating Gradle_check API retry frequency

existing when API is fail : 5 times in every 5 sec
changing to : 10 times in every 10 sec

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
