### PR TITLE
PR to Fix the missing Gradle Reports in `opensearch-integ-test/` folder

### DIFF
--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -140,7 +140,17 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
             return 0
 
     @property
+    def additional_test_report_dirs(self) -> list[str]:
+        return ["integrationTest", "integTestRemote"]
+
+    @property
     def test_artifact_files(self) -> dict:
-        return {
-            "opensearch-integ-test": os.path.join(self.repo_work_dir, "build", "reports", "tests", "integTest")
-        }
+        default_report_path = os.path.join(self.repo_work_dir, "build", "reports", "tests", "integTest")
+        if os.path.exists(default_report_path):
+            return {"opensearch-integ-test": default_report_path}
+        for root, dirs, files in os.walk(self.repo_work_dir):
+            for test_report_dir in self.additional_test_report_dirs:
+                potential_path = os.path.join(root, "build", "reports", "tests", test_report_dir)
+                if os.path.exists(potential_path):
+                    return {"opensearch-integ-test": potential_path}
+        return {"opensearch-integ-test": default_report_path}

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch.py
@@ -244,3 +244,56 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
 
         assert(mock_test_result_data.return_value in integ_test_suite.result_data)
         self.assertEqual(integ_test_suite.additional_cluster_config, None)
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.walk", return_value=[(os.path.join("/some", "path"), ["build"], ["integTest", "integrationTest", "integTestRemote"])])
+    def test_test_artifact_files_default(self, *mocks: Any) -> None:
+        dependency_installer = MagicMock()
+        test_config, component = self.__get_test_config_and_bundle_component("job-scheduler")
+        integ_test_suite = IntegTestSuiteOpenSearch(
+            dependency_installer,
+            component,
+            test_config,
+            self.bundle_manifest,
+            self.build_manifest,
+            self.work_dir,
+            MagicMock()
+        )
+        integ_test_suite.repo_work_dir = os.path.join("/some", "path")
+        expected_path = {
+            "opensearch-integ-test": os.path.join("/some", "path", "build", "reports", "tests", "integTest")
+        }
+        result = integ_test_suite.test_artifact_files
+        self.assertEqual(result, expected_path)
+
+    @patch("os.path.exists", return_value=False)
+    @patch("os.walk", return_value=[])
+    def test_test_artifact_files_no_default_path(self, *mocks: Any) -> None:
+        dependency_installer = MagicMock()
+        test_config, component = self.__get_test_config_and_bundle_component("job-scheduler")
+        integ_test_suite = IntegTestSuiteOpenSearch(
+            dependency_installer,
+            component,
+            test_config,
+            self.bundle_manifest,
+            self.build_manifest,
+            self.work_dir,
+            MagicMock()
+        )
+        integ_test_suite.repo_work_dir = os.path.join("/some", "path")
+        default_path = os.path.join(integ_test_suite.repo_work_dir, "build", "reports", "tests", "integTest")
+        expected_path = {"opensearch-integ-test": default_path}
+        result = integ_test_suite.test_artifact_files
+        self.assertEqual(result, expected_path)
+
+    def test_test_report_dirs(self, *mocks: Any) -> None:
+        integ_test_suite = IntegTestSuiteOpenSearch(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            self.bundle_manifest,
+            self.build_manifest,
+            self.work_dir,
+            MagicMock()
+        )
+        self.assertEqual(integ_test_suite.additional_test_report_dirs, ["integrationTest", "integTestRemote"])


### PR DESCRIPTION
### Description
Coming from the issue https://github.com/opensearch-project/opensearch-metrics/issues/68 to index the failed tests to the metrics cluster which will be useful during the release cycle to exactly find out the failed test metrics for a given RC, during this implementation @peterzhuamazon found out for some repos especially in OpenSearch category the Gradle reports are missing under `opensearch-integ-test/` folder.

Following are repos with missing/Gradle reports or in inconsistent path

- Security: Skip `integTest` with change to `integrationTest`, more details on this issue https://github.com/opensearch-project/security/issues/4805.

- Query insights: does not run with-security enabled, hence `opensearch-integ-test/` is not available for with-security.

- Alerting: The reports are under the sub folder `alerting/alerting/build/reports/tests/integTest`.

- CCR: Calls as `integTestRemote` and not `integTest`, the path for the reports is `cross-cluster-replication/build/reports/tests/integTestRemote`.

- ml_commons: The reports are in the sub path `ml-commons/plugin/build/reports/tests/integTest`.

- notifications: The reports are in the sub path (2 levels deeper), `notifications/notifications/notifications/build/reports/tests/integTest`.

- sql: The reports are in the sub path, `sql/integ-test/build/reports/tests/integTest`.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/68

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
