### PR TITLE
Fix the missing comma in check-for-build

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
                             string(name: 'INPUT_MANIFEST', value: "${INPUT_MANIFEST}"),
                             string(name: 'TEST_MANIFEST', value: "${TEST_MANIFEST}"),
                             string(name: 'BUILD_PLATFORM', value: "${BUILD_PLATFORM}"),
-                            string(name: 'BUILD_DISTRIBUTION', value: "${BUILD_DISTRIBUTION}")
+                            string(name: 'BUILD_DISTRIBUTION', value: "${BUILD_DISTRIBUTION}"),
                             string(name: 'TEST_PLATFORM', value: "${TEST_PLATFORM}"),
                             string(name: 'TEST_DISTRIBUTION', value: "${TEST_DISTRIBUTION}")
                             ], wait: true


### PR DESCRIPTION
### Description
Fix the missing comma in check-for-build

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4919

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
