### PR TITLE
Switch from ghcr.io to ecr for trivy db pull images

### DIFF
--- a/jenkins/docker/docker-scan.jenkinsfile
+++ b/jenkins/docker/docker-scan.jenkinsfile
@@ -17,6 +17,10 @@ pipeline {
         timeout(time: 30)
     }
     agent none  
+    environment {
+        TRIVY_DB_REPOSITORY = 'public.ecr.aws/aquasecurity/trivy-db'
+        TRIVY_JAVA_DB_REPOSITORY = 'public.ecr.aws/aquasecurity/trivy-java-db'
+    }
     parameters {
         string(
             name: 'IMAGE_FULL_NAME', 


### PR DESCRIPTION
### Description
Switch from ghcr.io to ecr for trivy db pull images

Resolves:
https://build.ci.opensearch.org/job/docker-scan/3965/
https://github.com/aquasecurity/trivy/discussions/7668


### Issues Resolved
#5004

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
