### PR TITLE
Switch 2.16.0 manifest to use al2 docker images

### DIFF
--- a/manifests/2.16.0/opensearch-2.16.0.yml
+++ b/manifests/2.16.0/opensearch-2.16.0.yml
@@ -5,7 +5,7 @@ build:
   version: 2.16.0
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
+    name: opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1
     args: -e JAVA_HOME=/opt/java/openjdk-21
 components:
   - name: OpenSearch


### PR DESCRIPTION
### Description
Switch 2.16.0 manifest to use al2 docker images

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4771

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
