### PR TITLE
Update gradle publish to handle invokeType

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@6.4.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.4.6', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -147,7 +147,31 @@ pipeline {
                     junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
                     archiveArtifacts artifacts: 'codeCoverage.xml', onlyIfSuccessful: true
                     script {
-                        publishGradleCheckTestResults(prNumber: "${pr_number}", prDescription: "${pr_title}")
+                        def invokedBy
+                        def pullRequest
+                        def pullRequestTitle
+                        switch (true) {
+                            case env.BUILD_CAUSE.contains('Started by user'):
+                                invokedBy = 'User'
+                                pullRequest = "${GIT_REFERENCE}"
+                                pullRequestTitle = "Null"
+                                break
+                            case env.BUILD_CAUSE.contains('Started by timer'):
+                                invokedBy = 'Timer'
+                                pullRequest = "${GIT_REFERENCE}"
+                                pullRequestTitle = "Null"
+                                break
+                            case "${pr_number}" == "Null":
+                                invokedBy = 'Post Merge Action'
+                                pullRequest = "${GIT_REFERENCE}"
+                                pullRequestTitle = "${pr_title}"
+                                break
+                            default:
+                                invokedBy = 'Pull Request'
+                                pullRequest = "${pr_number}"
+                                pullRequestTitle = "${pr_title}"
+                        }
+                        publishGradleCheckTestResults(prNumber: "${pullRequest}" , prDescription: "${pr_title}", invokeType: "${invokedBy}")
                         sh("rm -rf *")
                         postCleanup()
                     }


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/opensearch-build-libraries/pull/423/files, update gradle publish library to handle invokeType and not error out when invoked by parameterizedCron or manually triggered by user.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4708 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
