### PR TITLE
Onboard opensearch-learning-to-rank-base to Test Workflow

### DIFF
--- a/manifests/2.19.0/opensearch-2.19.0-test.yml
+++ b/manifests/2.19.0/opensearch-2.19.0-test.yml
@@ -85,6 +85,7 @@ components:
   - name: opensearch-learning-to-rank-base
     integ-test:
       test-configs:
+        - with-security
         - without-security
   - name: neural-search
     integ-test:

--- a/manifests/2.19.0/opensearch-2.19.0-test.yml
+++ b/manifests/2.19.0/opensearch-2.19.0-test.yml
@@ -82,6 +82,10 @@ components:
       test-configs:
         - with-security
         - without-security
+  - name: opensearch-learning-to-rank-base
+    integ-test:
+      test-configs:
+        - without-security
   - name: neural-search
     integ-test:
       test-configs:


### PR DESCRIPTION
### Description
Adds the [opensearch-learning-to-rank-base](https://github.com/opensearch-project/opensearch-learning-to-rank-base) plugin to the manifests/2.19.0/opensearch-2.19.0-test.yml file for test workflow.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
