### PR TITLE
Update the `gradle-check-flaky-test-issue-creation.jenkinsfile` to use 6.9.2 library.

### DIFF
--- a/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
+++ b/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@6.5.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@6.9.2', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Update the `gradle-check-flaky-test-issue-creation.jenkinsfile` to use 6.9.2 library.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build-libraries/issues/493

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
