### PR TITLE
Add errors='replace' handling for execute methods

### DIFF
--- a/src/system/execute.py
+++ b/src/system/execute.py
@@ -20,7 +20,7 @@ def execute(command: str, dir: str, capture: bool = True, raise_on_failure: bool
     :returns a tuple containing the exit code, stdout, and stderr.
     """
     logging.info(f'Executing "{command}" in {dir}')
-    result = subprocess.run(command, cwd=dir, shell=True, capture_output=capture, text=True, encoding='utf-8')
+    result = subprocess.run(command, cwd=dir, shell=True, capture_output=capture, text=True, errors='replace', encoding='utf-8')
     if raise_on_failure:
         result.check_returncode()
     return result.returncode, result.stdout, result.stderr


### PR DESCRIPTION
### Description
Add errors='replace' handling for execute methods

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/4563

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
