### PR TITLE
Switch 2.15.0 input manifest from commit ids to tags

### DIFF
--- a/manifests/2.15.0/opensearch-2.15.0.yml
+++ b/manifests/2.15.0/opensearch-2.15.0.yml
@@ -10,34 +10,34 @@ ci:
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git
-    ref: 61dbcd0795c9bfe9b81e5762175414bc38bbcadf
+    ref: tags/2.15.0
   - name: common-utils
     repository: https://github.com/opensearch-project/common-utils.git
-    ref: 4e407bd981929cb332f708bcf0acc87f9a3beb99
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
-    ref: 1963c998b0face391dfff8e16d19f5abeea96797
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
   - name: security
     repository: https://github.com/opensearch-project/security.git
-    ref: 96743013767dd7e57e88de7ef1dae01b9545b01c
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
   - name: k-NN
     repository: https://github.com/opensearch-project/k-NN.git
-    ref: 150c589849a8ec3bc442d830b43a3eaf4e25fa0c
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
   - name: geospatial
     repository: https://github.com/opensearch-project/geospatial.git
-    ref: ee4289213d72c63fec47758b74ab6c6376c216c9
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -45,7 +45,7 @@ components:
       - job-scheduler
   - name: cross-cluster-replication
     repository: https://github.com/opensearch-project/cross-cluster-replication.git
-    ref: f4af360f50d8335dcbf974001ea577f3b7428e25
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -53,7 +53,7 @@ components:
       - common-utils
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: 63aeaabd5a4e42a24a28044abf37b38bca3400af
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -61,7 +61,7 @@ components:
       - common-utils
   - name: neural-search
     repository: https://github.com/opensearch-project/neural-search.git
-    ref: e683e7455a1091d20ee5903bd115059f147870e3
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -70,7 +70,7 @@ components:
       - k-NN
   - name: notifications-core
     repository: https://github.com/opensearch-project/notifications.git
-    ref: aa9b6c464754f95fdb791ba9d7e29fa9c04293ac
+    ref: tags/2.15.0.0
     working_directory: notifications
     platforms:
       - linux
@@ -79,7 +79,7 @@ components:
       - common-utils
   - name: notifications
     repository: https://github.com/opensearch-project/notifications.git
-    ref: aa9b6c464754f95fdb791ba9d7e29fa9c04293ac
+    ref: tags/2.15.0.0
     working_directory: notifications
     platforms:
       - linux
@@ -88,7 +88,7 @@ components:
       - common-utils
   - name: opensearch-observability
     repository: https://github.com/opensearch-project/observability.git
-    ref: 2ec046b2e324c5de8acb0abb37efde3b4c6d8e0d
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -96,7 +96,7 @@ components:
       - common-utils
   - name: opensearch-reports
     repository: https://github.com/opensearch-project/reporting.git
-    ref: 50451382b671ac84081a5e48a3661cf6d1b1434b
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -105,7 +105,7 @@ components:
       - job-scheduler
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: aa606a944e5b31a32029fc25d3004154e08db197
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -113,7 +113,7 @@ components:
       - ml-commons
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
-    ref: 295bd1c831f64906709d6e25b6ad0d9bab2f45fb
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -121,7 +121,7 @@ components:
       - common-utils
   - name: anomaly-detection
     repository: https://github.com/opensearch-project/anomaly-detection.git
-    ref: f6d262e2d3a20309adc8ab2bbcb1248defc3a190
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -130,7 +130,7 @@ components:
       - job-scheduler
   - name: alerting
     repository: https://github.com/opensearch-project/alerting.git
-    ref: 82fea192437d305dbb1ae07536fee05e8f13ace2
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -138,7 +138,7 @@ components:
       - common-utils
   - name: security-analytics
     repository: https://github.com/opensearch-project/security-analytics.git
-    ref: c0de31a0e99bfc3ab8201706e4d8d74db8a0f4e6
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -146,7 +146,7 @@ components:
       - common-utils
   - name: index-management
     repository: https://github.com/opensearch-project/index-management.git
-    ref: ce7ee04856aeb18a5fa232a802f85b5d97fecc00
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -155,18 +155,18 @@ components:
       - job-scheduler
   - name: performance-analyzer
     repository: https://github.com/opensearch-project/performance-analyzer.git
