### PR TITLE
Update the plugin_onboarding_template.yaml template to include a documentation field

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
@@ -10,7 +10,7 @@ body:
         Thanks for taking the time to submit on-boarding request!
   - type: textarea
     attributes:
-      description: 'Provide the name link of your plugin.'
+      description: 'Provide the name of your plugin.'
       label: 'What is the name of your plugin?'
     id: plugin-name
     validations:

--- a/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
+++ b/.github/ISSUE_TEMPLATE/plugin_onboarding_template.yaml
@@ -10,14 +10,14 @@ body:
         Thanks for taking the time to submit on-boarding request!
   - type: textarea
     attributes:
-      description: 'Provide the name link of your plugin'
+      description: 'Provide the name link of your plugin.'
       label: 'What is the name of your plugin?'
     id: plugin-name
     validations:
       required: true
   - type: textarea
     attributes:
-      description: 'Provide the GitHub link for your repository'
+      description: 'Provide the GitHub link for your repository.'
       label: 'What is the link to your GitHub repo?'
     id: Github-link
     validations:
@@ -31,6 +31,13 @@ body:
       required: true
   - type: textarea
     attributes:
+      description: 'If so, provide the link to the associated documentation PR. For information on contributing documentation, see [Contributing.md](https://github.com/opensearch-project/documentation-website/blob/main/CONTRIBUTING.md).'
+      label: 'Does the plugin require documentation?'
+    id: documentation
+    validations:
+      required: true
+  - type: textarea
+    attributes:
       description: 'Is this OpenSearch, OpenSearch-dashboards plugin?'
       label: 'What type of the plugin are we on-boarding?'
     id: Type
@@ -38,8 +45,8 @@ body:
       required: true
   - type: textarea
     attributes:
-      description: 'Did you go through the [on-boarding document](https://github.com/opensearch-project/opensearch-build/blob/main/ONBOARDING.md#plugin-onboarding)'
-      label: 'Did you read the on-boarding document'
+      description: 'See the [on-boarding document](https://github.com/opensearch-project/opensearch-build/blob/main/ONBOARDING.md#plugin-onboarding).'
+      label: 'Did you read the on-boarding document?'
     id: document
     validations:
       required: true


### PR DESCRIPTION


### Description
Added a field to add a link to the documentation PR. Also fixed some punctuation issues.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
