### PR TITLE
Update `gradle-check-flaky-test-issue-creation.jenkinsfile`.

### DIFF
--- a/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
+++ b/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@6.5.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.5.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -20,15 +20,17 @@ pipeline {
         buildDiscarder(logRotator(daysToKeepStr: '180'))
     }
     triggers {
-        parameterizedCron '''
-            H */8 * * *
-        '''
+        parameterizedCron('''
+            H */6 * * *
+        ''')
     }
     stages {
         stage('Detect Gradle Check Flaky Tests') {
             steps {
                 script {
-                    gradleCheckFlakyTestChecker()
+                    gradleCheckFlakyTestDetector(
+                        issueLabels: 'autocut,>test-failure,flaky-test'
+                    )
                 }
             }
         }


### PR DESCRIPTION
### Description
_Describe what this change achieves._
Use the appropriate name as `gradleCheckFlakyTestDetector` and fix the `parameterizedCron` coming from https://plugins.jenkins.io/parameterized-scheduler/
The build library change: https://github.com/opensearch-project/opensearch-build-libraries/pull/445 

### Issues Resolved
Coming from https://github.com/opensearch-project/OpenSearch/issues/13950#issuecomment-2168385765 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
