### PR TITLE
Automate retrospective issue creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_retrospective_template.md
+++ b/.github/ISSUE_TEMPLATE/release_retrospective_template.md
@@ -1,0 +1,14 @@
+---
+name: Release retrospective
+title: "[Retrospective] Release Version {{ env.VERSION }}"
+labels: untriaged, release, v{{ env.VERSION }}
+---
+
+### **Related release issue?**
+{{ env.RELEASE_ISSUE_URL }}
+
+### **How to use this issue?**
+Please add comments to this [Retro Board](https://github.com/orgs/opensearch-project/projects/205/views/4), they can be small or large in scope. Honest feedback is important to improve our processes, suggestions are also welcomed but not required.
+
+### **What will happen to this issue post release?**
+There will be a discussion(s) about how the release went and how the next release can be improved. Then this issue will be updated with the notes of that discussion along side action items.

--- a/.github/ISSUE_TEMPLATE/release_retrospective_template.md
+++ b/.github/ISSUE_TEMPLATE/release_retrospective_template.md
@@ -8,7 +8,7 @@ labels: untriaged, release, v{{ env.VERSION }}
 {{ env.RELEASE_ISSUE_URL }}
 
 ### **How to use this issue?**
-Please add comments to this [Retro Board](https://github.com/orgs/opensearch-project/projects/205/views/4), they can be small or large in scope. Honest feedback is important to improve our processes, suggestions are also welcomed but not required.
+Please add comments to this issue, they can be small or large in scope. Honest feedback is important to improve our processes, suggestions are also welcomed but not required.
 
 ### **What will happen to this issue post release?**
 There will be a discussion(s) about how the release went and how the next release can be improved. Then this issue will be updated with the notes of that discussion along side action items.

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dblock/create-a-github-issue@v3.0.0
+        id: release-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ matrix.release_version }}
@@ -33,3 +34,13 @@ jobs:
           search_existing: all
           update_existing: false
           filename: .github/ISSUE_TEMPLATE/release_template.md
+      - uses: dblock/create-a-github-issue@v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ matrix.release_version }}
+          RELEASE_ISSUE_URL: ${{ steps.release-issue.outputs.url }}
+        with:
+          search_existing: all
+          update_existing: false
+          filename: .github/ISSUE_TEMPLATE/release_retrospective_template.md
+

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -43,4 +43,3 @@ jobs:
           search_existing: all
           update_existing: false
           filename: .github/ISSUE_TEMPLATE/release_retrospective_template.md
-

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -25,7 +25,8 @@ jobs:
         release_version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dblock/create-a-github-issue@v3.0.0
+      - name: Create release issue
+        uses: dblock/create-a-github-issue@v3.0.0
         id: release-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +35,9 @@ jobs:
           search_existing: all
           update_existing: false
           filename: .github/ISSUE_TEMPLATE/release_template.md
-      - uses: dblock/create-a-github-issue@v3.0.0
+      - name: Create retrospective issue
+        uses: dblock/create-a-github-issue@v3.0.0
+        if: ${{ steps.release-issue.outputs.status == 'created' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ matrix.release_version }}


### PR DESCRIPTION
### Description
This enhancement automates the release retrospective issue creation. As of today this process is manual. Example: https://github.com/opensearch-project/opensearch-build/issues/4847

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4761

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
