### PR TITLE
Update 2.14 manifests to use tags after release

### DIFF
--- a/manifests/2.14.0/opensearch-2.14.0.yml
+++ b/manifests/2.14.0/opensearch-2.14.0.yml
@@ -10,34 +10,34 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: aaa555453f4713d652b52436874e11ba258d8f03
+    ref: tags/2.14.0
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: 7531f1e853db28ca9deead97be053d58da7a7a9c
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: 7f9a2b120d9c7ff3422705be1b8fe4e7959bbd2a
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: 435856c919e4e92cf030fbdadc11bf87dd991543
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: bd1c99f2496c9671482a7177d906c661a2666b16
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
   - name: geospatial
     repository: https://github.com/opensearch-project/geospatial.git
-    ref: 365ed5f86cc41c0736f42cec198a44ce8cded9ba
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -45,7 +45,7 @@ components:
       - job-scheduler
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: 487ff81f29f3738b8ccaec92bc88fe8303a43576
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -53,7 +53,7 @@ components:
       - common-utils
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: 5cbeaa4645d32d759cd7176a836200ba14df9318
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -61,7 +61,7 @@ components:
       - common-utils
   - name: neural-search
     repository: https://github.com/opensearch-project/neural-search.git
-    ref: c95fe26b21ea90537639beb17ab1cb1defc30550
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -70,7 +70,7 @@ components:
       - k-NN
   - name: notifications-core
     repository: https://github.com/opensearch-project/notifications.git
-    ref: dc8a208a3d978c337113543c65ffac04ba1fb7cb
+    ref: tags/2.14.0.0
     working_directory: notifications
     platforms:
       - linux
@@ -79,7 +79,7 @@ components:
       - common-utils
   - name: notifications
     repository: https://github.com/opensearch-project/notifications.git
-    ref: dc8a208a3d978c337113543c65ffac04ba1fb7cb
+    ref: tags/2.14.0.0
     working_directory: notifications
     platforms:
       - linux
@@ -88,7 +88,7 @@ components:
       - common-utils
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: 8bd76309acdd7d8d45d292c6f53f67399d39e34b
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -96,7 +96,7 @@ components:
       - common-utils
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: c487fa37c54e2cdc10f56843efb6a0ebb60b3259
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -105,7 +105,7 @@ components:
       - job-scheduler
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: 7c7465c4318b06a00b56b11c026feab8a0496027
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -113,7 +113,7 @@ components:
       - ml-commons
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: f8121394f960d46842437ebcbdd17c5bb3d3022b
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -121,7 +121,7 @@ components:
       - common-utils
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: be2cce3d08062831cd5c86a421bd93d6f45b84ab
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -130,7 +130,7 @@ components:
       - job-scheduler
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: cb4ff3ee639e57695ca24d2ad27b6f6bb6e41914
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -138,7 +138,7 @@ components:
       - common-utils
   - name: security-analytics
     repository: https://github.com/opensearch-project/security-analytics.git
-    ref: ddbe6eddf83e0a6fa8b0e896e3173ac08262da14
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -146,7 +146,7 @@ components:
       - common-utils
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: fa05d71719e01ae5376d570f6db7f08d3886497d
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -155,18 +155,18 @@ components:
       - job-scheduler
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: 33e701d8070a8add7d14ae430880553adaa34d38
+    ref: tags/2.14.0.0
     platforms:
       - linux
   - name: custom-codecs
     repository: https://github.com/opensearch-project/custom-codecs.git
-    ref: df79b5d36f79e27a5a321bedc318f510a0f698b1
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
   - name: flow-framework
     repository: https://github.com/opensearch-project/flow-framework.git
-    ref: d94bc9461414d19a05a00c5eb85e2200f916faf1
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows
@@ -174,7 +174,7 @@ components:
       - common-utils
   - name: skills
     repository: https://github.com/opensearch-project/skills.git
-    ref: eba9e1c2863891282de86af87af4310b5b6c4a78
+    ref: tags/2.14.0.0
     platforms:
       - linux
       - windows

--- a/manifests/2.14.0/opensearch-dashboards-2.14.0.yml
+++ b/manifests/2.14.0/opensearch-dashboards-2.14.0.yml
@@ -9,49 +9,49 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: 1dbbc2a2e911d58f935d289a28cac0488dd77fd7
+    ref: tags/2.14.0
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '2.14'
+    ref: tags/2.14.0
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
-    ref: 441168efbf84de020a9bead333bff2e39c2e9d5c
+    ref: tags/2.14.0.0
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
-    ref: 789cf188b37af4940b2e42be7c99ab48caf550bc
+    ref: tags/2.14.0.0
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
-    ref: 95ae6165d4f376d24e075afb11c043350fadceed
+    ref: tags/2.14.0.0
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
-    ref: 76e18c3b529d210705fadccec9eed6b873ed4bd9
+    ref: tags/2.14.0.0
   - name: customImportMapDashboards
     repository: https://github.com/opensearch-project/dashboards-maps.git
-    ref: 2793c3dc806681dad822fa80c60102b670c013d2
+    ref: tags/2.14.0.0
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
-    ref: 3bbf18cf02dbc7af11c48c27acee2df3b829e028
+    ref: tags/2.14.0.0
   - name: mlCommonsDashboards
     repository: https://github.com/opensearch-project/ml-commons-dashboards.git
-    ref: f53875b3fc4feac8a01686b41a4c6a749007d68a
+    ref: tags/2.14.0.0
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
-    ref: d78e146e1463dd5397202521a22e87163f32b3d3
+    ref: tags/2.14.0.0
   - name: notificationsDashboards
     repository: https://github.com/opensearch-project/dashboards-notifications.git
-    ref: 0ca301f8630f42f4eec53b15e0a8eda9fae91203
+    ref: tags/2.14.0.0
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: 150280dd766c0f45ad3e489aecfcab295f82ad60
+    ref: tags/2.14.0.0
   - name: securityAnalyticsDashboards
     repository: https://github.com/opensearch-project/security-analytics-dashboards-plugin.git
-    ref: e7f946de234cd304d871525eb0ecb14a5513547b
+    ref: tags/2.14.0.0
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: 5f1c9f485c2ef53e65ec0af04f217a4d4c5bce17
+    ref: tags/2.14.0.0
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
-    ref: a93f20b1a336f15034412777e69409504caecb94
+    ref: tags/2.14.0.0
   - name: assistantDashboards
     repository: https://github.com/opensearch-project/dashboards-assistant.git
-    ref: 1a02edfa6187bd981dce93d3f1f7211c46a029a4
+    ref: tags/2.14.0.0


### PR DESCRIPTION
### Description
Update 2.14 manifests to use tags after release

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4562

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
