### PR TITLE
Update gcc from 9.2.1 to 12.2.1 to fix k-NN compile bug on ARM64

### DIFF
--- a/docker/ci/config/gcc-toolset-12-setup
+++ b/docker/ci/config/gcc-toolset-12-setup
@@ -1,0 +1,1 @@
+. /opt/rh/gcc-toolset-12/enable

--- a/docker/ci/config/gcc-toolset-9-setup
+++ b/docker/ci/config/gcc-toolset-9-setup
@@ -1,1 +1,0 @@
-. /opt/rh/gcc-toolset-9/enable

--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
@@ -90,9 +90,9 @@ RUN pip3 install cmake==3.23.3
 # Upgrade gcc
 # The setup part is partially based on Austin Dewey's article:
 # https://austindewey.com/2019/03/26/enabling-software-collections-binaries-on-a-docker-image/
-RUN dnf -y install gcc-toolset-9-gcc gcc-toolset-9-gcc-c++ && dnf clean all && \
-    echo "source /opt/rh/gcc-toolset-9/enable" > /etc/profile.d/gcc-toolset-9.sh
-COPY --chown=0:0 config/gcc-toolset-9-setup /usr/local/bin/gcc_setup
+RUN dnf -y install gcc-toolset-12-gcc gcc-toolset-12-gcc-c++ && dnf clean all && \
+    echo "source /opt/rh/gcc-toolset-12/enable" > /etc/profile.d/gcc-toolset-12.sh
+COPY --chown=0:0 config/gcc-toolset-12-setup /usr/local/bin/gcc_setup
 ENV BASH_ENV="/usr/local/bin/gcc_setup"
 ENV ENV="/usr/local/bin/gcc_setup"
 ENV PROMPT_COMMAND=". /usr/local/bin/gcc_setup"


### PR DESCRIPTION
### Description
Update gcc from 9.2.1 to 12.2.1 to fix k-NN compile bug on ARM64

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2067191682

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
