### PR TITLE
Add distribution build parameter to integ test notification workflow 

### DIFF
--- a/jenkins/integ-test-notification.jenkinsfile
+++ b/jenkins/integ-test-notification.jenkinsfile
@@ -28,6 +28,8 @@ pipeline {
     }
     triggers {
         parameterizedCron('''
+            H */6 * * * %INPUT_MANIFEST=2.1000.1000/opensearch-dashboards-2.1000.1000.yml
+            H */6 * * * %INPUT_MANIFEST=2.1000.1000/opensearch-2.1000.1000.yml
             H */6 * * * %INPUT_MANIFEST=2.17.2/opensearch-2.17.2.yml
             H */6 * * * %INPUT_MANIFEST=2.18.0/opensearch-2.18.0.yml
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml

--- a/jenkins/integ-test-notification.jenkinsfile
+++ b/jenkins/integ-test-notification.jenkinsfile
@@ -28,9 +28,6 @@ pipeline {
     }
     triggers {
         parameterizedCron('''
-            H */6 * * * %INPUT_MANIFEST=2.1000.1000/opensearch-dashboards-2.1000.1000.yml
-            H */6 * * * %INPUT_MANIFEST=2.1000.1000/opensearch-2.1000.1000.yml
-            H */6 * * * %INPUT_MANIFEST=2.17.2/opensearch-2.17.2.yml
             H */6 * * * %INPUT_MANIFEST=2.18.0/opensearch-2.18.0.yml
             H */6 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml
             H */6 * * * %INPUT_MANIFEST=2.18.0/opensearch-dashboards-2.18.0.yml
@@ -43,6 +40,11 @@ pipeline {
             description: 'Input manifest under the manifests folder, e.g. 2.0.0/opensearch-2.0.0.yml.',
             trim: true
         )
+        string(
+            name: 'DISTRIBUTION_NUMBER',
+            description: 'Ditribution number of OpenSearch/OpenSearch-Dashboards builds that was used to run the integration test. eg:10345',
+            trim: true
+        )
     }
     stages {
         stage('Update integ tests failure issues') {
@@ -53,7 +55,8 @@ pipeline {
                         error("Failed to start the workflow. Input manifest was not provided or not found in manifests/${params.INPUT_MANIFEST}.")
                     }
                     updateIntegTestFailureIssues(
-                        inputManifestPath: "manifests/${INPUT_MANIFEST}"
+                        inputManifestPath: "manifests/${INPUT_MANIFEST}",
+                        distributionBuildNumber: "${DISTRIBUTION_NUMBER}"
                     )
                 }
             }


### PR DESCRIPTION
### Description
Add distribution build parameter to integ test notification workflow. Defaults to latest in the library here https://github.com/opensearch-project/opensearch-build-libraries/blob/main/vars/updateIntegTestFailureIssues.groovy#L37

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
