### PR TITLE
Validation for OS and OSD fail with error when executed multiple times on local

### DIFF
--- a/src/run_validation.py
+++ b/src/run_validation.py
@@ -9,6 +9,7 @@ import logging
 import sys
 
 from system import console
+from system.temporary_directory import TemporaryDirectory
 from validation_workflow.validation_args import ValidationArgs
 from validation_workflow.validation_test_runner import ValidationTestRunner  # type: ignore
 
@@ -19,9 +20,10 @@ def main() -> int:
     console.configure(level=args.logging_level)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
 
-    test_result = ValidationTestRunner.dispatch(args, args.distribution).run()
-    logging.info(f'final test_result = {test_result}')
-    return 0 if test_result else 1  # type: ignore
+    with TemporaryDirectory() as work_dir:
+        test_result = ValidationTestRunner.dispatch(args, args.distribution, work_dir).run()
+        logging.info(f'final test_result = {test_result}')
+        return 0 if test_result else 1  # type: ignore
 
 
 if __name__ == "__main__":

--- a/src/validation_workflow/deb/validation_deb.py
+++ b/src/validation_workflow/deb/validation_deb.py
@@ -9,6 +9,7 @@ import logging
 import os
 
 from system.execute import execute
+from system.temporary_directory import TemporaryDirectory
 from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.download_utils import DownloadUtils
@@ -17,8 +18,8 @@ from validation_workflow.validation_args import ValidationArgs
 
 
 class ValidateDeb(Validation, DownloadUtils):
-    def __init__(self, args: ValidationArgs) -> None:
-        super().__init__(args)
+    def __init__(self, args: ValidationArgs, tmp_dir: TemporaryDirectory) -> None:
+        super().__init__(args, tmp_dir)
 
     def installation(self) -> bool:
         try:
@@ -48,6 +49,7 @@ class ValidateDeb(Validation, DownloadUtils):
                 logging.info(f'All tests Pass : {counter}')
                 return True
             else:
+                self.cleanup()
                 raise Exception(f'Not all tests Pass : {counter}')
         else:
             raise Exception("Cluster is not ready for API test")

--- a/src/validation_workflow/docker/validation_docker.py
+++ b/src/validation_workflow/docker/validation_docker.py
@@ -12,6 +12,7 @@ import subprocess
 from subprocess import PIPE
 from typing import Any
 
+from system.temporary_directory import TemporaryDirectory
 from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.docker.inspect_docker_image import InspectDockerImage
@@ -21,8 +22,8 @@ from validation_workflow.validation_args import ValidationArgs
 
 class ValidateDocker(Validation):
 
-    def __init__(self, args: ValidationArgs) -> None:
-        super().__init__(args)
+    def __init__(self, args: ValidationArgs, tmp_dir: TemporaryDirectory) -> None:
+        super().__init__(args, tmp_dir)
 
     def download_artifacts(self) -> bool:
         try:

--- a/src/validation_workflow/rpm/validation_rpm.py
+++ b/src/validation_workflow/rpm/validation_rpm.py
@@ -9,6 +9,7 @@ import logging
 import os
 
 from system.execute import execute
+from system.temporary_directory import TemporaryDirectory
 from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.download_utils import DownloadUtils
@@ -18,8 +19,8 @@ from validation_workflow.validation_args import ValidationArgs
 
 class ValidateRpm(Validation, DownloadUtils):
 
-    def __init__(self, args: ValidationArgs) -> None:
-        super().__init__(args)
+    def __init__(self, args: ValidationArgs, tmp_dir: TemporaryDirectory) -> None:
+        super().__init__(args, tmp_dir)
 
     def installation(self) -> bool:
         try:
@@ -54,6 +55,7 @@ class ValidateRpm(Validation, DownloadUtils):
                 logging.info(f'All tests Pass : {counter}')
                 return True
             else:
+                self.cleanup()
                 raise Exception(f'Not all tests Pass : {counter}')
         else:
             raise Exception("Cluster is not ready for API test")

--- a/src/validation_workflow/tar/validation_tar.py
+++ b/src/validation_workflow/tar/validation_tar.py
@@ -10,6 +10,7 @@ import os
 
 from system.execute import execute
 from system.process import Process
+from system.temporary_directory import TemporaryDirectory
 from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.download_utils import DownloadUtils
@@ -19,8 +20,8 @@ from validation_workflow.validation_args import ValidationArgs
 
 class ValidateTar(Validation, DownloadUtils):
 
-    def __init__(self, args: ValidationArgs) -> None:
-        super().__init__(args)
+    def __init__(self, args: ValidationArgs, tmp_dir: TemporaryDirectory) -> None:
+        super().__init__(args, tmp_dir)
         self.os_process = Process()
         self.osd_process = Process()
 
@@ -51,8 +52,10 @@ class ValidateTar(Validation, DownloadUtils):
                 logging.info(f'All tests Pass : {counter}')
                 return True
             else:
+                self.cleanup()
                 raise Exception(f'Not all tests Pass : {counter}')
         else:
+            self.cleanup()
             raise Exception("Cluster is not ready for API test")
 
     def cleanup(self) -> bool:

--- a/src/validation_workflow/validation_test_runner.py
+++ b/src/validation_workflow/validation_test_runner.py
@@ -6,6 +6,7 @@
 # compatible open source license.
 # type: ignore
 
+from system.temporary_directory import TemporaryDirectory
 from validation_workflow.deb.validation_deb import ValidateDeb
 from validation_workflow.docker.validation_docker import ValidateDocker
 from validation_workflow.rpm.validation_rpm import ValidateRpm
@@ -27,5 +28,5 @@ class ValidationTestRunner:
     }
 
     @classmethod
-    def dispatch(cls, args: ValidationArgs, dist: str) -> Validation:
-        return cls.RUNNERS[dist](args)
+    def dispatch(cls, args: ValidationArgs, dist: str, work_dir: TemporaryDirectory) -> Validation:
+        return cls.RUNNERS[dist](args, work_dir)

