### PR TITLE
Automate adding manifest to integTest notification cron

### DIFF
--- a/jenkins/integ-test-notification.jenkinsfile
+++ b/jenkins/integ-test-notification.jenkinsfile
@@ -28,6 +28,8 @@ pipeline {
     }
     triggers {
         parameterizedCron('''
+            H */6 * * * %INPUT_MANIFEST=2.1000.1000/opensearch-dashboards-2.1000.1000.yml
+            H */6 * * * %INPUT_MANIFEST=2.1000.1000/opensearch-2.1000.1000.yml
             H */6 * * * %INPUT_MANIFEST=2.17.2/opensearch-2.17.2.yml
             H */6 * * * %INPUT_MANIFEST=2.18.0/opensearch-2.18.0.yml
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml

--- a/jenkins/integ-test-notification.jenkinsfile
+++ b/jenkins/integ-test-notification.jenkinsfile
@@ -28,8 +28,6 @@ pipeline {
     }
     triggers {
         parameterizedCron('''
-            H */6 * * * %INPUT_MANIFEST=2.1000.1000/opensearch-dashboards-2.1000.1000.yml
-            H */6 * * * %INPUT_MANIFEST=2.1000.1000/opensearch-2.1000.1000.yml
             H */6 * * * %INPUT_MANIFEST=2.17.2/opensearch-2.17.2.yml
             H */6 * * * %INPUT_MANIFEST=2.18.0/opensearch-2.18.0.yml
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml

--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -52,6 +52,10 @@ class InputManifests(Manifests):
         return os.path.join(self.jenkins_path(), "check-for-build.jenkinsfile")
 
     @classmethod
+    def cron_integTest_notification_jenkinsfile(self) -> str:
+        return os.path.join(self.jenkins_path(), "integ-test-notification.jenkinsfile")
+
+    @classmethod
     def os_versionincrement_workflow(self) -> str:
         return os.path.join(self.workflows_path(), "os-increment-plugin-versions.yml")
 
@@ -120,6 +124,7 @@ class InputManifests(Manifests):
             for new_version_entry in new_versions:
                 self.write_manifest(new_version_entry, branch_versions[new_version_entry], known_versions)
                 self.add_to_cron(new_version_entry)
+                self.add_to_integTest_notification_cron(new_version_entry)
                 self.add_to_versionincrement_workflow(new_version_entry)
                 known_versions.append(new_version_entry)
 
@@ -211,6 +216,24 @@ class InputManifests(Manifests):
             f.write(data)
 
         logging.info(f"Wrote {jenkinsfile}")
+
+    def add_to_integTest_notification_cron(self, version: str) -> None:
+        logging.info(f"Adding new version to integ test notification cron: {version}")
+        integTestJenkinsfile = self.cron_integTest_notification_jenkinsfile()
+        with open(integTestJenkinsfile, "r") as f:
+            data = f.read()
+
+        cron_entry = f"H */6 * * * %INPUT_MANIFEST={version}/{self.prefix}-{version}.yml\n"
+
+        if cron_entry in data:
+            raise ValueError(f"{integTestJenkinsfile} already contains an entry for {self.prefix} {version}")
+
+        data = data.replace("parameterizedCron('''\n", f"parameterizedCron('''\n{' ' * 12}{cron_entry}")
+
+        with open(integTestJenkinsfile, "w") as f:
+            f.write(data)
+
+        logging.info(f"Wrote {integTestJenkinsfile}")
 
     def add_to_versionincrement_workflow(self, version: str) -> None:
         versionincrement_workflow_files = [self.os_versionincrement_workflow(), self.osd_versionincrement_workflow()]

--- a/tests/tests_manifests_workflow/test_input_manifests.py
+++ b/tests/tests_manifests_workflow/test_input_manifests.py
@@ -213,6 +213,12 @@ class TestInputManifests(unittest.TestCase):
             os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "jenkins", "check-for-build.jenkinsfile"))
         )
 
+    def test_cron_integTest_notification_jenkinsfilee(self) -> None:
+        self.assertEqual(
+            InputManifests.cron_integTest_notification_jenkinsfile(),
+            os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "jenkins", "integ-test-notification.jenkinsfile"))
+        )
+
     @patch("builtins.open", new_callable=mock_open)
     def test_add_to_cron(self, mock_open: MagicMock) -> None:
         mock_open().read.return_value = "parameterizedCron '''\n"
@@ -224,6 +230,17 @@ class TestInputManifests(unittest.TestCase):
             "parameterizedCron '''\n            H 1 * * * %INPUT_MANIFEST=0.1.2/test-0.1.2.yml;"
             "TARGET_JOB_NAME=distribution-build-test;BUILD_PLATFORM=linux;BUILD_DISTRIBUTION=tar;"
             "TEST_MANIFEST=0.1.2/test-0.1.2-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar\n"
+        )
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_add_to_integTest_notification_cron(self, mock_open: MagicMock) -> None:
+        mock_open().read.return_value = "parameterizedCron('''\n"
+        input_manifests = InputManifests("test")
+        input_manifests.add_to_integTest_notification_cron('0.1.2')
+        mock_open.assert_has_calls([call(InputManifests.cron_integTest_notification_jenkinsfile(), 'w')])
+        mock_open.assert_has_calls([call(InputManifests.cron_integTest_notification_jenkinsfile(), 'r')])
+        mock_open().write.assert_called_once_with(
+            "parameterizedCron('''\n            H */6 * * * %INPUT_MANIFEST=0.1.2/test-0.1.2.yml\n"
         )
 
     def test_os_versionincrement_workflow(self) -> None:

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch.py
@@ -32,9 +32,10 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
     @patch("os.chdir")
     @patch("manifests_workflow.input_manifests.InputManifests.add_to_versionincrement_workflow")
     @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_integTest_notification_cron")
     @patch("manifests.manifest.Manifest.to_file")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearchMin")
