### PR TITLE
Update the `gradle-check-flaky-test-issue-creation.jenkinsfile` with new library version

### DIFF
--- a/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
+++ b/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@6.5.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.5.2', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -29,7 +29,8 @@ pipeline {
             steps {
                 script {
                     gradleCheckFlakyTestDetector(
-                        issueLabels: 'autocut,>test-failure,flaky-test'
+                        issueLabels: 'autocut,>test-failure,flaky-test',
+                        timeFrame: '30d'
                     )
                 }
             }


### PR DESCRIPTION
### Description
Coming from the PR https://github.com/opensearch-project/opensearch-build-libraries/pull/448 use the latest version for updated `gradleCheckFlakyTestDetector` library.

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/14475

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