--- a/src/validation_workflow/yum/validation_yum.py
+++ b/src/validation_workflow/yum/validation_yum.py
@@ -9,6 +9,7 @@ import logging
 import os
 
 from system.execute import execute
+from system.temporary_directory import TemporaryDirectory
 from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
 from validation_workflow.download_utils import DownloadUtils
@@ -18,8 +19,8 @@ from validation_workflow.validation_args import ValidationArgs
 
 class ValidateYum(Validation, DownloadUtils):
 
-    def __init__(self, args: ValidationArgs) -> None:
-        super().__init__(args)
+    def __init__(self, args: ValidationArgs, tmp_dir: TemporaryDirectory) -> None:
+        super().__init__(args, tmp_dir)
 
     def installation(self) -> bool:
         try:
@@ -52,6 +53,7 @@ class ValidateYum(Validation, DownloadUtils):
                 logging.info(f'All tests Pass : {counter}')
                 return True
             else:
+                self.cleanup()
                 raise Exception(f'Not all tests Pass : {counter}')
         else:
             raise Exception("Cluster is not ready for API test")

--- a/src/validation_workflow/zip/validation_zip.py
+++ b/src/validation_workflow/zip/validation_zip.py
@@ -9,6 +9,7 @@ import logging
 import os
 
 from system.process import Process
+from system.temporary_directory import TemporaryDirectory
 from system.zip_file import ZipFile
 from test_workflow.integ_test.utils import get_password
 from validation_workflow.api_test_cases import ApiTestCases
@@ -18,8 +19,8 @@ from validation_workflow.validation_args import ValidationArgs
 
 
 class ValidateZip(Validation, DownloadUtils):
-    def __init__(self, args: ValidationArgs) -> None:
-        super().__init__(args)
+    def __init__(self, args: ValidationArgs, tmp_dir: TemporaryDirectory) -> None:
+        super().__init__(args, tmp_dir)
         self.os_process = Process()
         self.osd_process = Process()
 
@@ -51,8 +52,10 @@ class ValidateZip(Validation, DownloadUtils):
                 logging.info(f'All tests Pass : {counter}')
                 return True
             else:
+                self.cleanup()
                 raise Exception(f'Not all tests Pass : {counter}')
         else:
+            self.cleanup()
             raise Exception("Cluster is not ready for API test")
 
     def cleanup(self) -> bool:

--- a/tests/tests_validation_workflow/test_validation.py
+++ b/tests/tests_validation_workflow/test_validation.py
@@ -6,6 +6,7 @@
 # compatible open source license.
 
 import unittest
+from unittest import mock
 from unittest.mock import Mock, patch
 
 import requests
@@ -19,9 +20,8 @@ from validation_workflow.validation_args import ValidationArgs
 
 
 class ImplementValidation(Validation):
-    def __init__(self, args: ValidationArgs) -> None:
-        super().__init__(args)
-        self.tmp_dir = TemporaryDirectory()
+    def __init__(self, args: ValidationArgs, tmp_dir: TemporaryDirectory) -> None:
+        super().__init__(args, tmp_dir)
 
     def installation(self) -> None:
         return None
