### PR TITLE
Integtest failed test case check will skip infobox class

### DIFF
--- a/src/report_workflow/test_report_runner.py
+++ b/src/report_workflow/test_report_runner.py
@@ -236,7 +236,7 @@ def get_failed_tests(base_path: str, test_number: str, test_type: str, component
         return failed_test
 
     if result_content:
-        if ("infoBox success" in result_content) and ("<h2>Failed tests</h2>" not in result_content):
+        if ("<h2>Failed tests</h2>" not in result_content):
             failed_test.append("No Failed Test")
         else:
             soup = BeautifulSoup(result_content, "html.parser")


### PR DESCRIPTION
### Description
Integtest failed test case check will skip infobox class

### Issues Resolved
https://github.com/opensearch-project/opensearch-metrics/issues/68
https://github.com/opensearch-project/opensearch-build/pull/5101#issuecomment-2411869075

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
