### PR TITLE
Add 1.1 version of test report yml with bundle and rc information

### DIFF
--- a/src/manifests/test_report/test_report_manifest_1_0.py
+++ b/src/manifests/test_report/test_report_manifest_1_0.py
@@ -8,18 +8,15 @@
 from typing import Optional
 
 from manifests.component_manifest import Component, ComponentManifest, Components
-from manifests.test_report.test_report_manifest_1_0 import TestReportManifest_1_0
 
 
-class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents']):
+class TestReportManifest_1_0(ComponentManifest['TestReportManifest_1_0', 'TestComponents_1_0']):
     """
     TestReportManifest contains the aggregated test results for the components.
 
-    The format for schema version 1.1 is:
-        schema-version: '1.1'
+    The format for schema version 1.0 is:
+        schema-version: '1.0'
         name: name of the product e.g. OpenSearch
-        distribution: tar, zip, deb and rpm
-        rc_number: number of release candidates, -1 means not a release candidate
         test-run:
           Command: command to trigger the integ test
           TestType: type of test this manifest reports. e.g. integ-test
@@ -39,16 +36,9 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
                   - URL or local path to the OpenSearch cluster error logs
     """
 
-    VERSIONS = {
-        "1.0": TestReportManifest_1_0,
-        # "1.1": current
-    }
-
     SCHEMA = {
-        "schema-version": {"required": True, "type": "string", "allowed": ["1.1"]},
+        "schema-version": {"required": True, "type": "string", "allowed": ["1.0"]},
         "name": {"required": True, "type": "string", "allowed": ["OpenSearch", "OpenSearch Dashboards"]},
-        "distribution": {"type": "string"},
-        "rc_number": {"required": True, "type": "number"},
         "test-run": {
             "required": False,
             "type": "dict",
@@ -88,17 +78,13 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
     def __init__(self, data: dict) -> None:
         super().__init__(data)
         self.name = str(data["name"])
-        self.distribution = str(data["distribution"])
-        self.rc_number = data["rc_number"]
         self.test_run = self.TestRun(data.get("test-run", None))
-        self.components = TestComponents(data.get("components", []))  # type: ignore[assignment]
+        self.components = TestComponents_1_0(data.get("components", []))  # type: ignore[assignment]
 
     def __to_dict__(self) -> dict:
         return {
-            "schema-version": "1.1",
+            "schema-version": "1.0",
             "name": self.name,
-            "rc_number": self.rc_number,
-            "distribution": self.distribution,
             "test-run": None if self.test_run is None else self.test_run.__to_dict__(),
             "components": self.components.__to_dict__()
         }
@@ -127,17 +113,17 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
                 }
 
 
-class TestComponents(Components['TestComponent']):
+class TestComponents_1_0(Components['TestComponent_1_0']):
     @classmethod
-    def __create__(self, data: dict) -> 'TestComponent':
-        return TestComponent(data)
+    def __create__(self, data: dict) -> 'TestComponent_1_0':
+        return TestComponent_1_0(data)
 
 
-class TestComponent(Component):
+class TestComponent_1_0(Component):
     def __init__(self, data: dict) -> None:
         super().__init__(data)
         self.command = data["command"]
-        self.configs = self.TestComponentConfigs(data.get("configs", None))
+        self.configs = self.TestComponentConfigs_1_0(data.get("configs", None))
 
     def __to_dict__(self) -> dict:
         return {
@@ -146,16 +132,16 @@ class TestComponent(Component):
             "configs": self.configs.__to_list__()
         }
 
-    class TestComponentConfigs:
+    class TestComponentConfigs_1_0:
         def __init__(self, data: list) -> None:
             self.configs = []
             for config in data:
-                self.configs.append(self.TestComponentConfig(config).__to_dict__())
+                self.configs.append(self.TestComponentConfig_1_0(config).__to_dict__())
 
         def __to_list__(self) -> list:
             return self.configs
 
-        class TestComponentConfig:
+        class TestComponentConfig_1_0:
             def __init__(self, data: dict) -> None:
                 self.name = data["name"]
                 self.status = data["status"]
@@ -173,7 +159,7 @@ class TestComponent(Component):
                 }
 
 
-TestReportManifest.VERSIONS = {"1.0": TestReportManifest_1_0, "1.1": TestReportManifest}
+TestReportManifest_1_0.VERSIONS = {"1.0": TestReportManifest_1_0}
 
-TestComponent.__test__ = False  # type: ignore[attr-defined]
-TestReportManifest.__test__ = False  # type: ignore[attr-defined]
+TestComponent_1_0.__test__ = False  # type: ignore[attr-defined]
+TestReportManifest_1_0.__test__ = False  # type: ignore[attr-defined]

--- a/src/manifests/test_report_manifest.py
+++ b/src/manifests/test_report_manifest.py
@@ -18,7 +18,11 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
     The format for schema version 1.1 is:
         schema-version: '1.1'
         name: name of the product e.g. OpenSearch
+        version: string
+        platform: linux, darwin or windows
+        architecture: x64 or arm64
         distribution: tar, zip, deb and rpm
+        id: build id
         rc_number: number of release candidates, -1 means not a release candidate
         test-run:
           Command: command to trigger the integ test
