### PR TITLE
Ignore release notes folder for link checker workflow

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -14,7 +14,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1
         with:
-          args: --verbose --max-retries 5 --retry-wait-time 10 --accept=200,403,429 --exclude-path tests/ ./
+          args: --verbose --max-retries 5 --retry-wait-time 10 --accept=200,403,429 --exclude-path tests/ ./ release-notes/
           fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Link checker workflow has been consistently failing https://github.com/opensearch-project/opensearch-build/actions/workflows/link-checker.yml due to`Too many requests`
One of the culprit are the consolidated release notes which contains external links to many GH PRs and issues 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
