### PR TITLE
Explicitly set up CXX env for knn in AL2 build env

### DIFF
--- a/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
@@ -105,6 +105,7 @@ RUN yum install -y gcc10* && \
     update-alternatives --install /usr/bin/gcc gcc $(which gcc10-gcc) 1 && \
     update-alternatives --install /usr/bin/g++ g++ $(which gcc10-g++) 1
 ENV FC=gcc10-gfortran
+ENV CXX=g++
 
 # Change User
 USER $CONTAINER_USER


### PR DESCRIPTION
### Description
Explicitly set up CXX env with g++ for knn in AL2 build env.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4379

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
