### PR TITLE
Pin OSB docker version to 1.6.0

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_test_suite.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite.py
@@ -46,7 +46,7 @@ class BenchmarkTestSuite:
         self.command = f'docker run --name docker-container-{self.args.stack_suffix}'
         if self.args.benchmark_config:
             self.command += f" -v {args.benchmark_config}:/opensearch-benchmark/.benchmark/benchmark.ini"
-        self.command += f" opensearchproject/opensearch-benchmark:latest execute-test --workload={self.args.workload} " \
+        self.command += f" opensearchproject/opensearch-benchmark:1.6.0 execute-test --workload={self.args.workload} " \
                         f"--pipeline=benchmark-only --target-hosts={endpoint}"
 
         if self.args.workload_params:

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
@@ -47,7 +47,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
             test_suite.execute()
         self.assertEqual(mock_check_call.call_count, 2)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:latest execute-test '
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.6.0 execute-test '
                          f'--workload=nyc_taxis --pipeline=benchmark-only --target-hosts=abc.com:80 --client-options="timeout:300"')
 
     @patch('test_workflow.benchmark_test.benchmark_test_suite.subprocess.check_call')
@@ -61,7 +61,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         mock_check_call.assert_called_with(
             f"docker rm docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:latest execute-test'
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.6.0 execute-test'
                          f' --workload=nyc_taxis --pipeline=benchmark-only '
                          f'--target-hosts=abc.com:443 '
                          f'--client-options="timeout:300,use_ssl:true,verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'myStrongPassword123!\'"')
@@ -77,7 +77,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         mock_check_call.assert_called_with(
             f"docker rm docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:latest execute-test '
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.6.0 execute-test '
                          '--workload=nyc_taxis --pipeline=benchmark-only '
                          '--target-hosts=abc.com:443 --client-options="timeout:300,use_ssl:true,'
                          'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'"')
@@ -99,7 +99,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:latest execute-test '
+                         'opensearchproject/opensearch-benchmark:1.6.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -120,7 +120,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:latest execute-test '
+                         'opensearchproject/opensearch-benchmark:1.6.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -142,7 +142,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:latest execute-test '
+                         'opensearchproject/opensearch-benchmark:1.6.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -166,7 +166,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:latest execute-test '
+                         'opensearchproject/opensearch-benchmark:1.6.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -189,7 +189,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
                 f"docker rm docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
             self.assertEqual(test_suite.command, f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                                                  '/opensearch-benchmark/.benchmark/benchmark.ini '
-                                                 'opensearchproject/opensearch-benchmark:latest execute-test '
+                                                 'opensearchproject/opensearch-benchmark:1.6.0 execute-test '
                                                  '--workload=nyc_taxis '
                                                  '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                                                  '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -212,7 +212,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         mock_check_call.assert_called_with(
             f"docker rm docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:latest execute-test '
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.6.0 execute-test '
                          '--workload=nyc_taxis --pipeline=benchmark-only '
                          '--target-hosts=abc.com:443 --client-options="timeout:300,use_ssl:true,'
                          'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'"')


### PR DESCRIPTION
### Description
The latest docker image for opensearch-benchmark is broken and benchmarks are failing with below error:
```
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```
Fixing image tag to 1.6.0 to unblock nightlies. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
