### PR TITLE
Remove flow framework dashboards from 2.18 Manifest

### DIFF
--- a/manifests/2.18.0/opensearch-dashboards-2.18.0.yml
+++ b/manifests/2.18.0/opensearch-dashboards-2.18.0.yml
@@ -55,6 +55,3 @@ components:
   - name: assistantDashboards
     repository: https://github.com/opensearch-project/dashboards-assistant.git
     ref: 98fa5324900ffa365a24b027cf17f1f87c1beae4
-  - name: flowFrameworkDashboards
-    repository: https://github.com/opensearch-project/dashboards-flow-framework.git
-    ref: c037914ffa2b0c4617f8e20df0c29f02c1aa3a8e


### PR DESCRIPTION
### Description

- Remove flow framework dashboards from 2.18 Manifest
- Flow framework is not releasing with 2.18. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
