### PR TITLE
Lock manifest commit for 1.3.16 release candidates 

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -23,11 +23,9 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H */6 * * * %INPUT_MANIFEST=1.3.16/opensearch-dashboards-1.3.16.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.14.0/opensearch-dashboards-2.14.0.yml;TEST_MANIFEST=2.14.0/opensearch-dashboards-2.14.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.13.1/opensearch-2.13.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.14.0/opensearch-2.14.0.yml;TEST_MANIFEST=2.14.0/opensearch-2.14.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H */6 * * * %INPUT_MANIFEST=1.3.16/opensearch-1.3.16.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''

--- a/manifests/1.3.16/opensearch-1.3.16.yml
+++ b/manifests/1.3.16/opensearch-1.3.16.yml
@@ -10,13 +10,13 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: '1.3'
+    ref: 88e8e0e5e197dc8d5382e8c781bb072b67acaec2
     checks:
       - gradle:publish
       - gradle:properties:version
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: '1.3'
+    ref: 61d788e0fbb536e87c05e3c8023b002ac3b01fa4
     checks:
       - gradle:publish
       - gradle:properties:version
@@ -25,7 +25,7 @@ components:
       - windows
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: '1.3'
+    ref: 4baec15db4be99c8ccc9132ea5f4a338c7629995
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -34,7 +34,7 @@ components:
       - windows
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: '1.3'
+    ref: 227745370060f65f5351df6718595d80c3aad635
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -43,7 +43,7 @@ components:
       - windows
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: '1.3'
+    ref: 2412645cce6b5b6699009775fbe89b88d9f9da5a
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: opensearch-ml-plugin
@@ -54,7 +54,7 @@ components:
       - common-utils
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: '1.3'
+    ref: 0c98d5a0aaa5191cdd5154769a10a2c2ff73b803
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -62,7 +62,7 @@ components:
       - linux
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: '1.3'
+    ref: 950ef40ade14c490f2b663de2b2d7236191396d4
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: alerting
@@ -73,7 +73,7 @@ components:
       - common-utils
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: '1.3'
+    ref: dcaba0860e363261a30e41607949e1db6a167f4e
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -85,7 +85,7 @@ components:
       - job-scheduler
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: '1.3'
+    ref: 4efdc7ca1fa49917d92df42abac85f080b48ba73
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -96,7 +96,7 @@ components:
       - common-utils
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: '1.3'
+    ref: cfadef9e25c20866c9d60fab2c9ebd79330a2de3
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -107,7 +107,7 @@ components:
       - common-utils
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: '1.3'
+    ref: 2f8c2c3aee9f1d03d9ce15327692023f989827be
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -119,7 +119,7 @@ components:
       - job-scheduler
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: '1.3'
+    ref: 2d1821ea6cebaa18230ac8767b0e6d490a5d0b64
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -130,7 +130,7 @@ components:
       - common-utils
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: '1.3'
+    ref: ba18a402b88c3de993126e77c89b0898a66bda98
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version
@@ -139,7 +139,7 @@ components:
       - windows
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: '1.3'
+    ref: c7a5da43edcfb164f9ed419c2aa6b5834d5e8889
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version: plugin
@@ -150,7 +150,7 @@ components:
       - ml-commons
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: '1.3'
+    ref: df1e137c0561cb5eb06cda76298ea8d65f9d0199
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/1.3.16/opensearch-1.3.16.yml
+++ b/manifests/1.3.16/opensearch-1.3.16.yml
@@ -10,7 +10,7 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: 88e8e0e5e197dc8d5382e8c781bb072b67acaec2
+    ref: 1870e738c6c11c6500965d394ca920e5890234a1
     checks:
       - gradle:publish
       - gradle:properties:version
@@ -73,7 +73,7 @@ components:
       - common-utils
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: dcaba0860e363261a30e41607949e1db6a167f4e
+    ref: d5f8064dff99dbdb8d68caf836f7752d69985e75
     checks:
       - gradle:properties:version
       - gradle:dependencies:opensearch.version

--- a/manifests/1.3.16/opensearch-dashboards-1.3.16.yml
+++ b/manifests/1.3.16/opensearch-dashboards-1.3.16.yml
@@ -9,31 +9,31 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: '1.3'
+    ref: 900bef8e6132fa2c1c66ca9b0dd3bc80f2d16c2a
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '1.3'
+    ref: 1164ec01d5d517dba60831e0af8f9069f26bfbc4
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: '1.3'
+    ref: fb7c6cbd2f12c1299614af83c9232384e3220cdb
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
-    ref: '1.3'
+    ref: 1575f8c0bb5a9ed4c6aa22ff7bc5bb1bf7276949
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
-    ref: '1.3'
+    ref: 8d8fe0e09d742075801fa402fe5107dfe0253449
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: '1.3'
+    ref: e30cb56d07bab8e11543f3028af1bb33a31d466a
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin
-    ref: '1.3'
+    ref: 543cc0d23350344eb8d94436289eacc107cda953
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
-    ref: '1.3'
+    ref: 064f4660d687a3e95f394727692e2adf4aba18d1
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: '1.3'
+    ref: 759e5746abea9bc5dd6217c431ddaa57a1cd8822
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
-    ref: '1.3'
+    ref: 0c15172626a57d98bd5d0c4376ea5c14fe666230


### PR DESCRIPTION
### Description
Lock manifest commit for 1.3.16 release candidates 

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4531

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
