### PR TITLE
Add opensearch-learning-to-rank-base to manifest

### DIFF
--- a/manifests/2.19.0/opensearch-2.19.0.yml
+++ b/manifests/2.19.0/opensearch-2.19.0.yml
@@ -17,6 +17,12 @@ components:
     platforms:
       - linux
       - windows
+  - name: opensearch-learning-to-rank-base
+    repository: https://github.com/opensearch-project/opensearch-learning-to-rank-base.git
+    ref: 2.x
+    platforms:
+      - linux
+      - windows
   - name: opensearch-remote-metadata-sdk
     repository: https://github.com/opensearch-project/opensearch-remote-metadata-sdk.git
     ref: 2.x


### PR DESCRIPTION
### Description
Adds the [opensearch-learning-to-rank-base](https://github.com/opensearch-project/opensearch-learning-to-rank-base) plugin to the manifest files.

Following the onboarding steps mentioned [here](https://github.com/opensearch-project/opensearch-build/blob/main/ONBOARDING.md#:~:text=Publish%20a%20PR%20to%20this%20repo%20including%20the%20updated%20manifest%20and%20the%20names%20of%20the%20artifacts%20being%20added.).

PR implementing the build script in LTR: https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/97

Artifacts published:
```
artifacts/maven/org/opensearch/opensearch-ltr/2.19.0.0-SNAPSHOT/opensearch-ltr-2.19.0.0-20250117.192241-1.pom
artifacts/maven/org/opensearch/opensearch-ltr/2.19.0.0-SNAPSHOT/opensearch-ltr-2.19.0.0-20250117.192241-1.zip
artifacts/maven/org/opensearch/opensearch-ltr/2.19.0.0-SNAPSHOT/opensearch-ltr-2.19.0.0-20250117.192241-2.pom
artifacts/maven/org/opensearch/opensearch-ltr/2.19.0.0-SNAPSHOT/opensearch-ltr-2.19.0.0-20250117.192241-2.zip
artifacts/plugins/opensearch-ltr-2.19.0.0-SNAPSHOT.zip

```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
