### PR TITLE
Revert centos7 to al2 changes due to issues in 2.15.0

### DIFF
--- a/.github/workflows/get-ci-image-tag.yml
+++ b/.github/workflows/get-ci-image-tag.yml
@@ -50,7 +50,7 @@ jobs:
           TYPE=${{ inputs.type }}
           if [[ -z "$PLATFORM" ]]; then
               if [[ "$PRODUCT" = "opensearch" ]]; then
-                  PLATFORM="al2" # Temp measure before al2 deprecation on opensearch for k-NN
+                  PLATFORM="centos7" # Temp measure before al2 deprecation on opensearch for k-NN
               else
                   PLATFORM="almalinux8"
               fi

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -14,7 +14,7 @@ lib = library(identifier: 'jenkins@6.3.2', retriever: modernSCM([
 ]))
 
 def docker_images = [
-    'tar': 'opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1',
+    'tar': 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3',
     'rpm': 'opensearchstaging/ci-runner:ci-runner-almalinux8-systemd-base-integtest-v1',
     'deb': 'opensearchstaging/ci-runner:ci-runner-ubuntu2004-systemd-base-integtest-v3',
     'zip': 'opensearchstaging/ci-runner:ci-runner-windows2019-opensearch-build-v1',

--- a/manifests/2.15.0/opensearch-2.15.0.yml
+++ b/manifests/2.15.0/opensearch-2.15.0.yml
@@ -5,7 +5,7 @@ build:
   version: 2.15.0
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
     args: -e JAVA_HOME=/opt/java/openjdk-21
 components:
   - name: OpenSearch


### PR DESCRIPTION
### Description
Revert centos7 to al2 changes due to issues in 2.15.0

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4379#issuecomment-2161600573
https://github.com/opensearch-project/opensearch-build/issues/4681

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
