### PR TITLE
(Part 2) PR to Fix the missing Gradle Reports in `opensearch-integ-test/` folder

### DIFF
--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -141,7 +141,7 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
 
     @property
     def additional_test_report_dirs(self) -> list[str]:
-        return ["integrationTest", "integTestRemote"]
+        return ["integTest", "integrationTest", "integTestRemote"]
 
     @property
     def test_artifact_files(self) -> dict:

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_integ_test_suite_opensearch.py
@@ -296,4 +296,4 @@ class TestIntegSuiteOpenSearch(unittest.TestCase):
             self.work_dir,
             MagicMock()
         )
-        self.assertEqual(integ_test_suite.additional_test_report_dirs, ["integrationTest", "integTestRemote"])
+        self.assertEqual(integ_test_suite.additional_test_report_dirs, ["integTest", "integrationTest", "integTestRemote"])


### PR DESCRIPTION
### Description
Coming from initial PR https://github.com/opensearch-project/opensearch-build/pull/5092 and conversation https://github.com/opensearch-project/opensearch-build/pull/5092#discussion_r1795843073, removing `integTest` from `additional_test_report_dirs` will fail to identify the subpaths which as the  Gradle Reports under `integTest` folder.

This PR will cover the Gradle Reports inside the subfolders and under the `integTest` folder.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/68

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
