### PR TITLE
Add sleep for few seconds to ensure the container process are properly started

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -946,6 +946,7 @@ pipeline {
             node(AGENT_LINUX_X64) {
                 checkout scm
                 script {
+                    sleep 10
                     def rc = (params.RC_NUMBER.toInteger() > 0)
                     publishDistributionBuildResults(
                         failureMessages: buildMessage(search: 'Error building'),

--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -369,6 +369,7 @@ pipeline {
                         }
                         retry(5) {
                             node(agent_nodes['linux_x64']) {
+                                sleep 10
                                 def rc = (params.RC_NUMBER.toInteger() > 0)
                                 sh "mkdir -p test-results-osd-${env.BUILD_NUMBER}"
                                 sh "curl -sSL https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/${env.version}/${env.buildId}/${env.platform}/${env.architecture}/${env.distribution}/test-results/${env.BUILD_NUMBER}/integ-test/test-report.yml --output test-results-osd-${env.BUILD_NUMBER}/test-report.yml"

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -891,6 +891,7 @@ pipeline {
             node(AGENT_LINUX_X64) {
                 checkout scm
                 script {
+                    sleep 10
                     def rc = (params.RC_NUMBER.toInteger() > 0)
                     publishDistributionBuildResults(
                         failureMessages: buildMessage(search: 'Error building'),

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -326,6 +326,7 @@ pipeline {
                         }
                         retry(5) { 
                             node(agent_nodes['linux_x64']) {
+                                sleep 10
                                 def rc = (params.RC_NUMBER.toInteger() > 0)
                                 sh "mkdir -p test-results-os-${env.BUILD_NUMBER}"
                                 sh "curl -sSL https://ci.opensearch.org/ci/dbc/integ-test/${env.version}/${env.buildId}/${env.platform}/${env.architecture}/${env.distribution}/test-results/${env.BUILD_NUMBER}/integ-test/test-report.yml --output test-results-os-${env.BUILD_NUMBER}/test-report.yml"


### PR DESCRIPTION
### Description
Add sleep for few seconds to ensure the container process are properly started.

### Issues Resolved
https://build.ci.opensearch.org/job/integ-test-opensearch-dashboards/6303/console
`touch: cannot touch 'build-manifest.yml': Permission denied`

Similar to and closely related to the other resolved error https://github.com/opensearch-project/opensearch-build/issues/4894 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
