### PR TITLE
Add condition for OSD integ tests on deb and rpm

### DIFF
--- a/src/test_workflow/integ_test/distribution_deb.py
+++ b/src/test_workflow/integ_test/distribution_deb.py
@@ -46,7 +46,8 @@ class DistributionDeb(Distribution):
                 '--install',
                 bundle_name,
                 '&&',
-                f'sudo chmod 0666 {self.config_path} {os.path.dirname(self.config_path)}/jvm.options',
+                f'sudo chmod 0666 {self.config_path} {os.path.dirname(self.config_path)}/jvm.options'
+                if self.filename == "opensearch" else f'sudo chmod 0666 {self.config_path}',
                 '&&',
                 f'sudo chmod 0755 {os.path.dirname(self.config_path)} {self.log_dir}',
                 '&&',

--- a/src/test_workflow/integ_test/distribution_rpm.py
+++ b/src/test_workflow/integ_test/distribution_rpm.py
@@ -48,7 +48,8 @@ class DistributionRpm(Distribution):
                 '-y',
                 bundle_name,
                 '&&',
-                f'sudo chmod 0666 {self.config_path} {os.path.dirname(self.config_path)}/jvm.options',
+                f'sudo chmod 0666 {self.config_path} {os.path.dirname(self.config_path)}/jvm.options'
+                if self.filename == "opensearch" else f'sudo chmod 0666 {self.config_path}',
                 '&&',
                 f'sudo chmod 0755 {os.path.dirname(self.config_path)} {self.log_dir}',
                 '&&',

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
@@ -55,6 +55,25 @@ class TestDistributionDeb(unittest.TestCase):
             args_list[0][0][0],
         )
 
+    @patch("subprocess.check_call")
+    def test_install_opensearch_dashboards(self, check_call_mock: Mock) -> None:
+        self.distribution_deb_dashboards.install("opensearch-dashboards.deb")
+        args_list = check_call_mock.call_args_list
+
+        self.assertEqual(check_call_mock.call_count, 1)
+        self.assertEqual(
+            (
+                "sudo dpkg --purge opensearch-dashboards && "
+                "sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! "
+                "dpkg --install opensearch-dashboards.deb && "
+                f"sudo chmod 0666 {self.distribution_deb_dashboards.config_path} && "
+                f"sudo chmod 0755 {os.path.dirname(self.distribution_deb_dashboards.config_path)} {self.distribution_deb_dashboards.log_dir} && "
+                f"sudo usermod -a -G opensearch-dashboards `whoami` && "
+                f"sudo usermod -a -G adm `whoami`"
+            ),
+            args_list[0][0][0],
+        )
+
     def test_start_cmd(self) -> None:
         self.assertEqual(self.distribution_deb.start_cmd, "sudo systemctl start opensearch")
         self.assertEqual(self.distribution_deb_dashboards.start_cmd, "sudo systemctl start opensearch-dashboards")

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
@@ -55,6 +55,25 @@ class TestDistributionRpm(unittest.TestCase):
             args_list[0][0][0],
         )
 
+    @patch("subprocess.check_call")
+    def test_install_opensearch_dashboards(self, check_call_mock: Mock) -> None:
+        self.distribution_rpm_dashboards.install("opensearch-dashboards.rpm")
+        args_list = check_call_mock.call_args_list
+
+        self.assertEqual(check_call_mock.call_count, 1)
+        self.assertEqual(
+            (
+                "sudo yum remove -y opensearch-dashboards && "
+                "sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! "
+                "yum install -y opensearch-dashboards.rpm && "
+                f"sudo chmod 0666 {self.distribution_rpm_dashboards.config_path} && "
+                f"sudo chmod 0755 {os.path.dirname(self.distribution_rpm_dashboards.config_path)} {self.distribution_rpm_dashboards.log_dir} && "
+                f"sudo usermod -a -G opensearch-dashboards `whoami` && "
+                f"sudo usermod -a -G adm `whoami`"
+            ),
+            args_list[0][0][0],
+        )
+
     def test_start_cmd(self) -> None:
         self.assertEqual(self.distribution_rpm.start_cmd, "sudo systemctl start opensearch")
         self.assertEqual(self.distribution_rpm_dashboards.start_cmd, "sudo systemctl start opensearch-dashboards")


### PR DESCRIPTION
### Description
Add condition for OSD integ tests on deb and rpm

### Issues Resolved
Related to a issue we found here. https://github.com/opensearch-project/opensearch-build/pull/4662#issuecomment-2163750172

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
