### PR TITLE
[Release 2.16.0] Update FT repo to use 2.x

### DIFF
--- a/manifests/2.16.0/opensearch-dashboards-2.16.0.yml
+++ b/manifests/2.16.0/opensearch-dashboards-2.16.0.yml
@@ -12,7 +12,7 @@ components:
     ref: '2.16'
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
-    ref: '2.16'
+    ref: 2.x
   - name: observabilityDashboards
     repository: https://github.com/opensearch-project/dashboards-observability.git
     ref: '2.16'


### PR DESCRIPTION
### Description
[Release 2.16.0] Update FT repo to use 2.x

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4771

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
