### PR TITLE
Update 3.0.0 manifests to use JDK-23

### DIFF
--- a/manifests/3.0.0/opensearch-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-3.0.0-test.yml
@@ -4,7 +4,7 @@ name: OpenSearch
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1
-    args: -e JAVA_HOME=/opt/java/openjdk-21
+    args: -e JAVA_HOME=/opt/java/openjdk-23
 components:
   - name: alerting
     integ-test:

--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -6,7 +6,7 @@ build:
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1
-    args: -e JAVA_HOME=/opt/java/openjdk-21
+    args: -e JAVA_HOME=/opt/java/openjdk-23
 components:
   - name: OpenSearch
     repository: https://github.com/opensearch-project/OpenSearch.git


### PR DESCRIPTION
### Description
Update 3.0.0 manifests to use JDK-23

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/16255

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
