### PR TITLE
Allow all manifest PRs to run manifest-check workflow

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -3,7 +3,7 @@ name: manifests-ci-check
 
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [opened, synchronize]
     paths:
       - 'manifests/**/*.yml'
       - '!manifests/templates/**/'
@@ -11,7 +11,7 @@ on:
 
 jobs:
   list-changed-manifests:
-    if: ${{ github.repository == 'opensearch-project/opensearch-build' && github.event.label.name == 'manifest-ci-check' }}
+    if: ${{ github.repository == 'opensearch-project/opensearch-build' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
### Description
This PR removes the conditional check to see if the label is present in the given PR. Adding a label was manual overhead and is often missed. Also if the event is PR synchronize `github.event.label.name` condition is never met. Example: #5233 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
