### PR TITLE
Ensure error stack trace is always printed out for each build

### DIFF
--- a/src/run_build.py
+++ b/src/run_build.py
@@ -93,7 +93,8 @@ def main() -> int:
                 builder.build(build_recorder)
                 builder.export_artifacts(build_recorder)
                 logging.info(f"Successfully built {component.name}")
-            except:
+            except Exception as e:
+                logging.error(f"ERROR: {e}")
                 logging.error(f"Error building {component.name}, retry with: {args.component_command(component.name)}")
                 if args.continue_on_error and component.name not in ['OpenSearch', 'job-scheduler', 'common-utils', 'OpenSearch-Dashboards']:
                     failed_plugins.append(component.name)


### PR DESCRIPTION
### Description
Ensure error stack trace is always printed out for each build

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/4625

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
