### PR TITLE
Add a step to update releases page

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -51,6 +51,7 @@ Release blog is ready | :red_circle: |   |
 ### [Preparation](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#preparation)
 
 - [ ] [Release manager](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#release-manager) assigned.
+- [ ] Update [release page](https://opensearch.org/releases.html) on the website with release manager and release issue details. [Sample PR](https://github.com/opensearch-project/project-website/pull/2642)
 - [ ] Existence of label in each component repo. For more information check the [release-label](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#release-label) section.
 - [ ] [Increase the build frequency](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#increase-the-build-frequency).
 - [ ] [Release Issue](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#release-issue).


### PR DESCRIPTION
### Description
Adding an action item to update the release https://opensearch.org/releases.html with the associated release manager and release issue and other changes (if required) like shift in dates, etc

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
