### PR TITLE
Remove 1.3.19 check-for-build

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -25,7 +25,6 @@ pipeline {
         parameterizedCron '''
             H 1 * * * %INPUT_MANIFEST=2.16.1/opensearch-2.16.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.17.0/opensearch-2.17.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H 1 * * * %INPUT_MANIFEST=1.3.19/opensearch-1.3.19.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''


### PR DESCRIPTION
### Description

For the 1.3.19 release, removed core from check-for-build because we are starting RC generation.

### Issues Resolved

Part of https://github.com/opensearch-project/opensearch-build/issues/4888

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
