### PR TITLE
Remove typed-ast as it is deprecated

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -38,6 +38,7 @@ markdownify = "~=0.12.1"
 mistune = "~=3.0.1"
 semver = ">=3,<4"
 pandas = "~=2.2.2"
+idna = "~=3.10"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -24,9 +24,6 @@ pytest-cov = "~=2.10.0"
 jproperties = "~=2.1.1"
 retry = "~=0.9"
 sortedcontainers = "~=2.4.0"
-# TODO: pkg_resources is deprecated in Python 3.9 ever since Python 3.8 introduces importlib.metadata
-#       The latest version of cerberus is still using pkg_resources with this PR pending: https://github.com/pyeve/cerberus/pull/579
-#       You will see a new deprecation warning when running cerberus related code in this repository: 'DeprecationWarning: pkg_resources is deprecated as an API'
 cerberus = "~=1.3.5"
 psutil = "~=5.8"
 atomicwrites = "~=1.4.1"

--- a/Pipfile
+++ b/Pipfile
@@ -27,14 +27,13 @@ sortedcontainers = "~=2.4.0"
 # TODO: pkg_resources is deprecated in Python 3.9 ever since Python 3.8 introduces importlib.metadata
 #       The latest version of cerberus is still using pkg_resources with this PR pending: https://github.com/pyeve/cerberus/pull/579
 #       You will see a new deprecation warning when running cerberus related code in this repository: 'DeprecationWarning: pkg_resources is deprecated as an API'
-cerberus = "~=1.3.4"
+cerberus = "~=1.3.5"
 psutil = "~=5.8"
 atomicwrites = "~=1.4.1"
 validators = "~=0.21.2"
 yamlfix = "~=1.0.1"
 yamllint = "~=1.27.1"
 pytablewriter = "~=0.64.2"
-typed-ast = "~=1.5.4"
 zipp = "~=3.19.1"
 importlib-metadata = "~=4.12.0"
 ruamel-yaml = "~=0.17.21"

--- a/Pipfile
+++ b/Pipfile
@@ -39,6 +39,9 @@ mistune = "~=3.0.1"
 semver = ">=3,<4"
 pandas = "~=2.2.2"
 idna = "~=3.10"
+certifi = "~=2024.7.4"
+types-urllib3 = "~=1.26.25.14"
+charset-normalizer = "~=2.1.1"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3a793f8dbf08feffd54305b32fec09ab0534849c13e43f30048f23177451dd65"
+            "sha256": "17b15eca2c2de88060c9a7acca6b6cf399b1a7568fc05ada1a58298cc21a0d9f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -165,6 +165,15 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==2.5.36"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==3.10"
         },
         "importlib-metadata": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "17b15eca2c2de88060c9a7acca6b6cf399b1a7568fc05ada1a58298cc21a0d9f"
+            "sha256": "1a574dcffe39ed011c262bf508c9539bf865a8711bff3978f2d0b8b98357a581"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -47,6 +47,15 @@
             "index": "pypi",
             "version": "==1.3.5"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b",
+                "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.6'",
+            "version": "==2024.7.4"
+        },
         "cfgv": {
             "hashes": [
                 "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9",
@@ -62,6 +71,15 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==5.2.0"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
+                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
+            ],
+            "index": "pypi",
+            "markers": "python_full_version >= '3.6.0'",
+            "version": "==2.1.1"
         },
         "click": {
             "hashes": [
@@ -753,6 +771,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==2.31.0.6"
+        },
+        "types-urllib3": {
+            "hashes": [
+                "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f",
+                "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e"
+            ],
+            "index": "pypi",
+            "version": "==1.26.25.14"
         },
         "typing-extensions": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a248efd2a5ce087018ddad8eb046dc56bd4dcd7afcb0cc0b747bcf2d976b098c"
+            "sha256": "3a793f8dbf08feffd54305b32fec09ab0534849c13e43f30048f23177451dd65"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -47,15 +47,6 @@
             "index": "pypi",
             "version": "==1.3.5"
         },
