### PR TITLE
Add issue triaging document

### DIFF
--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -24,7 +24,7 @@ Meetings are 45 minutes and structured as follows:
 
 1. Initial Gathering: As we gather, feel free to turn on video and engage in informal and open-to-all conversation.  After a bit a volunteer will share their screen and proceed with the agenda.
 2. Announcements: If there are any announcements to be made they will happen at the start of the meeting.
-3. Review of New Issues: The meetings always start with reviewing all untriaged [issues](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch-build+repo%3Aopensearch-project%2Fhelm-charts+repo%3Aopensearch-project%2Fansible-playbook+repo%3Aopensearch-project%2Fopensearch-ci+repo%3Aopensearch-project%2Fopensearch-cluster-cdk+repo%3Aopensearch-project%2Fterraform-provider-opensearch+repo%3Aopensearch-project%2Fopensearch-devops+repo%3Aopensearch-project%2Fopensearch-build-libraries+is%3Aopen+) for below repositories:
+3. Review of New Issues: The meetings always start with reviewing all untriaged [issues](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch-build+repo%3Aopensearch-project%2Fhelm-charts+repo%3Aopensearch-project%2Fansible-playbook+repo%3Aopensearch-project%2Fopensearch-ci+repo%3Aopensearch-project%2Fopensearch-cluster-cdk+repo%3Aopensearch-project%2Fterraform-provider-opensearch+repo%3Aopensearch-project%2Fopensearch-devops+repo%3Aopensearch-project%2Fopensearch-build-libraries+is%3Aopen+ ) for below repositories:
     1. [opensearch-build](https://github.com/opensearch-project/opensearch-build)
     1. [opensearch-ci](https://github.com/opensearch-project/opensearch-ci)
     1. [opensearch-build-libraries](https://github.com/opensearch-project/opensearch-build-libraries)

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -24,7 +24,7 @@ Meetings are 45 minutes and structured as follows:
 
 1. Initial Gathering: As we gather, feel free to turn on video and engage in informal and open-to-all conversation.  After a bit a volunteer will share their screen and proceed with the agenda.
 2. Announcements: If there are any announcements to be made they will happen at the start of the meeting.
-3. Review of New Issues: The meetings always start with reviewing all untriaged [issues](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch-build+repo%3Aopensearch-project%2Fhelm-charts+repo%3Aopensearch-project%2Fansible-playbook+repo%3Aopensearch-project%2Fopensearch-ci+repo%3Aopensearch-project%2Fopensearch-cluster-cdk+repo%3Aopensearch-project%2Fterraform-provider-opensearch+repo%3Aopensearch-project%2Fopensearch-devops+repo%3Aopensearch-project%2Fopensearch-build-libraries+is%3Aopen+ ) for below repositories:
+3. Review of New Issues: The meetings always start with reviewing all untriaged [issues](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch-build+repo%3Aopensearch-project%2Fhelm-charts+repo%3Aopensearch-project%2Fansible-playbook+repo%3Aopensearch-project%2Fopensearch-ci+repo%3Aopensearch-project%2Fopensearch-cluster-cdk+repo%3Aopensearch-project%2Fterraform-provider-opensearch+repo%3Aopensearch-project%2Fopensearch-devops+repo%3Aopensearch-project%2Fopensearch-build-libraries+is%3Aopen+) for below repositories:
     1. [opensearch-build](https://github.com/opensearch-project/opensearch-build)
     1. [opensearch-ci](https://github.com/opensearch-project/opensearch-ci)
     1. [opensearch-build-libraries](https://github.com/opensearch-project/opensearch-build-libraries)
@@ -34,7 +34,7 @@ Meetings are 45 minutes and structured as follows:
     1. [opensearch-cluster-cdk](https://github.com/opensearch-project/opensearch-cluster-cdk)
     1. [opensearch-devops](https://github.com/opensearch-project/opensearch-devops)
 4. Member Requests: Opportunity for any meeting member to ask for consideration of an issue or pull request.
-5. Untriaged Items: Review any [issues](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch-build+repo%3Aopensearch-project%2Fhelm-charts+repo%3Aopensearch-project%2Fansible-playbook+repo%3Aopensearch-project%2Fopensearch-ci+repo%3Aopensearch-project%2Fopensearch-cluster-cdk+repo%3Aopensearch-project%2Fterraform-provider-opensearch+repo%3Aopensearch-project%2Fopensearch-devops+repo%3Aopensearch-project%2Fopensearch-build-libraries+is%3Aopen+ ) that might have had the 'untriaged' label removed but require additional triage discussion.
+5. Untriaged Items: Review any [issues](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch-build+repo%3Aopensearch-project%2Fhelm-charts+repo%3Aopensearch-project%2Fansible-playbook+repo%3Aopensearch-project%2Fopensearch-ci+repo%3Aopensearch-project%2Fopensearch-cluster-cdk+repo%3Aopensearch-project%2Fterraform-provider-opensearch+repo%3Aopensearch-project%2Fopensearch-devops+repo%3Aopensearch-project%2Fopensearch-build-libraries+is%3Aopen+) that might have had the 'untriaged' label removed but require additional triage discussion.
 6. Open Discussion: Allow for members of the meeting to surface any topics without issues filed or pull request created.
 
 

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -1,0 +1,69 @@
+<img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
+
+The maintainers of the OpenSearch-build Repo seek to promote an inclusive and engaged community of contributors. In order to facilitate this, bi-weekly triage meetings are open-to-all and attendance is encouraged for anyone who hopes to contribute, discuss an issue, or learn more about the project. To learn more about contributing to the OpenSearch-build Repo visit the [Contributing](./CONTRIBUTING.md) documentation.
+
+### Do I need to attend for my issue to be addressed/triaged?
+
+Attendance is not required for your issue to be triaged or addressed. All new issues are triaged bi-weekly.
+
+### What happens if my issue does not get covered this time?
+
+Each meeting we seek to address all new issues. However, should we run out of time before your issue is discussed, you are always welcome to attend the next meeting or to follow up on the issue post itself.
+
+### How do I join the Backlog & Triage meeting?
+
+Meetings are hosted regularly at 9 AM Pacific Time and can be joined via the links posted on the [OpenSearch Meetup Group](https://www.meetup.com/opensearch/events/) list of events. The event will be titled `Engineering Effectiveness Triage Meeting`.
+
+After joining the Zoom meeting, you can enable your video / voice to join the discussion.  If you do not have a webcam or microphone available, you can still join in via the text chat.
+
+If you have an issue you'd like to bring forth please consider getting a link to the issue so it can be presented to everyone in the meeting.
+
+### Is there an agenda for each week?
+
+Meetings are 45 minutes and structured as follows:
+
+1. Initial Gathering: As we gather, feel free to turn on video and engage in informal and open-to-all conversation.  After a bit a volunteer will share their screen and proceed with the agenda.
+2. Announcements: If there are any announcements to be made they will happen at the start of the meeting.
+3. Review of New Issues: The meetings always start with reviewing all untriaged [issues](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch-build+repo%3Aopensearch-project%2Fhelm-charts+repo%3Aopensearch-project%2Fansible-playbook+repo%3Aopensearch-project%2Fopensearch-ci+repo%3Aopensearch-project%2Fopensearch-cluster-cdk+repo%3Aopensearch-project%2Fterraform-provider-opensearch+repo%3Aopensearch-project%2Fopensearch-devops+repo%3Aopensearch-project%2Fopensearch-build-libraries+is%3Aopen+) for below repositories:
+    1. [opensearch-build](https://github.com/opensearch-project/opensearch-build)
+    1. [opensearch-ci](https://github.com/opensearch-project/opensearch-ci)
+    1. [opensearch-build-libraries](https://github.com/opensearch-project/opensearch-build-libraries)
+    1. [helm-charts](https://github.com/opensearch-project/helm-charts)
+    1. [terraform-provider-opensearch](https://github.com/opensearch-project/terraform-provider-opensearch)
+    1. [ansible-playbook](https://github.com/opensearch-project/ansible-playbook)
+    1. [opensearch-cluster-cdk](https://github.com/opensearch-project/opensearch-cluster-cdk)
+    1. [opensearch-devops](https://github.com/opensearch-project/opensearch-devops)
+4. Member Requests: Opportunity for any meeting member to ask for consideration of an issue or pull request.
+5. Untriaged Items: Review any [issues](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch-build+repo%3Aopensearch-project%2Fhelm-charts+repo%3Aopensearch-project%2Fansible-playbook+repo%3Aopensearch-project%2Fopensearch-ci+repo%3Aopensearch-project%2Fopensearch-cluster-cdk+repo%3Aopensearch-project%2Fterraform-provider-opensearch+repo%3Aopensearch-project%2Fopensearch-devops+repo%3Aopensearch-project%2Fopensearch-build-libraries+is%3Aopen+) that might have had the 'untriaged' label removed but require additional triage discussion.
+6. Open Discussion: Allow for members of the meeting to surface any topics without issues filed or pull request created.
+
+
+There is no specific ordering within each category.
+
+If you have an issue you would like to discuss but do not have the ability to attend the entire meeting please attend when is best for you and signal that you have an issue to discuss when you arrive.
+
+### Do I need to have already contributed to the project to attend a triage meeting?
+
+No, all are welcome and encouraged to attend. Attending the Backlog & Triage meetings is a great way for a new contributor to learn about the project as well as explore different avenues of contribution.
+
+### What if I have an issue that is almost a duplicate, should I open a new one to be triaged?
+
+You can always open an [issue](https://github.com/opensearch-project/opensearch-build/issues/new/choose) including one that you think may be a duplicate. However, in cases where you believe there is an important distinction to be made between an existing issue and your newly created one, you are encouraged to attend the triaging meeting to explain.
+
+### What if I have follow-up questions on an issue?
+
+If you have an existing issue you would like to discuss, you can always comment on the issue itself. Alternatively, you are welcome to come to the triage meeting to discuss.
+
+### What are the issue labels associated with triaging?
+
+Yes, there are several labels that are used to identify the 'state' of issues filed.
+
+| Label | When applied | Meaning |
+| ----- | ------------ | ------- |
+| Untriaged | When issues are created or re-opened. | Issues labeled as 'Untriaged' require the attention of the repository maintainers and may need to be prioritized for quicker resolution. |
+| Help Wanted | Anytime. | Issues marked as 'Help Wanted' signal that they are actionable and not the current focus of the project maintainers. Community contributions are especially encouraged for these issues. |
+| Good First Issue | Anytime. | Issues labeled as 'Good First Issue' are small in scope and can be resolved with a single pull request. These are recommended starting points for newcomers looking to make their first contributions. |
+
+### Who should I contact if I have further questions?
+
+You can always file an [issue](https://github.com/opensearch-project/opensearch-build/issues/new/choose) for any question you have about the project. Alternatively, you can use [opensearch slack](https://opensearch.org/slack.html) channels named #infra #devops to ask any queries.

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -34,7 +34,7 @@ Meetings are 45 minutes and structured as follows:
     1. [opensearch-cluster-cdk](https://github.com/opensearch-project/opensearch-cluster-cdk)
     1. [opensearch-devops](https://github.com/opensearch-project/opensearch-devops)
 4. Member Requests: Opportunity for any meeting member to ask for consideration of an issue or pull request.
-5. Untriaged Items: Review any [issues](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch-build+repo%3Aopensearch-project%2Fhelm-charts+repo%3Aopensearch-project%2Fansible-playbook+repo%3Aopensearch-project%2Fopensearch-ci+repo%3Aopensearch-project%2Fopensearch-cluster-cdk+repo%3Aopensearch-project%2Fterraform-provider-opensearch+repo%3Aopensearch-project%2Fopensearch-devops+repo%3Aopensearch-project%2Fopensearch-build-libraries+is%3Aopen+) that might have had the 'untriaged' label removed but require additional triage discussion.
+5. Untriaged Items: Review any [issues](https://github.com/issues?q=is%3Aissue+label%3Auntriaged+repo%3Aopensearch-project%2Fopensearch-build+repo%3Aopensearch-project%2Fhelm-charts+repo%3Aopensearch-project%2Fansible-playbook+repo%3Aopensearch-project%2Fopensearch-ci+repo%3Aopensearch-project%2Fopensearch-cluster-cdk+repo%3Aopensearch-project%2Fterraform-provider-opensearch+repo%3Aopensearch-project%2Fopensearch-devops+repo%3Aopensearch-project%2Fopensearch-build-libraries+is%3Aopen+ ) that might have had the 'untriaged' label removed but require additional triage discussion.
 6. Open Discussion: Allow for members of the meeting to surface any topics without issues filed or pull request created.
 
 

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -2,7 +2,7 @@
 
 The maintainers of the OpenSearch-build Repo seek to promote an inclusive and engaged community of contributors. In order to facilitate this, bi-weekly triage meetings are open-to-all and attendance is encouraged for anyone who hopes to contribute, discuss an issue, or learn more about the project. To learn more about contributing to the OpenSearch-build Repo visit the [Contributing](./CONTRIBUTING.md) documentation.
 
-### Do I need to attend for my issue to be addressed/triaged?
+### Do I need to attend the meeting for my issue to be addressed/triaged?
 
 Attendance is not required for your issue to be triaged or addressed. All new issues are triaged bi-weekly.
 
@@ -42,7 +42,7 @@ There is no specific ordering within each category.
 
 If you have an issue you would like to discuss but do not have the ability to attend the entire meeting, please attend when is best for you and signal that you have an issue to discuss when you arrive.
 
-### Do I need to have already contributed to the project to attend a triage meeting?
+### Is prior contribution to the project required to attend a triage meeting?
 
 No, all are welcome and encouraged to attend. Attending the Backlog & Triage meetings is a great way for a new contributor to learn about the project as well as explore different avenues of contribution.
 
@@ -66,4 +66,4 @@ Yes, there are several labels that are used to identify the 'state' of issues fi
 
 ### Who should I contact if I have further questions?
 
-You can always file an [issue](https://github.com/opensearch-project/opensearch-build/issues/new/choose) for any question you have about the project. Alternatively, you can use [opensearch slack](https://opensearch.org/slack.html) channels named #infra #devops to ask any queries.
+You can always file an [issue](https://github.com/opensearch-project/opensearch-build/issues/new/choose) for any question you have about the project. Alternatively, you can use [opensearch slack](https://opensearch.org/slack.html) channels such as #infra #devops for any related queries.

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -40,7 +40,7 @@ Meetings are 45 minutes and structured as follows:
 
 There is no specific ordering within each category.
 
-If you have an issue you would like to discuss but do not have the ability to attend the entire meeting please attend when is best for you and signal that you have an issue to discuss when you arrive.
+If you have an issue you would like to discuss but do not have the ability to attend the entire meeting, please attend when is best for you and signal that you have an issue to discuss when you arrive.
 
 ### Do I need to have already contributed to the project to attend a triage meeting?
 


### PR DESCRIPTION
### Description
Adding information and instructions to follow for community triage meetings that we will be starting shortly. Thank you to opensearch-security repo [triage doc](https://github.com/opensearch-project/security/blob/main/TRIAGING.md) for reference.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
