### PR TITLE
Resolve scoop Select-CurrentVersion error by locking to 0.4.2

### DIFF
--- a/docker/ci/config/windows-setup.ps1
+++ b/docker/ci/config/windows-setup.ps1
@@ -11,7 +11,12 @@
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 # Install Scoop as Administrator User here
-iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
+# Scoop version >= 0.5.0 has error with Select-CurrentVersion function
+# They have not fix the issue and will error out on Windows ltsc2019
+# https://github.com/ScoopInstaller/Scoop/issues/6180
+# A temp solution is to hardcode the scoop version to 0.4.2
+# iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
+iex "& {$(irm https://raw.githubusercontent.com/peterzhuamazon/scoop-Install/refs/heads/stable/install.ps1)} -RunAsAdmin"
 
 # Disable "current" alias directory as it is not preserved after AMI creation
 # Use static path in environment variable


### PR DESCRIPTION
### Description
Resolve scoop Select-CurrentVersion error by locking to 0.4.2

### Issues Resolved
Temp resolve: https://github.com/ScoopInstaller/Scoop/issues/6180

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
