### PR TITLE
Add ci-bot to list of approved users for automerge

### DIFF
--- a/.github/workflows/automatic-merges.yml
+++ b/.github/workflows/automatic-merges.yml
@@ -33,6 +33,7 @@ jobs:
           allowed-authors: |
             dependabot
             opensearch-trigger-bot
+            opensearch-ci-bot
             peterzhuamazon
             gaiksaya
             rishabh6788


### PR DESCRIPTION
### Description
In order to auto-merge PRs such as https://github.com/opensearch-project/opensearch-build/pull/5177, ci-bot needs to be added to the list of approved users.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
