### PR TITLE
Improve logic of finding legacy branches to ignore manifest update

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -91,15 +91,23 @@ class InputManifests(Manifests):
         with TemporaryDirectory(keep=keep, chdir=True) as work_dir:
             logging.info(f"Checking out components into {work_dir.name}")
 
-            outdated_branches = ["1.0", "1.1", "1.2"]
+            # ignore branches that are legacy/outdated and not maintained anymore
+            # get possible legacy branches based on legacy manifests, then cross check with current branches from current manifests
+            # ex: 1.0 failed due to certain dependencies not available anymore: https://github.com/avast/gradle-docker-compose-plugin/issues/446
+            all_manifests = set(InputManifests.files(self.prefix))
+            legacy_manifests = {m for m in all_manifests if "legacy-manifests" in m}
+            legacy_branches = {".".join(m.split(os.sep)[-2].rsplit(".", 1)[:-1]) for m in legacy_manifests}
+            current_manifests = all_manifests - legacy_manifests
+            current_branches = {".".join(m.split(os.sep)[-2].rsplit(".", 1)[:-1]) for m in current_manifests}
+
+            # make sure only branches in legacy-manifests but not in manifests get ignored
+            legacy_branches -= current_branches
 
             # check out and build #main, 1.x, etc.
-            # ignore branches that are outdated and not maintained anymore
-            # ex: 1.0 failed due to certain dependencies not available anymore: https://github.com/avast/gradle-docker-compose-plugin/issues/446
             all_branches = sorted(min_klass.branches())
-            branches = [b for b in all_branches if not any(b.startswith(o) for o in outdated_branches)]
-            logging.info(f"Checking {self.name} {branches} branches")
-            logging.info(f"Ignoring {self.name} {sorted(set(all_branches) - set(branches))} branches as they are outdated")
+            branches = [b for b in all_branches if not any(b == o or b.startswith((f"{o}-", f"{o}/")) for o in legacy_branches)]
+            logging.info(f"Checking {self.name} {sorted(branches)} branches")
+            logging.info(f"Ignoring {self.name} {sorted(set(all_branches) - set(branches))} branches as they are legacy")
 
             for branch in branches:
                 min_component_klass = min_klass.checkout(


### PR DESCRIPTION
### Description
Improve logic of finding legacy branches to ignore manifest update
Using legacy-manifests folder as indicator of legacy branch and cross checking with current manifests.

### Issues Resolved
Follow up to: https://github.com/opensearch-project/opensearch-build/pull/4867
Closes https://github.com/opensearch-project/opensearch-build/issues/4870

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
