### PR TITLE
Increase concurrent jobs limit to 30 for gradle-check

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             categories: [],
             limitOneJobWithMatchingParams: false,
             maxConcurrentPerNode: 0,
-            maxConcurrentTotal: 20,
+            maxConcurrentTotal: 30,
             paramsToUseForLimit: '',
             throttleEnabled: true,
             throttleOption: 'project',


### PR DESCRIPTION
### Description
Increase concurrent jobs limit to 30 for gradle-check due to multiple queued up jobs.

### Issues Resolved
#4908 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
