### PR TITLE
Bump lib to 7.1.0 and remove publishing notification

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -134,17 +134,9 @@ pipeline {
         }
     }
     post {
-        failure {
+        always {
             node(AGENT_X64) {
                 script {
-                    publishNotification(
-                        icon: ':warning:',
-                        message: 'Failed checking for build to trigger',
-                        credentialsId: 'jenkins-build-notice-webhook',
-                        manifest: "${INPUT_MANIFEST}",
-                        target_job_name: "${TARGET_JOB_NAME}"
-                    )
-
                     postCleanup()
                 }
             }

--- a/jenkins/integ-test-notification.jenkinsfile
+++ b/jenkins/integ-test-notification.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@7.0.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@7.1.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -24,13 +24,15 @@ pipeline {
     }
     options {
         timeout(time: 1, unit: 'HOURS')
-        buildDiscarder(logRotator(daysToKeepStr: '90'))
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
     }
     triggers {
         parameterizedCron('''
             H */6 * * * %INPUT_MANIFEST=2.17.2/opensearch-2.17.2.yml
             H */6 * * * %INPUT_MANIFEST=2.18.0/opensearch-2.18.0.yml
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml
+            H */6 * * * %INPUT_MANIFEST=2.18.0/opensearch-dashboards-2.18.0.yml
+            H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml
         ''')
     }
     parameters {

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@7.0.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@7.1.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -946,16 +946,7 @@ pipeline {
         }
         failure {
             node(AGENT_LINUX_X64) {
-                checkout scm
                 script {
-                    if (params.PUBLISH_NOTIFICATION) {
-                        publishNotification(
-                            icon: ':warning:',
-                            message: buildMessage(search: 'Error building'),
-                            credentialsId: 'jenkins-build-notice-webhook',
-                            manifest: "${INPUT_MANIFEST}"
-                        )
-                    }
                     postCleanup()
                 }
             }

--- a/jenkins/opensearch/bwc-test.jenkinsfile
+++ b/jenkins/opensearch/bwc-test.jenkinsfile
@@ -126,34 +126,9 @@ pipeline {
     }
 
     post {
-        success {
+        always {
             node(AGENT_LABEL) {
                 script {
-                    def stashed = lib.jenkins.Messages.new(this).get(['bwc-test'])
-                    publishNotification(
-                        icon: ':white_check_mark:',
-                        message: 'BWC Tests Successful',
-                        extra: stashed,
-                        credentialsId: 'jenkins-integ-test-webhook',
-                        manifest: TEST_MANIFEST,
-                    )
-
-                    postCleanup()
-                }
-            }
-        }
-        failure {
-            node(AGENT_LABEL) {
-                script  {
-                    def stashed = lib.jenkins.Messages.new(this).get(['bwc-test'])
-                    publishNotification(
-                        icon: ':warning:',
-                        message: 'Failed BWC Tests',
-                        extra: stashed,
-                        credentialsId: 'jenkins-integ-test-webhook',
-                        manifest: TEST_MANIFEST,
-                    )
-
                     postCleanup()
                 }
             }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@7.0.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@7.1.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/bwc-test.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/bwc-test.jenkinsfile.txt
@@ -63,21 +63,5 @@
             postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})
          bwc-test.node(Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host, groovy.lang.Closure)
             bwc-test.script(groovy.lang.Closure)
-               Messages.asBoolean()
-               Messages.get([bwc-test])
-                  bwc-test.unstash({name=messages-bwc-test})
-                  bwc-test.findFiles({excludes=, glob=messages/*})
-                  bwc-test.dir(messages, groovy.lang.Closure)
-                     bwc-test.deleteDir()
-               bwc-test.publishNotification({icon=:white_check_mark:, message=BWC Tests Successful, extra=, credentialsId=jenkins-integ-test-webhook, manifest=tests/jenkins/data/opensearch-1.3.0-test.yml})
-                  publishNotification.string({credentialsId=jenkins-integ-test-webhook, variable=WEBHOOK_URL})
-                  publishNotification.withCredentials([WEBHOOK_URL], groovy.lang.Closure)
-                     publishNotification.sh(curl -XPOST --header "Content-Type: application/json" --data '{"result_text":":white_check_mark:
-JOB_NAME=dummy_job
-BUILD_NUMBER=[717]
-MESSAGE=BWC Tests Successful
-BUILD_URL: htth://BUILD_URL_dummy.com
-MANIFEST: tests/jenkins/data/opensearch-1.3.0-test.yml
-"}' "WEBHOOK_URL")
                bwc-test.postCleanup()
                   postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})


### PR DESCRIPTION
### Description

- 7.1.0 brings mentioned changes https://github.com/opensearch-project/opensearch-build-libraries/releases/tag/7.1.0. Accommodating this in both build and test notification libraries. 
- Also removes `publishNotification` calls
- Adds missing manifests file from integTest notification workflow

### Issues Resolved
part of https://github.com/opensearch-project/opensearch-build/issues/5083

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
