### PR TITLE
Upgrade ruby from 2.6.0 to 3.1.2 for opensearch-ruby 3.2.0 requirements

### DIFF
--- a/docker/ci/dockerfiles/current/release.centos7.clients.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/release.centos7.clients.x64.arm64.dockerfile
@@ -135,10 +135,10 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 # Installing ruby related dependencies
 # Need to run either `. $CONTAINER_USER_HOME/.rvm/scripts/rvm` or `source $CONTAINER_USER_HOME/.rvm/scripts/rvm` 
 # and force bash if needed before using the rvm command for any activities, or rvm will not correctly use version
-RUN . $CONTAINER_USER_HOME/.rvm/scripts/rvm && rvm install 2.6.0 && rvm --default use 2.6.0 && \
+RUN . $CONTAINER_USER_HOME/.rvm/scripts/rvm && rvm install 3.1.2 && rvm --default use 3.1.2 && \
     rvm install jruby-9.3.0.0
 
-ENV RUBY_HOME=$CONTAINER_USER_HOME/.rvm/rubies/ruby-2.6.0/bin
+ENV RUBY_HOME=$CONTAINER_USER_HOME/.rvm/rubies/ruby-3.1.2/bin
 ENV RVM_HOME=$CONTAINER_USER_HOME/.rvm/bin
 ENV GEM_HOME=$CONTAINER_USER_HOME/.gem
 ENV GEM_PATH=$GEM_HOME

--- a/docker/ci/dockerfiles/current/release.centos7.clients.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/release.centos7.clients.x64.arm64.dockerfile
@@ -135,17 +135,17 @@ RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
 # Installing ruby related dependencies
 # Need to run either `. $CONTAINER_USER_HOME/.rvm/scripts/rvm` or `source $CONTAINER_USER_HOME/.rvm/scripts/rvm` 
 # and force bash if needed before using the rvm command for any activities, or rvm will not correctly use version
-RUN . $CONTAINER_USER_HOME/.rvm/scripts/rvm && rvm install 3.1.2 && rvm --default use 3.1.2 && \
+RUN . $CONTAINER_USER_HOME/.rvm/scripts/rvm && rvm install 2.6.0 && rvm install 3.1.2 && rvm --default use 2.6.0 && \
     rvm install jruby-9.3.0.0
 
-ENV RUBY_HOME=$CONTAINER_USER_HOME/.rvm/rubies/ruby-3.1.2/bin
 ENV RVM_HOME=$CONTAINER_USER_HOME/.rvm/bin
 ENV GEM_HOME=$CONTAINER_USER_HOME/.gem
 ENV GEM_PATH=$GEM_HOME
 ENV CARGO_PATH=$CONTAINER_USER_HOME/.cargo/bin
-ENV PATH=$RUBY_HOME:$RVM_HOME:$CARGO_PATH:$PATH
+ENV PATH=$RVM_HOME:$CARGO_PATH:$PATH
 
 # nvm environment variables
+# DO NOT add node version above 16 as CentOS7 does not support new versions
 ENV NVM_DIR $CONTAINER_USER_HOME/.nvm
 ENV NODE_VERSION 16.20.0
 ARG NODE_VERSION_LIST="10.24.1 14.19.1 14.20.0 14.20.1 14.21.3 16.20.0"


### PR DESCRIPTION
### Description
Upgrade ruby from 2.6.0 to 3.1.2 for opensearch-ruby 3.2.0 requirements

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4624

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
