### PR TITLE
[BENCHMARK] Copy the contents from sub-directory test_executions

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_test_suite.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite.py
@@ -90,8 +90,8 @@ class BenchmarkTestSuite:
 
     def convert(self) -> None:
         with TemporaryDirectory() as work_dir:
-            subprocess.check_call(f"docker cp docker-container-{self.args.stack_suffix}:opensearch-benchmark/. {str(work_dir.path)}", cwd=os.getcwd(), shell=True)
-            file_path = glob.glob(os.path.join(str(work_dir.path), "test_executions", "*", "test_execution.json"))
+            subprocess.check_call(f"docker cp docker-container-{self.args.stack_suffix}:opensearch-benchmark/test_executions/. {str(work_dir.path)}", cwd=os.getcwd(), shell=True)
+            file_path = glob.glob(os.path.join(str(work_dir.path), "*", "test_execution.json"))
             shutil.copy(file_path[0], os.path.join(os.getcwd(), f"test_execution_{self.args.stack_suffix}.json"))
             with open(file_path[0]) as file:
                 data = json.load(file)

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
@@ -243,7 +243,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
                 test_suite.convert()
                 mock_temp_directory.assert_called_once()
             mock_copy.assert_called_once()
-            mock_check_call.assert_called_with(f"docker cp docker-container-{test_suite.args.stack_suffix}:opensearch-benchmark/. /mock/temp/dir", cwd=os.getcwd(), shell=True)
+            mock_check_call.assert_called_with(f"docker cp docker-container-{test_suite.args.stack_suffix}:opensearch-benchmark/test_executions/. /mock/temp/dir", cwd=os.getcwd(), shell=True)
             mock_open.assert_called_once_with("/mock/test_execution.json")
             mock_json_load.assert_called_once()
             mock_json_normalize.assert_called_once()


### PR DESCRIPTION
### Description

Copy the contents of the docker container from sub-directory test_executions instead of opensearch-benchmark
The directory hierarchy is as follows
..//opensearch-benchmark/test_executions/ */test_execution.json 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
