### PR TITLE
URL encode test result files

### DIFF
--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -75,7 +75,11 @@ class TestRecorder:
 
     def _update_absolute_file_paths(self, files: list, base_path: str, relative_path: str) -> list:
         return [
-            os.path.join(base_path, relative_path, urllib.parse.quote_plus(file))
+            os.path.join(
+                base_path,
+                relative_path,
+                urllib.parse.quote_plus(file) if base_path.startswith("https://") else file
+            )
             for file in files
         ]
 

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -8,6 +8,7 @@
 import logging
 import os
 import shutil
+import urllib.parse
 from typing import Any
 
 import yaml
@@ -73,7 +74,10 @@ class TestRecorder:
         return os.path.realpath("%s.yml" % test_result_data.component_name)
 
     def _update_absolute_file_paths(self, files: list, base_path: str, relative_path: str) -> list:
-        return [os.path.join(base_path, relative_path, file) for file in files]
+        return [
+            os.path.join(base_path, relative_path, urllib.parse.quote_plus(file))
+            for file in files
+        ]
 
     # get a list of files within directory with relative paths.
     def _get_list_files(self, dir: str) -> list:

--- a/src/test_workflow/test_recorder/test_recorder.py
+++ b/src/test_workflow/test_recorder/test_recorder.py
@@ -50,9 +50,9 @@ class TestRecorder:
         return os.path.realpath(dest_directory)
 
     def _generate_std_files(self, stdout: str, stderr: str, output_path: str) -> None:
-        with open(os.path.join(output_path, "stdout.txt"), "w", encoding='utf-8') as stdout_file:
+        with open(os.path.join(output_path, "stdout.txt"), "w", encoding="utf-8") as stdout_file:
             stdout_file.write(stdout)
-        with open(os.path.join(output_path, "stderr.txt"), "w", encoding='utf-8') as stderr_file:
+        with open(os.path.join(output_path, "stderr.txt"), "w", encoding="utf-8") as stderr_file:
             stderr_file.write(stderr)
 
     def _generate_yml(self, test_result_data: TestResultData, output_path: str) -> str:
@@ -67,21 +67,17 @@ class TestRecorder:
             "component_name": test_result_data.component_name,
             "test_config": test_result_data.component_test_config,
             "test_result": "PASS" if (test_result_data.exit_code == 0) else "FAIL",
-            "test_result_files": test_result_file
+            "test_result_files": test_result_file,
         }
-        with open(os.path.join(output_path, "%s.yml" % test_result_data.component_name), "w", encoding='utf-8') as file:
+        with open(os.path.join(output_path, "%s.yml" % test_result_data.component_name), "w", encoding="utf-8") as file:
             yaml.dump(outcome, file)
         return os.path.realpath("%s.yml" % test_result_data.component_name)
 
     def _update_absolute_file_paths(self, files: list, base_path: str, relative_path: str) -> list:
-        return [
-            os.path.join(
-                base_path,
-                relative_path,
-                urllib.parse.quote_plus(file) if base_path.startswith("https://") else file
-            )
-            for file in files
-        ]
+        if base_path.startswith("https://"):
+            return [f"{base_path}/{relative_path}/{urllib.parse.quote_plus(file)}" for file in files]
+        else:
+            return [os.path.join(base_path, relative_path, file) for file in files]
 
     # get a list of files within directory with relative paths.
     def _get_list_files(self, dir: str) -> list:
@@ -141,7 +137,7 @@ class RemoteClusterLogs(LogRecorder):
 
 
 class TestResultsLogs(LogRecorder):
-    __test__ = False    # type:ignore
+    __test__ = False  # type:ignore
     parent_class: TestRecorder
 
     def __init__(self, parent_class: TestRecorder) -> None:

--- a/tests/tests_test_workflow/test_recorder/test_test_recorder.py
+++ b/tests/tests_test_workflow/test_recorder/test_test_recorder.py
@@ -99,6 +99,19 @@ class TestTestRecorder(unittest.TestCase):
         file_path = test_recorder._update_absolute_file_paths(["file1", "file2"], "working-directory", "sub-directory")
         self.assertEqual(file_path, [os.path.join("working-directory", "sub-directory", "file1"), os.path.join("working-directory", "sub-directory", "file2")])
 
+    @patch("test_workflow.test_recorder.test_recorder.TestResultsLogs")
+    @patch("test_workflow.test_recorder.test_recorder.RemoteClusterLogs")
+    @patch("test_workflow.test_recorder.test_recorder.LocalClusterLogs")
+    def test_update_absolute_file_paths(self, mock_local_cluster_logs: Mock, mock_remote_cluster_logs: Mock, mock_test_results_logs: Mock, *mock: Any) -> None:
+        test_recorder = TestRecorder(
+            "1234",
+            "integ-test",
+            "working-directory",
+            "https://ci.opensearch.org/ci/dbc/integ-test/"
+        )
+        file_path = test_recorder._update_absolute_file_paths(["A long test case name"], "working-directory", "sub-directory")
+        self.assertEqual(file_path, [os.path.join("working-directory", "sub-directory", "A+long+test+case+name")])
+
     @patch("os.walk")
     @patch("test_workflow.test_recorder.test_recorder.TestResultsLogs")
     @patch("test_workflow.test_recorder.test_recorder.RemoteClusterLogs")

