### PR TITLE
Add sleep for few seconds to ensure the container process are properly started - Part 2

### DIFF
--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -344,6 +344,7 @@ pipeline {
                                 docker.withRegistry('https://public.ecr.aws/') {
                                     docker.image(docker_images["$distribution"]).inside(docker_args["$distribution"]) {
                                         checkout scm
+                                        sleep 10
                                         downloadBuildManifest(
                                             url: BUILD_MANIFEST_URL,
                                             path: BUILD_MANIFEST

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -306,6 +306,7 @@ pipeline {
                                 docker.withRegistry('https://public.ecr.aws/') {
                                     docker.image(docker_images["$distribution"]).inside(docker_args["$distribution"]) {
                                         checkout scm
+                                        sleep 10
                                         downloadBuildManifest(
                                             url: BUILD_MANIFEST_URL,
                                             path: BUILD_MANIFEST


### PR DESCRIPTION
### Description
Coming from this initial PR https://github.com/opensearch-project/opensearch-build/pull/4964 adding the same logic to ensure the `downloadBuildManifest` library does not exit out with `touch: cannot touch 'build-manifest.yml': Permission denied`. 
Here is the exited build https://build.ci.opensearch.org/job/integ-test/8620/consoleFull.

As a trail adding sleep with ensure the underlying node and container process are properly started and the writing of files can start with `downloadBuildManifest`.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/51 and https://github.com/opensearch-project/opensearch-build/issues/4908.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
