### PR TITLE
Fix for only adding modified files in release-notes-check compile script

### DIFF
--- a/jenkins/release-workflows/release-notes-check.jenkinsfile
+++ b/jenkins/release-workflows/release-notes-check.jenkinsfile
@@ -139,7 +139,7 @@ pipeline {
                             def status = sh(returnStdout: true, script: 'git status --porcelain')
                             if (status) {
                                 sh """
-                                    git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
+                                    git add .
                                     git commit -sm "Add consolidated release notes for ${params.RELEASE_VERSION}"
                                     git push origin release-notes --force
                                     gh pr create --title 'Add consolidated release notes for ${params.RELEASE_VERSION}' --body 'Add consolidated release notes for ${params.RELEASE_VERSION}' -H release-notes -B main

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/release-notes-compile.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/release-notes-compile.jenkinsfile.txt
@@ -24,7 +24,7 @@
                             )
                   release-notes-check.sh({returnStdout=true, script=git status --porcelain})
                   release-notes-check.sh(
-                                    git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
+                                    git add .
                                     git commit -sm "Add consolidated release notes for 3.0.0"
                                     git push origin release-notes --force
                                     gh pr create --title 'Add consolidated release notes for 3.0.0' --body 'Add consolidated release notes for 3.0.0' -H release-notes -B main


### PR DESCRIPTION
### Description
Previously the release-notes-check compile script was only adding modified file, but it was causing fails because the file would be added. This change will fix this.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
