### PR TITLE
Add TEST_PLATFORM and TEST_DISTRIBUTION param to fine-grain control integ-test triggers

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -318,7 +318,7 @@ pipeline {
                                             triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch, 'linux', 'rpm')
                                         },
                                         'rpm-validation': {
-                                            triggerRpmValidation(bundleManifestUrl, 'linux', 'rpm')
+                                            triggerRpmValidation(bundleManifestUrl)
                                         }
                                     ])
                                 }
@@ -670,7 +670,7 @@ pipeline {
                                             triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch, 'linux', 'rpm')
                                         },
                                         'rpm-validation': {
-                                            triggerRpmValidation(bundleManifestUrl, 'linux', 'rpm')
+                                            triggerRpmValidation(bundleManifestUrl)
                                         }
                                     ])
                                 }

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -932,31 +932,31 @@ pipeline {
         }
     }
     post {
-        //always {
-        //    node(AGENT_LINUX_X64) {
-        //        checkout scm
-        //        script {
-        //            sleep 10
-        //            def rc = (params.RC_NUMBER.toInteger() > 0)
-        //            publishDistributionBuildResults(
-        //                failureMessages: buildMessage(search: 'Error building'),
-        //                passMessages: buildMessage(search: 'Successfully built'),
-        //                inputManifestPath: "manifests/$INPUT_MANIFEST",
-        //                rc: rc,
-        //                rcNumber: env.RC_NUMBER,
-        //                componentCategory: "OpenSearch Dashboards"
-        //            )
-        //            if (params.UPDATE_GITHUB_ISSUE) {
-        //                UpdateBuildFailureIssues(
-        //                    failureMessages: buildMessage(search: 'Error building'),
-        //                    passMessages: buildMessage(search: 'Successfully built'),
-        //                    inputManifestPath: "manifests/$INPUT_MANIFEST"
-        //                )
-        //            }
-        //            postCleanup()
-        //        }
-        //    }
-        //}
+        always {
+            node(AGENT_LINUX_X64) {
+                checkout scm
+                script {
+                    sleep 10
+                    def rc = (params.RC_NUMBER.toInteger() > 0)
+                    publishDistributionBuildResults(
+                        failureMessages: buildMessage(search: 'Error building'),
+                        passMessages: buildMessage(search: 'Successfully built'),
+                        inputManifestPath: "manifests/$INPUT_MANIFEST",
+                        rc: rc,
+                        rcNumber: env.RC_NUMBER,
+                        componentCategory: "OpenSearch Dashboards"
+                    )
+                    if (params.UPDATE_GITHUB_ISSUE) {
+                        UpdateBuildFailureIssues(
+                            failureMessages: buildMessage(search: 'Error building'),
+                            passMessages: buildMessage(search: 'Successfully built'),
+                            inputManifestPath: "manifests/$INPUT_MANIFEST"
+                        )
+                    }
+                    postCleanup()
+                }
+            }
+        }
         success {
             node(AGENT_LINUX_X64) {
                 script {
@@ -1001,14 +1001,14 @@ pipeline {
             node(AGENT_LINUX_X64) {
                 checkout scm
                 script {
-                    //if (params.PUBLISH_NOTIFICATION) {
-                    //    publishNotification(
-                    //        icon: ':warning:',
-                    //        message: buildMessage(search: 'Error building'),
-                    //        credentialsId: 'jenkins-build-notice-webhook',
-                    //        manifest: "${INPUT_MANIFEST}"
-                    //    )
-                    //}
+                    if (params.PUBLISH_NOTIFICATION) {
+                        publishNotification(
+                            icon: ':warning:',
+                            message: buildMessage(search: 'Error building'),
+                            credentialsId: 'jenkins-build-notice-webhook',
+                            manifest: "${INPUT_MANIFEST}"
+                        )
+                    }
                     postCleanup()
                 }
             }

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -56,20 +56,32 @@ pipeline {
         )
         string( // Note: need to update 'verify-parameters' entries if you add new platform(s)
             name: 'BUILD_PLATFORM',
-            description: 'Build selected platform related artifacts, choices include linux windows. Can combine multiple platforms with space in between (docker is only available on linux)',
+            description: "Build selected platform, choices include 'linux', 'windows'. Can combine multiple platforms with space in between (docker is only available on linux)",
             defaultValue: 'linux windows',
+            trim: true
+        )
+        string( // Note: need to update 'verify-parameters' entries if you add new distribution(s)
+            name: 'BUILD_DISTRIBUTION',
+            description: "Build selected distribution, choices include 'tar', 'rpm', 'deb', 'zip'. Can combine multiple distributions with space in between (docker is only available on tar)",
+            defaultValue: 'tar rpm deb zip',
+            trim: true
+        )
+        string( // Note: need to update 'verify-parameters' entries if you add new platform(s)
+            name: 'TEST_PLATFORM',
+            description: "Test selected platform, choices include 'linux', 'windows'. Can combine multiple platforms with space in between (docker is only available on linux)",
+            defaultValue: 'linux windows',
+            trim: true
+        )
+        string( // Note: need to update 'verify-parameters' entries if you add new distribution(s)
+            name: 'TEST_DISTRIBUTION',
+            description: "Build selected distribution, choices include 'tar', 'rpm', 'deb', 'zip'. Can combine multiple distributions with space in between (docker is only available on tar)",
+            defaultValue: 'tar rpm deb zip',
             trim: true
         )
         string(
             name: 'RC_NUMBER',
             description: 'The RC build count. Default is 0 which means its not an RC build.',
             defaultValue: '0'
-        )
-        string( // Note: need to update 'verify-parameters' entries if you add new distribution(s)
-            name: 'BUILD_DISTRIBUTION',
-            description: 'Build selected distribution related artifacts, choices include tar, rpm, deb, zip. Can combine multiple distributions with space in between (docker is only available on tar)',
-            defaultValue: 'tar rpm deb zip',
-            trim: true
         )
         choice(
             name: 'BUILD_DOCKER',
@@ -124,40 +136,15 @@ pipeline {
                     dockerAgent = detectDockerAgent()
                     currentBuild.description = INPUT_MANIFEST
 
-                    echo('Verify Build Platforms')
-                    def build_platform_array = params.BUILD_PLATFORM.tokenize(' ')
-                    echo("User Entry Platforms: '${params.BUILD_PLATFORM}', ${build_platform_array}")
-                    def all_platforms = 'linux windows'
-                    echo("All Supported Platforms: '${all_platforms}'")
+                    paramType = [
+                        'BUILD_PLATFORM': 'linux windows',
+                        'BUILD_DISTRIBUTION': 'tar rpm deb zip',
+                        'TEST_PLATFORM': 'linux windows',
+                        'TEST_DISTRIBUTION': 'tar rpm deb zip',
+                    ]
 
-                    if (params.BUILD_PLATFORM == null || params.BUILD_PLATFORM == '') {
-                        currentBuild.result = 'ABORTED'
-                        error("Missing parameter: BUILD_PLATFORM (possible entries: ${all_platforms}).")
-                    }
-
-                    for (String plat : build_platform_array) {
-                        if (! all_platforms.contains(plat)) {
-                            currentBuild.result = 'ABORTED'
-                            error("Missing parameter: BUILD_PLATFORM (possible entries: ${all_platforms}).")
-                        }
-                    }
-
-                    echo('Verify Build Distributions')
-                    def build_distribution_array = params.BUILD_DISTRIBUTION.tokenize(' ')
-                    echo("User Entry Distributions: '${params.BUILD_DISTRIBUTION}', ${build_distribution_array}")
-                    def all_distributions = 'tar rpm deb zip'
-                    echo("All Supported Platforms: '${all_distributions}'")
-
-                    if (params.BUILD_DISTRIBUTION == null || params.BUILD_DISTRIBUTION == '') {
-                        currentBuild.result = 'ABORTED'
-                        error("Missing parameter: BUILD_DISTRIBUTION (possible entries: ${all_distributions}).")
-                    }
-
-                    for (String plat : build_distribution_array) {
-                        if (! all_distributions.contains(plat)) {
-                            currentBuild.result = 'ABORTED'
-                            error("Missing parameter: BUILD_DISTRIBUTION (possible entries: ${all_distributions}).")
-                        }
+                    paramType.each { key, value ->
+                        verifyParameterPlatformDistribution(key, value)
                     }
                 }
             }
@@ -208,10 +195,10 @@ pipeline {
 
                             parallel([
                                 'integ-test': {
-                                    triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch)
+                                    triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch, 'linux', 'tar')
                                 },
                                 'bwc-test': {
-                                    triggerBWCTests(buildManifestUrl)
+                                    triggerBWCTests(buildManifestUrl, 'linux', 'tar')
                                 }
                             ])
                         }
@@ -328,10 +315,10 @@ pipeline {
                                     String bundleManifestUrl = buildManifestObj.getBundleManifestUrl(JOB_NAME, BUILD_NUMBER)
                                     parallel([
                                         'integ-test': {
-                                            triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch)
+                                            triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch, 'linux', 'rpm')
                                         },
                                         'rpm-validation': {
-                                            triggerRpmValidation(bundleManifestUrl)
+                                            triggerRpmValidation(bundleManifestUrl, 'linux', 'rpm')
                                         }
                                     ])
                                 }
@@ -443,7 +430,8 @@ pipeline {
 
                                     echo "buildManifestUrl (linux, x64, deb): ${buildManifestUrl}"
                                     echo "artifactUrl (linux, x64, deb): ${artifactUrl}"
-                                    triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch)
+
+                                    triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch, 'linux', 'deb')
                                 }
                             }
                             post {
@@ -559,10 +547,10 @@ pipeline {
 
                                     parallel([
                                         'integ-test': {
-                                            triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch)
+                                            triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch, 'linux', 'tar')
                                         },
                                         'bwc-test': {
-                                            triggerBWCTests(buildManifestUrl)
+                                            triggerBWCTests(buildManifestUrl, 'linux', 'tar')
                                         }
                                     ])
                                 }
