### PR TITLE
Enable 1.3.20 snapshots publishing on Jenkins runs

### DIFF
--- a/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
+++ b/jenkins/opensearch/maven-publish-1.3.x.jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H 1 * * * %INPUT_MANIFEST=1.3.19/opensearch-1.3.19.yml
+            H 1 * * * %INPUT_MANIFEST=1.3.20/opensearch-1.3.20.yml
         '''
     }
     parameters {


### PR DESCRIPTION
### Description
Enable 1.3.20 snapshots publishing on Jenkins runs

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4990

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
