### PR TITLE
Hard force Windows HOME Env Var in case bash.exe invoke late

### DIFF
--- a/docker/ci/dockerfiles/current/build.windows2019.x64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.windows2019.x64.dockerfile
@@ -29,6 +29,8 @@ RUN bash.exe -c "curl https://ci.opensearch.org > /dev/null 2>&1 || echo add cer
 
 RUN bash.exe -c "curl https://artifacts.opensearch.org > /dev/null 2>&1 || echo add certificates"
 
+ENV HOME="C:/Users/ContainerAdministrator"
+
 WORKDIR "C:/Users/ContainerAdministrator"
 
 CMD ["powershell.exe"]


### PR DESCRIPTION
### Description
Hard force Windows HOME Env Var in case bash.exe invoke late

### Issues Resolved
#5004

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
