### PR TITLE
Add conditional check for report workflow to skip component not in bundle

### DIFF
--- a/src/report_workflow/test_report_runner.py
+++ b/src/report_workflow/test_report_runner.py
@@ -49,6 +49,9 @@ class TestReportRunner:
             else os.path.join(self.args.artifact_paths[self.name], "dist", self.name, "manifest.yml")
         self.test_components = self.test_manifest.components
         self.bundle_manifest = BundleManifest.from_urlpath(self.dist_manifest)
+        self.bundle_components_list = []
+        for component in self.bundle_manifest.components.select(focus=self.args.components):
+            self.bundle_components_list.append(component.name)
 
     def update_data(self) -> dict:
         self.test_report_data["name"] = self.product_name
@@ -60,6 +63,9 @@ class TestReportRunner:
         self.test_report_data["rc"] = self.release_candidate
         self.test_report_data["test-run"] = self.update_test_run_data()
         for component in self.test_components.select(focus=self.args.components):
+            if component.name not in self.bundle_components_list:
+                logging.info(f"Skipping {component.name} as it's not included in the bundle manifest.")
+                continue
             if self.test_manifest.components[component.name].__to_dict__().get(self.test_type) is not None:
                 component_ci_group = getattr(component, self.test_type.replace("-", "_")).get("ci-groups", None)
                 if component_ci_group:

--- a/tests/tests_report_workflow/data/test_manifest.yml
+++ b/tests/tests_report_workflow/data/test_manifest.yml
@@ -65,3 +65,12 @@ components:
     bwc-test:
       test-configs:
         - with-security
+
+  - name: opensearch-system-templates
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+      additional-cluster-configs:
+        opensearch.experimental.feature.application_templates.enabled: true
+        cluster.application_templates.enabled: true

--- a/tests/tests_report_workflow/test_test_report_runner.py
+++ b/tests/tests_report_workflow/test_test_report_runner.py
@@ -61,6 +61,27 @@ class TestTestReportRunner(unittest.TestCase):
             self.assertTrue(os.path.isfile(output_path))
 
     @patch("report_workflow.report_args.ReportArgs")
+    def test_update_data_skip_component(self, report_args_mock: MagicMock) -> None:
+        report_args_mock.test_manifest_path = self.TEST_MANIFEST_PATH
+        report_args_mock.artifact_paths = {"opensearch": self.DATA_DIR}
+        report_args_mock.test_run_id = 123
+        report_args_mock.base_path = self.DATA_DIR
+        report_args_mock.test_type = "integ-test"
+        report_args_mock.release_candidate = "100"
+
+        test_report_runner = TestReportRunner(report_args_mock, self.TEST_MANIFEST)
+        test_report_runner_data = test_report_runner.update_data()
+
+        self.assertFalse("opensearch-system-templates" in test_report_runner.bundle_components_list)
+        self.assertEqual(len(test_report_runner_data["components"]), 6)
+
+        for i in range(len(self.TEST_MANIFEST.components.__to_dict__())):
+            if self.TEST_MANIFEST.components.__to_dict__()[i]["name"] == "opensearch-system-templates":
+                self.assertEqual(i, len(self.TEST_MANIFEST.components) - 1)
+            else:
+                self.assertEqual(self.TEST_MANIFEST.components.__to_dict__()[i]["name"], test_report_runner_data["components"][i]["name"])
+
+    @patch("report_workflow.report_args.ReportArgs")
     @patch("manifests.test_manifest.TestManifest")
     def test_runner_update_test_run_data_local(self, report_args_mock: MagicMock,
                                                test_manifest_mock: MagicMock) -> None:


### PR DESCRIPTION
### Description
Add conditional check for report workflow to skip component not in bundle.
If one component is not included in the bundle, the test would not be run and no need to report the status.
We would skip such component in report workflow.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5088

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
