### PR TITLE
Lock integTest resources to 4cpu/16g on linux agents

### DIFF
--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -21,9 +21,9 @@ def docker_images = [
 ]
 
 def docker_args = [
-    "tar": "-u 1000",
-    "rpm": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host",
-    "deb": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host",
+    "tar": "-u 1000 --cpus 4 -m 8g",
+    "rpm": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 8g",
+    "deb": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 8g",
     "zip": "-u ContainerAdministrator",
 ]
 

--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -21,9 +21,9 @@ def docker_images = [
 ]
 
 def docker_args = [
-    "tar": "-u 1000 --cpus 4 -m 8g",
-    "rpm": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 8g",
-    "deb": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 8g",
+    "tar": "-u 1000 --cpus 4 -m 16g",
+    "rpm": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 16g",
+    "deb": "--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 16g",
     "zip": "-u ContainerAdministrator",
 ]
 

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -21,9 +21,9 @@ def docker_images = [
 ]
 
 def docker_args = [
-    'tar': '-u 1000 --cpus 4 -m 8g',
-    'rpm': '--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 8g',
-    'deb': '--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 8g',
+    'tar': '-u 1000 --cpus 4 -m 16g',
+    'rpm': '--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 16g',
+    'deb': '--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 16g',
     'zip': '-u ContainerAdministrator',
 ]
 

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -21,9 +21,9 @@ def docker_images = [
 ]
 
 def docker_args = [
-    'tar': '-u 1000',
-    'rpm': '--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host',
-    'deb': '--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host',
+    'tar': '-u 1000 --cpus 4 -m 8g',
+    'rpm': '--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 8g',
+    'deb': '--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 8g',
     'zip': '-u ContainerAdministrator',
 ]
 


### PR DESCRIPTION
### Description
Lock integTest resources to 4cpu/16g on linux agents

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/412

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
