### PR TITLE
Reduce from 180 to 90 days for gradle check log rotation

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     agent { label AGENT_LABEL }
     options {
         timeout(time: 2, unit: 'HOURS')
-        buildDiscarder(logRotator(daysToKeepStr: '180'))
+        buildDiscarder(logRotator(daysToKeepStr: '90'))
         throttleJobProperty(
             categories: [],
             limitOneJobWithMatchingParams: false,


### PR DESCRIPTION
### Description
Reduce from 180 to 90 days for gradle check log rotation

### Issues Resolved
https://build.ci.opensearch.org/blue/organizations/jenkins/gradle-check/detail/gradle-check/43034/pipeline
```
java.io.FileNotFoundException: /var/jenkins_home/jobs/gradle-check/builds/43034/log (No such file or directory)

    at java.base/java.io.RandomAccessFile.open0(Native Method)

    at java.base/java.io.RandomAccessFile.open(RandomAccessFile.java:356)


```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