-    def test_update(self, mock_component_opensearch_min: MagicMock, mock_manifest_to_file: MagicMock,
+    def test_update(self, mock_component_opensearch_min: MagicMock, mock_manifest_to_file: MagicMock, mock_add_to_integTest_notification_cron: MagicMock,
                     mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock,
                     *mocks: MagicMock) -> None:
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
@@ -53,6 +54,9 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
             )
         ]
         mock_manifest_to_file.assert_has_calls(calls)
+        mock_add_to_integTest_notification_cron.assert_has_calls([
+            call('2.1000.1000'),
+        ])
         mock_add_to_cron.assert_has_calls([
             call('2.1000.1000'),
         ])
@@ -62,9 +66,10 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
 
     @patch("manifests_workflow.input_manifests.InputManifests.add_to_versionincrement_workflow")
     @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_integTest_notification_cron")
     @patch("manifests.manifest.Manifest.to_file")
     @patch("manifests_workflow.input_manifests_opensearch.ComponentOpenSearchMin")
-    def test_update_outdated_branch(self, mock_component_opensearch_min: MagicMock, mock_manifest_to_file: MagicMock,
+    def test_update_outdated_branch(self, mock_component_opensearch_min: MagicMock, mock_manifest_to_file: MagicMock, mock_add_to_integTest_notification_cron: MagicMock,
                                     mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock) -> None:
         mock_component_opensearch_min.return_value = MagicMock(name="OpenSearch")
         mock_component_opensearch_min.branches.return_value = ["1.2"]
@@ -73,4 +78,5 @@ class TestInputManifestsOpenSearch(unittest.TestCase):
         manifests.update()
         self.assertEqual(mock_manifest_to_file.call_count, 0)
         self.assertEqual(mock_add_to_cron.call_count, 0)
+        self.assertEqual(mock_add_to_integTest_notification_cron.call_count, 0)
         self.assertEqual(mock_add_to_versionincrement_workflow.call_count, 0)

--- a/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
+++ b/tests/tests_manifests_workflow/test_input_manifests_opensearch_dashboards.py
@@ -32,9 +32,10 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
     @patch("os.chdir")
     @patch("manifests_workflow.input_manifests.InputManifests.add_to_versionincrement_workflow")
     @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_integTest_notification_cron")
     @patch("manifests.manifest.Manifest.to_file")
     @patch("manifests_workflow.input_manifests_opensearch_dashboards.ComponentOpenSearchDashboardsMin")
-    def test_update(self, mock_component_opensearch_dashboards_min: MagicMock, mock_manifest_to_file: MagicMock,
+    def test_update(self, mock_component_opensearch_dashboards_min: MagicMock, mock_manifest_to_file: MagicMock, mock_add_to_integTest_notification_cron: MagicMock,
                     mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock,
                     mock_os_chdir: MagicMock, mock_os_makedirs: MagicMock) -> None:
         mock_component_opensearch_dashboards_min.return_value = MagicMock(name="OpenSearch-Dashboards")
@@ -57,15 +58,19 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
         mock_add_to_cron.assert_has_calls([
             call('2.1000.1000')
         ])
+        mock_add_to_integTest_notification_cron.assert_has_calls([
+            call('2.1000.1000')
+        ])
         mock_add_to_versionincrement_workflow.assert_has_calls([
             call('2.1000.1000')
         ])
 
     @patch("manifests_workflow.input_manifests.InputManifests.add_to_versionincrement_workflow")
     @patch("manifests_workflow.input_manifests.InputManifests.add_to_cron")
+    @patch("manifests_workflow.input_manifests.InputManifests.add_to_integTest_notification_cron")
     @patch("manifests.manifest.Manifest.to_file")
     @patch("manifests_workflow.input_manifests_opensearch_dashboards.ComponentOpenSearchDashboardsMin")
-    def test_update_outdated_branch(self, mock_component_opensearch_dashboards_min: MagicMock, mock_manifest_to_file: MagicMock,
+    def test_update_outdated_branch(self, mock_component_opensearch_dashboards_min: MagicMock, mock_manifest_to_file: MagicMock, mock_add_to_integTest_notification_cron: MagicMock,
                                     mock_add_to_cron: MagicMock, mock_add_to_versionincrement_workflow: MagicMock) -> None:
         mock_component_opensearch_dashboards_min.return_value = MagicMock(name="OpenSearch-Dashboards")
         mock_component_opensearch_dashboards_min.branches.return_value = ["1.2"]
@@ -75,4 +80,5 @@ class TestInputManifestsOpenSearchDashboards(unittest.TestCase):
         manifests.update()
         self.assertEqual(mock_manifest_to_file.call_count, 0)
         self.assertEqual(mock_add_to_cron.call_count, 0)
+        self.assertEqual(mock_add_to_integTest_notification_cron.call_count, 0)
         self.assertEqual(mock_add_to_versionincrement_workflow.call_count, 0)


### PR DESCRIPTION
### Description
Automate adding manifest to integTest notification jenkinsfile cronjob

### Issues Resolved
closes https://github.com/opensearch-project/opensearch-build/issues/5083

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
