### PR TITLE
Update configs and entrypoint for logging.ignoreEnospcError in 2.15.0

### DIFF
--- a/config/opensearch_dashboards-2.x.yml
+++ b/config/opensearch_dashboards-2.x.yml
@@ -103,6 +103,11 @@
 # Enables you to specify a file where OpenSearch Dashboards stores log output.
 # logging.dest: stdout
 
+# 2.15 Ignore 'ENOSPC' error for logging stream.
+# When set to true, the 'ENOSPC' error message will not cause the OpenSearch Dashboards process to crash. Otherwise,
+# the original behavior will be maintained. It is disabled by default.
+# logging.ignoreEnospcError: false
+
 # Set the value of this setting to true to suppress all logging output.
 # logging.silent: false
 

--- a/config/opensearch_dashboards-default.x.yml
+++ b/config/opensearch_dashboards-default.x.yml
@@ -103,6 +103,11 @@
 # Enables you to specify a file where OpenSearch Dashboards stores log output.
 # logging.dest: stdout
 
+# 2.15 Ignore 'ENOSPC' error for logging stream.
+# When set to true, the 'ENOSPC' error message will not cause the OpenSearch Dashboards process to crash. Otherwise,
+# the original behavior will be maintained. It is disabled by default.
+# logging.ignoreEnospcError: false
+
 # Set the value of this setting to true to suppress all logging output.
 # logging.silent: false
 

--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-2.x.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-2.x.sh
@@ -61,6 +61,7 @@ opensearch_dashboards_vars=(
     opensearchDashboards.defaultAppId
     opensearchDashboards.index
     logging.dest
+    logging.ignoreEnospcError
     logging.json
     logging.quiet
     logging.rotate.enabled

--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-default.x.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-default.x.sh
@@ -61,6 +61,7 @@ opensearch_dashboards_vars=(
     opensearchDashboards.defaultAppId
     opensearchDashboards.index
     logging.dest
+    logging.ignoreEnospcError
     logging.json
     logging.quiet
     logging.rotate.enabled


### PR DESCRIPTION
### Description
Update configs and entrypoint for logging.ignoreEnospcError in 2.15.0

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6733

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
