### PR TITLE
add ci-groups changes for OSD tests

### DIFF
--- a/manifests/2.15.0/opensearch-dashboards-2.15.0-test.yml
+++ b/manifests/2.15.0/opensearch-dashboards-2.15.0-test.yml
@@ -18,6 +18,7 @@ components:
         logging.json: false
         data.search.aggs.shardDelay.enabled: true
         csp.warnLegacyBrowsers: false
+      ci-groups: 9
   - name: alertingDashboards
     integ-test:
       test-configs:

--- a/src/manifests/test_manifest.py
+++ b/src/manifests/test_manifest.py
@@ -77,6 +77,7 @@ class TestManifest(ComponentManifest['TestManifest', 'TestComponents']):
                             },
                             "test-configs": {"type": "list", "allowed": ["with-security", "without-security"]},
                             "additional-cluster-configs": {"type": "dict"},
+                            "ci-groups": {"type": "integer"}
                         },
                     },
                     "bwc-test": {

--- a/src/test_workflow/integ_test/integ_test_runner.py
+++ b/src/test_workflow/integ_test/integ_test_runner.py
@@ -43,10 +43,19 @@ class IntegTestRunner(abc.ABC):
                 if component.name in self.test_manifest.components:
                     test_config = self.test_manifest.components[component.name]
                     if test_config.integ_test:
-                        test_suite = self.__create_test_suite__(component, test_config, work_dir.path)
-                        test_results = test_suite.execute_tests()
-                        [self.test_recorder.test_results_logs.generate_component_yml(result_data) for result_data in test_suite.result_data]
-                        all_results.append(component.name, test_results)
+                        if 'ci-groups' in test_config.integ_test.keys():
+                            orig_component_name = component.name
+                            for i in range(1, test_config.integ_test['ci-groups'] + 1):
+                                component.name = f"{orig_component_name}-ci-group-{i}"
+                                test_suite = self.__create_test_suite__(component, test_config, work_dir.path)
+                                test_results = test_suite.execute_tests()
+                                [self.test_recorder.test_results_logs.generate_component_yml(result_data) for result_data in test_suite.result_data]
+                                all_results.append(component.name, test_results)
+                        else:
+                            test_suite = self.__create_test_suite__(component, test_config, work_dir.path)
+                            test_results = test_suite.execute_tests()
+                            [self.test_recorder.test_results_logs.generate_component_yml(result_data) for result_data in test_suite.result_data]
+                            all_results.append(component.name, test_results)
                     else:
                         logging.info(f"Skipping integ-tests for {component.name}, as it is currently not supported")
                 else:


### PR DESCRIPTION
### Description
This PR adds support to split integration test specs for  OSD or any other component in the FT repo into multiple groups. For now the ci-groups will be run in sequence. We can take an action item after 2.15 release to run them in parallel. This change will not require any update in the jenkinsfile for integ-test. 

https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1411 needs to be merged and back-ported to 2.15 before this PR is merged. 
### Issues Resolved
#4745 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
