### PR TITLE
Trigger manifest lock workflow from release Tag workflow

### DIFF
--- a/jenkins/release-tag/release-tag.jenkinsfile
+++ b/jenkins/release-tag/release-tag.jenkinsfile
@@ -54,6 +54,16 @@ pipeline {
                 }
             }
         }
+        stage('Update Manifest') {
+            steps {
+                echo 'Triggering manifest lock workflow'
+                build job: 'release-manifest-commit-lock', wait: true, parameters: [
+                    string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                    string(name: 'MANIFEST_LOCK_ACTION', value: "UPDATE_TO_TAGS")
+                    ]
+                echo 'Pull Request to lock manifest created successfully!'
+            }
+        }
     }
     post() {
         always {


### PR DESCRIPTION
### Description
Once release tags are created, this change with automatically create a PR with refs updated to tags. 

### Issues Resolved
#4761 
closes https://github.com/opensearch-project/opensearch-build/issues/2546

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
