### PR TITLE
Increase jvm heap size of test cluster from default 1G to 2G for integration tests. 

### DIFF
--- a/src/test_workflow/integ_test/distribution.py
+++ b/src/test_workflow/integ_test/distribution.py
@@ -4,7 +4,8 @@
 # The OpenSearch Contributors require contributions made to
 # this file be licensed under the Apache-2.0 license or a
 # compatible open source license.
-
+import logging
+import os.path
 from abc import ABC, abstractmethod
 
 
@@ -69,3 +70,22 @@ class Distribution(ABC):
         Allow distribution to do proper cleanup
         """
         pass
+
+    def configure_jvm_options(self, options: list) -> None:
+        jvm_config_path = os.path.join(os.path.dirname(self.config_path), 'jvm.options')
+        try:
+            with open(jvm_config_path, 'r') as file:
+                file_content = file.read()
+
+            modified_content = file_content
+
+            for jvm_old, jvm_new in options:
+                modified_content = modified_content.replace(jvm_old, jvm_new)
+
+            with open(jvm_config_path, 'w') as file:
+                file.write(modified_content)
+            logging.info("Configured JVM options")
+        except FileNotFoundError:
+            logging.error("File not found.")
+        except Exception as e:
+            logging.error(f"An error occurred:{e}")

--- a/src/test_workflow/integ_test/distribution_deb.py
+++ b/src/test_workflow/integ_test/distribution_deb.py
@@ -46,7 +46,7 @@ class DistributionDeb(Distribution):
                 '--install',
                 bundle_name,
                 '&&',
-                f'sudo chmod 0666 {self.config_path}',
+                f'sudo chmod 0666 {self.config_path} {os.path.dirname(self.config_path)}/jvm.options',
                 '&&',
                 f'sudo chmod 0755 {os.path.dirname(self.config_path)} {self.log_dir}',
                 '&&',

--- a/src/test_workflow/integ_test/distribution_rpm.py
+++ b/src/test_workflow/integ_test/distribution_rpm.py
@@ -48,7 +48,7 @@ class DistributionRpm(Distribution):
                 '-y',
                 bundle_name,
                 '&&',
-                f'sudo chmod 0666 {self.config_path}',
+                f'sudo chmod 0666 {self.config_path} {os.path.dirname(self.config_path)}/jvm.options',
                 '&&',
                 f'sudo chmod 0755 {os.path.dirname(self.config_path)} {self.log_dir}',
                 '&&',

--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -44,6 +44,7 @@ class ServiceOpenSearch(Service):
 
     def start(self) -> None:
         self.dist.install(self.download())
+        self.dist.configure_jvm_options([("-Xms1g", "-Xms2g"), ("-Xmx1g", "-Xmx2g")])
 
         self.opensearch_yml_path = self.dist.config_path
         self.security_plugin_dir = os.path.join(self.install_dir, "plugins", "opensearch-security")

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
@@ -47,7 +47,7 @@ class TestDistributionDeb(unittest.TestCase):
                 "sudo dpkg --purge opensearch && "
                 "sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! "
                 "dpkg --install opensearch.deb && "
-                f"sudo chmod 0666 {self.distribution_deb.config_path} && "
+                f"sudo chmod 0666 {self.distribution_deb.config_path} {os.path.dirname(self.distribution_deb.config_path)}/jvm.options && "
                 f"sudo chmod 0755 {os.path.dirname(self.distribution_deb.config_path)} {self.distribution_deb.log_dir} && "
                 f"sudo usermod -a -G opensearch `whoami` && "
                 f"sudo usermod -a -G adm `whoami`"

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
@@ -47,7 +47,7 @@ class TestDistributionRpm(unittest.TestCase):
                 "sudo yum remove -y opensearch && "
                 "sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! "
                 "yum install -y opensearch.rpm && "
-                f"sudo chmod 0666 {self.distribution_rpm.config_path} && "
+                f"sudo chmod 0666 {self.distribution_rpm.config_path} {os.path.dirname(self.distribution_rpm.config_path)}/jvm.options && "
                 f"sudo chmod 0755 {os.path.dirname(self.distribution_rpm.config_path)} {self.distribution_rpm.log_dir} && "
                 f"sudo usermod -a -G opensearch `whoami` && "
                 f"sudo usermod -a -G adm `whoami`"


### PR DESCRIPTION
### Description
The OpenSearch cluster spun up by integration tests uses the defaults for jvm parameters, which only allocates 1G of heap memory. We have had issues with our integration tests where the tests failed due lack of memory, such as OOM errors and circuit_breaker_exceptions. 

This PR increases the heap size of the test OS cluster to 2G. 
This will work for tar and zip distribution types but may not work for rpm and deb distributions as the config files for them are located in the root directories. 
This will only throw permission error exception for rpm and deb, and test will still execute with 1G heap size. We can revisit this post 2.14 release to proper handle permissions in rpm and deb. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
