### PR TITLE
Update configs and entrypoint for observability.query_assist.enabled in 2.13.0

### DIFF
--- a/config/opensearch_dashboards-2.x.yml
+++ b/config/opensearch_dashboards-2.x.yml
@@ -200,6 +200,10 @@
 # Set the value of this setting to true to enable the assistant dashboards
 # assistant.chat.enabled: false
 
+# 2.13 New Query Assistant Feature
+# Set the value of this setting to false to disable the query assistant
+# observability.query_assist.enabled: false
+
 opensearch.hosts: [https://localhost:9200]
 opensearch.ssl.verificationMode: none
 opensearch.username: kibanaserver

--- a/config/opensearch_dashboards-default.x.yml
+++ b/config/opensearch_dashboards-default.x.yml
@@ -200,6 +200,10 @@
 # Set the value of this setting to true to enable the assistant dashboards
 # assistant.chat.enabled: false
 
+# 2.13 New Query Assistant Feature
+# Set the value of this setting to false to disable the query assistant
+# observability.query_assist.enabled: false
+
 opensearch.hosts: [https://localhost:9200]
 opensearch.ssl.verificationMode: none
 opensearch.username: kibanaserver

--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-2.x.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-2.x.sh
@@ -167,6 +167,7 @@ opensearch_dashboards_vars=(
     data_source.audit.appender.layout.pattern
     ml_commons_dashboards.enabled
     assistant.chat.enabled
+    observability.query_assist.enabled
 )
 
 function setupSecurityDashboardsPlugin {

--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-default.x.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-default.x.sh
@@ -167,6 +167,7 @@ opensearch_dashboards_vars=(
     data_source.audit.appender.layout.pattern
     ml_commons_dashboards.enabled
     assistant.chat.enabled
+    observability.query_assist.enabled
 )
 
 function setupSecurityDashboardsPlugin {


### PR DESCRIPTION


### Description
Update configs and entrypoint for observability.query_assist.enabled in 2.13.0

### Issues Resolved
https://github.com/opensearch-project/dashboards-observability/pull/1639
https://github.com/opensearch-project/opensearch-build/issues/4433

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
