### PR TITLE
Run manifest ci check only when PR is labelled

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -1,15 +1,17 @@
 ---
-name: manifests
+name: manifests-ci-check
 
 on:
   pull_request:
-  paths:
-    - 'manifests/**/*.yml'
-    - '!manifests/templates/**/'
-    - 'legacy-manifests/**/*.yml'
+    types: [labeled]
+    paths:
+      - 'manifests/**/*.yml'
+      - '!manifests/templates/**/'
+      - 'legacy-manifests/**/*.yml'
 
 jobs:
   list-changed-manifests:
+    if: ${{ github.repository == 'opensearch-project/opensearch-build' && github.event.label.name == 'manifest-ci-check' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
### Description
Running the ci check should be optional after merge of https://github.com/opensearch-project/opensearch-build/pull/4523
With this change whenever a maintainer adds `manifest-ci-check` label, only then manifest-ci-check workflow will run.
This workflow is super useful when to run checks in between release candidate creations when commits are updated manually. 

Will be useful also when https://github.com/opensearch-project/opensearch-build/issues/4561 will be implemented

### Issues Resolved
#4433

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