-    ref: 837bfe8a6ed11eb8a8a8b6ffc0049b8f4984a1b6
+    ref: tags/2.15.0.0
     platforms:
       - linux
   - name: custom-codecs
     repository: https://github.com/opensearch-project/custom-codecs.git
-    ref: 0d32cb08e8e326a6968b87961f7284311ad301ba
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
   - name: flow-framework
     repository: https://github.com/opensearch-project/flow-framework.git
-    ref: 1d01add552ad457074e5bf76a11112b5678c7ba3
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows
@@ -174,7 +174,7 @@ components:
       - common-utils
   - name: skills
     repository: https://github.com/opensearch-project/skills.git
-    ref: 27962077bc0afbb50cf4443c55b8cb81b76ecd85
+    ref: tags/2.15.0.0
     platforms:
       - linux
       - windows

--- a/manifests/2.15.0/opensearch-dashboards-2.15.0.yml
+++ b/manifests/2.15.0/opensearch-dashboards-2.15.0.yml
@@ -9,49 +9,49 @@ ci:
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
-    ref: aa37a6921f56a6ef6355b5ed8a6bd7b6017aae6a
+    ref: tags/2.15.0
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '2.15'
+    ref: tags/2.15.0
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
-    ref: bc03f8eb322383461d035431b4b1ba0aa67df298
+    ref: tags/2.15.0.0
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
-    ref: ebbee208e9ec348e12dfe23c3f6400d25bca3b50
+    ref: tags/2.15.0.0
   - name: ganttChartDashboards
     repository: https://github.com/opensearch-project/dashboards-visualizations.git
-    ref: 8b042be27cbf88f590d5e1e533504abd04cdbd98
+    ref: tags/2.15.0.0
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
-    ref: 3a1c75618c676ee7cd318fed5714b324c2aaf127
+    ref: tags/2.15.0.0
   - name: customImportMapDashboards
     repository: https://github.com/opensearch-project/dashboards-maps.git
-    ref: 7d0affc5498651b1a8f07387d96cac748c37a0f9
+    ref: tags/2.15.0.0
   - name: anomalyDetectionDashboards
     repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin.git
-    ref: 49b35f0849f80f860022d663b5e6746f0e3540ff
+    ref: tags/2.15.0.0
   - name: mlCommonsDashboards
     repository: https://github.com/opensearch-project/ml-commons-dashboards.git
-    ref: c7ace3e3de9fe2475debb2b4c310c025da629a58
+    ref: tags/2.15.0.0
   - name: indexManagementDashboards
     repository: https://github.com/opensearch-project/index-management-dashboards-plugin.git
-    ref: ec9725567dee7b688982838a58e09573e61c6e27
+    ref: tags/2.15.0.0
   - name: notificationsDashboards
     repository: https://github.com/opensearch-project/dashboards-notifications.git
-    ref: aa7e7eff4cd6302442531fb8ca75d781a37084b3
+    ref: tags/2.15.0.0
   - name: alertingDashboards
     repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
-    ref: 1af26aa4b53d5bc8fbb176e3272a211827c116ff
+    ref: tags/2.15.0.0
   - name: securityAnalyticsDashboards
     repository: https://github.com/opensearch-project/security-analytics-dashboards-plugin.git
-    ref: 76baf6b1a600df676900fc0ceda6c1023bcb68ca
+    ref: tags/2.15.0.0
   - name: securityDashboards
     repository: https://github.com/opensearch-project/security-dashboards-plugin.git
-    ref: 2a11d1d9250be6dbc9627374ba3fd86d096d6d17
+    ref: tags/2.15.0.0
   - name: searchRelevanceDashboards
     repository: https://github.com/opensearch-project/dashboards-search-relevance.git
-    ref: a1a1ed98b71e3721a0a44315f4b46f8733b7787b
+    ref: tags/2.15.0.0
   - name: assistantDashboards
     repository: https://github.com/opensearch-project/dashboards-assistant.git
-    ref: 5e7b493f652f59ea83d7a0bb7f1c97127157b74c
+    ref: tags/2.15.0.0


### PR DESCRIPTION
### Description
Switch 2.15.0 input manifest from commit ids to tags

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4681

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