@@ -40,97 +40,122 @@ class TestValidation(unittest.TestCase):
 
     @patch('validation_workflow.download_utils.DownloadUtils')
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_check_url_valid(self, mock_validation_args: Mock, mock_download_utils: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_check_url_valid(self, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_download_utils: Mock) -> None:
         mock_validation_args.projects.return_value = ["opensearch"]
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        mock_temporary_directory.return_value.name = "/tmp/trytytyuit/"
+        mock_validation = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
-        mock_validation = ValidateTar(mock_validation_args.return_value)
-        mock_download_utils_download = mock_download_utils.return_value
-        mock_download_utils_download.download.return_value = True
-        mock_download_utils_download.is_url_valid.return_value = True
         url = "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.12/latest/linux/x64/rpm/dist/opensearch/opensearch-1.3.12.staging.repo"
 
-        result = mock_validation.check_url(url)
-        self.assertTrue(result)
+        with mock.patch("os.path.join") as mock_join, \
+                mock.patch("os.path.basename") as mock_basename, \
+                mock.patch("builtins.open") as mock_open:
+            mock_join.return_value = "mocked_path"
+            mock_basename.return_value = "mocked_filename"
+            response_content = "Mocked content"
+            mock_open.return_value.write.return_value = len(response_content)
+
+            mock_download_utils_download = mock_download_utils.return_value
+            mock_download_utils_download.download.return_value = True
+            mock_download_utils_download.is_url_valid.return_value = True
+
+            result = mock_validation.check_url(url)
+
+            self.assertTrue(result)
 
     @patch('shutil.copy2', return_value=True)
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_copy_artifact(self, mock_validation_args: Mock, mock_copy: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_copy_artifact(self, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_copy: Mock) -> None:
         mock_validation_args.projects.return_value = ["opensearch"]
-        mock_validation = ValidateTar(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        mock_validation = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         url = "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.12/latest/linux/x64/rpm/dist/opensearch/opensearch-1.3.12.staging.repo"
 
-        result = mock_validation.copy_artifact(url, "tmp/tthcdhfh/")
+        result = mock_validation.copy_artifact(url, mock_temporary_directory.return_value.path)
         self.assertTrue(result)
 
     @patch('os.path.exists')
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_check_for_security_plugin(self, mock_validation_args: Mock, mock_path_exists: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_check_for_security_plugin(self, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_path_exists: Mock) -> None:
         mock_path_exists.return_value = True
-
         mock_validation_args.projects.return_value = ["opensearch"]
-        mock_validation = ValidateTar(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        result = mock_validation.check_for_security_plugin("/tmp/tmkuiuo/opensearch")
+        mock_validation = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
+
+        result = mock_validation.check_for_security_plugin("/tmp/trytytyuit/opensearch")
 
         self.assertTrue(result)
 
     @patch("time.sleep")
     @patch('validation_workflow.validation.Validation.check_http_request')
     @patch('validation_workflow.validation.ValidationArgs')
-    def test_check_cluster_readiness_error(self, mock_validation_args: Mock, mock_check_http: Mock, mock_sleep: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_check_cluster_readiness_error(self, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_check_http: Mock, mock_sleep: Mock) -> None:
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch"]
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
         mock_check_http.return_value = False
 
-        validate_docker = ValidateTar(mock_validation_args.return_value)
-        result = validate_docker.check_cluster_readiness()
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
+        result = validate_tar.check_cluster_readiness()
 
         self.assertFalse(result)
 
     @patch("time.sleep")
     @patch('validation_workflow.validation.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch.object(ApiTest, "api_get")
-    def test_check_http_request(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
+    def test_check_http_request(self, mock_api_get: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
         mock_validation_args.return_value.version = '1.3.13'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
         mock_api_get.return_value = (200, "text")
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_docker = ValidateTar(mock_validation_args.return_value)
-        result = validate_docker.check_http_request()
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
+        result = validate_tar.check_http_request()
 
         self.assertTrue(result)
 
     @patch("time.sleep")
     @patch('validation_workflow.validation.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch.object(ApiTest, "api_get")
-    def test_check_http_request_error(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
+    def test_check_http_request_error(self, mock_api_get: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
         mock_validation_args.return_value.version = '1.3.14'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_api_get.return_value = (400, "text")
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_docker = ValidateTar(mock_validation_args.return_value)
+        validate_docker = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
         result = validate_docker.check_http_request()
 
         self.assertFalse(result)
 
     @patch("time.sleep")
     @patch('validation_workflow.validation.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch.object(ApiTest, "api_get")
-    def test_check_http_request_connection_error(self, mock_api_get: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
+    def test_check_http_request_connection_error(self, mock_api_get: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_sleep: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch"]
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
         mock_api_get.side_effect = requests.exceptions.ConnectionError
 
-        validate_docker = ValidateDocker(mock_validation_args.return_value)
+        validate_docker = ValidateDocker(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         result = validate_docker.check_http_request()
 

--- a/tests/tests_validation_workflow/test_validation_docker.py
+++ b/tests/tests_validation_workflow/test_validation_docker.py
@@ -19,15 +19,16 @@ class TestValidateDocker(unittest.TestCase):
 
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.get_image_id')
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.is_container_daemon_running')
-    def test_download_artifacts(self, mock_is_container_daemon_running: Mock, mock_validation_args: Mock, mock_get_image_id: Mock) -> None:
-        mock_validation_args = Mock()
+    def test_download_artifacts(self, mock_is_container_daemon_running: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_get_image_id: Mock) -> None:
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_validation_args.return_value.docker_source = 'dockerhub'
         mock_validation_args.return_value.using_staging_artifact_only = True
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
         # create instance of ValidateDocker
-        validate_docker = ValidateDocker(mock_validation_args.return_value)
+        validate_docker = ValidateDocker(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         # set the desired value for args.docker_source
         validate_docker.args.docker_source = 'dockerhub'
@@ -41,11 +42,13 @@ class TestValidateDocker(unittest.TestCase):
 
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.check_http_request')
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.docker.validation_docker.InspectDockerImage')
     @patch('validation_workflow.docker.validation_docker.ApiTestCases')
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.run_container')
     @patch('validation_workflow.docker.validation_docker.InspectDockerImage.inspect_digest')
-    def test_staging(self, mock_digest: Mock, mock_container: Mock, mock_test: Mock, mock_docker_image: Mock, mock_validation_args: Mock, mock_check_http: Mock) -> None:
+    def test_staging(self, mock_digest: Mock, mock_container: Mock, mock_test: Mock, mock_docker_image: Mock, mock_temporary_directory: Mock,
+                     mock_validation_args: Mock, mock_check_http: Mock) -> None:
         # Set up mock objects
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
@@ -57,9 +60,10 @@ class TestValidateDocker(unittest.TestCase):
         mock_test_apis_instance.test_apis.return_value = (True, 2)
         mock_digest.return_value = True
         mock_check_http.return_value = True
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
         # Create instance of ValidateDocker class
-        validate_docker = ValidateDocker(mock_validation_args.return_value)
+        validate_docker = ValidateDocker(mock_validation_args.return_value, mock_temporary_directory.return_value)
         validate_docker.image_ids = {'opensearch': 'images_id_0'}
         validate_docker.replacements = [('opensearchproject/opensearch:1', 'images_id_0')]
 
@@ -74,8 +78,9 @@ class TestValidateDocker(unittest.TestCase):
 
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.check_cluster_readiness')
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.run_container')
-    def test_staging_cluster_not_ready(self, mock_container: Mock, mock_validation_args: Mock,
+    def test_staging_cluster_not_ready(self, mock_container: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock,
                                        mock_cluster_readiness: Mock) -> None:
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
@@ -83,8 +88,9 @@ class TestValidateDocker(unittest.TestCase):
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_cluster_readiness.return_value = False
         mock_container.return_value = (True, 'test_file.yml')
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_docker = ValidateDocker(mock_validation_args.return_value)
+        validate_docker = ValidateDocker(mock_validation_args.return_value, mock_temporary_directory.return_value)
         validate_docker.image_ids = {'opensearch': 'images_id_0'}
         validate_docker.replacements = [('opensearchproject/opensearch:1', 'images_id_0')]
 
@@ -94,16 +100,18 @@ class TestValidateDocker(unittest.TestCase):
         mock_cluster_readiness.assert_called_once()
 
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.run_container')
-    def test_container_startup_exception(self, mock_container: Mock, mock_validation_args: Mock) -> None:
+    def test_container_startup_exception(self, mock_container: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.validate_digest_only = False
         mock_validation_args.return_value.allow_http = False
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_container.return_value = (False, 'test_file.yml')
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
         # Create instance of ValidateDocker class
-        validate_docker = ValidateDocker(mock_validation_args.return_value)
+        validate_docker = ValidateDocker(mock_validation_args.return_value, mock_temporary_directory.return_value)
         validate_docker.image_ids = {'opensearch': 'images_id_0'}
         validate_docker.replacements = [('opensearchproject/opensearch:1', 'images_id_0')]
 
@@ -114,11 +122,13 @@ class TestValidateDocker(unittest.TestCase):
 
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.check_http_request')
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.docker.validation_docker.InspectDockerImage')
     @patch('validation_workflow.docker.validation_docker.ApiTestCases')
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.run_container')
     @patch('validation_workflow.docker.validation_docker.InspectDockerImage.inspect_digest')
-    def test_digests(self, mock_digest: Mock, mock_container: Mock, mock_test: Mock, mock_docker_image: Mock, mock_validation_args: Mock, mock_check_http: Mock) -> None:
+    def test_digests(self, mock_digest: Mock, mock_container: Mock, mock_test: Mock, mock_docker_image: Mock, mock_temporary_directory: Mock,
+                     mock_validation_args: Mock, mock_check_http: Mock) -> None:
         # Set up mock objects
         mock_validation_args.return_value.version = '1.0.0.1000'
         mock_validation_args.return_value.using_staging_artifact_only = False
@@ -130,9 +140,10 @@ class TestValidateDocker(unittest.TestCase):
         mock_test_apis_instance.test_apis.return_value = (True, 2)
         mock_digest.return_value = True
         mock_check_http.return_value = True
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
         # Create instance of ValidateDocker class
-        validate_docker = ValidateDocker(mock_validation_args.return_value)
+        validate_docker = ValidateDocker(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         validate_docker.image_names_list = ['opensearchproject/opensearch']
         validate_docker.image_ids = {'opensearch': 'images_id_0'}
@@ -144,10 +155,12 @@ class TestValidateDocker(unittest.TestCase):
         self.assertTrue(result)
 
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')
-    def test_cleanup(self, mock_validation_args: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_cleanup(self, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
         # Create instance of ValidateDocker class
-        validate_docker = ValidateDocker(mock_validation_args.return_value)
+        validate_docker = ValidateDocker(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         # Call cleanup method
         with patch.object(validate_docker, 'cleanup_process') as mock_cleanup_process:
@@ -158,16 +171,18 @@ class TestValidateDocker(unittest.TestCase):
             self.assertTrue(result)
 
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.docker.validation_docker.subprocess.run')
     @patch('validation_workflow.docker.validation_docker.os.remove')
-    def test_cleanup_process(self, mock_os_remove: Mock, mock_subprocess_run: Mock, mock_validation_args: Mock) -> None:
+    def test_cleanup_process(self, mock_os_remove: Mock, mock_subprocess_run: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
 
         # Set up mock objects
         mock_validation_args.return_value = 'validation_args'
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
         mock_subprocess_run.return_value = subprocess.CompletedProcess(args='docker-compose -f docker-compose.yml down', returncode=0, stdout=b'', stderr=b'')
 
         # Create instance of class
-        validate_docker = ValidateDocker(mock_validation_args)
+        validate_docker = ValidateDocker(mock_validation_args, mock_temporary_directory.return_value)
         validate_docker._target_yml_file = 'validation_args'
 
         # Call method to test
@@ -180,16 +195,18 @@ class TestValidateDocker(unittest.TestCase):
         mock_os_remove.assert_called_with('validation_args')
 
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.pull_image')
     @patch.object(subprocess, 'run')
-    def test_get_pull_image_id(self, mock_subprocess_run: Mock, mock_pull_image: Mock, mock_validation_args: Mock) -> None:
+    def test_get_pull_image_id(self, mock_subprocess_run: Mock, mock_pull_image: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
 
         # Set up mock objects
         mock_subprocess_run.return_value = MagicMock(returncode=0)
         mock_pull_image.return_value = 'opensearch/opensearch'
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
         # Create instance of class
-        validate_docker = ValidateDocker(mock_validation_args)
+        validate_docker = ValidateDocker(mock_validation_args, mock_temporary_directory.return_value)
 
         # Call method to test
         image_id = validate_docker.get_image_id('opensearch/opensearch', '1.0.0')
@@ -213,14 +230,17 @@ class TestValidateDocker(unittest.TestCase):
     @patch('validation_workflow.docker.validation_docker.get_password')
     @patch('validation_workflow.docker.validation_docker.ValidateDocker.inplace_change')
     @patch('validation_workflow.docker.validation_docker.ValidationArgs')
-    def test_run_container(self, mock_validation_args: Mock, mock_inplace: Mock, mock_password: Mock, mock_subprocess_run: MagicMock,
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_run_container(self, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_inplace: Mock, mock_password: Mock, mock_subprocess_run: MagicMock,
                            mock_check_output: MagicMock, mock_copy2: MagicMock) -> None:
         image_ids = {"opensearch": "sha1", "opensearch-dashboards": "sha2"}
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_subprocess_run.return_value = subprocess.CompletedProcess(args='docker-compose -f docker-compose.yml down', returncode=0, stdout=b'', stderr=b'')
         mock_password.return_value = "admin"
         mock_validation_args.return_value.version = '1.0.0'
-        validate_docker = ValidateDocker(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        mock_temporary_directory.return_value.name = "/tmp/trytytyuit/"
+        validate_docker = ValidateDocker(mock_validation_args.return_value, mock_temporary_directory.return_value)
         result, self._target_yml_file = validate_docker.run_container(image_ids, "2.11.0")
         self.assertEqual(result, True)
         mock_subprocess_run.assert_called_with(os.path.join(f'docker-compose -f {validate_docker.tmp_dir.path}', 'docker-compose.yml up -d opensearch-node1 opensearch-node2'),

--- a/tests/tests_validation_workflow/test_validation_rpm.py
+++ b/tests/tests_validation_workflow/test_validation_rpm.py
@@ -14,7 +14,8 @@ from validation_workflow.rpm.validation_rpm import ValidateRpm
 class TestValidationRpm(unittest.TestCase):
     def setUp(self) -> None:
         self.args = Mock()
-        self.call_methods = ValidateRpm(self.args)
+        self.tmp_dir = Mock()
+        self.call_methods = ValidateRpm(self.args, self.tmp_dir)
 
     def test_empty_file_path_and_production_artifact_type(self) -> None:
         self.args.projects = ["opensearch"]
@@ -66,61 +67,69 @@ class TestValidationRpm(unittest.TestCase):
         mock_copy_artifact.assert_called_once()
 
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
-    def test_exceptions(self, mock_validation_args: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_exceptions(self, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         with self.assertRaises(Exception) as e1:
             mock_validation_args.return_value.projects = ["opensearch"]
             mock_validation_args.return_value.file_path = {"opensearch": "/src/files/opensearch.rpm"}
-            validate_rpm = ValidateRpm(mock_validation_args.return_value)
+            mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+            validate_rpm = ValidateRpm(mock_validation_args.return_value, mock_temporary_directory.return_value)
             validate_rpm.installation()
         self.assertEqual(str(e1.exception), "Failed to install Opensearch")
 
         with self.assertRaises(Exception) as e2:
             mock_validation_args.return_value.projects = ["opensearch"]
-            validate_rpm = ValidateRpm(mock_validation_args.return_value)
+            validate_rpm = ValidateRpm(mock_validation_args.return_value, mock_temporary_directory.return_value)
             validate_rpm.start_cluster()
         self.assertEqual(str(e2.exception), "Failed to Start Cluster")
 
         with self.assertRaises(Exception) as e3:
             mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
-            validate_rpm = ValidateRpm(mock_validation_args.return_value)
+            validate_rpm = ValidateRpm(mock_validation_args.return_value, mock_temporary_directory.return_value)
             validate_rpm.cleanup()
         self.assertIn("Exception occurred either while attempting to stop cluster or removing OpenSearch/OpenSearch-Dashboards.",
                       str(e3.exception))
 
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch("validation_workflow.rpm.validation_rpm.execute")
-    def test_installation(self, mock_system: Mock, mock_validation_args: Mock) -> None:
+    def test_installation(self, mock_temporary_directory: Mock, mock_system: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platform = 'linux'
         mock_validation_args.return_value.allow_http = True
         mock_validation_args.return_value.projects = ["opensearch"]
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        validate_rpm = ValidateRpm(mock_validation_args.return_value, mock_temporary_directory.return_value)
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
         result = validate_rpm.installation()
         self.assertTrue(result)
 
     @patch("validation_workflow.rpm.validation_rpm.execute", return_value=True)
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
-    def test_start_cluster(self, mock_validation_args: Mock, mock_system: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_start_cluster(self, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_system: Mock) -> None:
         mock_validation_args.return_value.projects.return_value = ["opensearch", "opensearch-dashboards"]
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        validate_rpm = ValidateRpm(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         result = validate_rpm.start_cluster()
         self.assertTrue(result)
 
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.rpm.validation_rpm.ApiTestCases')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_validation(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_validation(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_test_apis_instance = mock_test_apis.return_value
         mock_check_cluster.return_value = True
         mock_test_apis_instance.test_apis.return_value = (True, 3)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        validate_rpm = ValidateRpm(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         result = validate_rpm.validation()
         self.assertTrue(result)
@@ -128,15 +137,18 @@ class TestValidationRpm(unittest.TestCase):
         mock_test_apis.assert_called_once()
 
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.rpm.validation_rpm.ApiTestCases')
     @patch('os.path.basename')
     @patch('validation_workflow.rpm.validation_rpm.execute')
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_validation_with_allow_http_check(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_validation_with_allow_http_check(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock,
+                                              mock_basename: Mock, mock_test_apis: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.allow_http = True
-        validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        validate_rpm = ValidateRpm(mock_validation_args.return_value, mock_temporary_directory.return_value)
         mock_check_cluster.return_value = True
         mock_basename.side_effect = lambda path: "mocked_filename"
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
@@ -150,10 +162,12 @@ class TestValidationRpm(unittest.TestCase):
         mock_security.assert_called_once()
 
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_cluster_not_ready(self, mock_check_cluster: Mock, mock_validation_args: Mock) -> None:
+    def test_cluster_not_ready(self, mock_check_cluster: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        validate_rpm = ValidateRpm(mock_validation_args.return_value, mock_temporary_directory.return_value)
         mock_check_cluster.return_value = False
 
         with self.assertRaises(Exception) as context:
@@ -162,15 +176,17 @@ class TestValidationRpm(unittest.TestCase):
         mock_check_cluster.assert_called_once()
 
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.rpm.validation_rpm.ApiTestCases')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_failed_testcases(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_failed_testcases(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_test_apis_instance = mock_test_apis.return_value
         mock_check_cluster.return_value = True
         mock_test_apis_instance.test_apis.return_value = (False, 1)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        validate_rpm = ValidateRpm(mock_validation_args, mock_temporary_directory)
 
         with self.assertRaises(Exception) as context:
             validate_rpm.validation()
@@ -181,11 +197,13 @@ class TestValidationRpm(unittest.TestCase):
 
     @patch("validation_workflow.rpm.validation_rpm.execute", return_value=True)
     @patch('validation_workflow.rpm.validation_rpm.ValidationArgs')
-    def test_cleanup(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_cleanup(self, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_execute: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
-        # Create instance of ValidateRpm class
-        validate_rpm = ValidateRpm(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+
+        validate_rpm = ValidateRpm(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         result = validate_rpm.cleanup()
         self.assertTrue(result)

--- a/tests/tests_validation_workflow/test_validation_tar.py
+++ b/tests/tests_validation_workflow/test_validation_tar.py
@@ -15,7 +15,8 @@ from validation_workflow.tar.validation_tar import ValidateTar
 class TestValidateTar(unittest.TestCase):
     def setUp(self) -> None:
         self.args = Mock()
-        self.call_methods = ValidateTar(self.args)
+        self.tmp_dir = Mock()
+        self.call_methods = ValidateTar(self.args, self.tmp_dir)
 
     def test_empty_file_path_and_production_artifact_type(self) -> None:
         self.args.projects = ["opensearch"]
@@ -67,45 +68,51 @@ class TestValidateTar(unittest.TestCase):
         mock_copy_artifact.assert_called_once()
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('os.path.basename')
     @patch('validation_workflow.tar.validation_tar.execute')
-    def test_installation(self, mock_system: Mock, mock_basename: Mock, mock_validation_args: Mock) -> None:
+    def test_installation(self, mock_system: Mock, mock_basename: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platform = 'linux'
         mock_validation_args.return_value.allow_http = True
         mock_validation_args.return_value.projects = ["opensearch"]
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_tar = ValidateTar(mock_validation_args.return_value)
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
         mock_basename.side_effect = lambda path: "mocked_filename"
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
         result = validate_tar.installation()
         self.assertTrue(result)
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch.object(Process, 'start')
     @patch('validation_workflow.tar.validation_tar.get_password')
-    def test_start_cluster(self, mock_password: Mock, mock_start: Mock, mock_validation_args: Mock) -> None:
+    def test_start_cluster(self, mock_password: Mock, mock_start: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platforms = 'linux'
         mock_validation_args.return_value.allow_http = True
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
         mock_password.return_value = "admin"
 
-        validate_tar = ValidateTar(mock_validation_args.return_value)
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
         result = validate_tar.start_cluster()
         self.assertTrue(result)
         mock_password.assert_called_once()
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('time.sleep')
     @patch('src.test_workflow.integ_test.utils.get_password')
-    def test_start_cluster_exception_os(self, mock_password: Mock, mock_sleep: Mock, mock_validation_args: Mock) -> None:
+    def test_start_cluster_exception_os(self, mock_password: Mock, mock_sleep: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.projects = ["opensearch"]
         mock_validation_args.return_value.allow_http = True
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_tar = ValidateTar(mock_validation_args.return_value)
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
         validate_tar.os_process.start = MagicMock(side_effect=Exception('Failed to Start Cluster'))  # type: ignore
         with self.assertRaises(Exception) as context:
             validate_tar.start_cluster()
@@ -113,15 +120,17 @@ class TestValidateTar(unittest.TestCase):
         self.assertEqual(str(context.exception), 'Failed to Start Cluster')
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.tar.validation_tar.ApiTestCases')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_validation(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_validation(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_test_apis_instance = mock_test_apis.return_value
         mock_check_cluster.return_value = True
         mock_test_apis_instance.test_apis.return_value = (True, 3)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_tar = ValidateTar(mock_validation_args.return_value)
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         result = validate_tar.validation()
         self.assertTrue(result)
@@ -129,21 +138,24 @@ class TestValidateTar(unittest.TestCase):
         mock_test_apis.assert_called_once()
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.tar.validation_tar.ApiTestCases')
     @patch('os.path.basename')
     @patch('validation_workflow.tar.validation_tar.execute')
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_validation_with_allow_http(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_validation_with_allow_http(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock, mock_basename: Mock,
+                                        mock_test_apis: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.allow_http = True
-        validate_tar = ValidateTar(mock_validation_args.return_value)
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
         mock_check_cluster.return_value = True
         mock_basename.side_effect = lambda path: "mocked_filename"
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
         mock_security.return_value = True
         mock_test_apis_instance = mock_test_apis.return_value
         mock_test_apis_instance.test_apis.return_value = (True, 4)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
         result = validate_tar.validation()
         self.assertTrue(result)
@@ -151,11 +163,15 @@ class TestValidateTar(unittest.TestCase):
         mock_security.assert_called_once()
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
+    @patch('validation_workflow.tar.validation_tar.ValidateTar.cleanup')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_cluster_not_ready(self, mock_check_cluster: Mock, mock_validation_args: Mock) -> None:
+    def test_cluster_not_ready(self, mock_check_cluster: Mock, mock_cleanup: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        validate_tar = ValidateTar(mock_validation_args.return_value)
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
         mock_check_cluster.return_value = False
+        mock_cleanup.return_value = True
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
         with self.assertRaises(Exception) as context:
             validate_tar.validation()
@@ -163,15 +179,18 @@ class TestValidateTar(unittest.TestCase):
         mock_check_cluster.assert_called_once()
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
+    @patch('validation_workflow.tar.validation_tar.ValidateTar.cleanup')
     @patch('validation_workflow.tar.validation_tar.ApiTestCases')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_failed_testcases(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_failed_testcases(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_cleanup: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_test_apis_instance = mock_test_apis.return_value
         mock_check_cluster.return_value = True
+        mock_cleanup.return_value = True
         mock_test_apis_instance.test_apis.return_value = (False, 1)
-
-        validate_tar = ValidateTar(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         with self.assertRaises(Exception) as context:
             validate_tar.validation()
@@ -181,21 +200,25 @@ class TestValidateTar(unittest.TestCase):
         mock_test_apis.assert_called_once()
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch.object(Process, 'terminate')
-    def test_cleanup(self, mock_terminate: Mock, mock_validation_args: Mock) -> None:
+    def test_cleanup(self, mock_terminate: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.platform = 'linux'
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_tar = ValidateTar(mock_validation_args.return_value)
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
         result = validate_tar.cleanup()
         self.assertTrue(result)
 
     @patch('validation_workflow.tar.validation_tar.ValidationArgs')
-    def test_cleanup_exception(self, mock_validation_args: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_cleanup_exception(self, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
-        validate_tar = ValidateTar(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        validate_tar = ValidateTar(mock_validation_args.return_value, mock_temporary_directory.return_value)
         with self.assertRaises(Exception) as context:
             validate_tar.cleanup()
 

--- a/tests/tests_validation_workflow/test_validation_test_runner.py
+++ b/tests/tests_validation_workflow/test_validation_test_runner.py
@@ -14,6 +14,7 @@ from validation_workflow.validation_test_runner import ValidationTestRunner  # t
 class TestValidationTestRunner(unittest.TestCase):
     def test_docker(self) -> None:
         mock_args = MagicMock()
+        mock_tmp_dir = MagicMock()
         mock_dist = "docker"
         mock_docker_runner_object = MagicMock()
         mock_docker_runner = MagicMock()
@@ -21,18 +22,23 @@ class TestValidationTestRunner(unittest.TestCase):
         mock_tar_runner = MagicMock()
         mock_rpm_runner = MagicMock()
         mock_yum_runner = MagicMock()
+        mock_deb_runner = MagicMock()
+        mock_zip_runner = MagicMock()
         with patch.dict("validation_workflow.validation_test_runner.ValidationTestRunner.RUNNERS", {
             "docker": mock_docker_runner,
             "tar": mock_tar_runner,
             "rpm": mock_rpm_runner,
             "yum": mock_yum_runner,
+            "deb": mock_deb_runner,
+            "zip": mock_zip_runner,
         }):
-            runner = ValidationTestRunner.dispatch(mock_args, mock_dist)
+            runner = ValidationTestRunner.dispatch(mock_args, mock_dist, mock_tmp_dir)
             self.assertEqual(runner, mock_docker_runner_object)
-            mock_docker_runner.assert_called_once_with(mock_args)
+            mock_docker_runner.assert_called_once_with(mock_args, mock_tmp_dir)
 
     def test_tar(self) -> None:
         mock_args = MagicMock()
+        mock_tmp_dir = MagicMock()
         mock_dist = "tar"
         mock_tar_runner_object = MagicMock()
         mock_docker_runner = MagicMock()
@@ -40,18 +46,23 @@ class TestValidationTestRunner(unittest.TestCase):
         mock_tar_runner.return_value = mock_tar_runner_object
         mock_rpm_runner = MagicMock()
         mock_yum_runner = MagicMock()
+        mock_deb_runner = MagicMock()
+        mock_zip_runner = MagicMock()
         with patch.dict("validation_workflow.validation_test_runner.ValidationTestRunner.RUNNERS", {
             "docker": mock_docker_runner,
             "tar": mock_tar_runner,
             "rpm": mock_rpm_runner,
             "yum": mock_yum_runner,
+            "deb": mock_deb_runner,
+            "zip": mock_zip_runner,
         }):
-            runner = ValidationTestRunner.dispatch(mock_args, mock_dist)
+            runner = ValidationTestRunner.dispatch(mock_args, mock_dist, mock_tmp_dir)
             self.assertEqual(runner, mock_tar_runner_object)
-            mock_tar_runner.assert_called_once_with(mock_args)
+            mock_tar_runner.assert_called_once_with(mock_args, mock_tmp_dir)
 
     def test_rpm(self) -> None:
         mock_args = MagicMock()
+        mock_tmp_dir = MagicMock()
         mock_dist = "rpm"
         mock_rpm_runner_object = MagicMock()
         mock_docker_runner = MagicMock()
@@ -59,34 +70,43 @@ class TestValidationTestRunner(unittest.TestCase):
         mock_rpm_runner = MagicMock()
         mock_rpm_runner.return_value = mock_rpm_runner_object
         mock_yum_runner = MagicMock()
+        mock_deb_runner = MagicMock()
+        mock_zip_runner = MagicMock()
         with patch.dict("validation_workflow.validation_test_runner.ValidationTestRunner.RUNNERS", {
             "docker": mock_docker_runner,
             "tar": mock_tar_runner,
             "rpm": mock_rpm_runner,
             "yum": mock_yum_runner,
+            "deb": mock_deb_runner,
+            "zip": mock_zip_runner,
         }):
-            runner = ValidationTestRunner.dispatch(mock_args, mock_dist)
+            runner = ValidationTestRunner.dispatch(mock_args, mock_dist, mock_tmp_dir)
             self.assertEqual(runner, mock_rpm_runner_object)
-            mock_rpm_runner.assert_called_once_with(mock_args)
+            mock_rpm_runner.assert_called_once_with(mock_args, mock_tmp_dir)
 
     def test_yum(self) -> None:
         mock_args = MagicMock()
+        mock_tmp_dir = MagicMock()
         mock_dist = "yum"
         mock_yum_runner_object = MagicMock()
         mock_docker_runner = MagicMock()
         mock_tar_runner = MagicMock()
         mock_rpm_runner = MagicMock()
         mock_yum_runner = MagicMock()
+        mock_deb_runner = MagicMock()
+        mock_zip_runner = MagicMock()
         mock_yum_runner.return_value = mock_yum_runner_object
         with patch.dict("validation_workflow.validation_test_runner.ValidationTestRunner.RUNNERS", {
             "docker": mock_docker_runner,
             "tar": mock_tar_runner,
             "rpm": mock_rpm_runner,
             "yum": mock_yum_runner,
+            "deb": mock_deb_runner,
+            "zip": mock_zip_runner,
         }):
-            runner = ValidationTestRunner.dispatch(mock_args, mock_dist)
+            runner = ValidationTestRunner.dispatch(mock_args, mock_dist, mock_tmp_dir)
             self.assertEqual(runner, mock_yum_runner_object)
-            mock_yum_runner.assert_called_once_with(mock_args)
+            mock_yum_runner.assert_called_once_with(mock_args, mock_tmp_dir)
 
 
 if __name__ == '__main__':

--- a/tests/tests_validation_workflow/test_validation_yum.py
+++ b/tests/tests_validation_workflow/test_validation_yum.py
@@ -15,7 +15,8 @@ class TestValidationYum(unittest.TestCase):
 
     def setUp(self) -> None:
         self.args = Mock()
-        self.call_methods = ValidateYum(self.args)
+        self.tmp_dir = Mock()
+        self.call_methods = ValidateYum(self.args, self.tmp_dir)
 
     def test_empty_file_path_and_production_artifact_type(self) -> None:
         self.args.projects = ["opensearch"]
@@ -67,61 +68,68 @@ class TestValidationYum(unittest.TestCase):
         mock_copy_artifact.assert_called_once()
 
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
-    def test_exceptions(self, mock_validation_args: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_exceptions(self, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         with self.assertRaises(Exception) as e1:
             mock_validation_args.return_value.projects = ["opensearch"]
             mock_validation_args.return_value.file_path = {"opensearch": "/src/files/opensearch.staging.repo"}
-            validate_yum = ValidateYum(mock_validation_args.return_value)
+            mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+            validate_yum = ValidateYum(mock_validation_args.return_value, mock_temporary_directory.return_value)
             validate_yum.installation()
         self.assertEqual(str(e1.exception), "Failed to install Opensearch")
 
         with self.assertRaises(Exception) as e2:
             mock_validation_args.return_value.projects = ["opensearch"]
-            validate_yum = ValidateYum(mock_validation_args.return_value)
+            validate_yum = ValidateYum(mock_validation_args.return_value, mock_temporary_directory.return_value)
             validate_yum.start_cluster()
         self.assertEqual(str(e2.exception), "Failed to Start Cluster")
 
         with self.assertRaises(Exception) as e3:
             mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
-            validate_yum = ValidateYum(mock_validation_args.return_value)
+            validate_yum = ValidateYum(mock_validation_args.return_value, mock_temporary_directory.return_value)
             validate_yum.cleanup()
         self.assertIn("Exception occurred either while attempting to stop cluster or removing OpenSearch/OpenSearch-Dashboards.",
                       str(e3.exception))
 
     @patch("validation_workflow.yum.validation_yum.execute")
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
-    def test_installation(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_installation(self, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_execute: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.arch = 'x64'
         mock_validation_args.return_value.allow_http = False
 
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
         mock_execute.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
-        validate_yum = ValidateYum(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        validate_yum = ValidateYum(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         result = validate_yum.installation()
         self.assertTrue(result)
 
     @patch("validation_workflow.yum.validation_yum.execute", return_value=True)
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
-    def test_start_cluster(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_start_cluster(self, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_execute: Mock) -> None:
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
-
-        validate_yum = ValidateYum(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        validate_yum = ValidateYum(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         result = validate_yum.start_cluster()
         self.assertTrue(result)
 
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.yum.validation_yum.ApiTestCases')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_validation(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_validation(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_test_apis_instance = mock_test_apis.return_value
         mock_check_cluster.return_value = True
         mock_test_apis_instance.test_apis.return_value = (True, 3)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_yum = ValidateYum(mock_validation_args.return_value)
+        validate_yum = ValidateYum(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         result = validate_yum.validation()
         self.assertTrue(result)
@@ -129,15 +137,18 @@ class TestValidationYum(unittest.TestCase):
         mock_test_apis.assert_called_once()
 
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.yum.validation_yum.ApiTestCases')
     @patch('os.path.basename')
     @patch('validation_workflow.yum.validation_yum.execute')
     @patch('validation_workflow.validation.Validation.check_for_security_plugin')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_validation_with_allow_http(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock, mock_basename: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_validation_with_allow_http(self, mock_check_cluster: Mock, mock_security: Mock, mock_system: Mock,
+                                        mock_basename: Mock, mock_test_apis: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.allow_http = True
-        validate_yum = ValidateYum(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        validate_yum = ValidateYum(mock_validation_args.return_value, mock_temporary_directory.return_value)
         mock_check_cluster.return_value = True
         mock_basename.side_effect = lambda path: "mocked_filename"
         mock_system.side_effect = lambda *args, **kwargs: (0, "stdout_output", "stderr_output")
@@ -151,10 +162,12 @@ class TestValidationYum(unittest.TestCase):
         mock_security.assert_called_once()
 
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_cluster_not_ready(self, mock_check_cluster: Mock, mock_validation_args: Mock) -> None:
+    def test_cluster_not_ready(self, mock_check_cluster: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
-        validate_yum = ValidateYum(mock_validation_args.return_value)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
+        validate_yum = ValidateYum(mock_validation_args.return_value, mock_temporary_directory.return_value)
         mock_check_cluster.return_value = False
 
         with self.assertRaises(Exception) as context:
@@ -163,15 +176,17 @@ class TestValidationYum(unittest.TestCase):
         mock_check_cluster.assert_called_once()
 
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
+    @patch('system.temporary_directory.TemporaryDirectory')
     @patch('validation_workflow.yum.validation_yum.ApiTestCases')
     @patch('validation_workflow.validation.Validation.check_cluster_readiness')
-    def test_failed_testcases(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_validation_args: Mock) -> None:
+    def test_failed_testcases(self, mock_check_cluster: Mock, mock_test_apis: Mock, mock_temporary_directory: Mock, mock_validation_args: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_test_apis_instance = mock_test_apis.return_value
         mock_check_cluster.return_value = True
         mock_test_apis_instance.test_apis.return_value = (False, 1)
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_yum = ValidateYum(mock_validation_args.return_value)
+        validate_yum = ValidateYum(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         with self.assertRaises(Exception) as context:
             validate_yum.validation()
@@ -182,11 +197,13 @@ class TestValidationYum(unittest.TestCase):
 
     @patch("validation_workflow.yum.validation_yum.execute", return_value=True)
     @patch('validation_workflow.yum.validation_yum.ValidationArgs')
-    def test_cleanup(self, mock_validation_args: Mock, mock_execute: Mock) -> None:
+    @patch('system.temporary_directory.TemporaryDirectory')
+    def test_cleanup(self, mock_temporary_directory: Mock, mock_validation_args: Mock, mock_execute: Mock) -> None:
         mock_validation_args.return_value.version = '2.3.0'
         mock_validation_args.return_value.projects = ["opensearch", "opensearch-dashboards"]
+        mock_temporary_directory.return_value.path = "/tmp/trytytyuit/"
 
-        validate_yum = ValidateYum(mock_validation_args.return_value)
+        validate_yum = ValidateYum(mock_validation_args.return_value, mock_temporary_directory.return_value)
 
         result = validate_yum.cleanup()
         self.assertTrue(result)


### PR DESCRIPTION
### Description
Handle complete cleanup after running the workflow.

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/4442

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
