### PR TITLE
Avoid checking outdated branches during manifest update

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -91,10 +91,16 @@ class InputManifests(Manifests):
         with TemporaryDirectory(keep=keep, chdir=True) as work_dir:
             logging.info(f"Checking out components into {work_dir.name}")
 
-            # check out and build #main, 1.x, etc.
-            branches = sorted(min_klass.branches())
+            outdated_branches = ["1.0", "1.1", "1.2"]
 
+            # check out and build #main, 1.x, etc.
+            # ignore branches that are outdated and not maintained anymore
+            # ex: 1.0 failed due to certain dependencies not available anymore: https://github.com/avast/gradle-docker-compose-plugin/issues/446
+            all_branches = sorted(min_klass.branches())
+            branches = [b for b in all_branches if not any(b.startswith(o) for o in outdated_branches)]
             logging.info(f"Checking {self.name} {branches} branches")
+            logging.info(f"Ignoring {self.name} {sorted(set(all_branches) - set(branches))} branches as they are outdated")
+
             for branch in branches:
                 min_component_klass = min_klass.checkout(
                     path=os.path.join(work_dir.name, self.name.replace(" ", ""), branch),

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
@@ -65,7 +65,7 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
     @patch("manifests.manifest.Manifest.to_file")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearchMin")
     def test_update_outdated_branch(self, mock_component_opensearch_min: MagicMock, mock_manifest_to_file: MagicMock,
-                    mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock) -> None:
+                                    mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock) -> None:
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
         mock_component_opensearch_min.branches.return_value = ["1.2"]
         mock_component_opensearch_min.checkout.return_value = MagicMock(version="1.2.1000")

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
@@ -59,3 +59,18 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
         mock_add_to_versionincrement_workflow.assert_has_calls([
             call('2.12.1000'),
         ])
+
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_versionincrement_workflow")
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
+    @patch("manifests.manifest.Manifest.to_file")
+    @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearchMin")
+    def test_update_outdated_branch(self, mock_component_opensearch_min: MagicMock, mock_manifest_to_file: MagicMock,
+                    mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock) -> None:
+        mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
+        mock_component_opensearch_min.branches.return_value = ["1.2"]
+        mock_component_opensearch_min.checkout.return_value = MagicMock(version="1.2.1000")
+        manifests = InputManifestsOpenSearch()
+        manifests.update()
+        self.assertEqual(mock_manifest_to_file.call_count, 0)
+        self.assertEqual(mock_add_to_cron.call_count, 0)
+        self.assertEqual(mock_add_to_versionincrement_workflow.call_count, 0)

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
@@ -60,3 +60,19 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
         mock_add_to_versionincrement_workflow.assert_has_calls([
             call('2.12.1000')
         ])
+
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_versionincrement_workflow")
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
+    @patch("manifests.manifest.Manifest.to_file")
+    @patch("manifests_workflow.input_manifests_opensearch_dashboards.ComponentOpenSearchDashboardsMin")
+    def test_update_outdated_branch(self, mock_component_opensearch_dashboards_min: MagicMock, mock_manifest_to_file: MagicMock,
+                    mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock) -> None:
+        mock_component_opensearch_dashboards_min.return_value = MagicMock(name="OpenSearch-Dashboards")
+        mock_component_opensearch_dashboards_min.branches.return_value = ["1.2"]
+        mock_component_opensearch_dashboards_min.checkout.return_value = MagicMock(version="1.2.1000")
+
+        manifests = InputManifestsOpenSearchDashboards()
+        manifests.update()
+        self.assertEqual(mock_manifest_to_file.call_count, 0)
+        self.assertEqual(mock_add_to_cron.call_count, 0)
+        self.assertEqual(mock_add_to_versionincrement_workflow.call_count, 0)

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
@@ -66,7 +66,7 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
     @patch("manifests.manifest.Manifest.to_file")
     @patch("manifests_workflow.input_manifests_opensearch_dashboards.ComponentOpenSearchDashboardsMin")
     def test_update_outdated_branch(self, mock_component_opensearch_dashboards_min: MagicMock, mock_manifest_to_file: MagicMock,
-                    mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock) -> None:
+                                    mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock) -> None:
         mock_component_opensearch_dashboards_min.return_value = MagicMock(name="OpenSearch-Dashboards")
         mock_component_opensearch_dashboards_min.branches.return_value = ["1.2"]
         mock_component_opensearch_dashboards_min.checkout.return_value = MagicMock(version="1.2.1000")


### PR DESCRIPTION
### Description
Avoid checking outdated branches during manifest update

### Issues Resolved
https://github.com/avast/gradle-docker-compose-plugin/issues/446

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
