### PR TITLE
Add publishGradleCheckTestResults lib to gradle-check

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@5.3.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.4.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -147,6 +147,7 @@ pipeline {
                     junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
                     archiveArtifacts artifacts: 'codeCoverage.xml', onlyIfSuccessful: true
                     script {
+                        publishGradleCheckTestResults(prNumber: "${pr_number}", prDescription: "${pr_title}")
                         sh("rm -rf *")
                         postCleanup()
                     }


### PR DESCRIPTION
### Description
This PR adds gradle-check test results publishing script to post stage. See https://github.com/opensearch-project/opensearch-build-libraries/pull/397 for more details.

### Issues Resolved
#4469 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
