### PR TITLE
docker: start opensearch with exec for graceful termination

### DIFF
--- a/docker/release/config/opensearch/opensearch-docker-entrypoint-1.x.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint-1.x.sh
@@ -98,7 +98,7 @@ function runOpensearch {
     setupPerformanceAnalyzerPlugin
 
     # Start opensearch
-    "$@" "${opensearch_opts[@]}"
+    exec "$@" "${opensearch_opts[@]}"
 
 }
 

--- a/docker/release/config/opensearch/opensearch-docker-entrypoint-2.x.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint-2.x.sh
@@ -97,7 +97,7 @@ function runOpensearch {
     setupPerformanceAnalyzerPlugin
 
     # Start opensearch
-    "$@" "${opensearch_opts[@]}"
+    exec "$@" "${opensearch_opts[@]}"
 
 }
 

--- a/docker/release/config/opensearch/opensearch-docker-entrypoint-default.x.sh
+++ b/docker/release/config/opensearch/opensearch-docker-entrypoint-default.x.sh
@@ -97,7 +97,7 @@ function runOpensearch {
     setupPerformanceAnalyzerPlugin
 
     # Start opensearch
-    "$@" "${opensearch_opts[@]}"
+    exec "$@" "${opensearch_opts[@]}"
 
 }
 


### PR DESCRIPTION
### Description
Testing with Podman on Ubuntu 24.04:
```
root@test ~ # podman run --name=test --ulimit memlock=-1:-1 --env discovery.type=single-node --env OPENSEARCH_INITIAL_ADMIN_PASSWORD='myStrongPassword123!' --pull never --security-opt=apparmor=unconfined --stop-signal=SIGINT opensearchproject/opensearch:2.13.0
```
Stopping it via an additional terminal:
```
root@test ~ # podman stop test
WARN[0010] StopSignal SIGINT failed to stop container test in 10 seconds, resorting to SIGKILL 
test
```
Opensearch gets terminated without any graceful shutdown.

Self build image with `exec` in `opensearch-docker-entrypoint.sh` to start container:
```Dockerfile
FROM opensearchproject/opensearch:2.13.0
RUN sed -i 's/    "$@"/    exec "$@"/g' opensearch-docker-entrypoint.sh
``` 
```
root@test ~ # podman run --name=test --ulimit memlock=-1:-1 --env discovery.type=single-node --env OPENSEARCH_INITIAL_ADMIN_PASSWORD='myStrongPassword123!' --pull never --security-opt=apparmor=unconfined --stop-signal=SIGINT localhost/opensearch-test
```
```
root@test ~ # podman stop test
test
```
Opensearch stops graceful with following log lines:
```
[2024-05-08T10:08:48,758][INFO ][o.o.s.a.r.AuditMessageRouter] [9cb111d7ce0d] Closing AuditMessageRouter
[2024-05-08T10:08:48,758][INFO ][o.o.n.Node               ] [9cb111d7ce0d] stopping ...
[2024-05-08T10:08:48,759][INFO ][o.o.s.a.s.SinkProvider   ] [9cb111d7ce0d] Closing InternalOpenSearchSink
[2024-05-08T10:08:48,759][INFO ][o.o.s.a.s.SinkProvider   ] [9cb111d7ce0d] Closing DebugSink
[2024-05-08T10:08:48,796][INFO ][o.o.n.Node               ] [9cb111d7ce0d] stopped
[2024-05-08T10:08:48,796][INFO ][o.o.n.Node               ] [9cb111d7ce0d] closing ...
[2024-05-08T10:08:48,798][INFO ][o.o.s.a.i.AuditLogImpl   ] [9cb111d7ce0d] Closing AuditLogImpl
[2024-05-08T10:08:48,798][INFO ][o.o.n.Node               ] [9cb111d7ce0d] closed
```


### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/3229

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
