### PR TITLE
Enable check-for-build to trigger linux-tar integTest during distribution build cron

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         parameterizedCron '''
             H 1 * * * %INPUT_MANIFEST=2.16.1/opensearch-2.16.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.17.0/opensearch-2.17.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.17.0/opensearch-2.17.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
-            H 1 * * * %INPUT_MANIFEST=2.17.0/opensearch-dashboards-2.17.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.17.0/opensearch-2.17.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
+            H 1 * * * %INPUT_MANIFEST=2.17.0/opensearch-dashboards-2.17.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.17.0/opensearch-dashboards-2.17.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''

--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -23,10 +23,10 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H 1 * * * %INPUT_MANIFEST=2.16.1/opensearch-2.16.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H 1 * * * %INPUT_MANIFEST=2.17.0/opensearch-2.17.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H 1 * * * %INPUT_MANIFEST=2.17.0/opensearch-dashboards-2.17.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
-            H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux macos windows;BUILD_DISTRIBUTION=tar rpm deb zip
+            H 1 * * * %INPUT_MANIFEST=2.16.1/opensearch-2.16.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
+            H 1 * * * %INPUT_MANIFEST=2.17.0/opensearch-2.17.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.17.0/opensearch-2.17.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
+            H 1 * * * %INPUT_MANIFEST=2.17.0/opensearch-dashboards-2.17.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.17.0/opensearch-2.17.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
+            H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''
     }
@@ -54,6 +54,16 @@ pipeline {
         string(
             name: 'BUILD_DISTRIBUTION',
             description: 'Distribution to build',
+            trim: true
+        )
+        string(
+            name: 'TEST_PLATFORM',
+            description: 'Platform to test',
+            trim: true
+        )
+        string(
+            name: 'TEST_DISTRIBUTION',
+            description: 'Distribution to test',
             trim: true
         )
     }
@@ -102,6 +112,8 @@ pipeline {
                             string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}"),
                             string(name: 'BUILD_PLATFORM', value: "${BUILD_PLATFORM}"),
                             string(name: 'BUILD_DISTRIBUTION', value: "${BUILD_DISTRIBUTION}")
+                            string(name: 'TEST_PLATFORM', value: "${TEST_PLATFORM}"),
+                            string(name: 'TEST_DISTRIBUTION', value: "${TEST_DISTRIBUTION}")
                             ], wait: true
 
                             echo "Build succeeded, uploading build SHA for that job"

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -154,8 +154,9 @@ class TestInputManifests(unittest.TestCase):
         mock_open.assert_has_calls([call(InputManifests.cron_jenkinsfile(), 'w')])
         mock_open.assert_has_calls([call(InputManifests.cron_jenkinsfile(), 'r')])
         mock_open().write.assert_called_once_with(
-            f"parameterizedCron '''\n{' ' * 12}H 1 * * * %INPUT_MANIFEST=0.1.2/test-0.1.2.yml;"
-            f"TARGET_JOB_NAME=distribution-build-test;BUILD_PLATFORM=linux;BUILD_DISTRIBUTION=tar\n"
+            "parameterizedCron '''\n            H 1 * * * %INPUT_MANIFEST=0.1.2/test-0.1.2.yml;"
+            "TARGET_JOB_NAME=distribution-build-test;BUILD_PLATFORM=linux;BUILD_DISTRIBUTION=tar;"
+            "TEST_MANIFEST=0.1.2/test-0.1.2-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar\n"
         )
 
     def test_os_versionincrement_workflow(self) -> None:


### PR DESCRIPTION
### Description
Enable check-for-build to trigger linux-tar integTest during distribution build cron

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4919

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
