### PR TITLE
Allow empty TEST paramsters in distribution build workflows

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -69,13 +69,11 @@ pipeline {
         string( // Note: need to update 'verify-parameters' entries if you add new platform(s)
             name: 'TEST_PLATFORM',
             description: "Test selected platform, choices include 'linux', 'windows'. Can combine multiple platforms with space in between (docker is only available on linux)",
-            defaultValue: 'linux windows',
             trim: true
         )
         string( // Note: need to update 'verify-parameters' entries if you add new distribution(s)
             name: 'TEST_DISTRIBUTION',
             description: "Build selected distribution, choices include 'tar', 'rpm', 'deb', 'zip'. Can combine multiple distributions with space in between (docker is only available on tar)",
-            defaultValue: 'tar rpm deb zip',
             trim: true
         )
         string(
@@ -142,6 +140,15 @@ pipeline {
                         'TEST_PLATFORM': 'linux windows',
                         'TEST_DISTRIBUTION': 'tar rpm deb zip',
                     ]
+
+                    // BUILD params are required while TEST params are not
+                    if (params.TEST_PLATFORM == null || params.TEST_PLATFORM == '') {
+                        paramType.remove('TEST_PLATFORM')
+                    }
+
+                    if (params.TEST_DISTRIBUTION == null || params.TEST_DISTRIBUTION == '') {
+                        paramType.remove('TEST_DISTRIBUTION')
+                    }
 
                     paramType.each { key, value ->
                         verifyParameterPlatformDistribution(key, value)

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -68,13 +68,11 @@ pipeline {
         string( // Note: need to update 'verify-parameters' entries if you add new platform(s)
             name: 'TEST_PLATFORM',
             description: "Test selected platform, choices include 'linux', 'windows'. Can combine multiple platforms with space in between (docker is only available on linux)",
-            defaultValue: 'linux windows',
             trim: true
         )
         string( // Note: need to update 'verify-parameters' entries if you add new distribution(s)
             name: 'TEST_DISTRIBUTION',
             description: "Build selected distribution, choices include 'tar', 'rpm', 'deb', 'zip'. Can combine multiple distributions with space in between (docker is only available on tar)",
-            defaultValue: 'tar rpm deb zip',
             trim: true
         )
         string(
@@ -142,6 +140,15 @@ pipeline {
                         'TEST_PLATFORM': 'linux windows',
                         'TEST_DISTRIBUTION': 'tar rpm deb zip',
                     ]
+
+                    // BUILD params are required while TEST params are not
+                    if (params.TEST_PLATFORM == null || params.TEST_PLATFORM == '') {
+                        paramType.remove('TEST_PLATFORM')
+                    }
+
+                    if (params.TEST_DISTRIBUTION == null || params.TEST_DISTRIBUTION == '') {
+                        paramType.remove('TEST_DISTRIBUTION')
+                    }
 
                     paramType.each { key, value ->
                         verifyParameterPlatformDistribution(key, value)


### PR DESCRIPTION
### Description
Allow empty TEST paramsters in distribution build workflows

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4919

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
