### PR TITLE
Automate locking manifests with tags

### DIFF
--- a/jenkins/release-manifest-commit-lock/release-manifest-commit-lock.jenkinsfile
+++ b/jenkins/release-manifest-commit-lock/release-manifest-commit-lock.jenkinsfile
@@ -41,9 +41,9 @@ pipeline {
             trim: true
         )
         choice(
-                choices: ['MATCH_BUILD_MANIFEST', 'UPDATE_TO_RECENT_COMMITS'],
+                choices: ['MATCH_BUILD_MANIFEST', 'UPDATE_TO_RECENT_COMMITS', 'UPDATE_TO_TAGS'],
                 name: 'MANIFEST_LOCK_ACTION',
-                description: 'The manifest lock action to choose.<br>MATCH_BUILD_MANIFEST: Will update the manifest with commit ID from release candidate build manifest.<br>UPDATE_TO_RECENT_COMMITS: Will update the manifest with component repo release branch head commit.',
+                description: 'The manifest lock action to choose.<br>MATCH_BUILD_MANIFEST: Will update the manifest with commit ID from release candidate build manifest.<br>UPDATE_TO_RECENT_COMMITS: Will update the manifest with component repo release branch head commit.<br>UPDATE_TO_TAGS: Will update the manifest with ref tags',
         )
         string(
             name: 'COMPONENTS',
@@ -56,9 +56,13 @@ pipeline {
             steps {
                 script {
                     currentBuild.description = """Action: ${MANIFEST_LOCK_ACTION}<br>Release: ${RELEASE_VERSION} OS=${OPENSEARCH_RELEASE_CANDIDATE} OSD=${OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE}"""
-                    if (MANIFEST_LOCK_ACTION.isEmpty() || RELEASE_VERSION.isEmpty() || OPENSEARCH_RELEASE_CANDIDATE.isEmpty() || OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE.isEmpty()) {
+                    if (MANIFEST_LOCK_ACTION.isEmpty() || RELEASE_VERSION.isEmpty()) {
                                 currentBuild.result = 'ABORTED'
-                                error('Make sure all the parameters are passed in.')
+                                error('MANIFEST_LOCK_ACTION and/or RELEASE_VERSION cannot be empty!')
+                    }
+                    if ((params.MANIFEST_LOCK_ACTION == 'MATCH_BUILD_MANIFEST' || params.MANIFEST_LOCK_ACTION == 'UPDATE_TO_RECENT_COMMITS') && (OPENSEARCH_RELEASE_CANDIDATE.isEmpty() || OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE.isEmpty())) {
+                                currentBuild.result = 'ABORTED'
+                                error('OPENSEARCH_RELEASE_CANDIDATE and/or OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE cannot be empty when MANIFEST_LOCK_ACTION is MATCH_BUILD_MANIFEST or UPDATE_TO_RECENT_COMMITS.')
                     }
                 }
             }
@@ -134,6 +138,41 @@ pipeline {
                     }
                     updateManifest("opensearch", params.OPENSEARCH_RELEASE_CANDIDATE)
                     updateManifest("opensearch-dashboards", params.OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE)
+                }
+            }
+        }
+        stage('UPDATE_TO_TAGS') {
+            when {
+                expression { params.MANIFEST_LOCK_ACTION == 'UPDATE_TO_TAGS' }
+            }
+            steps {
+                script {
+                    def updateManifest = { String productName ->
+                        def existingManifest = readYaml file: "manifests/${params.RELEASE_VERSION}/${productName}-${params.RELEASE_VERSION}.yml"
+                        def selectedComponents = params.COMPONENTS.isEmpty() ? existingManifest.components : existingManifest.components.findAll { component ->
+                            params.COMPONENTS.split(',').any { it.trim() == component.name }
+                        }
+                        selectedComponents.each { componentName ->
+                            def existingComponent = existingManifest.components.find { it.name == componentName.name }
+                            if (existingComponent) {
+                                def releaseTag = params.RELEASE_VERSION + ".0"
+                                if (componentName.name == 'OpenSearch' || componentName.name == 'OpenSearch-Dashboards' || componentName.name == 'functionalTestDashboards') {
+                                    releaseTag = params.RELEASE_VERSION
+                                }
+                                def newComponentRef = existingManifest.components.find { it.name == componentName.name }?.ref
+                                        if (newComponentRef) {
+                                            existingComponent.ref = "tags/" + releaseTag
+                                        }
+                            }
+                        }
+                        writeYaml file:  "manifests/${params.RELEASE_VERSION}/${productName}-${params.RELEASE_VERSION}.yml", data: existingManifest, overwrite: true
+                        sh """
+                                yq eval -i '.' manifests/${params.RELEASE_VERSION}/${productName}-${params.RELEASE_VERSION}.yml
+                                sed -i '1s/^/---\\n/' manifests/${params.RELEASE_VERSION}/${productName}-${params.RELEASE_VERSION}.yml
+                        """
+                    }
+                    updateManifest("opensearch")
+                    updateManifest("opensearch-dashboards")
                 }
             }
         }

