### PR TITLE
Update github ci checks opensearch build image to al2

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -58,7 +58,7 @@ Release blog is ready | :red_circle: |   |
 
 ### [Campaigns](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#campaigns)
 
-- [ ] [Component Release Issue](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#component-release-issue).
+- [ ] [Component Release Issue](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#component-release-issues).
 - [ ] [Release Campaigns](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#release-campaigns).
 
 ### [Release Branch and Version Increment](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#release-branch-readiness) - _Ends __REPLACE_RELEASE-minus-4-days__

--- a/.github/workflows/get-ci-image-tag.yml
+++ b/.github/workflows/get-ci-image-tag.yml
@@ -50,7 +50,7 @@ jobs:
           TYPE=${{ inputs.type }}
           if [[ -z "$PLATFORM" ]]; then
               if [[ "$PRODUCT" = "opensearch" ]]; then
-                  PLATFORM="centos7" # Temp measure before centos7 deprecation on opensearch for k-NN
+                  PLATFORM="al2" # Temp measure before al2 deprecation on opensearch for k-NN
               else
                   PLATFORM="almalinux8"
               fi

--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -24,8 +24,8 @@ pipeline {
     triggers {
         parameterizedCron '''
             H 1 * * * %INPUT_MANIFEST=2.14.1/opensearch-2.14.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H 1 * * * %INPUT_MANIFEST=2.15.0/opensearch-2.15.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H 1 * * * %INPUT_MANIFEST=2.15.0/opensearch-dashboards-2.15.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
+            H */6 * * * %INPUT_MANIFEST=2.15.0/opensearch-2.15.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
+            H */6 * * * %INPUT_MANIFEST=2.15.0/opensearch-dashboards-2.15.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''


### PR DESCRIPTION
### Description
Update github ci checks opensearch build image to al2

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4379
https://github.com/opensearch-project/opensearch-build/issues/4681

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
