### PR TITLE
feat: split osd core test into ci groups

### DIFF
--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -186,7 +186,7 @@ pipeline {
                     echo "componentList: ${componentList}"
 
                     for (component_check in componentList) {
-                        if (!componentDefaultList.contains(component_check)) {
+                        if (!componentDefaultList.contains(component_check) && !component_check.startsWith("OpenSearch-Dashboards-ci-group-")) {
                            error("${component_check} is not in build manifest: ${componentDefaultList}, exit 1")
                         }
                     }

--- a/manifests/2.15.0/opensearch-dashboards-2.15.0-test.yml
+++ b/manifests/2.15.0/opensearch-dashboards-2.15.0-test.yml
@@ -5,7 +5,111 @@ ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v4
 components:
-  - name: OpenSearch-Dashboards
+  - name: OpenSearch-Dashboards-ci-group-1
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        vis_builder.enabled: true
+        data_source.enabled: true
+        savedObjects.maxImportPayloadBytes: 10485760
+        server.maxPayloadBytes: 1759977
+        logging.json: false
+        data.search.aggs.shardDelay.enabled: true
+        csp.warnLegacyBrowsers: false
+  - name: OpenSearch-Dashboards-ci-group-2
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        vis_builder.enabled: true
+        data_source.enabled: true
+        savedObjects.maxImportPayloadBytes: 10485760
+        server.maxPayloadBytes: 1759977
+        logging.json: false
+        data.search.aggs.shardDelay.enabled: true
+        csp.warnLegacyBrowsers: false
+  - name: OpenSearch-Dashboards-ci-group-3
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        vis_builder.enabled: true
+        data_source.enabled: true
+        savedObjects.maxImportPayloadBytes: 10485760
+        server.maxPayloadBytes: 1759977
+        logging.json: false
+        data.search.aggs.shardDelay.enabled: true
+        csp.warnLegacyBrowsers: false
+  - name: OpenSearch-Dashboards-ci-group-4
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        vis_builder.enabled: true
+        data_source.enabled: true
+        savedObjects.maxImportPayloadBytes: 10485760
+        server.maxPayloadBytes: 1759977
+        logging.json: false
+        data.search.aggs.shardDelay.enabled: true
+        csp.warnLegacyBrowsers: false
+  - name: OpenSearch-Dashboards-ci-group-5
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        vis_builder.enabled: true
+        data_source.enabled: true
+        savedObjects.maxImportPayloadBytes: 10485760
+        server.maxPayloadBytes: 1759977
+        logging.json: false
+        data.search.aggs.shardDelay.enabled: true
+        csp.warnLegacyBrowsers: false
+  - name: OpenSearch-Dashboards-ci-group-6
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        vis_builder.enabled: true
+        data_source.enabled: true
+        savedObjects.maxImportPayloadBytes: 10485760
+        server.maxPayloadBytes: 1759977
+        logging.json: false
+        data.search.aggs.shardDelay.enabled: true
+        csp.warnLegacyBrowsers: false
+  - name: OpenSearch-Dashboards-ci-group-7
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        vis_builder.enabled: true
+        data_source.enabled: true
+        savedObjects.maxImportPayloadBytes: 10485760
+        server.maxPayloadBytes: 1759977
+        logging.json: false
+        data.search.aggs.shardDelay.enabled: true
+        csp.warnLegacyBrowsers: false
+  - name: OpenSearch-Dashboards-ci-group-8
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        vis_builder.enabled: true
+        data_source.enabled: true
+        savedObjects.maxImportPayloadBytes: 10485760
+        server.maxPayloadBytes: 1759977
+        logging.json: false
+        data.search.aggs.shardDelay.enabled: true
+        csp.warnLegacyBrowsers: false
+  - name: OpenSearch-Dashboards-ci-group-9
     integ-test:
       test-configs:
         - with-security


### PR DESCRIPTION
### Description

OSD core contains more than 50 specs, with hundreds of tests getting ran sequentially. While many side effects are performed across test cases, It is usually the case that core dashboards test cases are failed or flaky, and hard to troubleshoot. In order to maintain a more stable test env and more reproducible CI, this PR split sanity test cases of core dashboards into CI groups.

In order to make this work, https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1411 has to be merged in advance.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