--- a/tests/jenkins/TestReleaseManifestCommitLock.groovy
+++ b/tests/jenkins/TestReleaseManifestCommitLock.groovy
@@ -67,6 +67,19 @@ class TestReleaseManifestCommitLock extends BuildPipelineTest {
     }
 
     @Test
+    public void testManifestCommitLock_updateToTags() {
+        addParam('MANIFEST_LOCK_ACTION', 'UPDATE_TO_TAGS')
+        super.testPipeline('jenkins/release-manifest-commit-lock/release-manifest-commit-lock.jenkinsfile',
+                'tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testManifestCommitLock_updateToTags')
+        def callStack = helper.getCallStack()
+        assertCallStack().contains('stage(Parameters Check, groovy.lang.Closure)')
+        assertCallStack().contains('stage(UPDATE_TO_TAGS, groovy.lang.Closure)')
+        assertCallStack().contains('Skipping stage MATCH_BUILD_MANIFEST')
+        assertCallStack().contains('Skipping stage UPDATE_TO_RECENT_COMMITS')
+        assertCallStack().contains('release-manifest-commit-lock.writeYaml({file=manifests/2.0.0/opensearch-2.0.0.yml, data={schema-version=1.0, build={name=OpenSearch, version=2.0.0, qualifier=alpha1}, ci={image={name=opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2, args=-e JAVA_HOME=/opt/java/openjdk-17}}, components=[{name=OpenSearch, ref=tags/2.0.0, repository=https://github.com/opensearch-project/OpenSearch.git, checks=[gradle:publish, gradle:properties:version]}, {name=common-utils, repository=https://github.com/opensearch-project/common-utils.git, ref=2.0, checks=[gradle:publish, gradle:properties:version]}, {name=job-scheduler, repository=https://github.com/opensearch-project/job-scheduler.git, ref=2.0, checks=[gradle:properties:version, gradle:dependencies:opensearch.version]}]}, overwrite=true})')
+    }
+
+    @Test
     public void testManifestCommitLock_createPullRequest() {
         super.testPipeline('jenkins/release-manifest-commit-lock/release-manifest-commit-lock.jenkinsfile',
                 'tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testManifestCommitLock_createPullRequest')

--- a/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testManifestCommitLock_createPullRequest.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testManifestCommitLock_createPullRequest.txt
@@ -27,6 +27,7 @@ ccc})
                                     sed -i '1s/^/---\n/' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
                         )
          release-manifest-commit-lock.echo(Skipping stage UPDATE_TO_RECENT_COMMITS)
+         release-manifest-commit-lock.echo(Skipping stage UPDATE_TO_TAGS)
          release-manifest-commit-lock.stage(Create Pull Request, groovy.lang.Closure)
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})