@@ -47,8 +51,12 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
     SCHEMA = {
         "schema-version": {"required": True, "type": "string", "allowed": ["1.1"]},
         "name": {"required": True, "type": "string", "allowed": ["OpenSearch", "OpenSearch Dashboards"]},
-        "distribution": {"type": "string"},
-        "rc_number": {"required": True, "type": "number"},
+        "version": {"required": True, "type": "string"},  # added in 1.1
+        "platform": {"required": True, "type": "string"},  # added in 1.1
+        "architecture": {"required": True, "type": "string"},  # added in 1.1
+        "distribution": {"required": True, "type": "string"},  # added in 1.1
+        "id": {"required": True, "type": "string"},  # added in 1.1
+        "rc_number": {"required": True, "type": "number"},  # added in 1.1
         "test-run": {
             "required": False,
             "type": "dict",
@@ -88,8 +96,12 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
     def __init__(self, data: dict) -> None:
         super().__init__(data)
         self.name = str(data["name"])
+        self.version = str(data["version"])
+        self.platform = str(data["platform"])
+        self.architecture = str(data["architecture"])
         self.distribution = str(data["distribution"])
-        self.rc_number = data["rc_number"]
+        self.build_id = str(data["id"])
+        self.rc_number = int(data["rc_number"])
         self.test_run = self.TestRun(data.get("test-run", None))
         self.components = TestComponents(data.get("components", []))  # type: ignore[assignment]
 
@@ -97,8 +109,12 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
         return {
             "schema-version": "1.1",
             "name": self.name,
-            "rc_number": self.rc_number,
+            "version": self.version,
+            "platform": self.platform,
+            "architecture": self.architecture,
             "distribution": self.distribution,
+            "id": self.build_id,
+            "rc": self.rc_number,
             "test-run": None if self.test_run is None else self.test_run.__to_dict__(),
             "components": self.components.__to_dict__()
         }

--- a/src/manifests/test_report_manifest.py
+++ b/src/manifests/test_report_manifest.py
@@ -23,7 +23,7 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
         architecture: x64 or arm64
         distribution: tar, zip, deb and rpm
         id: build id
-        rc_number: number of release candidates, -1 means not a release candidate
+        rc: release candidate information
         test-run:
           Command: command to trigger the integ test
           TestType: type of test this manifest reports. e.g. integ-test
@@ -56,7 +56,7 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
         "architecture": {"required": True, "type": "string"},  # added in 1.1
         "distribution": {"required": True, "type": "string"},  # added in 1.1
         "id": {"required": True, "type": "string"},  # added in 1.1
-        "rc_number": {"required": True, "type": "number"},  # added in 1.1
+        "rc": {"required": True, "type": "string"},  # added in 1.1
         "test-run": {
             "required": False,
             "type": "dict",
@@ -101,7 +101,7 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
         self.architecture = str(data["architecture"])
         self.distribution = str(data["distribution"])
         self.build_id = str(data["id"])
-        self.rc_number = int(data["rc_number"])
+        self.release_candidate = str(data["rc"])
         self.test_run = self.TestRun(data.get("test-run", None))
         self.components = TestComponents(data.get("components", []))  # type: ignore[assignment]
 
@@ -114,7 +114,7 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
             "architecture": self.architecture,
             "distribution": self.distribution,
             "id": self.build_id,
-            "rc": self.rc_number,
+            "rc": self.release_candidate,
             "test-run": None if self.test_run is None else self.test_run.__to_dict__(),
             "components": self.components.__to_dict__()
         }

--- a/src/report_workflow/report_args.py
+++ b/src/report_workflow/report_args.py
@@ -19,6 +19,8 @@ class ReportArgs:
     test_manifest_path: str
     artifact_paths: dict
     test_type: str
+    schema_version: str
+    rc_number: int
     logging_level: int
 
     def __init__(self) -> None:
@@ -33,6 +35,8 @@ class ReportArgs:
         parser.add_argument("--output-path", type=str, help="Specify the path location for the test-report manifest.")
         parser.add_argument("--test-run-id", type=int, help="The unique execution id for the test")
         parser.add_argument("--component", type=str, dest="components", nargs='*', help="Test a specific component or components instead of the entire distribution.")
+        parser.add_argument("--schema-version", type=str, default="1.1", help="The schema version for the test-report manifest")
+        parser.add_argument("--rc-number", type=int, default=-1, help="The release candidate (rc) number of the artifacts, -1 means not a release candidate")
         parser.add_argument(
             "-v", "--verbose", help="Show more verbose output.", action="store_const", default=logging.INFO, const=logging.DEBUG, dest="logging_level"
         )
@@ -45,4 +49,6 @@ class ReportArgs:
         self.base_path = args.base_path
         self.test_type = args.test_type
         self.components = args.components
+        self.schema_version = args.schema_version
+        self.rc_number = args.rc_number
         self.output_path = args.output_path

--- a/src/report_workflow/report_args.py
+++ b/src/report_workflow/report_args.py
@@ -20,7 +20,7 @@ class ReportArgs:
     artifact_paths: dict
     test_type: str
     schema_version: str
-    rc_number: int
+    release_candidate: str
     logging_level: int
 
     def __init__(self) -> None:
@@ -35,8 +35,8 @@ class ReportArgs:
         parser.add_argument("--output-path", type=str, help="Specify the path location for the test-report manifest.")
         parser.add_argument("--test-run-id", type=int, help="The unique execution id for the test")
         parser.add_argument("--component", type=str, dest="components", nargs='*', help="Test a specific component or components instead of the entire distribution.")
-        parser.add_argument("--schema-version", type=str, default="1.1", help="The schema version for the test-report manifest")
-        parser.add_argument("--rc-number", type=int, default=-1, help="The release candidate (rc) number of the artifacts, -1 means not a release candidate")
+        parser.add_argument("--schema-version", type=str, default="1.1", help="The schema version for the test-report manifest.")
+        parser.add_argument("--release-candidate", type=str, default="0", help="The release candidate (rc) information of the artifacts, added in schema-version='1.1'.")
         parser.add_argument(
             "-v", "--verbose", help="Show more verbose output.", action="store_const", default=logging.INFO, const=logging.DEBUG, dest="logging_level"
         )
@@ -50,5 +50,5 @@ class ReportArgs:
         self.test_type = args.test_type
         self.components = args.components
         self.schema_version = args.schema_version
-        self.rc_number = args.rc_number
+        self.release_candidate = args.release_candidate
         self.output_path = args.output_path

--- a/src/report_workflow/report_args.py
+++ b/src/report_workflow/report_args.py
@@ -19,7 +19,6 @@ class ReportArgs:
     test_manifest_path: str
     artifact_paths: dict
     test_type: str
-    schema_version: str
     release_candidate: str
     logging_level: int
 
@@ -35,7 +34,6 @@ class ReportArgs:
         parser.add_argument("--output-path", type=str, help="Specify the path location for the test-report manifest.")
         parser.add_argument("--test-run-id", type=int, help="The unique execution id for the test")
         parser.add_argument("--component", type=str, dest="components", nargs='*', help="Test a specific component or components instead of the entire distribution.")
-        parser.add_argument("--schema-version", type=str, default="1.1", help="The schema version for the test-report manifest.")
         parser.add_argument("--release-candidate", type=str, default="0", help="The release candidate (rc) information of the artifacts, added in schema-version='1.1'.")
         parser.add_argument(
             "-v", "--verbose", help="Show more verbose output.", action="store_const", default=logging.INFO, const=logging.DEBUG, dest="logging_level"
@@ -49,6 +47,5 @@ class ReportArgs:
         self.base_path = args.base_path
         self.test_type = args.test_type
         self.components = args.components
-        self.schema_version = args.schema_version
         self.release_candidate = args.release_candidate
         self.output_path = args.output_path

--- a/src/report_workflow/test_report_runner.py
+++ b/src/report_workflow/test_report_runner.py
@@ -117,7 +117,6 @@ class TestReportRunner:
         return component
 
     def test_report_manifest_data_template(self, template_type: str) -> Any:
-
         templates = {
             "manifest": {
                 "schema-version": "1.1",

--- a/src/report_workflow/test_report_runner.py
+++ b/src/report_workflow/test_report_runner.py
@@ -12,12 +12,11 @@ import urllib.request
 from typing import Any
 from urllib.error import HTTPError
 
-import shutil
 import validators
 import yaml
 
-from manifests.test_manifest import TestManifest
 from manifests.bundle_manifest import BundleManifest
+from manifests.test_manifest import TestManifest
 from manifests.test_report_manifest import TestReportManifest
 from report_workflow.report_args import ReportArgs
 

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -109,7 +109,7 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
         if os.path.exists(script):
             if len(cluster_endpoints) == 1:
                 single_data_node = cluster_endpoints[0].data_nodes[0]
-                cmd = f"bash {script} -b {single_data_node.endpoint} -p {single_data_node.port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
+                cmd = f"bash {script} -b {single_data_node.endpoint} -p {single_data_node.port} -s {str(security).lower()} -v {self.bundle_manifest.build.version} | tee /tmp/123 2>&1"
             else:
                 endpoints_list = []
                 for cluster_details in cluster_endpoints:

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -109,7 +109,7 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
         if os.path.exists(script):
             if len(cluster_endpoints) == 1:
                 single_data_node = cluster_endpoints[0].data_nodes[0]
-                cmd = f"bash {script} -b {single_data_node.endpoint} -p {single_data_node.port} -s {str(security).lower()} -v {self.bundle_manifest.build.version} | tee /tmp/123 2>&1"
+                cmd = f"bash {script} -b {single_data_node.endpoint} -p {single_data_node.port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
             else:
                 endpoints_list = []
                 for cluster_details in cluster_endpoints:

--- a/tests/tests_report_workflow/data/dist/opensearch-dashboards/manifest.yml
+++ b/tests/tests_report_workflow/data/dist/opensearch-dashboards/manifest.yml
@@ -1,0 +1,60 @@
+---
+schema-version: '1.1'
+build:
+  name: OpenSearch Dashboards
+  version: 1.3.18
+  platform: linux
+  architecture: x64
+  distribution: tar
+  location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.18/7791/linux/x64/tar/dist/opensearch-dashboards/opensearch-dashboards-1.3.18-linux-x64.tar.gz
+  id: '7791'
+components:
+  - name: OpenSearch-Dashboards
+    repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+    ref: '1.3'
+    commit_id: 26d95c2bb5d43e3d540d4612884ff98f66938046
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.18/7791/linux/x64/tar/builds/opensearch-dashboards/dist/opensearch-dashboards-min-1.3.18-linux-x64.tar.gz
+  - name: functionalTestDashboards
+    repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
+    ref: '1.3'
+    commit_id: 8b999677608cbe09f3f412ba1b3b57c9731a7ffc
+  - name: anomalyDetectionDashboards
+    repository: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin
+    ref: '1.3'
+    commit_id: 1da96108484cf891f071ca54634b8df815dccec9
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.18/7791/linux/x64/tar/builds/opensearch-dashboards/plugins/anomalyDetectionDashboards-1.3.18.zip
+  - name: ganttChartDashboards
+    repository: https://github.com/opensearch-project/dashboards-visualizations.git
+    ref: '1.3'
+    commit_id: 968bcf9f028e7fdd503eaf25e0c877efff0c9ed8
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.18/7791/linux/x64/tar/builds/opensearch-dashboards/plugins/ganttChartDashboards-1.3.18.zip
+  - name: observabilityDashboards
+    repository: https://github.com/opensearch-project/dashboards-observability.git
+    ref: '1.3'
+    commit_id: a1d4df6bc56b04197f6fc3611c8e7aee6fd51b9f
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.18/7791/linux/x64/tar/builds/opensearch-dashboards/plugins/observabilityDashboards-1.3.18.zip
+  - name: alertingDashboards
+    repository: https://github.com/opensearch-project/alerting-dashboards-plugin.git
+    ref: '1.3'
+    commit_id: 7c133586fec9cc4d0f3e4d98b2182e2e8563f3dc
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.18/7791/linux/x64/tar/builds/opensearch-dashboards/plugins/alertingDashboards-1.3.18.zip
+  - name: indexManagementDashboards
+    repository: https://github.com/opensearch-project/index-management-dashboards-plugin
+    ref: '1.3'
+    commit_id: 189fd6b9d81059d4d0485e3a84e2aecebf020b58
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.18/7791/linux/x64/tar/builds/opensearch-dashboards/plugins/indexManagementDashboards-1.3.18.zip
+  - name: reportsDashboards
+    repository: https://github.com/opensearch-project/dashboards-reporting.git
+    ref: '1.3'
+    commit_id: 45fa281c2f2f727b460d2d8cfdbb61d502046d73
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.18/7791/linux/x64/tar/builds/opensearch-dashboards/plugins/reportsDashboards-1.3.18.zip
+  - name: securityDashboards
+    repository: https://github.com/opensearch-project/security-dashboards-plugin.git
+    ref: '1.3'
+    commit_id: 7d471b1db91f4452e1fb03ec31cea2862ff69017
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.18/7791/linux/x64/tar/builds/opensearch-dashboards/plugins/securityDashboards-1.3.18.zip
+  - name: queryWorkbenchDashboards
+    repository: https://github.com/opensearch-project/dashboards-query-workbench.git
+    ref: '1.3'
+    commit_id: 38cebc903e5a3a3247b6493002f235d6389e535d
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/1.3.18/7791/linux/x64/tar/builds/opensearch-dashboards/plugins/queryWorkbenchDashboards-1.3.18.zip

--- a/tests/tests_report_workflow/data/dist/opensearch/manifest.yml
+++ b/tests/tests_report_workflow/data/dist/opensearch/manifest.yml
@@ -1,0 +1,125 @@
+---
+schema-version: '1.1'
+build:
+  name: OpenSearch
+  version: 2.15.0
+  platform: linux
+  architecture: x64
+  distribution: tar
+  location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/dist/opensearch/opensearch-2.15.0-linux-x64.tar.gz
+  id: '9992'
+components:
+  - name: OpenSearch
+    repository: https://github.com/opensearch-project/OpenSearch.git
+    ref: 61dbcd0795c9bfe9b81e5762175414bc38bbcadf
+    commit_id: 61dbcd0795c9bfe9b81e5762175414bc38bbcadf
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/dist/opensearch-min-2.15.0-linux-x64.tar.gz
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: 4e407bd981929cb332f708bcf0acc87f9a3beb99
+    commit_id: 4e407bd981929cb332f708bcf0acc87f9a3beb99
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: 1963c998b0face391dfff8e16d19f5abeea96797
+    commit_id: 1963c998b0face391dfff8e16d19f5abeea96797
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-job-scheduler-2.15.0.0.zip
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: 96743013767dd7e57e88de7ef1dae01b9545b01c
+    commit_id: 96743013767dd7e57e88de7ef1dae01b9545b01c
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-security-2.15.0.0.zip
+  - name: k-NN
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: 150c589849a8ec3bc442d830b43a3eaf4e25fa0c
+    commit_id: 150c589849a8ec3bc442d830b43a3eaf4e25fa0c
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-knn-2.15.0.0.zip
+  - name: geospatial
+    repository: https://github.com/opensearch-project/geospatial.git
+    ref: ee4289213d72c63fec47758b74ab6c6376c216c9
+    commit_id: ee4289213d72c63fec47758b74ab6c6376c216c9
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-geospatial-2.15.0.0.zip
+  - name: cross-cluster-replication
+    repository: https://github.com/opensearch-project/cross-cluster-replication.git
+    ref: f4af360f50d8335dcbf974001ea577f3b7428e25
+    commit_id: f4af360f50d8335dcbf974001ea577f3b7428e25
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-cross-cluster-replication-2.15.0.0.zip
+  - name: ml-commons
+    repository: https://github.com/opensearch-project/ml-commons.git
+    ref: 63aeaabd5a4e42a24a28044abf37b38bca3400af
+    commit_id: 63aeaabd5a4e42a24a28044abf37b38bca3400af
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-ml-2.15.0.0.zip
+  - name: neural-search
+    repository: https://github.com/opensearch-project/neural-search.git
+    ref: e683e7455a1091d20ee5903bd115059f147870e3
+    commit_id: e683e7455a1091d20ee5903bd115059f147870e3
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-neural-search-2.15.0.0.zip
+  - name: notifications-core
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: aa9b6c464754f95fdb791ba9d7e29fa9c04293ac
+    commit_id: aa9b6c464754f95fdb791ba9d7e29fa9c04293ac
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-notifications-core-2.15.0.0.zip
+  - name: notifications
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: aa9b6c464754f95fdb791ba9d7e29fa9c04293ac
+    commit_id: aa9b6c464754f95fdb791ba9d7e29fa9c04293ac
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-notifications-2.15.0.0.zip
+  - name: opensearch-observability
+    repository: https://github.com/opensearch-project/observability.git
+    ref: 2ec046b2e324c5de8acb0abb37efde3b4c6d8e0d
+    commit_id: 2ec046b2e324c5de8acb0abb37efde3b4c6d8e0d
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-observability-2.15.0.0.zip
+  - name: opensearch-reports
+    repository: https://github.com/opensearch-project/reporting.git
+    ref: 50451382b671ac84081a5e48a3661cf6d1b1434b
+    commit_id: 50451382b671ac84081a5e48a3661cf6d1b1434b
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-reports-scheduler-2.15.0.0.zip
+  - name: sql
+    repository: https://github.com/opensearch-project/sql.git
+    ref: aa606a944e5b31a32029fc25d3004154e08db197
+    commit_id: aa606a944e5b31a32029fc25d3004154e08db197
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-sql-2.15.0.0.zip
+  - name: asynchronous-search
+    repository: https://github.com/opensearch-project/asynchronous-search.git
+    ref: 295bd1c831f64906709d6e25b6ad0d9bab2f45fb
+    commit_id: 295bd1c831f64906709d6e25b6ad0d9bab2f45fb
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-asynchronous-search-2.15.0.0.zip
+  - name: anomaly-detection
+    repository: https://github.com/opensearch-project/anomaly-detection.git
+    ref: f6d262e2d3a20309adc8ab2bbcb1248defc3a190
+    commit_id: f6d262e2d3a20309adc8ab2bbcb1248defc3a190
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-anomaly-detection-2.15.0.0.zip
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: 82fea192437d305dbb1ae07536fee05e8f13ace2
+    commit_id: 82fea192437d305dbb1ae07536fee05e8f13ace2
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-alerting-2.15.0.0.zip
+  - name: security-analytics
+    repository: https://github.com/opensearch-project/security-analytics.git
+    ref: c0de31a0e99bfc3ab8201706e4d8d74db8a0f4e6
+    commit_id: c0de31a0e99bfc3ab8201706e4d8d74db8a0f4e6
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-security-analytics-2.15.0.0.zip
+  - name: index-management
+    repository: https://github.com/opensearch-project/index-management.git
+    ref: ce7ee04856aeb18a5fa232a802f85b5d97fecc00
+    commit_id: ce7ee04856aeb18a5fa232a802f85b5d97fecc00
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-index-management-2.15.0.0.zip
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
+    ref: 837bfe8a6ed11eb8a8a8b6ffc0049b8f4984a1b6
+    commit_id: 837bfe8a6ed11eb8a8a8b6ffc0049b8f4984a1b6
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-performance-analyzer-2.15.0.0.zip
+  - name: custom-codecs
+    repository: https://github.com/opensearch-project/custom-codecs.git
+    ref: 0d32cb08e8e326a6968b87961f7284311ad301ba
+    commit_id: 0d32cb08e8e326a6968b87961f7284311ad301ba
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-custom-codecs-2.15.0.0.zip
+  - name: flow-framework
+    repository: https://github.com/opensearch-project/flow-framework.git
+    ref: 1d01add552ad457074e5bf76a11112b5678c7ba3
+    commit_id: 1d01add552ad457074e5bf76a11112b5678c7ba3
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-flow-framework-2.15.0.0.zip
+  - name: skills
+    repository: https://github.com/opensearch-project/skills.git
+    ref: 27962077bc0afbb50cf4443c55b8cb81b76ecd85
+    commit_id: 27962077bc0afbb50cf4443c55b8cb81b76ecd85
+    location: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.15.0/9992/linux/x64/tar/builds/opensearch/plugins/opensearch-skills-2.15.0.0.zip

--- a/tests/tests_report_workflow/test_report_args.py
+++ b/tests/tests_report_workflow/test_report_args.py
@@ -45,13 +45,7 @@ class TestReportArgs(unittest.TestCase):
         self.assertIsNotNone(report_args.test_type)
         self.assertEqual(report_args.logging_level, logging.INFO)
         self.assertEqual(report_args.test_manifest_path, self.TEST_MANIFEST_PATH)
-        self.assertEqual(report_args.schema_version, "1.1")
         self.assertEqual(report_args.release_candidate, "0")
-
-    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--schema-version", "1.0"])
-    def test_schema_version(self) -> None:
-        report_args = ReportArgs()
-        self.assertEqual(report_args.schema_version, "1.0")
 
     @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--release-candidate", "100"])
     def test_release_candidate(self) -> None:

--- a/tests/tests_report_workflow/test_report_args.py
+++ b/tests/tests_report_workflow/test_report_args.py
@@ -45,6 +45,18 @@ class TestReportArgs(unittest.TestCase):
         self.assertIsNotNone(report_args.test_type)
         self.assertEqual(report_args.logging_level, logging.INFO)
         self.assertEqual(report_args.test_manifest_path, self.TEST_MANIFEST_PATH)
+        self.assertEqual(report_args.schema_version, "1.1" )
+        self.assertEqual(report_args.release_candidate, "0" )
+
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--schema-version", "1.0"])
+    def test_schema_version(self) -> None:
+        report_args = ReportArgs()
+        self.assertEqual(report_args.schema_version, "1.0")
+
+    @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--release-candidate", "100"])
+    def test_release_candidate(self) -> None:
+        report_args = ReportArgs()
+        self.assertEqual(report_args.release_candidate, "100")
 
     @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--component", "component1", "component2"])
     def test_components(self) -> None:

--- a/tests/tests_report_workflow/test_report_args.py
+++ b/tests/tests_report_workflow/test_report_args.py
@@ -45,8 +45,8 @@ class TestReportArgs(unittest.TestCase):
         self.assertIsNotNone(report_args.test_type)
         self.assertEqual(report_args.logging_level, logging.INFO)
         self.assertEqual(report_args.test_manifest_path, self.TEST_MANIFEST_PATH)
-        self.assertEqual(report_args.schema_version, "1.1" )
-        self.assertEqual(report_args.release_candidate, "0" )
+        self.assertEqual(report_args.schema_version, "1.1")
+        self.assertEqual(report_args.release_candidate, "0")
 
     @patch("argparse._sys.argv", [ARGS_PY, TEST_MANIFEST_PATH, "--schema-version", "1.0"])
     def test_schema_version(self) -> None:

--- a/tests/tests_report_workflow/test_test_report_runner.py
+++ b/tests/tests_report_workflow/test_test_report_runner.py
@@ -16,12 +16,8 @@ from system.temporary_directory import TemporaryDirectory
 
 
 class TestTestReportRunner(unittest.TestCase):
-    DATA_DIR = os.path.join(
-        os.path.dirname(__file__), "data"
-    )
-    TEST_MANIFEST_PATH = os.path.join(
-        DATA_DIR, "test_manifest.yml"
-    )
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+    TEST_MANIFEST_PATH = os.path.join(DATA_DIR, "test_manifest.yml")
     TEST_MANIFEST = TestManifest.from_path(TEST_MANIFEST_PATH)
 
     @patch("report_workflow.report_args.ReportArgs")
@@ -44,7 +40,7 @@ class TestTestReportRunner(unittest.TestCase):
     @patch("validators.url")
     @patch("report_workflow.report_args.ReportArgs")
     def test_generate_file_url_1_0(self, report_args_mock: MagicMock, validators_mock: MagicMock, urlopen_mock: MagicMock,
-                           yaml_safe_load_mock: MagicMock) -> None:
+                                   yaml_safe_load_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
         report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
         report_args_mock.test_run_id = 123

--- a/tests/tests_report_workflow/test_test_report_runner.py
+++ b/tests/tests_report_workflow/test_test_report_runner.py
@@ -16,11 +16,11 @@ from system.temporary_directory import TemporaryDirectory
 
 
 class TestTestReportRunner(unittest.TestCase):
-    TEST_MANIFEST_PATH = os.path.join(
-        os.path.dirname(__file__), "data", "test_manifest.yml"
-    )
     DATA_DIR = os.path.join(
         os.path.dirname(__file__), "data"
+    )
+    TEST_MANIFEST_PATH = os.path.join(
+        DATA_DIR, "test_manifest.yml"
     )
     TEST_MANIFEST = TestManifest.from_path(TEST_MANIFEST_PATH)
 
@@ -39,8 +39,33 @@ class TestTestReportRunner(unittest.TestCase):
         self.assertEqual(test_run_runner.test_type, "integ-test")
         self.assertEqual(test_run_runner.test_manifest_path, self.TEST_MANIFEST_PATH)
 
+    @patch("yaml.safe_load")
+    @patch("urllib.request.urlopen")
+    @patch("validators.url")
     @patch("report_workflow.report_args.ReportArgs")
-    def test_generate_file(self, report_args_mock: MagicMock) -> None:
+    def test_generate_file_url_1_0(self, report_args_mock: MagicMock, validators_mock: MagicMock, urlopen_mock: MagicMock,
+                           yaml_safe_load_mock: MagicMock) -> None:
+        report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
+        report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
+        report_args_mock.test_run_id = 123
+        report_args_mock.base_path = "https://ci.opensearch.org/ci/dbc/mock"
+        report_args_mock.test_type = "integ-test"
+        report_args_mock.schema_version = "1.0"
+
+        validators_mock.return_value = True
+        yaml_safe_load_mock.return_value = {"test_result": "PASS"}
+        urlopen_mock.return_value = MagicMock()
+
+        test_run_runner = TestReportRunner(report_args_mock, self.TEST_MANIFEST)
+        test_run_runner_data = test_run_runner.update_data()
+
+        with TemporaryDirectory() as path:
+            output_path = os.path.join(path.name, "test-report.yml")
+            test_run_runner.generate_report(test_run_runner_data, path.name)
+            self.assertTrue(os.path.isfile(output_path))
+
+    @patch("report_workflow.report_args.ReportArgs")
+    def test_generate_file_local_path(self, report_args_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
         report_args_mock.artifact_paths = {"opensearch": self.DATA_DIR}
         report_args_mock.test_run_id = 123

--- a/tests/tests_report_workflow/test_test_report_runner.py
+++ b/tests/tests_report_workflow/test_test_report_runner.py
@@ -19,6 +19,9 @@ class TestTestReportRunner(unittest.TestCase):
     TEST_MANIFEST_PATH = os.path.join(
         os.path.dirname(__file__), "data", "test_manifest.yml"
     )
+    DATA_DIR = os.path.join(
+        os.path.dirname(__file__), "data"
+    )
     TEST_MANIFEST = TestManifest.from_path(TEST_MANIFEST_PATH)
 
     @patch("report_workflow.report_args.ReportArgs")
@@ -28,6 +31,7 @@ class TestTestReportRunner(unittest.TestCase):
         report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
         report_args_mock.test_run_id = 123
         report_args_mock.test_type = "integ-test"
+        report_args_mock.schema_version = "1.1"
 
         test_run_runner = TestReportRunner(report_args_mock, self.TEST_MANIFEST)
         self.assertEqual(test_run_runner.name, "opensearch")
@@ -35,21 +39,15 @@ class TestTestReportRunner(unittest.TestCase):
         self.assertEqual(test_run_runner.test_type, "integ-test")
         self.assertEqual(test_run_runner.test_manifest_path, self.TEST_MANIFEST_PATH)
 
-    @patch("yaml.safe_load")
-    @patch("urllib.request.urlopen")
-    @patch("validators.url")
     @patch("report_workflow.report_args.ReportArgs")
-    def test_generate_file(self, report_args_mock: MagicMock, validators_mock: MagicMock, urlopen_mock: MagicMock,
-                           yaml_safe_load_mock: MagicMock) -> None:
+    def test_generate_file(self, report_args_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
-        report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
+        report_args_mock.artifact_paths = {"opensearch": self.DATA_DIR}
         report_args_mock.test_run_id = 123
-        report_args_mock.base_path = "https://ci.opensearch.org/ci/dbc/mock"
+        report_args_mock.base_path = self.DATA_DIR
         report_args_mock.test_type = "integ-test"
-
-        validators_mock.return_value = True
-        yaml_safe_load_mock.return_value = {"test_result": "PASS"}
-        urlopen_mock.return_value = MagicMock()
+        report_args_mock.schema_version = "1.1"
+        report_args_mock.release_candidate = "100"
 
         test_run_runner = TestReportRunner(report_args_mock, self.TEST_MANIFEST)
         test_run_runner_data = test_run_runner.update_data()
@@ -67,6 +65,7 @@ class TestTestReportRunner(unittest.TestCase):
         report_args_mock.artifact_paths = {"opensearch": "foo/bar"}
         report_args_mock.test_run_id = 123
         report_args_mock.test_type = "integ-test"
+        report_args_mock.schema_version = "1.1"
 
         test_run_dict = TestReportRunner(report_args_mock, self.TEST_MANIFEST).update_test_run_data()
         self.assertEqual(test_run_dict.get("Command"), " ".join(
@@ -84,6 +83,7 @@ class TestTestReportRunner(unittest.TestCase):
         report_args_mock.artifact_paths = {"opensearch": "https://foo/bar"}
         report_args_mock.test_run_id = 123
         report_args_mock.test_type = "integ-test"
+        report_args_mock.schema_version = "1.1"
 
         test_run_dict = TestReportRunner(report_args_mock, self.TEST_MANIFEST).update_test_run_data()
         self.assertEqual(test_run_dict.get("Command"), " ".join(
@@ -105,6 +105,7 @@ class TestTestReportRunner(unittest.TestCase):
         report_args_mock.test_run_id = 123
         report_args_mock.base_path = "https://ci.opensearch.org/ci/dbc/mock"
         report_args_mock.test_type = "integ-test"
+        report_args_mock.schema_version = "1.1"
 
         validators_mock.return_value = True
         yaml_safe_load_mock.return_value = {"test_result": "PASS"}
@@ -139,6 +140,7 @@ class TestTestReportRunner(unittest.TestCase):
         report_args_mock.test_run_id = 123
         report_args_mock.base_path = "https://ci.opensearch.org/ci/dbc/mock"
         report_args_mock.test_type = "integ-test"
+        report_args_mock.schema_version = "1.1"
 
         validators_mock.return_value = False
         yaml_safe_load_mock.return_value = {"test_result": "PASS"}
@@ -165,6 +167,7 @@ class TestTestReportRunner(unittest.TestCase):
         report_args_mock.test_run_id = 123
         report_args_mock.base_path = "https://ci.opensearch.org/ci/dbc/mock"
         report_args_mock.test_type = "integ-test"
+        report_args_mock.schema_version = "1.1"
 
         validators_mock.return_value = True
 
@@ -188,6 +191,7 @@ class TestTestReportRunner(unittest.TestCase):
         report_args_mock.test_run_id = 123
         report_args_mock.base_path = "https://ci.opensearch.org/ci/dbc/mock"
         report_args_mock.test_type = "integ-test"
+        report_args_mock.schema_version = "1.1"
 
         validators_mock.return_value = False
         yaml_safe_load_mock.return_value = {"test_result": "PASS"}

--- a/tests/tests_report_workflow/test_test_report_runner_dashboards.py
+++ b/tests/tests_report_workflow/test_test_report_runner_dashboards.py
@@ -16,13 +16,8 @@ from system.temporary_directory import TemporaryDirectory
 
 
 class TestTestReportRunnerDashboards(unittest.TestCase):
-    DATA_DIR = os.path.join(
-            os.path.dirname(__file__), "data"
-                )
-    TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH = os.path.join(
-        DATA_DIR, "test-manifest-opensearch-dashboards.yml"
-    )
-
+    DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+    TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH = os.path.join(DATA_DIR, "test-manifest-opensearch-dashboards.yml")
     TEST_MANIFEST_OPENSEARCH_DASHBOARDS = TestManifest.from_path(TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH)
 
     @patch("report_workflow.report_args.ReportArgs")
@@ -45,7 +40,7 @@ class TestTestReportRunnerDashboards(unittest.TestCase):
     @patch("validators.url")
     @patch("report_workflow.report_args.ReportArgs")
     def test_generate_file_url_1_0(self, report_args_mock: MagicMock, validators_mock: MagicMock, urlopen_mock: MagicMock,
-                           yaml_safe_load_mock: MagicMock) -> None:
+                                   yaml_safe_load_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH
         report_args_mock.artifact_paths = {"opensearch-dashboards": "foo/bar"}
         report_args_mock.test_run_id = 123

--- a/tests/tests_report_workflow/test_test_report_runner_dashboards.py
+++ b/tests/tests_report_workflow/test_test_report_runner_dashboards.py
@@ -21,53 +21,34 @@ class TestTestReportRunnerDashboards(unittest.TestCase):
     TEST_MANIFEST_OPENSEARCH_DASHBOARDS = TestManifest.from_path(TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH)
 
     @patch("report_workflow.report_args.ReportArgs")
-    @patch("manifests.test_manifest.TestManifest")
-    def test_runner_dashboards_init(self, report_args_mock: MagicMock, test_manifest_mock: MagicMock) -> None:
-        report_args_mock.test_manifest_path = self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH
-        report_args_mock.artifact_paths = {"opensearch-dashboards": "foo/bar"}
-        report_args_mock.test_run_id = 123
-        report_args_mock.test_type = "integ-test"
-        report_args_mock.schema_version = "1.1"
-
-        test_run_runner = TestReportRunner(report_args_mock, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS)
-        self.assertEqual(test_run_runner.name, "opensearch-dashboards")
-        self.assertEqual(test_run_runner.test_run_id, 123)
-        self.assertEqual(test_run_runner.test_type, "integ-test")
-        self.assertEqual(test_run_runner.test_manifest_path, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH)
-
-    @patch("yaml.safe_load")
-    @patch("urllib.request.urlopen")
-    @patch("validators.url")
-    @patch("report_workflow.report_args.ReportArgs")
-    def test_generate_file_url_1_0(self, report_args_mock: MagicMock, validators_mock: MagicMock, urlopen_mock: MagicMock,
-                                   yaml_safe_load_mock: MagicMock) -> None:
-        report_args_mock.test_manifest_path = self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH
-        report_args_mock.artifact_paths = {"opensearch-dashboards": "foo/bar"}
-        report_args_mock.test_run_id = 123
-        report_args_mock.base_path = "https://ci.opensearch.org/ci/dbc/mock"
-        report_args_mock.test_type = "integ-test"
-        report_args_mock.schema_version = "1.0"
-
-        validators_mock.return_value = True
-        yaml_safe_load_mock.return_value = {"test_result": "PASS"}
-        urlopen_mock.return_value = MagicMock()
-
-        test_run_runner = TestReportRunner(report_args_mock, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS)
-        test_run_runner_data = test_run_runner.update_data()
-
-        with TemporaryDirectory() as path:
-            output_path = os.path.join(path.name, "test-report.yml")
-            test_run_runner.generate_report(test_run_runner_data, path.name)
-            self.assertTrue(os.path.isfile(output_path))
-
-    @patch("report_workflow.report_args.ReportArgs")
-    def test_generate_file_local_path(self, report_args_mock: MagicMock) -> None:
+    def test_runner_dashboards_init(self, report_args_mock: MagicMock) -> None:
         report_args_mock.test_manifest_path = self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH
         report_args_mock.artifact_paths = {"opensearch-dashboards": self.DATA_DIR}
         report_args_mock.test_run_id = 123
         report_args_mock.base_path = self.DATA_DIR
         report_args_mock.test_type = "integ-test"
-        report_args_mock.schema_version = "1.1"
+        report_args_mock.release_candidate = "100"
+
+        test_run_runner = TestReportRunner(report_args_mock, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS)
+        test_run_runner_data = test_run_runner.update_data()
+        self.assertEqual(test_run_runner.name, "opensearch-dashboards")
+        self.assertEqual(test_run_runner.test_run_id, 123)
+        self.assertEqual(test_run_runner.test_type, "integ-test")
+        self.assertEqual(test_run_runner.test_manifest_path, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH)
+        self.assertEqual(test_run_runner_data["version"], "1.3.18")
+        self.assertEqual(test_run_runner_data["platform"], "linux")
+        self.assertEqual(test_run_runner_data["architecture"], "x64")
+        self.assertEqual(test_run_runner_data["distribution"], "tar")
+        self.assertEqual(test_run_runner_data["id"], "7791")
+        self.assertEqual(test_run_runner_data["rc"], "100")
+
+    @patch("report_workflow.report_args.ReportArgs")
+    def test_generate_file(self, report_args_mock: MagicMock) -> None:
+        report_args_mock.test_manifest_path = self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS_PATH
+        report_args_mock.artifact_paths = {"opensearch-dashboards": self.DATA_DIR}
+        report_args_mock.test_run_id = 123
+        report_args_mock.base_path = self.DATA_DIR
+        report_args_mock.test_type = "integ-test"
         report_args_mock.release_candidate = "100"
 
         test_run_runner = TestReportRunner(report_args_mock, self.TEST_MANIFEST_OPENSEARCH_DASHBOARDS)
@@ -89,7 +70,6 @@ class TestTestReportRunnerDashboards(unittest.TestCase):
         report_args_mock.test_run_id = 123
         report_args_mock.base_path = "https://ci.opensearch.org/ci/dbc/mock"
         report_args_mock.test_type = "integ-test"
-        report_args_mock.schema_version = "1.1"
 
         validators_mock.return_value = True
         yaml_safe_load_mock.return_value = {"test_result": "PASS"}


### PR DESCRIPTION
### Description
Add 1.1 version of test report yml with bundle and rc information
Adding version, platform, architecture, distribution, build id, rc number information.

### Issues Resolved
https://github.com/opensearch-project/opensearch-metrics/issues/51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
