### PR TITLE
Typo: wrong remote URL in `gradle-check-flaky-test-issue-creation.jenkinsfile`

### DIFF
--- a/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
+++ b/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
@@ -9,7 +9,7 @@
 
 lib = library(identifier: 'jenkins@6.5.0', retriever: modernSCM([
     $class: 'GitSCMSource',
-    remote: 'https://github.com/opensearch-build-libraries/opensearch-build-libraries.git',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
 
 


### PR DESCRIPTION
### Description
Coming from initial PR https://github.com/opensearch-project/opensearch-build/pull/4777, Typo: wrong remote URL in `gradle-check-flaky-test-issue-creation.jenkinsfile`

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/13950 and https://github.com/opensearch-project/opensearch-build-libraries/issues/441

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
