### PR TITLE
Raise osd integTest timeout to 6 hours due to OSD core length

### DIFF
--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -35,7 +35,7 @@ def agent_nodes = [
 
 pipeline {
     options {
-        timeout(time: 5, unit: 'HOURS')
+        timeout(time: 6, unit: 'HOURS')
         buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     agent none

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test-without-validation.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test-without-validation.jenkinsfile.txt
@@ -3,7 +3,7 @@
       integ-test.library({identifier=jenkins@6.3.2, retriever=null})
       integ-test.pipeline(groovy.lang.Closure)
          integ-test.credentials(jenkins-artifact-bucket-name)
-         integ-test.timeout({time=5, unit=HOURS})
+         integ-test.timeout({time=6, unit=HOURS})
          integ-test.logRotator({daysToKeepStr=30})
          integ-test.buildDiscarder(null)
          integ-test.echo(Executing on agent [label:none])

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
@@ -3,7 +3,7 @@
       integ-test.library({identifier=jenkins@6.3.2, retriever=null})
       integ-test.pipeline(groovy.lang.Closure)
          integ-test.credentials(jenkins-artifact-bucket-name)
-         integ-test.timeout({time=5, unit=HOURS})
+         integ-test.timeout({time=6, unit=HOURS})
          integ-test.logRotator({daysToKeepStr=30})
          integ-test.buildDiscarder(null)
          integ-test.echo(Executing on agent [label:none])


### PR DESCRIPTION
### Description
Raise osd integTest timeout to 6 hours due to OSD core length

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4681

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
