### PR TITLE
Make endpoint_string one line for ccr test

### DIFF
--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -114,7 +114,7 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
                 endpoints_list = []
                 for cluster_details in cluster_endpoints:
                     endpoints_list.append(cluster_details.__dict__)
-                endpoints_string = json.dumps(endpoints_list, indent=0, default=custom_node_endpoint_encoder)
+                endpoints_string = json.dumps(endpoints_list, indent=0, default=custom_node_endpoint_encoder).replace("\n", "")
                 cmd = f"bash {script} -e '"
                 cmd = cmd + endpoints_string + "'"
                 cmd = cmd + f" -s {str(security).lower()} -v {self.bundle_manifest.build.version}"


### PR DESCRIPTION
### Description
Make endpoint_string one line for ccr test

On Windows, it could not able to handle multi-line parameters well like on *nix system through bash.exe.

Therefore, we will group the entire json into one line.

https://ci.opensearch.org/ci/dbc/integ-test/2.15.0/9992/windows/x64/zip/test-results/[…]nteg-test/cross-cluster-replication/with-security/stderr.txt

https://ci.opensearch.org/ci/dbc/integ-test/2.15.0/9992/windows/x64/zip/test-results/[…]nteg-test/cross-cluster-replication/with-security/stdout.txt

https://build.ci.opensearch.org/blue/rest/organizations/jenkins/pipelines/integ-test/runs/8299/nodes/112/steps/500/log/?start=0

Thanks.

### Issues Resolved
#4681
https://github.com/opensearch-project/cross-cluster-replication/issues/1395

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
