### PR TITLE
Add test_stdout and test_stderr path/url for test-report.yml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.black]
 line-length = 160
-target-version = ['py37']
+target-version = ['py39']
 
 [tool.isort]
 profile = "black"
 line_length = 160
 
 [tool.mypy]
-python_version = 3.7
+python_version = 3.9
 disallow_untyped_defs = true
 warn_return_any = true
 warn_unused_configs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.black]
 line-length = 160
-target-version = ['py39']
+target-version = ['py37']
 
 [tool.isort]
 profile = "black"
 line_length = 160
 
 [tool.mypy]
-python_version = 3.9
+python_version = 3.7
 disallow_untyped_defs = true
 warn_return_any = true
 warn_unused_configs = true

--- a/src/manifests/test_report_manifest.py
+++ b/src/manifests/test_report_manifest.py
@@ -37,6 +37,8 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
               - name: with-security
                 status: the status of the test run with this config. e.g. pass/fail
                 yml: URL or local path to the component yml file
+                test_stdout: URL or local path to the test stdout log
+                test_stderr: URL or local path to the test stderr log
                 cluster_stdout:
                   - URL or local path to the OpenSearch cluster logs
                 cluster_stderr:
@@ -83,6 +85,8 @@ class TestReportManifest(ComponentManifest['TestReportManifest', 'TestComponents
                                 "name": {"type": "string"},
                                 "status": {"type": "string"},
                                 "yml": {"type": "string"},
+                                "test_stdout": {"type": "string"},
+                                "test_stderr": {"type": "string"},
                                 "cluster_stdout": {"type": "list"},
                                 "cluster_stderr": {"type": "list"}
                             }
@@ -176,6 +180,8 @@ class TestComponent(Component):
                 self.name = data["name"]
                 self.status = data["status"]
                 self.yml = data["yml"]
+                self.test_stdout = data["test_stdout"]
+                self.test_stderr = data["test_stderr"]
                 self.cluster_stdout = data["cluster_stdout"]
                 self.cluster_stderr = data["cluster_stderr"]
 
@@ -184,6 +190,8 @@ class TestComponent(Component):
                     "name": self.name,
                     "status": self.status,
                     "yml": self.yml,
+                    "test_stdout": self.test_stdout,
+                    "test_stderr": self.test_stderr,
                     "cluster_stdout": self.cluster_stdout,
                     "cluster_stderr": self.cluster_stderr
                 }

--- a/src/report_workflow/test_report_runner.py
+++ b/src/report_workflow/test_report_runner.py
@@ -117,6 +117,8 @@ class TestReportRunner:
                 component_yml_ref = "URL not available"
             config_dict["yml"] = component_yml_ref
             config_dict["status"] = test_result
+            config_dict["test_stdout"] = get_test_logs(self.base_path, str(self.test_run_id), self.test_type, test_report_component_name, config, self.name)[0]
+            config_dict["test_stderr"] = get_test_logs(self.base_path, str(self.test_run_id), self.test_type, test_report_component_name, config, self.name)[1]
             config_dict["cluster_stdout"] = get_os_cluster_logs(self.base_path, str(self.test_run_id), self.test_type, test_report_component_name, config, self.name)[0]
             config_dict["cluster_stderr"] = get_os_cluster_logs(self.base_path, str(self.test_run_id), self.test_type, test_report_component_name, config, self.name)[1]
             component["configs"].append(config_dict)
@@ -162,6 +164,16 @@ def generate_test_command(test_type: str, test_manifest_path: str, artifacts_pat
         command = " ".join([command, "--component", component])
     logging.info(command)
     return command
+
+
+def get_test_logs(base_path: str, test_number: str, test_type: str, component_name: str, config: str,
+                  product_name: str) -> typing.List[str]:
+    if base_path.startswith("https://"):
+        return ["/".join([base_path.strip("/"), "test-results", test_number, test_type, component_name, config, "stdout.txt"]),
+                "/".join([base_path.strip("/"), "test-results", test_number, test_type, component_name, config, "stderr.txt"])]
+    else:
+        return [os.path.join(base_path, "test-results", test_number, test_type, component_name, config, "stdout.txt"),
+                os.path.join(base_path, "test-results", test_number, test_type, component_name, config, "stderr.txt")]
 
 
 def get_os_cluster_logs(base_path: str, test_number: str, test_type: str, component_name: str, config: str,

--- a/tests/tests_report_workflow/test_test_report_runner.py
+++ b/tests/tests_report_workflow/test_test_report_runner.py
@@ -117,12 +117,19 @@ class TestTestReportRunner(unittest.TestCase):
         self.assertEqual(test_run_component_dict.get("configs")[0]["name"], "with-security")
         self.assertEqual(test_run_component_dict.get("configs")[0]["yml"],
                          "https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["test_stdout"], "https://ci.opensearch.org/ci"
+                                                                                   "/dbc/mock/test-results/123/integ-test/geospatial/with-security/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["test_stderr"], "https://ci.opensearch.org/ci"
+                                                                                   "/dbc/mock/test-results/123/integ-test/geospatial/with-security/stderr.txt")
         self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
                                                                                          "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stdout.txt")
         self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stderr"][0], "https://ci.opensearch.org/ci"
                                                                                          "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stderr.txt")
