### PR TITLE
Switch from C54xlarge Windows Docker Builder to M54xlarge and lock public_suffix to 5.1.1 on almalinux OSD image

### DIFF
--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
@@ -80,7 +80,7 @@ USER $CONTAINER_USER
 WORKDIR $CONTAINER_USER_HOME
 
 # Install fpm for opensearch dashboards core
-RUN gem install dotenv -v 2.8.1 && gem install fpm -v 1.14.2
+RUN gem install dotenv -v 2.8.1 && gem install public_suffix -v 5.1.1 && gem install fpm -v 1.14.2
 ENV PATH=$CONTAINER_USER_HOME/.gem/gems/fpm-1.14.2/bin:$PATH
 
 # Hard code node version and yarn version for now

--- a/jenkins/docker/docker-build.jenkinsfile
+++ b/jenkins/docker/docker-build.jenkinsfile
@@ -19,7 +19,7 @@ def docker_args = [
 
 def agent_nodes = [
     "linux": "Jenkins-Agent-Ubuntu2004-X64-M52xlarge-Docker-Builder",
-    "windows": "Jenkins-Agent-Windows2019-X64-C54xlarge-Docker-Builder",
+    "windows": "Jenkins-Agent-Windows2019-X64-M54xlarge-Docker-Builder",
 ]
 
 pipeline {


### PR DESCRIPTION
### Description
Switch from C54xlarge Windows Docker Builder to M54xlarge and lock public_suffix to 5.1.1 on almalinux OSD image

### Issues Resolved
https://github.com/opensearch-project/opensearch-ci/issues/412

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