@@ -679,10 +667,10 @@ pipeline {
                                     String bundleManifestUrl = buildManifestObj.getBundleManifestUrl(JOB_NAME, BUILD_NUMBER)
                                     parallel([
                                         'integ-test': {
-                                            triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch)
+                                            triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch, 'linux', 'rpm')
                                         },
                                         'rpm-validation': {
-                                            triggerRpmValidation(bundleManifestUrl)
+                                            triggerRpmValidation(bundleManifestUrl, 'linux', 'rpm')
                                         }
                                     ])
                                 }
@@ -794,7 +782,8 @@ pipeline {
 
                                     echo "buildManifestUrl (linux, arm64, deb): ${buildManifestUrl}"
                                     echo "artifactUrl (linux, arm64, deb): ${artifactUrl}"
-                                    triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch)
+
+                                    triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch, 'linux', 'deb')
                                 }
                             }
                             post {
@@ -866,7 +855,8 @@ pipeline {
 
                             echo "buildManifestUrl (windows, x64, zip): ${buildManifestUrl}"
                             echo "artifactUrl (windows, x64, zip): ${artifactUrl}"
-                            triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch)
+
+                            triggerIntegrationTests(buildManifestUrl, buildManifestUrlOpenSearch, 'windows', 'zip')
                         }
                     }
                     post {
@@ -942,31 +932,31 @@ pipeline {
         }
     }
     post {
-        always {
-            node(AGENT_LINUX_X64) {
-                checkout scm
-                script {
-                    sleep 10
-                    def rc = (params.RC_NUMBER.toInteger() > 0)
-                    publishDistributionBuildResults(
-                        failureMessages: buildMessage(search: 'Error building'),
-                        passMessages: buildMessage(search: 'Successfully built'),
-                        inputManifestPath: "manifests/$INPUT_MANIFEST",
-                        rc: rc,
-                        rcNumber: env.RC_NUMBER,
-                        componentCategory: "OpenSearch Dashboards"
-                    )
-                    if (params.UPDATE_GITHUB_ISSUE) {
-                        UpdateBuildFailureIssues(
-                            failureMessages: buildMessage(search: 'Error building'),
-                            passMessages: buildMessage(search: 'Successfully built'),
-                            inputManifestPath: "manifests/$INPUT_MANIFEST"
-                        )
-                    }
-                    postCleanup()
-                }
-            }
-        }
+        //always {
+        //    node(AGENT_LINUX_X64) {
+        //        checkout scm
+        //        script {
+        //            sleep 10
+        //            def rc = (params.RC_NUMBER.toInteger() > 0)
+        //            publishDistributionBuildResults(
+        //                failureMessages: buildMessage(search: 'Error building'),
+        //                passMessages: buildMessage(search: 'Successfully built'),
+        //                inputManifestPath: "manifests/$INPUT_MANIFEST",
+        //                rc: rc,
+        //                rcNumber: env.RC_NUMBER,
+        //                componentCategory: "OpenSearch Dashboards"
+        //            )
+        //            if (params.UPDATE_GITHUB_ISSUE) {
+        //                UpdateBuildFailureIssues(
+        //                    failureMessages: buildMessage(search: 'Error building'),
+        //                    passMessages: buildMessage(search: 'Successfully built'),
+        //                    inputManifestPath: "manifests/$INPUT_MANIFEST"
+        //                )
+        //            }
+        //            postCleanup()
+        //        }
+        //    }
+        //}
         success {
             node(AGENT_LINUX_X64) {
                 script {
@@ -1011,14 +1001,14 @@ pipeline {
             node(AGENT_LINUX_X64) {
                 checkout scm
                 script {
-                    if (params.PUBLISH_NOTIFICATION) {
-                        publishNotification(
-                            icon: ':warning:',
-                            message: buildMessage(search: 'Error building'),
-                            credentialsId: 'jenkins-build-notice-webhook',
-                            manifest: "${INPUT_MANIFEST}"
-                        )
-                    }
+                    //if (params.PUBLISH_NOTIFICATION) {
+                    //    publishNotification(
+                    //        icon: ':warning:',
+                    //        message: buildMessage(search: 'Error building'),
+                    //        credentialsId: 'jenkins-build-notice-webhook',
+                    //        manifest: "${INPUT_MANIFEST}"
+                    //    )
+                    //}
                     postCleanup()
                 }
             }
@@ -1033,9 +1023,9 @@ def markStageUnstableIfPluginsFailedToBuild() {
     }
 }
 
-def triggerIntegrationTests(String buildManifestUrl, String buildManifestUrlOpenSearch) {
-    Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '' || buildManifestUrlOpenSearch == '')
-    echo "${skipIntegTests ? 'Skipping integration tests as one of the values has empty string: INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl, buildManifestUrlOpenSearch' : 'Running integration tests'}"
+def triggerIntegrationTests(String buildManifestUrl, String buildManifestUrlOpenSearch, String platform, String distribution) {
+    Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '' || buildManifestUrlOpenSearch == '' || !TEST_PLATFORM.contains(platform) || !TEST_DISTRIBUTION.contains(distribution))
+    echo "${skipIntegTests ? 'Skipping INTEG tests as one of the values has empty or wrong string: INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl, buildManifestUrlOpenSearch, TEST_PLATFORM, TEST_DISTRIBUTION' : 'Running INTEG tests'}"
     if (!skipIntegTests) {
         def integTestResults =
                 build job: INTEG_TEST_JOB_NAME,
@@ -1051,9 +1041,9 @@ def triggerIntegrationTests(String buildManifestUrl, String buildManifestUrlOpen
     }
 }
 
-def triggerBWCTests(String buildManifestUrl) {
-    Boolean skipBwcTests = (BWC_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
-    echo "${skipBwcTests ? 'Skipping BWC tests as one of the values has empty string: BWC_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running BWC tests'}"
+def triggerBWCTests(String buildManifestUrl, String platform, String distribution) {
+    Boolean skipBwcTests = (BWC_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '' || !TEST_PLATFORM.contains(platform) || !TEST_DISTRIBUTION.contains(distribution))
+    echo "${skipBwcTests ? 'Skipping BWC tests as one of the values has empty or wrong string: BWC_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl, TEST_PLATFORM, TEST_DISTRIBUTION' : 'Running BWC tests'}"
     if (!skipBwcTests) {
         def bwcTestResults =
                 build job: BWC_TEST_JOB_NAME,
@@ -1081,4 +1071,26 @@ def triggerRpmValidation(String bundleManifestUrl) {
 
 def addMessageToNotificationQueue() {
     lib.jenkins.Messages.new(this).add("${STAGE_NAME}", lib.jenkins.Messages.new(this).get(["${STAGE_NAME}"]))
+}
+
+def verifyParameterPlatformDistribution(String paramName, String allowedValue) {
+    echo("Verify Parameter '$paramName'")
+    def paramValue = env."$paramName"
+    def checkArray = paramValue.tokenize(' ')
+    echo("Parameter Entry: '$paramValue', $checkArray")
+    echo("Supported Entry: '$allowedValue'")
+
+    if (paramValue == null || paramValue == '') {
+        currentBuild.result = 'ABORTED'
+        error("Missing parameter '$paramName' (possible entries: $allowedValue).")
+    }
+
+    for (String entry : paramValue) {
+        if (! allowedValue.contains(entry)) {
+            currentBuild.result = 'ABORTED'
+            error("Error parameter '$paramName': $paramValue (possible entries: ${allowedValue}).")
+        }
+    }
+
+    echo("Verified '$paramName': $paramValue\n")
 }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -55,8 +55,26 @@ pipeline {
         )
         string( // Note: need to update 'verify-parameters' entries if you add new platform(s)
             name: 'BUILD_PLATFORM',
-            description: "Build selected platform related artifacts, choices include 'linux', 'macos', 'windows'. Can combine multiple platforms with space in between (maven snapshot is only on linux)",
-            defaultValue: 'linux macos windows',
+            description: "Build selected platform, choices include 'linux', 'windows'. Can combine multiple platforms with space in between (docker is only available on linux)",
+            defaultValue: 'linux windows',
+            trim: true
+        )
+        string( // Note: need to update 'verify-parameters' entries if you add new distribution(s)
+            name: 'BUILD_DISTRIBUTION',
+            description: "Build selected distribution, choices include 'tar', 'rpm', 'deb', 'zip'. Can combine multiple distributions with space in between (docker is only available on tar)",
+            defaultValue: 'tar rpm deb zip',
+            trim: true
+        )
+        string( // Note: need to update 'verify-parameters' entries if you add new platform(s)
+            name: 'TEST_PLATFORM',
+            description: "Test selected platform, choices include 'linux', 'windows'. Can combine multiple platforms with space in between (docker is only available on linux)",
+            defaultValue: 'linux windows',
+            trim: true
+        )
+        string( // Note: need to update 'verify-parameters' entries if you add new distribution(s)
+            name: 'TEST_DISTRIBUTION',
+            description: "Build selected distribution, choices include 'tar', 'rpm', 'deb', 'zip'. Can combine multiple distributions with space in between (docker is only available on tar)",
+            defaultValue: 'tar rpm deb zip',
             trim: true
         )
         string(
@@ -118,54 +136,50 @@ pipeline {
                     env.javaVersionNumber = dockerAgent.javaVersion.replaceAll('[^0-9]', '') // Only get number
                     currentBuild.description = INPUT_MANIFEST
 
-                    echo('Verify Build Platforms')
-                    def build_platform_array = params.BUILD_PLATFORM.tokenize(' ')
-                    echo("User Entry Platforms: '${params.BUILD_PLATFORM}', ${build_platform_array}")
-                    def all_platforms = 'linux macos windows'
-                    echo("All Supported Platforms: '${all_platforms}'")
+                    paramType = [
+                        'BUILD_PLATFORM': 'linux windows',
+                        'BUILD_DISTRIBUTION': 'tar rpm deb zip',
+                        'TEST_PLATFORM': 'linux windows',
+                        'TEST_DISTRIBUTION': 'tar rpm deb zip',
+                    ]
 
-                    if (params.BUILD_PLATFORM == null || params.BUILD_PLATFORM == '') {
-                        currentBuild.result = 'ABORTED'
-                        error("Missing parameter: BUILD_PLATFORM (possible entries: ${all_platforms}).")
-                    }
-
-                    for (String plat : build_platform_array) {
-                        if (! all_platforms.contains(plat)) {
-                            currentBuild.result = 'ABORTED'
-                            error("Missing parameter: BUILD_PLATFORM (possible entries: ${all_platforms}).")
-                        }
+                    paramType.each { key, value ->
+                        verifyParameterPlatformDistribution(key, value)
                     }
                 }
             }
         }
         stage('build') {
             parallel {
-                stage('Trigger-min-snapshot-build') {
-                    agent {
-                        docker {
-                            label 'Jenkins-Agent-AL2023-X64-C54xlarge-Docker-Host'
-                            image 'docker/library/alpine:3'
-                            registryUrl 'https://public.ecr.aws/'
-                            alwaysPull true
-                        }
-                    }
-                    steps {
-                        script {
-                            def snapshotBuild =
-                                build job: 'publish-opensearch-min-snapshots',
-                                propagate: false,
-                                wait: false,
-                                parameters: [
-                                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
-                                ]
-                        }
-                    }
-                }
+                //stage('Trigger-min-snapshot-build') {
+                //    agent {
+                //        docker {
+                //            label 'Jenkins-Agent-AL2023-X64-C54xlarge-Docker-Host'
+                //            image 'docker/library/alpine:3'
+                //            registryUrl 'https://public.ecr.aws/'
+                //            alwaysPull true
+                //        }
+                //    }
+                //    steps {
+                //        script {
+                //            def snapshotBuild =
+                //                build job: 'publish-opensearch-min-snapshots',
+                //                propagate: false,
+                //                wait: false,
+                //                parameters: [
+                //                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
+                //                ]
+                //        }
+                //    }
+                //}
                 stage('build-and-test-linux-x64-tar') {
                     when {
                         beforeAgent true
                         expression {
                             params.BUILD_PLATFORM.contains('linux')
+                        }
+                        expression {
+                            params.BUILD_DISTRIBUTION.contains('tar')
                         }
                     }
                     agent {
@@ -199,24 +213,12 @@ pipeline {
 
                             parallel([
                                 'integ-test': {
-                                    triggerIntegrationTests(buildManifestUrl)
+                                    triggerIntegrationTests(buildManifestUrl, 'linux', 'tar')
                                 },
                                 'bwc-test': {
-                                    Boolean skipBwcTests = (BWC_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
-                                    echo "${skipBwcTests ? 'Skipping BWC tests as one of the values has empty string: BWC_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running BWC tests'}"
-                                    if (!skipBwcTests) {
-                                        def bwcTestResults =
-                                            build job: BWC_TEST_JOB_NAME,
-                                            propagate: false,
-                                            wait: false,
-                                            parameters: [
-                                                string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                                                string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
-                                                string(name: 'AGENT_LABEL', value: AGENT_LINUX_X64)
-                                            ]
-                                    }
+                                    triggerBWCTests(buildManifestUrl, 'linux', 'tar')
                                 }
-                                ])
+                            ])
                         }
                     }
                     post {
@@ -257,6 +259,9 @@ pipeline {
                         beforeAgent true
                         expression {
                             params.BUILD_PLATFORM.contains('linux')
+                        }
+                        expression {
+                            params.BUILD_DISTRIBUTION.contains('rpm')
                         }
                     }
                     agent { label AGENT_LINUX_X64 }
@@ -328,7 +333,7 @@ pipeline {
                                     String bundleManifestUrl = buildManifestObj.getBundleManifestUrl(JOB_NAME, BUILD_NUMBER)
                                     parallel([
                                         'integ-test': {
-                                            triggerIntegrationTests(buildManifestUrl)
+                                            triggerIntegrationTests(buildManifestUrl, 'linux', 'rpm')
                                         },
                                         'rpm-validation': {
                                             triggerRpmValidation(bundleManifestUrl)
@@ -373,6 +378,9 @@ pipeline {
                         beforeAgent true
                         expression {
                             params.BUILD_PLATFORM.contains('linux')
+                        }
+                        expression {
+                            params.BUILD_DISTRIBUTION.contains('deb')
                         }
                     }
                     agent { label AGENT_LINUX_X64 }
@@ -442,7 +450,8 @@ pipeline {
                                     echo "artifactUrl (linux, x64, deb): ${artifactUrl}"
 
                                     String bundleManifestUrl = buildManifestObj.getBundleManifestUrl(JOB_NAME, BUILD_NUMBER)
-                                    triggerIntegrationTests(buildManifestUrl)
+
+                                    triggerIntegrationTests(buildManifestUrl, 'linux', 'deb')
                                 }
                             }
                             post {
@@ -484,6 +493,9 @@ pipeline {
                         expression {
                             params.BUILD_PLATFORM.contains('linux')
                         }
+                        expression {
+                            params.BUILD_DISTRIBUTION.contains('tar')
+                        }
                     }
                     agent {
                         docker {
@@ -513,7 +525,8 @@ pipeline {
 
                             echo "buildManifestUrl (linux, arm64, tar): ${buildManifestUrl}"
                             echo "artifactUrl (linux, arm64, tar): ${artifactUrl}"
-                            triggerIntegrationTests(buildManifestUrl)
+
+                            triggerIntegrationTests(buildManifestUrl, 'linux', 'tar')
                         }
                     }
                     post {
@@ -554,6 +567,9 @@ pipeline {
                         beforeAgent true
                         expression {
                             params.BUILD_PLATFORM.contains('linux')
+                        }
+                        expression {
+                            params.BUILD_DISTRIBUTION.contains('rpm')
                         }
                     }
                     agent { label AGENT_LINUX_X64 }
@@ -625,7 +641,7 @@ pipeline {
                                     String bundleManifestUrl = buildManifestObj.getBundleManifestUrl(JOB_NAME, BUILD_NUMBER)
                                     parallel([
                                         'integ-test': {
-                                            triggerIntegrationTests(buildManifestUrl)
+                                            triggerIntegrationTests(buildManifestUrl, 'linux', 'rpm')
                                         },
                                         'rpm-validation': {
                                             triggerRpmValidation(bundleManifestUrl)
@@ -670,6 +686,9 @@ pipeline {
                         beforeAgent true
                         expression {
                             params.BUILD_PLATFORM.contains('linux')
+                        }
+                        expression {
+                            params.BUILD_DISTRIBUTION.contains('deb')
                         }
                         
                     }
@@ -740,7 +759,8 @@ pipeline {
                                     echo "artifactUrl (linux, arm64, deb): ${artifactUrl}"
 
                                     String bundleManifestUrl = buildManifestObj.getBundleManifestUrl(JOB_NAME, BUILD_NUMBER)
-                                    triggerIntegrationTests(buildManifestUrl)
+
+                                    triggerIntegrationTests(buildManifestUrl, 'linux', 'deb')
                                 }
                             }
                             post {
@@ -781,6 +801,9 @@ pipeline {
                         expression {
                             params.BUILD_PLATFORM.contains('windows')
                         }
+                        expression {
+                            params.BUILD_DISTRIBUTION.contains('zip')
+                        }
                     }
                     agent {
                         docker {
@@ -811,7 +834,8 @@ pipeline {
 
                             echo "buildManifestUrl (windows, x64, zip): ${buildManifestUrl}"
                             echo "artifactUrl (windows, x64, zip): ${artifactUrl}"
-                            triggerIntegrationTests(buildManifestUrl)
+
+                            triggerIntegrationTests(buildManifestUrl, 'windows', 'zip')
                         }
                     }
                     post {
@@ -887,32 +911,32 @@ pipeline {
         }
     }
     post {
-        always {
-            node(AGENT_LINUX_X64) {
-                checkout scm
-                script {
-                    sleep 10
-                    def rc = (params.RC_NUMBER.toInteger() > 0)
-                    publishDistributionBuildResults(
-                        failureMessages: buildMessage(search: 'Error building'),
-                        passMessages: buildMessage(search: 'Successfully built'),
-                        inputManifestPath: "manifests/$INPUT_MANIFEST",
-                        rc: rc,
-                        rcNumber: env.RC_NUMBER,
-                        componentCategory: "OpenSearch"
-                    )
-                    if (params.UPDATE_GITHUB_ISSUE) {
-                        UpdateBuildFailureIssues(
-                            failureMessages: buildMessage(search: 'Error building'),
-                            passMessages: buildMessage(search: 'Successfully built'),
-                            inputManifestPath: "manifests/$INPUT_MANIFEST"
-                        )
-                    }
-                    postCleanup()
-                }
-            
-            }
-        }
+        //always {
+        //    node(AGENT_LINUX_X64) {
+        //        checkout scm
+        //        script {
+        //            sleep 10
+        //            def rc = (params.RC_NUMBER.toInteger() > 0)
+        //            publishDistributionBuildResults(
+        //                failureMessages: buildMessage(search: 'Error building'),
+        //                passMessages: buildMessage(search: 'Successfully built'),
+        //                inputManifestPath: "manifests/$INPUT_MANIFEST",
+        //                rc: rc,
+        //                rcNumber: env.RC_NUMBER,
+        //                componentCategory: "OpenSearch"
+        //            )
+        //            if (params.UPDATE_GITHUB_ISSUE) {
+        //                UpdateBuildFailureIssues(
+        //                    failureMessages: buildMessage(search: 'Error building'),
+        //                    passMessages: buildMessage(search: 'Successfully built'),
+        //                    inputManifestPath: "manifests/$INPUT_MANIFEST"
+        //                )
+        //            }
+        //            postCleanup()
+        //        }
+        //    
+        //    }
+        //}
         success {
             node(AGENT_LINUX_X64) {
                 script {
@@ -950,14 +974,14 @@ pipeline {
             node(AGENT_LINUX_X64) {
                 checkout scm
                 script {
-                    if (params.PUBLISH_NOTIFICATION) {
-                        publishNotification(
-                            icon: ':warning:',
-                            message: buildMessage(search: 'Error building'),
-                            credentialsId: 'jenkins-build-notice-webhook',
-                            manifest: "${INPUT_MANIFEST}"
-                        )
-                    }
+                    //if (params.PUBLISH_NOTIFICATION) {
+                    //    publishNotification(
+                    //        icon: ':warning:',
+                    //        message: buildMessage(search: 'Error building'),
+                    //        credentialsId: 'jenkins-build-notice-webhook',
+                    //        manifest: "${INPUT_MANIFEST}"
+                    //    )
+                    //}
                     postCleanup()
                 }
             }
@@ -972,9 +996,9 @@ def markStageUnstableIfPluginsFailedToBuild() {
 }
     }
 
-def triggerIntegrationTests(String buildManifestUrl) {
-    Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '')
-    echo "${skipIntegTests ? 'Skipping integration tests as one of the values has empty string: INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl' : 'Running integration tests'}"
+def triggerIntegrationTests(String buildManifestUrl, String platform, String distribution) {
+    Boolean skipIntegTests = (INTEG_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '' || !TEST_PLATFORM.contains(platform) || !TEST_DISTRIBUTION.contains(distribution))
+    echo "${skipIntegTests ? 'Skipping INTEG tests as one of the values has empty or wrong string: INTEG_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl, TEST_PLATFORM, TEST_DISTRIBUTION' : 'Running INTEG tests'}"
     if (!skipIntegTests) {
         def integTestResults =
                 build job: INTEG_TEST_JOB_NAME,
@@ -989,6 +1013,22 @@ def triggerIntegrationTests(String buildManifestUrl) {
     }
 }
 
+def triggerBWCTests(String buildManifestUrl, String platform, String distribution) {
+    Boolean skipBwcTests = (BWC_TEST_JOB_NAME == '' || TEST_MANIFEST == '' || buildManifestUrl == '' || !TEST_PLATFORM.contains(platform) || !TEST_DISTRIBUTION.contains(distribution))
+    echo "${skipBwcTests ? 'Skipping BWC tests as one of the values has empty or wrong string: BWC_TEST_JOB_NAME, TEST_MANIFEST, buildManifestUrl, TEST_PLATFORM, TEST_DISTRIBUTION' : 'Running BWC tests'}"
+    if (!skipBwcTests) {
+        def bwcTestResults =
+                build job: BWC_TEST_JOB_NAME,
+                propagate: false,
+                wait: false,
+                parameters: [
+                    string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
+                    string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                    string(name: 'AGENT_LABEL', value: AGENT_LINUX_X64)
+                ]
+    }
+}
+
 def triggerRpmValidation(String bundleManifestUrl) {
     echo "Triggering RPM validation for ${bundleManifestUrl}"
     def rpmValidationResults =
@@ -999,4 +1039,26 @@ def triggerRpmValidation(String bundleManifestUrl) {
                 string(name: 'BUNDLE_MANIFEST_URL', value: bundleManifestUrl),
                 string(name: 'AGENT_LABEL', value: AGENT_LINUX_X64)
             ]
+}
+
+def verifyParameterPlatformDistribution(String paramName, String allowedValue) {
+    echo("Verify Parameter '$paramName'")
+    def paramValue = env."$paramName"
+    def checkArray = paramValue.tokenize(' ')
+    echo("Parameter Entry: '$paramValue', $checkArray")
+    echo("Supported Entry: '$allowedValue'")
+
+    if (paramValue == null || paramValue == '') {
+        currentBuild.result = 'ABORTED'
+        error("Missing parameter '$paramName' (possible entries: $allowedValue).")
+    }
+
+    for (String entry : paramValue) {
+        if (! allowedValue.contains(entry)) {
+            currentBuild.result = 'ABORTED'
+            error("Error parameter '$paramName': $paramValue (possible entries: ${allowedValue}).")
+        }
+    }
+
+    echo("Verified '$paramName': $paramValue\n")
 }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -151,27 +151,27 @@ pipeline {
         }
         stage('build') {
             parallel {
-                //stage('Trigger-min-snapshot-build') {
-                //    agent {
-                //        docker {
-                //            label 'Jenkins-Agent-AL2023-X64-C54xlarge-Docker-Host'
-                //            image 'docker/library/alpine:3'
-                //            registryUrl 'https://public.ecr.aws/'
-                //            alwaysPull true
-                //        }
-                //    }
-                //    steps {
-                //        script {
-                //            def snapshotBuild =
-                //                build job: 'publish-opensearch-min-snapshots',
-                //                propagate: false,
-                //                wait: false,
-                //                parameters: [
-                //                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
-                //                ]
-                //        }
-                //    }
-                //}
+                stage('Trigger-min-snapshot-build') {
+                    agent {
+                        docker {
+                            label 'Jenkins-Agent-AL2023-X64-C54xlarge-Docker-Host'
+                            image 'docker/library/alpine:3'
+                            registryUrl 'https://public.ecr.aws/'
+                            alwaysPull true
+                        }
+                    }
+                    steps {
+                        script {
+                            def snapshotBuild =
+                                build job: 'publish-opensearch-min-snapshots',
+                                propagate: false,
+                                wait: false,
+                                parameters: [
+                                    string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
+                                ]
+                        }
+                    }
+                }
                 stage('build-and-test-linux-x64-tar') {
                     when {
                         beforeAgent true
@@ -911,32 +911,32 @@ pipeline {
         }
     }
     post {
-        //always {
-        //    node(AGENT_LINUX_X64) {
-        //        checkout scm
-        //        script {
-        //            sleep 10
-        //            def rc = (params.RC_NUMBER.toInteger() > 0)
-        //            publishDistributionBuildResults(
-        //                failureMessages: buildMessage(search: 'Error building'),
-        //                passMessages: buildMessage(search: 'Successfully built'),
-        //                inputManifestPath: "manifests/$INPUT_MANIFEST",
-        //                rc: rc,
-        //                rcNumber: env.RC_NUMBER,
-        //                componentCategory: "OpenSearch"
-        //            )
-        //            if (params.UPDATE_GITHUB_ISSUE) {
-        //                UpdateBuildFailureIssues(
-        //                    failureMessages: buildMessage(search: 'Error building'),
-        //                    passMessages: buildMessage(search: 'Successfully built'),
-        //                    inputManifestPath: "manifests/$INPUT_MANIFEST"
-        //                )
-        //            }
-        //            postCleanup()
-        //        }
-        //    
-        //    }
-        //}
+        always {
+            node(AGENT_LINUX_X64) {
+                checkout scm
+                script {
+                    sleep 10
+                    def rc = (params.RC_NUMBER.toInteger() > 0)
+                    publishDistributionBuildResults(
+                        failureMessages: buildMessage(search: 'Error building'),
+                        passMessages: buildMessage(search: 'Successfully built'),
+                        inputManifestPath: "manifests/$INPUT_MANIFEST",
+                        rc: rc,
+                        rcNumber: env.RC_NUMBER,
+                        componentCategory: "OpenSearch"
+                    )
+                    if (params.UPDATE_GITHUB_ISSUE) {
+                        UpdateBuildFailureIssues(
+                            failureMessages: buildMessage(search: 'Error building'),
+                            passMessages: buildMessage(search: 'Successfully built'),
+                            inputManifestPath: "manifests/$INPUT_MANIFEST"
+                        )
+                    }
+                    postCleanup()
+                }
+            
+            }
+        }
         success {
             node(AGENT_LINUX_X64) {
                 script {
@@ -974,14 +974,14 @@ pipeline {
             node(AGENT_LINUX_X64) {
                 checkout scm
                 script {
-                    //if (params.PUBLISH_NOTIFICATION) {
-                    //    publishNotification(
-                    //        icon: ':warning:',
-                    //        message: buildMessage(search: 'Error building'),
-                    //        credentialsId: 'jenkins-build-notice-webhook',
-                    //        manifest: "${INPUT_MANIFEST}"
-                    //    )
-                    //}
+                    if (params.PUBLISH_NOTIFICATION) {
+                        publishNotification(
+                            icon: ':warning:',
+                            message: buildMessage(search: 'Error building'),
+                            credentialsId: 'jenkins-build-notice-webhook',
+                            manifest: "${INPUT_MANIFEST}"
+                        )
+                    }
                     postCleanup()
                 }
             }


### PR DESCRIPTION
### Description
Add TEST_PLATFORM and TEST_DISTRIBUTION param to fine-grain control integ-test triggers.

Also add the BUILD_DISTRIBUTION param back to OS distribution as the file is smaller now.

Also clean up a lot of leftovers such as macos snapshot, and improve the verify-parameter functionalities as well.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4919

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
