### PR TITLE
Fix release notes checker workflow

### DIFF
--- a/jenkins/release-workflows/release-notes-check.jenkinsfile
+++ b/jenkins/release-workflows/release-notes-check.jenkinsfile
@@ -64,11 +64,11 @@ pipeline {
                         currentBuild.result = 'ABORTED'
                         error('ACTION and RELEASE_VERSION parameters cannot be empty!')
                     }
-                    if (ACTION == "check" && (GIT_LOG_DATE.isEmpty() || COMMENT == "ADD" || GIT_ISSUE_NUMBER.isEmpty())) {
+                    if ((ACTION == "check" && COMMENT == "ADD") && (GIT_LOG_DATE.isEmpty() || GIT_ISSUE_NUMBER.isEmpty())) {
                         currentBuild.result = 'ABORTED'
                         error('GIT_LOG_DATE, COMMENT or GIT_ISSUE_NUMBER parameters cannot be empty when ACTION = check!')
                     }
-                    if (ACTION == "check" && (GIT_LOG_DATE.isEmpty() || COMMENT == "UPDATE" || COMMENT_UNIQUE_ID.isEmpty())) {
+                    if ((ACTION == "check" && COMMENT == "UPDATE") && (GIT_LOG_DATE.isEmpty() || COMMENT_UNIQUE_ID.isEmpty())) {
                         currentBuild.result = 'ABORTED'
                         error('GIT_LOG_DATE, COMMENT or COMMENT_UNIQUE_ID parameters cannot be empty when ACTION = check!')
                     }


### PR DESCRIPTION
### Description
Fixing the operators in the parameters check of release notes checker workflow

### Issues Resolved
#4761 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
