### PR TITLE
Fix validation workflow params in central release workflow

### DIFF
--- a/jenkins/promotion/release-promotion.jenkinsfile
+++ b/jenkins/promotion/release-promotion.jenkinsfile
@@ -497,7 +497,7 @@ pipeline {
                 string(name: 'PROJECTS', value: 'Both'),
                 string(name: 'DOCKER_SOURCE', value: 'Both'),
                 string(name: 'ARTIFACT_TYPE', value: 'production'),
-                string(name: 'OPTIONAL_ARGS', value: 'validate-digests-only')
+                string(name: 'OPTIONAL_ARGS', value: 'validate-digest-only')
                 ]
             echo 'Artifacts are successfully validated!'
             }

--- a/tests/jenkins/TestOpenSearchReleasePromotionTest.groovy
+++ b/tests/jenkins/TestOpenSearchReleasePromotionTest.groovy
@@ -189,7 +189,7 @@ class TestOpenSearchReleasePromotionTest extends BuildPipelineTest {
         assertCallStack().contains('release-promotion.string({name=PROJECTS, value=Both})')
         assertCallStack().contains('release-promotion.string({name=DOCKER_SOURCE, value=Both})')
         assertCallStack().contains('release-promotion.string({name=ARTIFACT_TYPE, value=production})')
-        assertCallStack().contains('release-promotion.string({name=OPTIONAL_ARGS, value=validate-digests-only})')
+        assertCallStack().contains('release-promotion.string({name=OPTIONAL_ARGS, value=validate-digest-only})')
         assertCallStack().contains('release-promotion.build({job=distribution-validation, wait=true, parameters=[null, null, null, null, null, null, null, null]})')
 
         // Maven Promotion Workflow

--- a/tests/jenkins/jenkinsjob-regression-files/promotion/release-promotion.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/promotion/release-promotion.jenkinsfile.txt
@@ -227,7 +227,7 @@
             release-promotion.string({name=PROJECTS, value=Both})
             release-promotion.string({name=DOCKER_SOURCE, value=Both})
             release-promotion.string({name=ARTIFACT_TYPE, value=production})
-            release-promotion.string({name=OPTIONAL_ARGS, value=validate-digests-only})
+            release-promotion.string({name=OPTIONAL_ARGS, value=validate-digest-only})
             release-promotion.build({job=distribution-validation, wait=true, parameters=[null, null, null, null, null, null, null, null]})
             release-promotion.echo(Artifacts are successfully validated!)
          release-promotion.stage(Publish to Maven, groovy.lang.Closure)


### PR DESCRIPTION
### Description
The most recent central promotion workflow failed due to parameter type variation. See https://build.ci.opensearch.org/blue/organizations/jenkins/central-release-promotion/detail/central-release-promotion/10/pipeline

This change fixes the parameter value.


### Issues Resolved
#4801 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
