### PR TITLE
Add cleanup for the data dir after integtests

### DIFF
--- a/src/test_workflow/integ_test/distribution.py
+++ b/src/test_workflow/integ_test/distribution.py
@@ -43,6 +43,15 @@ class Distribution(ABC):
         pass
 
     @property
+    @abstractmethod
+    def data_dir(self) -> str:
+        """
+        Return the data directory for the distribution
+        """
+        pass
+
+    @property
+    @abstractmethod
     def log_dir(self) -> str:
         """
         Return the log directory for the distribution

--- a/src/test_workflow/integ_test/distribution_deb.py
+++ b/src/test_workflow/integ_test/distribution_deb.py
@@ -26,6 +26,10 @@ class DistributionDeb(Distribution):
         return os.path.join(os.sep, "etc", self.filename, self.config_filename)
 
     @property
+    def data_dir(self) -> str:
+        return os.path.join(os.sep, "var", "lib", self.filename)
+
+    @property
     def log_dir(self) -> str:
         return os.path.join(os.sep, "var", "log", self.filename)
 
@@ -38,6 +42,8 @@ class DistributionDeb(Distribution):
                 'dpkg',
                 '--purge',
                 self.filename,
+                '&&',
+                f'sudo rm -rf {os.path.dirname(self.config_path)} {self.data_dir} {self.log_dir}',
                 '&&',
                 'sudo',
                 'env',
@@ -64,4 +70,4 @@ class DistributionDeb(Distribution):
 
     def uninstall(self) -> None:
         logging.info(f"Uninstall {self.filename} package after the test")
-        subprocess.check_call(f"sudo dpkg --purge {self.filename} && sudo rm -rf {os.path.dirname(self.config_path)} {self.log_dir}", shell=True)
+        subprocess.check_call(f"sudo dpkg --purge {self.filename} && sudo rm -rf {os.path.dirname(self.config_path)} {self.data_dir} {self.log_dir}", shell=True)

--- a/src/test_workflow/integ_test/distribution_rpm.py
+++ b/src/test_workflow/integ_test/distribution_rpm.py
@@ -26,6 +26,10 @@ class DistributionRpm(Distribution):
         return os.path.join(os.sep, "etc", self.filename, self.config_filename)
 
     @property
+    def data_dir(self) -> str:
+        return os.path.join(os.sep, "var", "lib", self.filename)
+
+    @property
     def log_dir(self) -> str:
         return os.path.join(os.sep, "var", "log", self.filename)
 
@@ -39,6 +43,8 @@ class DistributionRpm(Distribution):
                 'remove',
                 '-y',
                 self.filename,
+                '&&',
+                f'sudo rm -rf {os.path.dirname(self.config_path)} {self.data_dir} {self.log_dir}',
                 '&&',
                 'sudo',
                 'env',
@@ -66,4 +72,4 @@ class DistributionRpm(Distribution):
 
     def uninstall(self) -> None:
         logging.info(f"Uninstall {self.filename} package after the test")
-        subprocess.check_call(f"sudo yum remove -y {self.filename} && sudo rm -rf {os.path.dirname(self.config_path)} {self.log_dir}", shell=True)
+        subprocess.check_call(f"sudo yum remove -y {self.filename} && sudo rm -rf {os.path.dirname(self.config_path)} {self.data_dir} {self.log_dir}", shell=True)

--- a/src/test_workflow/integ_test/distribution_tar.py
+++ b/src/test_workflow/integ_test/distribution_tar.py
@@ -26,6 +26,10 @@ class DistributionTar(Distribution):
         return os.path.join(self.install_dir, "config", self.config_filename)
 
     @property
+    def data_dir(self) -> str:
+        return os.path.join(self.install_dir, "data")
+
+    @property
     def log_dir(self) -> str:
         return os.path.join(self.install_dir, "logs")
 

--- a/src/test_workflow/integ_test/distribution_zip.py
+++ b/src/test_workflow/integ_test/distribution_zip.py
@@ -26,6 +26,10 @@ class DistributionZip(Distribution):
         return os.path.join(self.install_dir, "config", self.config_filename)
 
     @property
+    def data_dir(self) -> str:
+        return os.path.join(self.install_dir, "data")
+
+    @property
     def log_dir(self) -> str:
         return os.path.join(self.install_dir, "logs")
 

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
@@ -90,4 +90,10 @@ class TestDistributionDeb(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"sudo dpkg --purge opensearch && sudo rm -rf {os.path.dirname(self.distribution_deb.config_path)} {self.distribution_deb.data_dir} {self.distribution_deb.log_dir}", args_list[0][0][0])
+        self.assertEqual(
+            (
+                "sudo dpkg --purge opensearch && "
+                f"sudo rm -rf {os.path.dirname(self.distribution_deb.config_path)} {self.distribution_deb.data_dir} {self.distribution_deb.log_dir}"
+            ),
+            args_list[0][0][0],
+        )

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_deb.py
@@ -32,6 +32,10 @@ class TestDistributionDeb(unittest.TestCase):
         self.assertEqual(self.distribution_deb.config_path, os.path.join(os.sep, "etc", "opensearch", "opensearch.yml"))
         self.assertEqual(self.distribution_deb_dashboards.config_path, os.path.join(os.sep, "etc", "opensearch-dashboards", "opensearch_dashboards.yml"))
 
+    def test_data_dir(self) -> None:
+        self.assertEqual(self.distribution_deb.data_dir, os.path.join(os.sep, "var", "lib", "opensearch"))
+        self.assertEqual(self.distribution_deb_dashboards.data_dir, os.path.join(os.sep, "var", "lib", "opensearch-dashboards"))
+
     def test_log_dir(self) -> None:
         self.assertEqual(self.distribution_deb.log_dir, os.path.join(os.sep, "var", "log", "opensearch"))
         self.assertEqual(self.distribution_deb_dashboards.log_dir, os.path.join(os.sep, "var", "log", "opensearch-dashboards"))
@@ -45,6 +49,7 @@ class TestDistributionDeb(unittest.TestCase):
         self.assertEqual(
             (
                 "sudo dpkg --purge opensearch && "
+                f"sudo rm -rf {os.path.dirname(self.distribution_deb.config_path)} {self.distribution_deb.data_dir} {self.distribution_deb.log_dir} && "
                 "sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! "
                 "dpkg --install opensearch.deb && "
                 f"sudo chmod 0666 {self.distribution_deb.config_path} {os.path.dirname(self.distribution_deb.config_path)}/jvm.options && "
@@ -64,6 +69,7 @@ class TestDistributionDeb(unittest.TestCase):
         self.assertEqual(
             (
                 "sudo dpkg --purge opensearch-dashboards && "
+                f"sudo rm -rf {os.path.dirname(self.distribution_deb_dashboards.config_path)} {self.distribution_deb_dashboards.data_dir} {self.distribution_deb_dashboards.log_dir} && "
                 "sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! "
                 "dpkg --install opensearch-dashboards.deb && "
                 f"sudo chmod 0666 {self.distribution_deb_dashboards.config_path} && "
@@ -84,4 +90,4 @@ class TestDistributionDeb(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"sudo dpkg --purge opensearch && sudo rm -rf {os.path.dirname(self.distribution_deb.config_path)} {self.distribution_deb.log_dir}", args_list[0][0][0])
+        self.assertEqual(f"sudo dpkg --purge opensearch && sudo rm -rf {os.path.dirname(self.distribution_deb.config_path)} {self.distribution_deb.data_dir} {self.distribution_deb.log_dir}", args_list[0][0][0])

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
@@ -32,7 +32,6 @@ class TestDistributionRpm(unittest.TestCase):
         self.assertEqual(self.distribution_rpm.config_path, os.path.join(os.sep, "etc", "opensearch", "opensearch.yml"))
         self.assertEqual(self.distribution_rpm_dashboards.config_path, os.path.join(os.sep, "etc", "opensearch-dashboards", "opensearch_dashboards.yml"))
 
-
     def test_data_dir(self) -> None:
         self.assertEqual(self.distribution_rpm.data_dir, os.path.join(os.sep, "var", "lib", "opensearch"))
         self.assertEqual(self.distribution_rpm_dashboards.data_dir, os.path.join(os.sep, "var", "lib", "opensearch-dashboards"))
@@ -91,4 +90,10 @@ class TestDistributionRpm(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"sudo yum remove -y opensearch && sudo rm -rf {os.path.dirname(self.distribution_rpm.config_path)} {self.distribution_rpm.data_dir} {self.distribution_rpm.log_dir}", args_list[0][0][0])
+        self.assertEqual(
+            (
+                "sudo yum remove -y opensearch && "
+                f"sudo rm -rf {os.path.dirname(self.distribution_rpm.config_path)} {self.distribution_rpm.data_dir} {self.distribution_rpm.log_dir}"
+            ),
+            args_list[0][0][0],
+        )

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_rpm.py
@@ -32,6 +32,11 @@ class TestDistributionRpm(unittest.TestCase):
         self.assertEqual(self.distribution_rpm.config_path, os.path.join(os.sep, "etc", "opensearch", "opensearch.yml"))
         self.assertEqual(self.distribution_rpm_dashboards.config_path, os.path.join(os.sep, "etc", "opensearch-dashboards", "opensearch_dashboards.yml"))
 
+
+    def test_data_dir(self) -> None:
+        self.assertEqual(self.distribution_rpm.data_dir, os.path.join(os.sep, "var", "lib", "opensearch"))
+        self.assertEqual(self.distribution_rpm_dashboards.data_dir, os.path.join(os.sep, "var", "lib", "opensearch-dashboards"))
+
     def test_log_dir(self) -> None:
         self.assertEqual(self.distribution_rpm.log_dir, os.path.join(os.sep, "var", "log", "opensearch"))
         self.assertEqual(self.distribution_rpm_dashboards.log_dir, os.path.join(os.sep, "var", "log", "opensearch-dashboards"))
@@ -45,6 +50,7 @@ class TestDistributionRpm(unittest.TestCase):
         self.assertEqual(
             (
                 "sudo yum remove -y opensearch && "
+                f"sudo rm -rf {os.path.dirname(self.distribution_rpm.config_path)} {self.distribution_rpm.data_dir} {self.distribution_rpm.log_dir} && "
                 "sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! "
                 "yum install -y opensearch.rpm && "
                 f"sudo chmod 0666 {self.distribution_rpm.config_path} {os.path.dirname(self.distribution_rpm.config_path)}/jvm.options && "
@@ -64,6 +70,7 @@ class TestDistributionRpm(unittest.TestCase):
         self.assertEqual(
             (
                 "sudo yum remove -y opensearch-dashboards && "
+                f"sudo rm -rf {os.path.dirname(self.distribution_rpm_dashboards.config_path)} {self.distribution_rpm_dashboards.data_dir} {self.distribution_rpm_dashboards.log_dir} && "
                 "sudo env OPENSEARCH_INITIAL_ADMIN_PASSWORD=myStrongPassword123! "
                 "yum install -y opensearch-dashboards.rpm && "
                 f"sudo chmod 0666 {self.distribution_rpm_dashboards.config_path} && "
@@ -84,4 +91,4 @@ class TestDistributionRpm(unittest.TestCase):
         args_list = check_call_mock.call_args_list
 
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual(f"sudo yum remove -y opensearch && sudo rm -rf {os.path.dirname(self.distribution_rpm.config_path)} {self.distribution_rpm.log_dir}", args_list[0][0][0])
+        self.assertEqual(f"sudo yum remove -y opensearch && sudo rm -rf {os.path.dirname(self.distribution_rpm.config_path)} {self.distribution_rpm.data_dir} {self.distribution_rpm.log_dir}", args_list[0][0][0])

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_tar.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_tar.py
@@ -34,6 +34,10 @@ class TestDistributionTar(unittest.TestCase):
         self.assertEqual(self.distribution_tar.config_path, os.path.join(self.work_dir, "opensearch-1.3.0", "config", "opensearch.yml"))
         self.assertEqual(self.distribution_tar_dashboards.config_path, os.path.join(self.work_dir, "opensearch-dashboards-1.3.0", "config", "opensearch_dashboards.yml"))
 
+    def test_data_dir(self) -> None:
+        self.assertEqual(self.distribution_tar.data_dir, os.path.join(self.work_dir, "opensearch-1.3.0", "data"))
+        self.assertEqual(self.distribution_tar_dashboards.data_dir, os.path.join(self.work_dir, "opensearch-dashboards-1.3.0", "data"))
+
     def test_log_dir(self) -> None:
         self.assertEqual(self.distribution_tar.log_dir, os.path.join(self.work_dir, "opensearch-1.3.0", "logs"))
         self.assertEqual(self.distribution_tar_dashboards.log_dir, os.path.join(self.work_dir, "opensearch-dashboards-1.3.0", "logs"))

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_zip.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_distribution_zip.py
@@ -37,6 +37,10 @@ class TestDistributionZipOpenSearch(unittest.TestCase):
         self.assertEqual(self.distribution_zip.config_path, os.path.join(self.work_dir, f"{self.product}-{self.version}", "config", "opensearch.yml"))
         self.assertEqual(self.distribution_zip_dashboards.config_path, os.path.join(self.work_dir, f"{self.product_dashboards}-{self.version}", "config", "opensearch_dashboards.yml"))
 
+    def test_data_dir(self) -> None:
+        self.assertEqual(self.distribution_zip.data_dir, os.path.join(self.work_dir, f"{self.product}-{self.version}", "data"))
+        self.assertEqual(self.distribution_zip_dashboards.data_dir, os.path.join(self.work_dir, f"{self.product_dashboards}-{self.version}", "data"))
+
     def test_log_dir(self) -> None:
         self.assertEqual(self.distribution_zip.log_dir, os.path.join(self.work_dir, f"{self.product}-{self.version}", "logs"))
         self.assertEqual(self.distribution_zip_dashboards.log_dir, os.path.join(self.work_dir, f"{self.product_dashboards}-{self.version}", "logs"))


### PR DESCRIPTION
### Description
Add cleanup for the data dir after integtests

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4745
https://github.com/opensearch-project/opensearch-build/issues/4681

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
