### PR TITLE
Bump maven publish 1.x cron to 1.3.19 and switch docker copy agent to avoid cache cleaning race condition

### DIFF
--- a/jenkins/docker/docker-copy.jenkinsfile
+++ b/jenkins/docker/docker-copy.jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
         stage("Image Copy") {
             agent {
                 docker {
-                    label 'Jenkins-Agent-AL2023-X64-C54xlarge-Docker-Host'
+                    label 'Jenkins-Agent-Ubuntu2004-X64-M52xlarge-Docker-Builder'
                     image 'opensearchstaging/ci-runner:ubuntu2004-x64-docker-buildx0.9.1-qemu5.0-v1'
                     args '-u root -v /var/run/docker.sock:/var/run/docker.sock'
                     registryUrl 'https://public.ecr.aws/'

--- a/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
+++ b/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
@@ -20,11 +20,6 @@ pipeline {
     environment {
         AGENT_X64 = 'Jenkins-Agent-AL2023-X64-C54xlarge-Docker-Host'
     }
-    triggers {
-        parameterizedCron '''
-            H 1 * * * %INPUT_MANIFEST=1.3.15/opensearch-1.3.15.yml
-        '''
-    }
     parameters {
         string(
             name: 'COMPONENT_NAME',

--- a/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
+++ b/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
@@ -20,6 +20,11 @@ pipeline {
     environment {
         AGENT_X64 = 'Jenkins-Agent-AL2023-X64-C54xlarge-Docker-Host'
     }
+    triggers {
+        parameterizedCron '''
+            H 1 * * * %INPUT_MANIFEST=1.3.19/opensearch-1.3.19.yml
+        '''
+    }
     parameters {
         string(
             name: 'COMPONENT_NAME',


### PR DESCRIPTION

### Description
Bump maven publish 1.x cron to 1.3.19 and switch docker copy agent to avoid cache cleaning race condition

### Issues Resolved
Resolve two issues:
1. Bump maven publish 1.x cron to 1.3.19.
2. Switch the docker copy agent to Jenkins-Agent-Ubuntu2004-X64-M52xlarge-Docker-Builder to avoid docker cache cleaning issues on the images having race conditions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
