### PR TITLE
Changed days to keep integ test logs from 30 to 60 in OS and OSD

### DIFF
--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -35,7 +35,7 @@ def agent_nodes = [
 pipeline {
     options {
         timeout(time: 7, unit: 'HOURS')
-        buildDiscarder(logRotator(daysToKeepStr: '30'))
+        buildDiscarder(logRotator(daysToKeepStr: '60'))
     }
     agent none
     environment {

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -35,7 +35,7 @@ def agent_nodes = [
 pipeline {
     options {
         timeout(time: 4, unit: 'HOURS')
-        buildDiscarder(logRotator(daysToKeepStr: '30'))
+        buildDiscarder(logRotator(daysToKeepStr: '60'))
     }
     agent none
     environment {

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test-without-validation.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test-without-validation.jenkinsfile.txt
@@ -4,7 +4,7 @@
       integ-test.pipeline(groovy.lang.Closure)
          integ-test.credentials(jenkins-artifact-bucket-name)
          integ-test.timeout({time=7, unit=HOURS})
-         integ-test.logRotator({daysToKeepStr=30})
+         integ-test.logRotator({daysToKeepStr=60})
          integ-test.buildDiscarder(null)
          integ-test.echo(Executing on agent [label:none])
          integ-test.stage(verify-parameters, groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-dashboards/integ-test.jenkinsfile.txt
@@ -4,7 +4,7 @@
       integ-test.pipeline(groovy.lang.Closure)
          integ-test.credentials(jenkins-artifact-bucket-name)
          integ-test.timeout({time=7, unit=HOURS})
-         integ-test.logRotator({daysToKeepStr=30})
+         integ-test.logRotator({daysToKeepStr=60})
          integ-test.buildDiscarder(null)
          integ-test.echo(Executing on agent [label:none])
          integ-test.stage(verify-parameters, groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test-without-validation.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test-without-validation.jenkinsfile.txt
@@ -4,7 +4,7 @@
       integ-test.pipeline(groovy.lang.Closure)
          integ-test.credentials(jenkins-artifact-bucket-name)
          integ-test.timeout({time=4, unit=HOURS})
-         integ-test.logRotator({daysToKeepStr=30})
+         integ-test.logRotator({daysToKeepStr=60})
          integ-test.buildDiscarder(null)
          integ-test.echo(Executing on agent [label:none])
          integ-test.stage(verify-parameters, groovy.lang.Closure)

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/integ-test.jenkinsfile.txt
@@ -4,7 +4,7 @@
       integ-test.pipeline(groovy.lang.Closure)
          integ-test.credentials(jenkins-artifact-bucket-name)
          integ-test.timeout({time=4, unit=HOURS})
-         integ-test.logRotator({daysToKeepStr=30})
+         integ-test.logRotator({daysToKeepStr=60})
          integ-test.buildDiscarder(null)
          integ-test.echo(Executing on agent [label:none])
          integ-test.stage(verify-parameters, groovy.lang.Closure)


### PR DESCRIPTION
### Description
Increase number of days to retain integ test logs to view logs of past OS and OSD releases.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