-        "certifi": {
-            "hashes": [
-                "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b",
-                "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.6'",
-            "version": "==2024.7.4"
-        },
         "cfgv": {
             "hashes": [
                 "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9",
@@ -71,14 +62,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==5.2.0"
-        },
-        "charset-normalizer": {
-            "hashes": [
-                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
-                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
-            ],
-            "markers": "python_full_version >= '3.6.0'",
-            "version": "==2.1.1"
         },
         "click": {
             "hashes": [
@@ -182,14 +165,6 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==2.5.36"
-        },
-        "idna": {
-            "hashes": [
-                "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc",
-                "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.7"
         },
         "importlib-metadata": {
             "hashes": [
@@ -741,54 +716,6 @@
             "markers": "python_version < '3.11'",
             "version": "==2.0.1"
         },
-        "typed-ast": {
-            "hashes": [
-                "sha256:042eb665ff6bf020dd2243307d11ed626306b82812aba21836096d229fdc6a10",
-                "sha256:045f9930a1550d9352464e5149710d56a2aed23a2ffe78946478f7b5416f1ede",
-                "sha256:0635900d16ae133cab3b26c607586131269f88266954eb04ec31535c9a12ef1e",
-                "sha256:118c1ce46ce58fda78503eae14b7664163aa735b620b64b5b725453696f2a35c",
-                "sha256:16f7313e0a08c7de57f2998c85e2a69a642e97cb32f87eb65fbfe88381a5e44d",
-                "sha256:1efebbbf4604ad1283e963e8915daa240cb4bf5067053cf2f0baadc4d4fb51b8",
-                "sha256:2188bc33d85951ea4ddad55d2b35598b2709d122c11c75cffd529fbc9965508e",
-                "sha256:2b946ef8c04f77230489f75b4b5a4a6f24c078be4aed241cfabe9cbf4156e7e5",
-                "sha256:335f22ccb244da2b5c296e6f96b06ee9bed46526db0de38d2f0e5a6597b81155",
-                "sha256:381eed9c95484ceef5ced626355fdc0765ab51d8553fec08661dce654a935db4",
-                "sha256:429ae404f69dc94b9361bb62291885894b7c6fb4640d561179548c849f8492ba",
-                "sha256:44f214394fc1af23ca6d4e9e744804d890045d1643dd7e8229951e0ef39429b5",
-                "sha256:48074261a842acf825af1968cd912f6f21357316080ebaca5f19abbb11690c8a",
-                "sha256:4bc1efe0ce3ffb74784e06460f01a223ac1f6ab31c6bc0376a21184bf5aabe3b",
-                "sha256:57bfc3cf35a0f2fdf0a88a3044aafaec1d2f24d8ae8cd87c4f58d615fb5b6311",
-                "sha256:597fc66b4162f959ee6a96b978c0435bd63791e31e4f410622d19f1686d5e769",
-                "sha256:5f7a8c46a8b333f71abd61d7ab9255440d4a588f34a21f126bbfc95f6049e686",
-                "sha256:5fe83a9a44c4ce67c796a1b466c270c1272e176603d5e06f6afbc101a572859d",
-                "sha256:61443214d9b4c660dcf4b5307f15c12cb30bdfe9588ce6158f4a005baeb167b2",
-                "sha256:622e4a006472b05cf6ef7f9f2636edc51bda670b7bbffa18d26b255269d3d814",
-                "sha256:6eb936d107e4d474940469e8ec5b380c9b329b5f08b78282d46baeebd3692dc9",
-                "sha256:7f58fabdde8dcbe764cef5e1a7fcb440f2463c1bbbec1cf2a86ca7bc1f95184b",
-                "sha256:83509f9324011c9a39faaef0922c6f720f9623afe3fe220b6d0b15638247206b",
-                "sha256:8c524eb3024edcc04e288db9541fe1f438f82d281e591c548903d5b77ad1ddd4",
-                "sha256:94282f7a354f36ef5dbce0ef3467ebf6a258e370ab33d5b40c249fa996e590dd",
-                "sha256:b445c2abfecab89a932b20bd8261488d574591173d07827c1eda32c457358b18",
-                "sha256:be4919b808efa61101456e87f2d4c75b228f4e52618621c77f1ddcaae15904fa",
-                "sha256:bfd39a41c0ef6f31684daff53befddae608f9daf6957140228a08e51f312d7e6",
-                "sha256:c631da9710271cb67b08bd3f3813b7af7f4c69c319b75475436fcab8c3d21bee",
-                "sha256:cc95ffaaab2be3b25eb938779e43f513e0e538a84dd14a5d844b8f2932593d88",
-                "sha256:d09d930c2d1d621f717bb217bf1fe2584616febb5138d9b3e8cdd26506c3f6d4",
-                "sha256:d40c10326893ecab8a80a53039164a224984339b2c32a6baf55ecbd5b1df6431",
-                "sha256:d41b7a686ce653e06c2609075d397ebd5b969d821b9797d029fccd71fdec8e04",
-                "sha256:d5c0c112a74c0e5db2c75882a0adf3133adedcdbfd8cf7c9d6ed77365ab90a1d",
-                "sha256:e1a976ed4cc2d71bb073e1b2a250892a6e968ff02aa14c1f40eba4f365ffec02",
-                "sha256:e48bf27022897577d8479eaed64701ecaf0467182448bd95759883300ca818c8",
-                "sha256:ed4a1a42df8a3dfb6b40c3d2de109e935949f2f66b19703eafade03173f8f437",
-                "sha256:f0aefdd66f1784c58f65b502b6cf8b121544680456d1cebbd300c2c813899274",
-                "sha256:fc2b8c4e1bc5cd96c1a823a885e6b158f8451cf6f5530e1829390b4d27d0807f",
-                "sha256:fd946abf3c31fb50eee07451a6aedbfff912fcd13cf357363f5b4e834cc5e71a",
-                "sha256:fe58ef6a764de7b4b36edfc8592641f56e69b7163bba9f9c8089838ee596bfb2"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.6'",
-            "version": "==1.5.5"
-        },
         "typepy": {
             "extras": [
                 "datetime"
@@ -817,13 +744,6 @@
             "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==2.31.0.6"
-        },
-        "types-urllib3": {
-            "hashes": [
-                "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f",
-                "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e"
-            ],
-            "version": "==1.26.25.14"
         },
         "typing-extensions": {
             "hashes": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.black]
 line-length = 160
-target-version = ['py37']
+target-version = ['py39']
 
 [tool.isort]
 profile = "black"
 line_length = 160
 
 [tool.mypy]
-python_version = 3.7
+python_version = 3.9
 disallow_untyped_defs = true
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
### Description
Remove typed-ast as it is deprecated

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/5054

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
