### PR TITLE
Use the build `RC_NUMBER` value for integration test build.

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -1043,6 +1043,7 @@ def triggerIntegrationTests(String buildManifestUrl, String buildManifestUrlOpen
                 parameters: [
                     string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
                     string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                    string(name: 'RC_NUMBER', value: RC_NUMBER),
                     string(name: 'BUILD_MANIFEST_URL_OPENSEARCH', value: buildManifestUrlOpenSearch),
                     booleanParam(name: 'UPDATE_GITHUB_ISSUES', value: true)
                 ]

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -982,6 +982,7 @@ def triggerIntegrationTests(String buildManifestUrl) {
                 parameters: [
                     string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
                     string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                    string(name: 'RC_NUMBER', value: RC_NUMBER),
                     booleanParam(name: 'UPDATE_GITHUB_ISSUES', value: true)
                 ]
     }


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/opensearch-build/pull/4876 Use the build `RC_NUMBER` value for integration test build.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/56 and https://github.com/opensearch-project/opensearch-metrics/issues/51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
