### PR TITLE
Add specific download path for ` downloadBuildManifest`

### DIFF
--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -346,16 +346,20 @@ pipeline {
                                     sh 'sleep 10'
                                     downloadBuildManifest(
                                         url: BUILD_MANIFEST_URL,
-                                        path: BUILD_MANIFEST
+                                        path: "manifests-osd-${env.BUILD_NUMBER}/${env.BUILD_MANIFEST}"
+                                        // path: BUILD_MANIFEST
                                     )
                                     downloadBuildManifest(
                                         url: BUILD_MANIFEST_URL_OPENSEARCH,
-                                        path: BUILD_MANIFEST_OPENSEARCH
+                                        path: "manifests-osd-${env.BUILD_NUMBER}/${env.BUILD_MANIFEST_OPENSEARCH}"
+                                        // path: BUILD_MANIFEST_OPENSEARCH
                                     )
                                     createUploadTestReportManifest(
                                         testManifest: "manifests/${TEST_MANIFEST}",
-                                        buildManifest: BUILD_MANIFEST_OPENSEARCH,
-                                        dashboardsBuildManifest: BUILD_MANIFEST,
+                                        buildManifest: "manifests-osd-${env.BUILD_NUMBER}/${env.BUILD_MANIFEST_OPENSEARCH}",
+                                        dashboardsBuildManifest: "manifests-osd-${env.BUILD_NUMBER}/${env.BUILD_MANIFEST}",
+                                        // buildManifest: BUILD_MANIFEST_OPENSEARCH,
+                                        // dashboardsBuildManifest: BUILD_MANIFEST,
                                         testRunID: "${env.BUILD_NUMBER}",
                                         testType: "integ-test",
                                         componentName: "${COMPONENT_NAME}",

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -300,11 +300,11 @@ pipeline {
                                     sh 'sleep 10'
                                     downloadBuildManifest(
                                         url: BUILD_MANIFEST_URL,
-                                        path: BUILD_MANIFEST
+                                        path: "manifests-os-${env.BUILD_NUMBER}/${env.BUILD_MANIFEST}"
                                     )
                                     createUploadTestReportManifest(
                                         testManifest: "manifests/${TEST_MANIFEST}",
-                                        buildManifest: BUILD_MANIFEST,
+                                        buildManifest: "manifests-os-${env.BUILD_NUMBER}/${BUILD_MANIFEST}",
                                         testRunID: "${env.BUILD_NUMBER}",
                                         testType: 'integ-test',
                                         componentName: "${COMPONENT_NAME}",
@@ -313,6 +313,7 @@ pipeline {
                                     archiveArtifacts artifacts: 'test-report.yml'
                                 }
                             }
+                            postCleanup()
                         }
                         node(agent_nodes['linux_x64']) {
                             def rc = (params.RC_NUMBER.toInteger() > 0)

--- a/tests/jenkins/TestOpenSearchIntegTest.groovy
+++ b/tests/jenkins/TestOpenSearchIntegTest.groovy
@@ -76,11 +76,14 @@ class TestOpenSearchIntegTest extends BuildPipelineTest {
                 return new Yaml().load((testManifest as File).text)
             } else if (args.file == 'tests/jenkins/data/opensearch-3.0.0-build.yml') {
                 return new Yaml().load((buildManifest as File).text)
+            } else if (args.file == 'manifests-os-234/tests/jenkins/data/opensearch-3.0.0-build.yml') {
+                return new Yaml().load(('manifests-os-234/tests/jenkins/data/opensearch-3.0.0-build.yml' as File).text)
             } else {
                 println("Manifest not found ${args.file}")
             }
         })
         helper.addFileExistsMock("manifests/${testManifest}", true)
+        helper.addFileExistsMock("manifests-os-234/tests/jenkins/data/opensearch-3.0.0-build.yml", true)
         helper.registerAllowedMethod("s3Upload", [Map])
         helper.registerAllowedMethod('findFiles', [Map.class], null)
         helper.registerAllowedMethod('unstash', [String.class], null)


### PR DESCRIPTION
### Description
Add specific download path for `downloadBuildManifest`.

### Issues Resolved
`(touch: cannot touch 'build-manifest.yml': Permission denied)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