--- a/tests/tests_test_workflow/test_recorder/test_test_recorder.py
+++ b/tests/tests_test_workflow/test_recorder/test_test_recorder.py
@@ -110,7 +110,7 @@ class TestTestRecorder(unittest.TestCase):
             "https://ci.opensearch.org/ci/dbc/integ-test/"
         )
         file_path = test_recorder._update_absolute_file_paths(["A long test case name"], "https://working-directory", "sub-directory")
-        self.assertEqual(file_path, [os.path.join("https://working-directory", "sub-directory", "A+long+test+case+name")])
+        self.assertEqual(file_path, ["https://working-directory/sub-directory/A+long+test+case+name"])
 
     @patch("os.walk")
     @patch("test_workflow.test_recorder.test_recorder.TestResultsLogs")

--- a/tests/tests_test_workflow/test_recorder/test_test_recorder.py
+++ b/tests/tests_test_workflow/test_recorder/test_test_recorder.py
@@ -109,8 +109,8 @@ class TestTestRecorder(unittest.TestCase):
             "working-directory",
             "https://ci.opensearch.org/ci/dbc/integ-test/"
         )
-        file_path = test_recorder._update_absolute_file_paths(["A long test case name"], "working-directory", "sub-directory")
-        self.assertEqual(file_path, [os.path.join("working-directory", "sub-directory", "A+long+test+case+name")])
+        file_path = test_recorder._update_absolute_file_paths(["A long test case name"], "https://working-directory", "sub-directory")
+        self.assertEqual(file_path, [os.path.join("https://working-directory", "sub-directory", "A+long+test+case+name")])
 
     @patch("os.walk")
     @patch("test_workflow.test_recorder.test_recorder.TestResultsLogs")
@@ -123,9 +123,9 @@ class TestTestRecorder(unittest.TestCase):
             "working-directory",
             "https://ci.opensearch.org/ci/dbc/integ-test/"
         )
-        mock_os_walk.return_value = [("mock_dir", (), ("file1", "file2"))]
+        mock_os_walk.return_value = [("mock_dir", (), ("file1", "file2 with spaces"))]
         list_files = test_recorder._get_list_files("mock_dir")
-        self.assertEqual(list_files, ["file1", "file2"])
+        self.assertEqual(list_files, ["file1", "file2 with spaces"])
 
     @patch("builtins.open", new_callable=mock_open)
     def test_generate_std_files(self, mock_open: Mock, *mock: Any) -> None:

--- a/tests/tests_test_workflow/test_recorder/test_test_recorder.py
+++ b/tests/tests_test_workflow/test_recorder/test_test_recorder.py
@@ -96,8 +96,15 @@ class TestTestRecorder(unittest.TestCase):
             "working-directory",
             "https://ci.opensearch.org/ci/dbc/integ-test/"
         )
-        file_path = test_recorder._update_absolute_file_paths(["file1", "file2"], "working-directory", "sub-directory")
-        self.assertEqual(file_path, [os.path.join("working-directory", "sub-directory", "file1"), os.path.join("working-directory", "sub-directory", "file2")])
+        file_path = test_recorder._update_absolute_file_paths(
+            ["file1", "file2 with spaces"],
+            "working-directory",
+            "sub-directory"
+        )
+        self.assertEqual(file_path, [
+            os.path.join("working-directory", "sub-directory", "file1"),
+            os.path.join("working-directory", "sub-directory", "file2 with spaces")
+        ])
 
     @patch("test_workflow.test_recorder.test_recorder.TestResultsLogs")
     @patch("test_workflow.test_recorder.test_recorder.RemoteClusterLogs")
@@ -123,9 +130,9 @@ class TestTestRecorder(unittest.TestCase):
             "working-directory",
             "https://ci.opensearch.org/ci/dbc/integ-test/"
         )
-        mock_os_walk.return_value = [("mock_dir", (), ("file1", "file2 with spaces"))]
+        mock_os_walk.return_value = [("mock_dir", (), ("file1", "file2"))]
         list_files = test_recorder._get_list_files("mock_dir")
-        self.assertEqual(list_files, ["file1", "file2 with spaces"])
+        self.assertEqual(list_files, ["file1", "file2"])
 
     @patch("builtins.open", new_callable=mock_open)
     def test_generate_std_files(self, mock_open: Mock, *mock: Any) -> None:

--- a/tests/tests_test_workflow/test_recorder/test_test_recorder.py
+++ b/tests/tests_test_workflow/test_recorder/test_test_recorder.py
@@ -102,7 +102,7 @@ class TestTestRecorder(unittest.TestCase):
     @patch("test_workflow.test_recorder.test_recorder.TestResultsLogs")
     @patch("test_workflow.test_recorder.test_recorder.RemoteClusterLogs")
     @patch("test_workflow.test_recorder.test_recorder.LocalClusterLogs")
-    def test_update_absolute_file_paths(self, mock_local_cluster_logs: Mock, mock_remote_cluster_logs: Mock, mock_test_results_logs: Mock, *mock: Any) -> None:
+    def test_update_absolute_file_paths_escaping(self, mock_local_cluster_logs: Mock, mock_remote_cluster_logs: Mock, mock_test_results_logs: Mock, *mock: Any) -> None:
         test_recorder = TestRecorder(
             "1234",
             "integ-test",


### PR DESCRIPTION
### Description
Following up on #4569: URL encode the filenames in the test manifest file to better support tools scanning these files for links.

### Issues Resolved
Closes #4569.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
