### PR TITLE
Fix argument hierarchy in benchmark test workflow. 

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_test_suite_compare.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite_compare.py
@@ -27,23 +27,23 @@ class BenchmarkTestSuiteCompare(BenchmarkTestSuite):
             self.cleanup()
 
     def form_command(self) -> str:
-        command = f'docker run --name docker-container-{self.args.stack_suffix} ' \
-                  "-v ~/.benchmark/benchmark.ini:/opensearch-benchmark/.benchmark/benchmark.ini " \
-                  f"opensearchproject/opensearch-benchmark:1.6.0 " \
-                  f"compare --baseline={self.args.baseline} --contender={self.args.contender} "
+        self.command = f'docker run --name docker-container-{self.args.stack_suffix} '
+        if self.args.benchmark_config:
+            self.command += f" -v {self.args.benchmark_config}:/opensearch-benchmark/.benchmark/benchmark.ini "
+        self.command += f"opensearchproject/opensearch-benchmark:1.6.0 " \
+                        f"compare --baseline={self.args.baseline} --contender={self.args.contender} "
 
         if self.args.results_format:
-            command += f"--results-format={self.args.results_format} "
+            self.command += f"--results-format={self.args.results_format} "
 
         if self.args.results_numbers_align:
-            command += f"--results-numbers-align={self.args.results_numbers_align} "
+            self.command += f"--results-numbers-align={self.args.results_numbers_align} "
 
-        command += "--results-file=final_result.md "
+        self.command += "--results-file=final_result.md "
 
         if self.args.show_in_results:
-            command += f"--show-in-results={self.args.show_in_results} "
+            self.command += f"--show-in-results={self.args.show_in_results} "
 
-        self.command = command
         return self.command
 
     def copy_comparison_results_to_local(self) -> None:

--- a/tests/test_run_compare.py
+++ b/tests/test_run_compare.py
@@ -17,7 +17,7 @@ from test_workflow.benchmark_test.benchmark_test_suite_compare import BenchmarkT
 from test_workflow.benchmark_test.benchmark_test_suite_runners import BenchmarkTestSuiteRunners
 
 
-class TestRunBenchmarkTest(unittest.TestCase):
+class TestRunBenchmarkTestCompare(unittest.TestCase):
     @pytest.fixture(autouse=True)
     def _capfd(self, capfd: Any) -> None:
         self.capfd = capfd
@@ -111,7 +111,6 @@ class TestRunBenchmarkTest(unittest.TestCase):
         # define the expected command
         expected_command = (
             f"docker run --name docker-container-{args.stack_suffix} "
-            "-v ~/.benchmark/benchmark.ini:/opensearch-benchmark/.benchmark/benchmark.ini "
             "opensearchproject/opensearch-benchmark:1.6.0 "
             "compare --baseline=12345 --contender=54321 "
             "--results-format=markdown "


### PR DESCRIPTION
### Description
This PR improves argument structuring for benchmark workflow. There are two arguments, `benchmark_config` and `suffix` that are common to `execute-test` and `compare` sub-parser commands. Moved them to parent parser so that they can be utilized by both commands without duplicating their initialization. 
Fixed respective failing tests. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