-
         self.assertEqual(test_run_component_dict.get("configs")[1]["name"], "without-security")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["test_stdout"], "https://ci.opensearch.org/ci"
+                                                                                   "/dbc/mock/test-results/123/integ-test/geospatial/without-security/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["test_stderr"], "https://ci.opensearch.org/ci"
+                                                                                   "/dbc/mock/test-results/123/integ-test/geospatial/without-security/stderr.txt")
         self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
                                                                                          "/dbc/mock/test-results/123/integ-test/geospatial/without-security/local-cluster-logs/id-1/stdout.txt")
         self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stderr"][0], "https://ci.opensearch.org/ci"
@@ -154,6 +161,8 @@ class TestTestReportRunner(unittest.TestCase):
                          "https://ci.opensearch.org/ci/dbc/mock/test-results/123/integ-test/geospatial/with-security/geospatial.yml")
         self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
                                                                                          "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["test_stdout"], "https://ci.opensearch.org/ci"
+                                                                                   "/dbc/mock/test-results/123/integ-test/geospatial/with-security/stdout.txt")
 
     @patch("yaml.safe_load")
     @patch("validators.url")
@@ -172,6 +181,10 @@ class TestTestReportRunner(unittest.TestCase):
         self.assertEqual(test_run_component_dict.get("configs")[0]["status"], "Not Available")
         self.assertEqual(test_run_component_dict.get("configs")[0]["name"], "with-security")
         self.assertEqual(test_run_component_dict.get("configs")[0]["yml"], "URL not available")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["test_stdout"], "https://ci.opensearch.org/ci"
+                                                                                   "/dbc/mock/test-results/123/integ-test/geospatial/with-security/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["test_stdout"], "https://ci.opensearch.org/ci"
+                                                                                   "/dbc/mock/test-results/123/integ-test/geospatial/without-security/stdout.txt")
         self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
                                                                                          "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stdout.txt")
         self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
@@ -200,6 +213,10 @@ class TestTestReportRunner(unittest.TestCase):
         self.assertEqual(test_run_component_dict.get("configs")[0]["status"], "Not Available")
         self.assertEqual(test_run_component_dict.get("configs")[0]["name"], "with-security")
         self.assertEqual(test_run_component_dict.get("configs")[0]["yml"], "URL not available")
+        self.assertEqual(test_run_component_dict.get("configs")[0]["test_stdout"], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/with-security/stdout.txt")
+        self.assertEqual(test_run_component_dict.get("configs")[1]["test_stdout"], "https://ci.opensearch.org/ci"
+                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/without-security/stdout.txt")
         self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
                                                                                          "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stdout.txt")
         self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stdout"][0], "https://ci.opensearch.org/ci"

--- a/tests/tests_report_workflow/test_test_report_runner.py
+++ b/tests/tests_report_workflow/test_test_report_runner.py
@@ -214,9 +214,9 @@ class TestTestReportRunner(unittest.TestCase):
         self.assertEqual(test_run_component_dict.get("configs")[0]["name"], "with-security")
         self.assertEqual(test_run_component_dict.get("configs")[0]["yml"], "URL not available")
         self.assertEqual(test_run_component_dict.get("configs")[0]["test_stdout"], "https://ci.opensearch.org/ci"
-                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/with-security/stdout.txt")
+                                                                                   "/dbc/mock/test-results/123/integ-test/geospatial/with-security/stdout.txt")
         self.assertEqual(test_run_component_dict.get("configs")[1]["test_stdout"], "https://ci.opensearch.org/ci"
-                                                                                         "/dbc/mock/test-results/123/integ-test/geospatial/without-security/stdout.txt")
+                                                                                   "/dbc/mock/test-results/123/integ-test/geospatial/without-security/stdout.txt")
         self.assertEqual(test_run_component_dict.get("configs")[0]["cluster_stdout"][0], "https://ci.opensearch.org/ci"
                                                                                          "/dbc/mock/test-results/123/integ-test/geospatial/with-security/local-cluster-logs/id-0/stdout.txt")
         self.assertEqual(test_run_component_dict.get("configs")[1]["cluster_stdout"][0], "https://ci.opensearch.org/ci"


### PR DESCRIPTION
### Description
Add test_stdout and test_stderr path/url for test-report.yml

### Issues Resolved
https://github.com/opensearch-project/opensearch-metrics/issues/51

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