--- a/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testManifestCommitLock_matchBuildManifest.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testManifestCommitLock_matchBuildManifest.txt
@@ -27,6 +27,7 @@ ccc})
                                     sed -i '1s/^/---\n/' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
                         )
          release-manifest-commit-lock.echo(Skipping stage UPDATE_TO_RECENT_COMMITS)
+         release-manifest-commit-lock.echo(Skipping stage UPDATE_TO_TAGS)
          release-manifest-commit-lock.stage(Create Pull Request, groovy.lang.Closure)
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})

--- a/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testManifestCommitLock_updateToRecentCommits.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testManifestCommitLock_updateToRecentCommits.txt
@@ -25,6 +25,7 @@ ccc, repository=https://github.com/opensearch-project/OpenSearch.git, checks=[gr
                                 yq eval -i '.' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
                                 sed -i '1s/^/---\n/' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
                         )
+         release-manifest-commit-lock.echo(Skipping stage UPDATE_TO_TAGS)
          release-manifest-commit-lock.stage(Create Pull Request, groovy.lang.Closure)
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})

--- a/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testManifestCommitLock_updateToTags.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testManifestCommitLock_updateToTags.txt
@@ -7,21 +7,21 @@
          release-manifest-commit-lock.stage(Parameters Check, groovy.lang.Closure)
             release-manifest-commit-lock.script(groovy.lang.Closure)
          release-manifest-commit-lock.echo(Skipping stage MATCH_BUILD_MANIFEST)
