### PR TITLE
Remove 2.17.1 builds

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -23,8 +23,6 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H 1 * * * %INPUT_MANIFEST=2.17.1/opensearch-dashboards-2.17.1.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.17.1/opensearch-dashboards-2.17.1-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
-            H 1 * * * %INPUT_MANIFEST=2.17.1/opensearch-2.17.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=2.18.0/opensearch-2.18.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.18.0/opensearch-2.18.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
             H 1 * * * %INPUT_MANIFEST=2.18.0/opensearch-dashboards-2.18.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.18.0/opensearch-dashboards-2.18.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
             H 1 * * * %INPUT_MANIFEST=1.3.20/opensearch-1.3.20.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=1.3.20/opensearch-1.3.20-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar


### PR DESCRIPTION
### Description
Remove 2.17.1 builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
