### PR TITLE
Fix position of abort stale job script in gradle-check

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -79,13 +79,6 @@ pipeline {
         BUILD_CAUSE = currentBuild.getBuildCauses()
     }
     stages {
-        stage('Check and abort stale runs') {
-            steps {
-                script {
-                    abortStaleJenkinsJobs(jobName: 'gradle-check', lookupTime: 3)
-                }
-            }
-        }
         stage('Run Gradle Check') {
             steps {
                 script {
@@ -128,6 +121,8 @@ pipeline {
                                 currentBuild.description = """runner: ${agent_name}<br><a href="${pr_url}">PR #${pr_number}</a>: ${pr_title} with bwc.checkout.align=true"""
                                 bwc_checkout_align = "true"
                             }
+
+                            abortStaleJenkinsJobs(jobName: 'gradle-check', lookupTime: 3)
 
                             runGradleCheck(
                                 gitRepoUrl: "${pr_from_clone_url}",


### PR DESCRIPTION
### Description

The `abortStaleJenkinsJobs` depends on build description check to verify if there are stale jobs for the same PR. 
It is currently not working because it is getting executed before the build description is being set for gradle-check job. 
This lib needs to be called once the build description has been set. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
