### PR TITLE
Add opensearch-remote-metadata-sdk to manifest

### DIFF
--- a/manifests/2.19.0/opensearch-2.19.0.yml
+++ b/manifests/2.19.0/opensearch-2.19.0.yml
@@ -17,6 +17,12 @@ components:
     platforms:
       - linux
       - windows
+  - name: opensearch-remote-metadata-sdk
+    repository: https://github.com/opensearch-project/opensearch-remote-metadata-sdk.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
   - name: job-scheduler
     repository: https://github.com/opensearch-project/job-scheduler.git
     ref: 2.x
@@ -174,6 +180,7 @@ components:
       - windows
     depends_on:
       - common-utils
+      - opensearch-remote-metadata-sdk
   - name: skills
     repository: https://github.com/opensearch-project/skills.git
     ref: 2.x

--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -23,6 +23,15 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: opensearch-remote-metadata-sdk
+    repository: https://github.com/opensearch-project/opensearch-remote-metadata-sdk.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:publish
+      - gradle:properties:version
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
     ref: main
@@ -221,6 +230,7 @@ components:
       - windows
     depends_on:
       - common-utils
+      - opensearch-remote-metadata-sdk
   - name: opensearch-system-templates
     repository: https://github.com/opensearch-project/opensearch-system-templates.git
     ref: main


### PR DESCRIPTION
### Description

Adds the [opensearch-remote-metadata-sdk](https://github.com/opensearch-project/opensearch-remote-metadata-sdk) library to the manifest.

This PR is step 6 of this checklist: https://github.com/opensearch-project/opensearch-build/blob/main/ONBOARDING.md#onboard-to-build-workflow

Note that this is _not a plugin_.  It is a library to be used by plugins in order to refactor common code to a single location.  It is similar to `common-utils` in that respect and I attempted to follow that pattern (plain jar rather than zip).

PR implementing the build script:
 - https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/45

Artifacts published:
```
> find artifacts/maven/org/opensearch -type f \( -name "*.jar" -o -name "*.pom" \) | sed 's|^artifacts/maven/org/opensearch/||' | sort

opensearch-remote-metadata-sdk-aos-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-aos-client-2.19.0-20250108.223743-1-javadoc.jar
opensearch-remote-metadata-sdk-aos-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-aos-client-2.19.0-20250108.223743-1-sources.jar
opensearch-remote-metadata-sdk-aos-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-aos-client-2.19.0-20250108.223743-1.jar
opensearch-remote-metadata-sdk-aos-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-aos-client-2.19.0-20250108.223743-1.pom
opensearch-remote-metadata-sdk-ddb-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-ddb-client-2.19.0-20250108.223743-1-javadoc.jar
opensearch-remote-metadata-sdk-ddb-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-ddb-client-2.19.0-20250108.223743-1-sources.jar
opensearch-remote-metadata-sdk-ddb-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-ddb-client-2.19.0-20250108.223743-1.jar
opensearch-remote-metadata-sdk-ddb-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-ddb-client-2.19.0-20250108.223743-1.pom
opensearch-remote-metadata-sdk-remote-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-remote-client-2.19.0-20250108.223743-1-javadoc.jar
opensearch-remote-metadata-sdk-remote-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-remote-client-2.19.0-20250108.223743-1-sources.jar
opensearch-remote-metadata-sdk-remote-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-remote-client-2.19.0-20250108.223743-1.jar
opensearch-remote-metadata-sdk-remote-client/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-remote-client-2.19.0-20250108.223743-1.pom
opensearch-remote-metadata-sdk/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-2.19.0-20250108.223743-1-javadoc.jar
opensearch-remote-metadata-sdk/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-2.19.0-20250108.223743-1-sources.jar
opensearch-remote-metadata-sdk/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-2.19.0-20250108.223743-1.jar
opensearch-remote-metadata-sdk/2.19.0-SNAPSHOT/opensearch-remote-metadata-sdk-2.19.0-20250108.223743-1.pom
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
