### PR TITLE
Update parameter requirement for manifest-commit-lock workflow

### DIFF
--- a/jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile
+++ b/jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                     }
                     if (params.MANIFEST_LOCK_ACTION == 'MATCH_BUILD_MANIFEST' && (OPENSEARCH_RELEASE_CANDIDATE.isEmpty() || OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE.isEmpty())) {
                                 currentBuild.result = 'ABORTED'
-                                error('OPENSEARCH_RELEASE_CANDIDATE and/or OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE cannot be empty when MANIFEST_LOCK_ACTION is MATCH_BUILD_MANIFEST or UPDATE_TO_RECENT_COMMITS.')
+                                error('OPENSEARCH_RELEASE_CANDIDATE and/or OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE cannot be empty when MANIFEST_LOCK_ACTION is MATCH_BUILD_MANIFEST.')
                     }
                 }
             }

--- a/jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile
+++ b/jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
                                 currentBuild.result = 'ABORTED'
                                 error('MANIFEST_LOCK_ACTION and/or RELEASE_VERSION cannot be empty!')
                     }
-                    if ((params.MANIFEST_LOCK_ACTION == 'MATCH_BUILD_MANIFEST' || params.MANIFEST_LOCK_ACTION == 'UPDATE_TO_RECENT_COMMITS') && (OPENSEARCH_RELEASE_CANDIDATE.isEmpty() || OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE.isEmpty())) {
+                    if (params.MANIFEST_LOCK_ACTION == 'MATCH_BUILD_MANIFEST' && (OPENSEARCH_RELEASE_CANDIDATE.isEmpty() || OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE.isEmpty())) {
                                 currentBuild.result = 'ABORTED'
                                 error('OPENSEARCH_RELEASE_CANDIDATE and/or OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE cannot be empty when MANIFEST_LOCK_ACTION is MATCH_BUILD_MANIFEST or UPDATE_TO_RECENT_COMMITS.')
                     }
@@ -112,7 +112,7 @@ pipeline {
             }
             steps {
                 script {
-                    def updateManifest = { String productName, String releaseCandidate ->
+                    def updateManifest = { String productName ->
                         def existingManifest = readYaml file: "manifests/${params.RELEASE_VERSION}/${productName}-${params.RELEASE_VERSION}.yml"
                         def selectedComponents = params.COMPONENTS.isEmpty() ? existingManifest.components : existingManifest.components.findAll { component ->
                             params.COMPONENTS.split(',').any { it.trim() == component.name }
@@ -136,8 +136,8 @@ pipeline {
                                 sed -i '1s/^/---\\n/' manifests/${params.RELEASE_VERSION}/${productName}-${params.RELEASE_VERSION}.yml
                         """
                     }
-                    updateManifest("opensearch", params.OPENSEARCH_RELEASE_CANDIDATE)
-                    updateManifest("opensearch-dashboards", params.OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE)
+                    updateManifest("opensearch")
+                    updateManifest("opensearch-dashboards")
                 }
             }
         }

--- a/tests/jenkins/TestReleaseManifestCommitLock.groovy
+++ b/tests/jenkins/TestReleaseManifestCommitLock.groovy
@@ -34,12 +34,13 @@ class TestReleaseManifestCommitLock extends BuildPipelineTest {
 
         super.setUp()
         addParam('RELEASE_VERSION', '2.0.0')
-        addParam('OPENSEARCH_RELEASE_CANDIDATE', '3813')
-        addParam('OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE', '3050')
         addParam('COMPONENTS', 'OpenSearch')
 
         helper.registerAllowedMethod("withCredentials", [Map])
         def buildManifest = "tests/jenkins/data/opensearch-2.0.0.yml"
+        helper.registerAllowedMethod('error', [String], { String message ->
+        throw new Exception(message)
+        })
         helper.registerAllowedMethod('readYaml', [Map.class], { args ->
             return new Yaml().load((buildManifest as File).text)
         })
@@ -49,11 +50,25 @@ class TestReleaseManifestCommitLock extends BuildPipelineTest {
     @Test
     public void testManifestCommitLock_matchBuildManifest() {
         addParam('MANIFEST_LOCK_ACTION', 'MATCH_BUILD_MANIFEST')
+        addParam('OPENSEARCH_RELEASE_CANDIDATE', '3813')
+        addParam('OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE', '3050')
         super.testPipeline('jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile',
                 'tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_matchBuildManifest')
         def callStack = helper.getCallStack()
         assertCallStack().contains('stage(Parameters Check, groovy.lang.Closure)')
         assertCallStack().contains('stage(MATCH_BUILD_MANIFEST, groovy.lang.Closure)')
+    }
+
+    @Test
+    public void testManifestCommitLock_matchBuildManifest_exception() {
+        addParam('MANIFEST_LOCK_ACTION', 'MATCH_BUILD_MANIFEST')
+        binding.setVariable('OPENSEARCH_RELEASE_CANDIDATE', '')
+        binding.setVariable('OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE', '')
+        Exception exception = assertThrows(Exception) {
+        runScript('jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile')
+        }
+        def callStack = helper.getCallStack()
+        assertCallStack().contains('OPENSEARCH_RELEASE_CANDIDATE and/or OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE cannot be empty when MANIFEST_LOCK_ACTION is MATCH_BUILD_MANIFEST or UPDATE_TO_RECENT_COMMITS.')
     }
 
     @Test
@@ -81,6 +96,8 @@ class TestReleaseManifestCommitLock extends BuildPipelineTest {
 
     @Test
     public void testManifestCommitLock_createPullRequest() {
+        addParam('OPENSEARCH_RELEASE_CANDIDATE', '3813')
+        addParam('OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE', '3050')
         super.testPipeline('jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile',
                 'tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_createPullRequest')
         assertThat(getShellCommands('git'), hasItem("\n                                git remote set-url origin \"https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build\"\n                                git config user.email \"opensearch-infra@amazon.com\"\n                                git config user.name \"opensearch-ci\"\n                                git checkout -b manifest-lock\n                            "))
@@ -106,6 +123,8 @@ class TestReleaseManifestCommitLock extends BuildPipelineTest {
     @Test
     public void testMatchBuildManifest() {   
         addParam('MANIFEST_LOCK_ACTION', 'MATCH_BUILD_MANIFEST')
+        addParam('OPENSEARCH_RELEASE_CANDIDATE', '3813')
+        addParam('OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE', '3050')
         def buildManifest = "tests/jenkins/data/opensearch-2.0.0-build.yml"
         helper.registerAllowedMethod('readYaml', [Map.class], { args ->
             return new Yaml().load((buildManifest as File).text)

--- a/tests/jenkins/TestReleaseManifestCommitLock.groovy
+++ b/tests/jenkins/TestReleaseManifestCommitLock.groovy
@@ -68,7 +68,7 @@ class TestReleaseManifestCommitLock extends BuildPipelineTest {
         runScript('jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile')
         }
         def callStack = helper.getCallStack()
-        assertCallStack().contains('OPENSEARCH_RELEASE_CANDIDATE and/or OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE cannot be empty when MANIFEST_LOCK_ACTION is MATCH_BUILD_MANIFEST or UPDATE_TO_RECENT_COMMITS.')
+        assertCallStack().contains('OPENSEARCH_RELEASE_CANDIDATE and/or OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE cannot be empty when MANIFEST_LOCK_ACTION is MATCH_BUILD_MANIFEST.')
     }
 
     @Test


### PR DESCRIPTION
### Description
Remove the mandatory RC number field for which is not required for UPDATE_TO_RECENT_COMMITS option.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
