### PR TITLE
Update the gradle-check.jenkinsfile library version to 6.4.8

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@6.4.7', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.4.8', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Update the gradle-check.jenkinsfile library version to 6.4.8 which has the new mapping updates for library `publishGradleCheckTestResults.groovy`.
https://github.com/opensearch-project/opensearch-build-libraries/releases/tag/6.4.8

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/11217

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
