### PR TITLE
Removed 1.3.20 from check-for-build

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -25,9 +25,7 @@ pipeline {
         parameterizedCron '''
             H 1 * * * %INPUT_MANIFEST=2.19.0/opensearch-dashboards-2.19.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.19.0/opensearch-dashboards-2.19.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
             H 1 * * * %INPUT_MANIFEST=2.18.1/opensearch-2.18.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.18.1/opensearch-2.18.1-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
-            H */6 * * * %INPUT_MANIFEST=1.3.20/opensearch-dashboards-1.3.20.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=1.3.20/opensearch-dashboards-1.3.20-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
             H 1 * * * %INPUT_MANIFEST=2.19.0/opensearch-2.19.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.19.0/opensearch-2.19.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
-            H */6 * * * %INPUT_MANIFEST=1.3.20/opensearch-1.3.20.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=1.3.20/opensearch-1.3.20-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
             H 4 * * * %INPUT_MANIFEST=3.0.0/opensearch-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 4 * * * %INPUT_MANIFEST=3.0.0/opensearch-dashboards-3.0.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''


### PR DESCRIPTION
### Description
Removed 1.3.20 from check-for-build, as RC generation has started

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/4990

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
