### PR TITLE
Fix the bundle_artifact_path value and remove wrong comments for deb assemble

### DIFF
--- a/src/assemble_workflow/bundle_linux_deb.py
+++ b/src/assemble_workflow/bundle_linux_deb.py
@@ -126,6 +126,8 @@ class BundleLinuxDeb:
         subprocess.check_call(bundle_cmd, cwd=ext_dest, shell=True)
 
         # Move artifact to repo root before being published to {dest}
-        # for dirpath, dirnames, filenames in os.walk(os.path.join('/tmp/opensearch*')):
+        # In debuild, the final package is created in the parent directory of the sources
+        # https://github.com/opensearch-project/opensearch-build/issues/4532#issuecomment-2091726868
+        bundle_artifact_path = f"/tmp/{self.filename}_{deb_version}_{deb_architecture(build_cls.architecture)}.deb"
         logging.info(f"Found deb file: {bundle_artifact_path}")
-        shutil.move(f"/tmp/{self.filename}_{deb_version}_{deb_architecture(build_cls.architecture)}.deb", name)
+        shutil.move(bundle_artifact_path, name)


### PR DESCRIPTION

### Description
Fix the bundle_artifact_path value and remove wrong comments for deb assemble

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/4532

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
