### PR TITLE
Onboard query-insights in 2.16

### DIFF
--- a/.github/workflows/os-increment-plugin-versions.yml
+++ b/.github/workflows/os-increment-plugin-versions.yml
@@ -48,6 +48,7 @@ jobs:
           - {repo: custom-codecs}
           - {repo: flow-framework}
           - {repo: skills}
+          - {repo: query-insights}
         branch:
           - 1.x
           - '1.3'

--- a/.github/workflows/os-release-issues.yml
+++ b/.github/workflows/os-release-issues.yml
@@ -60,6 +60,7 @@ jobs:
           - {repo: custom-codecs}
           - {repo: flow-framework}
           - {repo: skills}
+          - {repo: query-insights}
         release_version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
       - name: GitHub App token

--- a/manifests/2.16.0/opensearch-2.16.0.yml
+++ b/manifests/2.16.0/opensearch-2.16.0.yml
@@ -183,3 +183,9 @@ components:
       - anomaly-detection
       - sql
       - ml-commons
+  - name: query-insights
+    repository: https://github.com/opensearch-project/query-insights.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows


### PR DESCRIPTION
### Description
This PR onboards query insights plugin in 2.16. 
- It bundles query-insights in 2.16 components so that opensearch 2.16 distribution will have query insights by default. 
- Add query insights in os-increment-plugin-versions and os-release-issues workflows.

### Issues Resolved
related to https://github.com/opensearch-project/opensearch-build/issues/4826

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
