### PR TITLE
Add workspace.enabled param as 2.x/default osd entrypoint

### DIFF
--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-2.x.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-2.x.sh
@@ -170,6 +170,7 @@ opensearch_dashboards_vars=(
     assistant.chat.enabled
     observability.query_assist.enabled
     usageCollection.uiMetric.enabled
+    workspace.enabled
 )
 
 function setupSecurityDashboardsPlugin {

--- a/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-default.x.sh
+++ b/docker/release/config/opensearch-dashboards/opensearch-dashboards-docker-entrypoint-default.x.sh
@@ -170,6 +170,7 @@ opensearch_dashboards_vars=(
     assistant.chat.enabled
     observability.query_assist.enabled
     usageCollection.uiMetric.enabled
+    workspace.enabled
 )
 
 function setupSecurityDashboardsPlugin {


### PR DESCRIPTION
### Description
Add workspace.enabled param as 2.x/default osd entrypoint

### Issues Resolved
This param was initially added in:
* https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5949

Would need to update the docker entrypoint to take effect there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
