### PR TITLE
Bump opensearch-benchmark docker version to 1.9.0

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_test_suite_compare.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite_compare.py
@@ -30,7 +30,7 @@ class BenchmarkTestSuiteCompare(BenchmarkTestSuite):
         self.command = f'docker run --name docker-container-{self.args.stack_suffix} '
         if self.args.benchmark_config:
             self.command += f" -v {self.args.benchmark_config}:/opensearch-benchmark/.benchmark/benchmark.ini "
-        self.command += f"opensearchproject/opensearch-benchmark:1.6.0 " \
+        self.command += f"opensearchproject/opensearch-benchmark:1.9.0 " \
                         f"compare --baseline={self.args.baseline} --contender={self.args.contender} "
 
         if self.args.results_format:

--- a/src/test_workflow/benchmark_test/benchmark_test_suite_execute.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite_execute.py
@@ -39,7 +39,7 @@ class BenchmarkTestSuiteExecute(BenchmarkTestSuite):
         self.command = f'docker run --name docker-container-{self.args.stack_suffix}'
         if self.args.benchmark_config:
             self.command += f" -v {self.args.benchmark_config}:/opensearch-benchmark/.benchmark/benchmark.ini"
-        self.command += f" opensearchproject/opensearch-benchmark:1.6.0 execute-test --workload={self.args.workload} " \
+        self.command += f" opensearchproject/opensearch-benchmark:1.9.0 execute-test --workload={self.args.workload} " \
                         f"--pipeline=benchmark-only --target-hosts={self.endpoint}"
 
         if self.args.workload_params:

--- a/tests/test_run_compare.py
+++ b/tests/test_run_compare.py
@@ -111,7 +111,7 @@ class TestRunBenchmarkTestCompare(unittest.TestCase):
         # define the expected command
         expected_command = (
             f"docker run --name docker-container-{args.stack_suffix} "
-            "opensearchproject/opensearch-benchmark:1.6.0 "
+            "opensearchproject/opensearch-benchmark:1.9.0 "
             "compare --baseline=12345 --contender=54321 "
             "--results-format=markdown "
             "--results-numbers-align=right "

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
@@ -48,7 +48,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
             test_suite.execute()
         self.assertEqual(mock_check_call.call_count, 2)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.6.0 execute-test '
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.9.0 execute-test '
                          f'--workload=nyc_taxis --pipeline=benchmark-only --target-hosts=abc.com:80 --client-options="timeout:300" --results-file=final_result.md')
 
     @patch('test_workflow.benchmark_test.benchmark_test_suite_execute.subprocess.check_call')
@@ -62,7 +62,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         mock_check_call.assert_called_with(
             f"docker rm -f docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.6.0 execute-test'
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.9.0 execute-test'
                          f' --workload=nyc_taxis --pipeline=benchmark-only '
                          f'--target-hosts=abc.com:443 '
                          f'--client-options="timeout:300,use_ssl:true,verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'myStrongPassword123!\'" --results-file=final_result.md')
@@ -78,7 +78,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         mock_check_call.assert_called_with(
             f"docker rm -f docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.6.0 execute-test '
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.9.0 execute-test '
                          '--workload=nyc_taxis --pipeline=benchmark-only '
                          '--target-hosts=abc.com:443 --client-options="timeout:300,use_ssl:true,'
                          'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'" --results-file=final_result.md')
@@ -100,7 +100,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:1.6.0 execute-test '
+                         'opensearchproject/opensearch-benchmark:1.9.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -121,7 +121,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:1.6.0 execute-test '
+                         'opensearchproject/opensearch-benchmark:1.9.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -143,7 +143,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:1.6.0 execute-test '
+                         'opensearchproject/opensearch-benchmark:1.9.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -167,7 +167,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:1.6.0 execute-test '
+                         'opensearchproject/opensearch-benchmark:1.9.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -190,7 +190,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
                 f"docker rm -f docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
             self.assertEqual(test_suite.command, f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                                                  '/opensearch-benchmark/.benchmark/benchmark.ini '
-                                                 'opensearchproject/opensearch-benchmark:1.6.0 execute-test '
+                                                 'opensearchproject/opensearch-benchmark:1.9.0 execute-test '
                                                  '--workload=nyc_taxis '
                                                  '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                                                  '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -213,7 +213,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         mock_check_call.assert_called_with(
             f"docker rm -f docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.6.0 execute-test '
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.9.0 execute-test '
                          '--workload=nyc_taxis --pipeline=benchmark-only '
                          '--target-hosts=abc.com:443 --client-options="timeout:300,use_ssl:true,'
                          'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'" --results-file=final_result.md')

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite_compare.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite_compare.py
@@ -34,7 +34,7 @@ class TestBenchmarkTestSuiteCompare(unittest.TestCase):
         mock_check_call.assert_called_once()
 
         self.assertEqual(compare.command, 'docker run --name docker-container-test-suffix '
-                                          'opensearchproject/opensearch-benchmark:1.6.0 compare '
+                                          'opensearchproject/opensearch-benchmark:1.9.0 compare '
                                           '--baseline=baseline-id --contender=contender-id --results-format=markdown '
                                           '--results-numbers-align=right --results-file=final_result.md '
                                           '--show-in-results=all ')
@@ -51,7 +51,7 @@ class TestBenchmarkTestSuiteCompare(unittest.TestCase):
         mock_check_call.assert_called_once()
         self.assertEqual(compare.command, 'docker run --name docker-container-test-suffix  -v '
                                           '/some/path/benchmark.ini:/opensearch-benchmark/.benchmark/benchmark.ini '
-                                          'opensearchproject/opensearch-benchmark:1.6.0 compare '
+                                          'opensearchproject/opensearch-benchmark:1.9.0 compare '
                                           '--baseline=baseline-id --contender=contender-id --results-format=markdown '
                                           '--results-numbers-align=right --results-file=final_result.md '
                                           '--show-in-results=all ')


### PR DESCRIPTION
### Description
Bump opensearch-benchmark docker version to 1.9.0. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
