### PR TITLE
Add synchronize to manifest-check

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -3,7 +3,7 @@ name: manifests-ci-check
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize]
     paths:
       - 'manifests/**/*.yml'
       - '!manifests/templates/**/'


### PR DESCRIPTION
### Description
Currently, the workflow won't re-run if a new commit is pushed to the same labelled PR. Adding synchronize to enable that as per https://github.com/orgs/community/discussions/24567 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
