### PR TITLE
Disable 2.16.0 cron on distribution build workflow

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -24,9 +24,6 @@ pipeline {
     triggers {
         parameterizedCron '''
             H 1 * * * %INPUT_MANIFEST=1.3.19/opensearch-1.3.19.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H 1 * * * %INPUT_MANIFEST=2.15.1/opensearch-2.15.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H */6 * * * %INPUT_MANIFEST=2.16.0/opensearch-dashboards-2.16.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.16.0/opensearch-dashboards-2.16.0-test.yml
-            H */6 * * * %INPUT_MANIFEST=2.16.0/opensearch-2.16.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.16.0/opensearch-2.16.0-test.yml
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''


### PR DESCRIPTION
### Description
Disable 2.16.0 cron on distribution build workflow

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4771

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
