### PR TITLE
Add current user to adm group to access logs

### DIFF
--- a/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
@@ -110,6 +110,7 @@ RUN dnf install -y sudo && \
     useradd -u 1002 -g 1002 opensearch-dashboards && \
     usermod -a -G opensearch $CONTAINER_USER && \
     usermod -a -G opensearch-dashboards $CONTAINER_USER && \
+    usermod -a -G adm $CONTAINER_USER && \
     id && \
     echo "$CONTAINER_USER ALL=(root) NOPASSWD:`which systemctl`, `which env`, `which usermod`, `which dnf`, `which yum`, `which rpm`, `which chmod`, `which kill`, `which curl`, /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin" >> /etc/sudoers.d/$CONTAINER_USER
 

--- a/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.ubuntu2004.systemd-base.x64.arm64.ppc64le.dockerfile
@@ -128,6 +128,7 @@ RUN apt-get install -y sudo && \
     useradd -u 1002 -g 1002 -s /bin/bash -d /home/opensearch-dashboards -m opensearch-dashboards && \
     usermod -a -G opensearch $CONTAINER_USER && \
     usermod -a -G opensearch-dashboards $CONTAINER_USER && \
+    usermod -a -G adm $CONTAINER_USER && \
     id && \
     echo "$CONTAINER_USER ALL=(root) NOPASSWD:`which systemctl`, `which env`, `which usermod`, `which apt`, `which apt-get`, `which apt-key`, `which dpkg`, `which chmod`, `which kill`, `which curl`, `which tee`, /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin" >> /etc/sudoers.d/$CONTAINER_USER
 

--- a/docker/ci/dockerfiles/legacy/test.rockylinux8.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/legacy/test.rockylinux8.systemd-base.x64.arm64.dockerfile
@@ -109,7 +109,7 @@ RUN dnf install -y sudo && \
     groupadd -g 1002 opensearch-dashboards && \
     useradd -u 1002 -g 1002 opensearch-dashboards && \
     usermod -a -G opensearch $CONTAINER_USER && \
-    usermod -a -G opensearch-dashboards $CONTAINER_USER && \
+    usermod -a -G adm $CONTAINER_USER && \
     id && \
     echo "$CONTAINER_USER ALL=(root) NOPASSWD:`which systemctl`, `which env`, `which usermod`, `which dnf`, `which yum`, `which rpm`, `which chmod`, `which kill`, `which curl`, /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin" >> /etc/sudoers.d/$CONTAINER_USER
 

--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -21,9 +21,9 @@ def docker_images = [
 ]
 
 def docker_args = [
-    "tar": "-u 1000 -e BROWSER_PATH=electron",
-    "rpm": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host -e BROWSER_PATH=electron",
-    "deb": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host -e BROWSER_PATH=electron",
+    "tar": "-u 1000",
+    "rpm": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host",
+    "deb": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host",
     "zip": "-u ContainerAdministrator",
 ]
 

--- a/src/test_workflow/integ_test/distribution_deb.py
+++ b/src/test_workflow/integ_test/distribution_deb.py
@@ -52,7 +52,7 @@ class DistributionDeb(Distribution):
                 '&&',
                 f'sudo usermod -a -G {self.filename} `whoami`',
                 '&&',
-                f'sudo usermod -a -G adm `whoami`'
+                'sudo usermod -a -G adm `whoami`'
             ]
         )
         subprocess.check_call(deb_install_cmd, cwd=self.work_dir, shell=True)

--- a/src/test_workflow/integ_test/distribution_deb.py
+++ b/src/test_workflow/integ_test/distribution_deb.py
@@ -50,7 +50,9 @@ class DistributionDeb(Distribution):
                 '&&',
                 f'sudo chmod 0755 {os.path.dirname(self.config_path)} {self.log_dir}',
                 '&&',
-                f'sudo usermod -a -G {self.filename} `whoami`'
+                f'sudo usermod -a -G {self.filename} `whoami`',
+                '&&',
+                f'sudo usermod -a -G adm `whoami`'
             ]
         )
         subprocess.check_call(deb_install_cmd, cwd=self.work_dir, shell=True)

--- a/src/test_workflow/integ_test/distribution_rpm.py
+++ b/src/test_workflow/integ_test/distribution_rpm.py
@@ -54,7 +54,7 @@ class DistributionRpm(Distribution):
                 '&&',
                 f'sudo usermod -a -G {self.filename} `whoami`',
                 '&&',
-                f'sudo usermod -a -G adm `whoami`'
+                'sudo usermod -a -G adm `whoami`'
             ]
         )
         subprocess.check_call(rpm_install_cmd, cwd=self.work_dir, shell=True)

--- a/src/test_workflow/integ_test/distribution_rpm.py
+++ b/src/test_workflow/integ_test/distribution_rpm.py
@@ -52,7 +52,9 @@ class DistributionRpm(Distribution):
                 '&&',
                 f'sudo chmod 0755 {os.path.dirname(self.config_path)} {self.log_dir}',
                 '&&',
-                f'sudo usermod -a -G {self.filename} `whoami`'
+                f'sudo usermod -a -G {self.filename} `whoami`',
+                '&&',
+                f'sudo usermod -a -G adm `whoami`'
             ]
         )
         subprocess.check_call(rpm_install_cmd, cwd=self.work_dir, shell=True)

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
@@ -49,7 +49,8 @@ class TestDistributionDeb(unittest.TestCase):
                 "dpkg --install opensearch.deb && "
                 f"sudo chmod 0666 {self.distribution_deb.config_path} && "
                 f"sudo chmod 0755 {os.path.dirname(self.distribution_deb.config_path)} {self.distribution_deb.log_dir} && "
-                f"sudo usermod -a -G opensearch `whoami`"
+                f"sudo usermod -a -G opensearch `whoami` && "
+                f"sudo usermod -a -G adm `whoami`"
             ),
             args_list[0][0][0],
         )

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
@@ -49,7 +49,8 @@ class TestDistributionRpm(unittest.TestCase):
                 "yum install -y opensearch.rpm && "
                 f"sudo chmod 0666 {self.distribution_rpm.config_path} && "
                 f"sudo chmod 0755 {os.path.dirname(self.distribution_rpm.config_path)} {self.distribution_rpm.log_dir} && "
-                f"sudo usermod -a -G opensearch `whoami`"
+                f"sudo usermod -a -G opensearch `whoami` && "
+                f"sudo usermod -a -G adm `whoami`"
             ),
             args_list[0][0][0],
         )


### PR DESCRIPTION
### Description
Add current user to adm group to access logs

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3815

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