-         release-manifest-commit-lock.stage(UPDATE_TO_RECENT_COMMITS, groovy.lang.Closure)
+         release-manifest-commit-lock.echo(Skipping stage UPDATE_TO_RECENT_COMMITS)
+         release-manifest-commit-lock.stage(UPDATE_TO_TAGS, groovy.lang.Closure)
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.readYaml({file=manifests/2.0.0/opensearch-2.0.0.yml})
-               release-manifest-commit-lock.writeYaml({file=manifests/2.0.0/opensearch-2.0.0.yml, data={ci={image={name=opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028}}, build={name=OpenSearch Dashboards, version=3.0.0}, components=[{name=OpenSearch-Dashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/OpenSearch-Dashboards.git}, {name=functionalTestDashboards, repository=https://github.com/opensearch-project/opensearch-dashboards-functional-test.git, ref=3.0}, {name=observabilityDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-observability.git}, {name=indexManagementDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/index-management-dashboards-plugin}, {name=ganttChartDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-visualizations.git}, {name=reportsDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-reports.git}, {name=queryWorkbenchDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/sql.git}, {name=anomalyDetectionDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/anomaly-detection-dashboards-plugin}], schema-version=1.0}, overwrite=true})
+               release-manifest-commit-lock.writeYaml({file=manifests/2.0.0/opensearch-2.0.0.yml, data={schema-version=1.0, build={name=OpenSearch, version=2.0.0, qualifier=alpha1}, ci={image={name=opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2, args=-e JAVA_HOME=/opt/java/openjdk-17}}, components=[{name=OpenSearch, ref=tags/2.0.0, repository=https://github.com/opensearch-project/OpenSearch.git, checks=[gradle:publish, gradle:properties:version]}, {name=common-utils, repository=https://github.com/opensearch-project/common-utils.git, ref=2.0, checks=[gradle:publish, gradle:properties:version]}, {name=job-scheduler, repository=https://github.com/opensearch-project/job-scheduler.git, ref=2.0, checks=[gradle:properties:version, gradle:dependencies:opensearch.version]}]}, overwrite=true})
                release-manifest-commit-lock.sh(
                                 yq eval -i '.' manifests/2.0.0/opensearch-2.0.0.yml
                                 sed -i '1s/^/---\n/' manifests/2.0.0/opensearch-2.0.0.yml
                         )
                release-manifest-commit-lock.readYaml({file=manifests/2.0.0/opensearch-dashboards-2.0.0.yml})
-               release-manifest-commit-lock.writeYaml({file=manifests/2.0.0/opensearch-dashboards-2.0.0.yml, data={ci={image={name=opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211028}}, build={name=OpenSearch Dashboards, version=3.0.0}, components=[{name=OpenSearch-Dashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/OpenSearch-Dashboards.git}, {name=functionalTestDashboards, repository=https://github.com/opensearch-project/opensearch-dashboards-functional-test.git, ref=3.0}, {name=observabilityDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-observability.git}, {name=indexManagementDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/index-management-dashboards-plugin}, {name=ganttChartDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-visualizations.git}, {name=reportsDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/dashboards-reports.git}, {name=queryWorkbenchDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/sql.git}, {name=anomalyDetectionDashboards, ref=tags/3.0.0, repository=https://github.com/opensearch-project/anomaly-detection-dashboards-plugin}], schema-version=1.0}, overwrite=true})
+               release-manifest-commit-lock.writeYaml({file=manifests/2.0.0/opensearch-dashboards-2.0.0.yml, data={schema-version=1.0, build={name=OpenSearch, version=2.0.0, qualifier=alpha1}, ci={image={name=opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v2, args=-e JAVA_HOME=/opt/java/openjdk-17}}, components=[{name=OpenSearch, ref=tags/2.0.0, repository=https://github.com/opensearch-project/OpenSearch.git, checks=[gradle:publish, gradle:properties:version]}, {name=common-utils, repository=https://github.com/opensearch-project/common-utils.git, ref=2.0, checks=[gradle:publish, gradle:properties:version]}, {name=job-scheduler, repository=https://github.com/opensearch-project/job-scheduler.git, ref=2.0, checks=[gradle:properties:version, gradle:dependencies:opensearch.version]}]}, overwrite=true})
                release-manifest-commit-lock.sh(
                                 yq eval -i '.' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
                                 sed -i '1s/^/---\n/' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
                         )
-         release-manifest-commit-lock.echo(Skipping stage UPDATE_TO_TAGS)
          release-manifest-commit-lock.stage(Create Pull Request, groovy.lang.Closure)
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})
@@ -37,7 +37,7 @@
                                     git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
                                     git commit -sm "Manifest Commit Lock for Release 2.0.0"
                                     git push origin manifest-lock --force
-                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_RECENT_COMMITS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
+                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_TAGS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
                                 )
          release-manifest-commit-lock.script(groovy.lang.Closure)
             release-manifest-commit-lock.postCleanup()

--- a/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testMatchBuildManifest.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testMatchBuildManifest.txt
@@ -27,6 +27,7 @@ ccc})
                                     sed -i '1s/^/---\n/' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
                         )
          release-manifest-commit-lock.echo(Skipping stage UPDATE_TO_RECENT_COMMITS)
+         release-manifest-commit-lock.echo(Skipping stage UPDATE_TO_TAGS)
          release-manifest-commit-lock.stage(Create Pull Request, groovy.lang.Closure)
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})

--- a/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testUpdateToRecentCommit.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-manifest-commit-lock/testUpdateToRecentCommit.txt
@@ -25,6 +25,7 @@ ccc, repository=https://github.com/opensearch-project/OpenSearch.git, checks=[gr
                                 yq eval -i '.' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
                                 sed -i '1s/^/---\n/' manifests/2.0.0/opensearch-dashboards-2.0.0.yml
                         )
+         release-manifest-commit-lock.echo(Skipping stage UPDATE_TO_TAGS)
          release-manifest-commit-lock.stage(Create Pull Request, groovy.lang.Closure)
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.usernamePassword({credentialsId=jenkins-github-bot-token, passwordVariable=GITHUB_TOKEN, usernameVariable=GITHUB_USER})


### PR DESCRIPTION
### Description
Adding an automation to replace refs with tags in the input manifests after tags are cut. 

### Issues Resolved
#4761 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
