### PR TITLE
Add new stage in gradle-check to check and abort stale runs

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@6.6.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.9.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -79,6 +79,13 @@ pipeline {
         BUILD_CAUSE = currentBuild.getBuildCauses()
     }
     stages {
+        stage('Check and abort stale runs') {
+            steps {
+                script {
+                    abortStaleJenkinsJobs(jobName: 'gradle-check', lookupTime: 3)
+                }
+            }
+        }
         stage('Run Gradle Check') {
             steps {
                 script {


### PR DESCRIPTION
### Description
This PR adds a new stage in gradle-check to check and abort previous in-progress runs for the same pull-request. 

### Issues Resolved
#5008 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
