### PR TITLE
Remove .i18nrc.json as OSD do not bundle it anymore

### DIFF
--- a/scripts/pkg/build_templates/current/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
+++ b/scripts/pkg/build_templates/current/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
@@ -123,7 +123,6 @@ exit 0
 %license %{product_dir}/LICENSE.txt
 %{product_dir}/package.json
 %{product_dir}/manifest.yml
-%{product_dir}/.i18nrc.json
 
 # Config dirs/files
 %dir %{config_dir}


### PR DESCRIPTION
### Description
Remove .i18nrc.json as OSD do not bundle it anymore

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/5099

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
