### PR TITLE
Move texinfo specifically for binutils on al2 x64

### DIFF
--- a/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
@@ -125,12 +125,14 @@ RUN if [ `uname -m` = "x86_64" ]; then \
 # Upgrade binutils
 # This is only required if gcc upgrade to 12 or above
 RUN if [ `uname -m` = "x86_64" ]; then \
+        yum install -y texinfo && \
         curl -SLO https://ci.opensearch.org/ci/dbc/tools/gcc/binutils-2.42.90.tar.xz && \
         tar -xf binutils-2.42.90.tar.xz && cd binutils-2.42.90 && \
         mkdir build && cd build && \
         ../configure --prefix=/usr && \
         make && make install && ld --version && \
-        cd ../../ && rm -rf binutils-2.42.90.tar.xz binutils-2.42.90; \
+        cd ../../ && rm -rf binutils-2.42.90.tar.xz binutils-2.42.90 && \
+        yum remove -y texinfo; \
     fi
 
 ENV FC=gfortran


### PR DESCRIPTION
### Description
Move texinfo specifically for binutils on al2 x64

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/5226

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
