### PR TITLE
Update tj-actions/changed-files to use sha ref

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Get changed manifest files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
         id: list-changed-manifests
         with:
           files: manifests/**/opensearch*.yml


### PR DESCRIPTION
### Description
Use sha ref in the action as we received a ticket claiming potential threat of unauthorized access on the build repo from any external actor from the upstream [repo](https://github.com/tj-actions/aws-lightsail-push-container) 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
