### PR TITLE
Adding footer and sidebar for build repo wiki

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -5,7 +5,7 @@
 This repository hosts the build, test and release scripts for OpenSearch and OpenSearch Dashboards distributions.
 
 See each page below for more details:
+- [OpenSearch Project Build System Quick Overview](https://github.com/opensearch-project/opensearch-build/wiki/OpenSearch-Project-Build-System-Quick-Overview)
 - [Building a Distribution from the source](https://github.com/opensearch-project/opensearch-build/wiki/Building-an-OpenSearch-and-OpenSearch-Dashboards-Distribution)
 - [Testing a Distribution](https://github.com/opensearch-project/opensearch-build/wiki/Testing-the-Distribution)
 - [Releasing the Distribution](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution)
-- [OpenSearch Project Build System Quick Overview](https://github.com/opensearch-project/opensearch-build/wiki/OpenSearch-Project-Build-System-Quick-Overview)

--- a/docs/_Footer.md
+++ b/docs/_Footer.md
@@ -1,0 +1,1 @@
+Anything unclear or inaccurate in our Wiki? You can contribute a change [here](https://github.com/opensearch-project/opensearch-build/tree/main/docs).

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -1,0 +1,11 @@
+# Overview
+[OpenSearch Project Build System Quick Overview](OpenSearch-Project-Build-System-Quick-Overview)
+
+# Build Workflow
+[Building a Distribution from the source](Building-an-OpenSearch-and-OpenSearch-Dashboards-Distribution)
+
+# Test Workflow
+[Testing a Distribution](Testing-the-Distribution)
+
+# Release Workflow
+[Releasing the Distribution](Releasing-the-Distribution)


### PR DESCRIPTION

### Description
Move build system overview to top of the home page before detailed sections
It is logical to read the overview before go into each individual workflow.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4489

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
