### PR TITLE
Exclude `functionalTestDashboards` repo in manifest lock

### DIFF
--- a/jenkins/release-manifest-commit-lock/release-manifest-commit-lock.jenkinsfile
+++ b/jenkins/release-manifest-commit-lock/release-manifest-commit-lock.jenkinsfile
@@ -78,11 +78,16 @@ pipeline {
                             params.COMPONENTS.split(',').any { it.trim() == component.name }
                         }
                         selectedComponents.each { componentName ->
-                            def existingComponent = existingManifest.components.find { it.name == componentName.name }
-                            if (existingComponent) {
-                                def newComponentRef = buildManifest.components.find { it.name == componentName.name }?.commit_id
-                                if (newComponentRef) {
-                                    existingComponent.ref = newComponentRef
+                        // Excluding FT repo from locking the commit and continue to use the release branch.
+                            if (componentName.name != "functionalTestDashboards") {
+                                def existingComponent = existingManifest.components.find { it.name == componentName.name }
+                                if (existingComponent) {
+                                    if (existingComponent != 'functionalTestDashboards') {
+                                        def newComponentRef = buildManifest.components.find { it.name == componentName.name }?.commit_id
+                                        if (newComponentRef) {
+                                            existingComponent.ref = newComponentRef
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -109,12 +114,15 @@ pipeline {
                             params.COMPONENTS.split(',').any { it.trim() == component.name }
                         }
                         selectedComponents.each { componentName ->
-                            def existingComponent = existingManifest.components.find { it.name == componentName.name }
-                            if (existingComponent) {
-                                def releaseBranch = params.RELEASE_VERSION.split('\\.')[0..1].join('.')
-                                def repoHeadCommit = sh(script: "git ls-remote ${componentName.repository} ${releaseBranch} | cut -f 1", returnStdout: true).trim()
-                                if (repoHeadCommit) {
-                                    existingComponent.ref = repoHeadCommit
+                        // Excluding FT repo from locking the commit and continue to use the release branch.
+                            if (componentName.name != "functionalTestDashboards") {
+                                def existingComponent = existingManifest.components.find { it.name == componentName.name }
+                                if (existingComponent) {
+                                    def releaseBranch = params.RELEASE_VERSION.split('\\.')[0..1].join('.')
+                                    def repoHeadCommit = sh(script: "git ls-remote ${componentName.repository} ${releaseBranch} | cut -f 1", returnStdout: true).trim()
+                                    if (repoHeadCommit) {
+                                        existingComponent.ref = repoHeadCommit
+                                    }
                                 }
                             }
                         }

--- a/tests/jenkins/TestReleaseManifestCommitLock.groovy
+++ b/tests/jenkins/TestReleaseManifestCommitLock.groovy
@@ -105,6 +105,19 @@ class TestReleaseManifestCommitLock extends BuildPipelineTest {
 
     }
 
+    @Test
+    public void test_excludeFTRepo() {
+        addParam('MANIFEST_LOCK_ACTION', 'UPDATE_TO_RECENT_COMMITS')
+        def buildManifest = "tests/jenkins/data/opensearch-dashboards-3.0.0.yml"
+        helper.registerAllowedMethod('readYaml', [Map.class], { args ->
+            return new Yaml().load((buildManifest as File).text)
+        }) 
+        super.testPipeline('jenkins/release-manifest-commit-lock/release-manifest-commit-lock.jenkinsfile',
+                'tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testUpdateToRecentCommit_excludeFTRepo')
+        // The test asserts that FT repo uses the release branch
+        assertCallStack().contains("release-manifest-commit-lock.writeYaml({file=manifests/2.0.0/opensearch-dashboards-2.0.0.yml, data={ci={image={name=opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028}}, build={name=OpenSearch Dashboards, version=3.0.0}, components=[{name=OpenSearch-Dashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/OpenSearch-Dashboards.git}, {name=functionalTestDashboards, repository=https://github.com/opensearch-project/opensearch-dashboards-functional-test.git, ref=3.0}, {name=observabilityDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-observability.git}, {name=indexManagementDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/index-management-dashboards-plugin}, {name=ganttChartDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-visualizations.git}, {name=reportsDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-reports.git}, {name=queryWorkbenchDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/sql.git}, {name=anomalyDetectionDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/anomaly-detection-dashboards-plugin}], schema-version=1.0}, overwrite=true})")
+    }
+
     def getShellCommands(searchtext) {
         def shCommands = helper.callStack.findAll { call ->
             call.methodName == 'sh'

--- a/tests/jenkins/data/opensearch-dashboards-3.0.0.yml
+++ b/tests/jenkins/data/opensearch-dashboards-3.0.0.yml
@@ -9,6 +9,9 @@ components:
   - name: OpenSearch-Dashboards
     ref: tags/3.0.0
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+  - name: functionalTestDashboards
+    repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
+    ref: '3.0'
   - name: observabilityDashboards
     ref: tags/3.0.0
     repository: https://github.com/opensearch-project/dashboards-observability.git

--- a/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testUpdateToRecentCommit_excludeFTRepo.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testUpdateToRecentCommit_excludeFTRepo.txt
@@ -1,0 +1,43 @@
+   release-manifest-commit-lock.run()
+      release-manifest-commit-lock.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
+      release-manifest-commit-lock.library({identifier=jenkins@6.4.0, retriever=null})
+      release-manifest-commit-lock.pipeline(groovy.lang.Closure)
+         release-manifest-commit-lock.timeout({time=2, unit=HOURS})
+         release-manifest-commit-lock.echo(Executing on agent [docker:[alwaysPull:true, args:, containerPerStageRoot:false, label:Jenkins-Agent-AL2023-X64-C54xlarge-Docker-Host, image:opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3, reuseNode:false, registryUrl:https://public.ecr.aws/, stages:[:]]])
+         release-manifest-commit-lock.stage(Parameters Check, groovy.lang.Closure)
+            release-manifest-commit-lock.script(groovy.lang.Closure)
+         release-manifest-commit-lock.echo(Skipping stage MATCH_BUILD_MANIFEST)
+         release-manifest-commit-lock.stage(UPDATE_TO_RECENT_COMMITS, groovy.lang.Closure)
+            release-manifest-commit-lock.script(groovy.lang.Closure)
+               release-manifest-commit-lock.readYaml({file=manifests/2.0.0/opensearch-2.0.0.yml})
+               release-manifest-commit-lock.writeYaml({file=manifests/2.0.0/opensearch-2.0.0.yml, data={ci={image={name=opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028}}, build={name=OpenSearch Dashboards, version=3.0.0}, components=[{name=OpenSearch-Dashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/OpenSearch-Dashboards.git}, {name=functionalTestDashboards, repository=https://github.com/opensearch-project/opensearch-dashboards-functional-test.git, ref=3.0}, {name=observabilityDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-observability.git}, {name=indexManagementDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/index-management-dashboards-plugin}, {name=ganttChartDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-visualizations.git}, {name=reportsDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-reports.git}, {name=queryWorkbenchDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/sql.git}, {name=anomalyDetectionDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/anomaly-detection-dashboards-plugin}], schema-version=1.0}, overwrite=true})
+               release-manifest-commit-lock.sh(
+                                yq eval -i '.' manifests/2.0.0/opensearch-2.0.0.yml
+                                sed -i '1s/^/---\n/' manifests/2.0.0/opensearch-2.0.0.yml
+                        )
+               release-manifest-commit-lock.readYaml({file=manifests/2.0.0/opensearch-dashboards-2.0.0.yml})
+               release-manifest-commit-lock.writeYaml({file=manifests/2.0.0/opensearch-dashboards-2.0.0.yml, data={ci={image={name=opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028}}, build={name=OpenSearch Dashboards, version=3.0.0}, components=[{name=OpenSearch-Dashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/OpenSearch-Dashboards.git}, {name=functionalTestDashboards, repository=https://github.com/opensearch-project/opensearch-dashboards-functional-test.git, ref=3.0}, {name=observabilityDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-observability.git}, {name=indexManagementDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/index-management-dashboards-plugin}, {name=ganttChartDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-visualizations.git}, {name=reportsDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-reports.git}, {name=queryWorkbenchDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/sql.git}, {name=anomalyDetectionDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/anomaly-detection-dashboards-plugin}], schema-version=1.0}, overwrite=true})
+               release-manifest-commit-lock.sh(
+                                yq eval -i '.' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+                                sed -i '1s/^/---\n/' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
+                        )
+         release-manifest-commit-lock.stage(Create Pull Request, groovy.lang.Closure)
+            release-manifest-commit-lock.script(groovy.lang.Closure)
+               release-manifest-commit-lock.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
+               release-manifest-commit-lock.withCredentials([[GITHUB_USER, GITHUB_TOKEN]], groovy.lang.Closure)
+                  release-manifest-commit-lock.sh(
+                                git remote set-url origin "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build"
+                                git config user.email "opensearch-infra@amazon.com"
+                                git config user.name "opensearch-ci"
+                                git checkout -b manifest-lock
+                            )
+                  release-manifest-commit-lock.sh({returnStdout=true, script=git status --porcelain})
+                  release-manifest-commit-lock.sh(
+                                    git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
+                                    git commit -sm "Manifest Commit Lock for Release 2.0.0"
+                                    git push origin manifest-lock --force
+                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_RECENT_COMMITS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
+                                )
+         release-manifest-commit-lock.script(groovy.lang.Closure)
+            release-manifest-commit-lock.postCleanup()
+               postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})


### PR DESCRIPTION
### Description
Exclude `functionalTestDashboards` repo in manifest lock
Sample test PR: https://github.com/prudhvigodithi/opensearch-build/pull/101

### Issues Resolved
Coming from this PR https://github.com/opensearch-project/opensearch-build/pull/4419 and Part of https://github.com/opensearch-project/opensearch-build/issues/4561.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
