### PR TITLE
Replace gcc12 with gcc11 due to binutils 2.38 bug

### DIFF
--- a/docker/ci/config/gcc-toolset-10-setup
+++ b/docker/ci/config/gcc-toolset-10-setup
@@ -1,0 +1,1 @@
+. /opt/rh/gcc-toolset-10/enable

--- a/docker/ci/config/gcc-toolset-10-setup
+++ b/docker/ci/config/gcc-toolset-10-setup
@@ -1,1 +1,0 @@
-. /opt/rh/gcc-toolset-10/enable

--- a/docker/ci/config/gcc-toolset-11-setup
+++ b/docker/ci/config/gcc-toolset-11-setup
@@ -1,0 +1,1 @@
+. /opt/rh/gcc-toolset-11/enable

--- a/docker/ci/config/gcc-toolset-12-setup
+++ b/docker/ci/config/gcc-toolset-12-setup
@@ -1,1 +1,0 @@
-. /opt/rh/gcc-toolset-12/enable

--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
@@ -90,9 +90,9 @@ RUN pip3 install cmake==3.23.3
 # Upgrade gcc
 # The setup part is partially based on Austin Dewey's article:
 # https://austindewey.com/2019/03/26/enabling-software-collections-binaries-on-a-docker-image/
-RUN dnf -y install gcc-toolset-10-gcc gcc-toolset-10-gcc-c++ && dnf clean all && \
-    echo "source /opt/rh/gcc-toolset-10/enable" > /etc/profile.d/gcc-toolset-10.sh
-COPY --chown=0:0 config/gcc-toolset-10-setup /usr/local/bin/gcc_setup
+RUN dnf -y install gcc-toolset-11-gcc gcc-toolset-11-gcc-c++ && dnf clean all && \
+    echo "source /opt/rh/gcc-toolset-11/enable" > /etc/profile.d/gcc-toolset-11.sh
+COPY --chown=0:0 config/gcc-toolset-11-setup /usr/local/bin/gcc_setup
 ENV BASH_ENV="/usr/local/bin/gcc_setup"
 ENV ENV="/usr/local/bin/gcc_setup"
 ENV PROMPT_COMMAND=". /usr/local/bin/gcc_setup"

--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
@@ -90,9 +90,9 @@ RUN pip3 install cmake==3.23.3
 # Upgrade gcc
 # The setup part is partially based on Austin Dewey's article:
 # https://austindewey.com/2019/03/26/enabling-software-collections-binaries-on-a-docker-image/
-RUN dnf -y install gcc-toolset-12-gcc gcc-toolset-12-gcc-c++ && dnf clean all && \
-    echo "source /opt/rh/gcc-toolset-12/enable" > /etc/profile.d/gcc-toolset-12.sh
-COPY --chown=0:0 config/gcc-toolset-12-setup /usr/local/bin/gcc_setup
+RUN dnf -y install gcc-toolset-10-gcc gcc-toolset-10-gcc-c++ && dnf clean all && \
+    echo "source /opt/rh/gcc-toolset-10/enable" > /etc/profile.d/gcc-toolset-10.sh
+COPY --chown=0:0 config/gcc-toolset-10-setup /usr/local/bin/gcc_setup
 ENV BASH_ENV="/usr/local/bin/gcc_setup"
 ENV ENV="/usr/local/bin/gcc_setup"
 ENV PROMPT_COMMAND=". /usr/local/bin/gcc_setup"


### PR DESCRIPTION
### Description
Replace gcc12 with gcc11 due to binutils 2.38 bug

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2083623882
https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2084133839

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
