### PR TITLE
Switch AL2 arm64 with libstdc++ 6.0.24 version of node 20 binaries

### DIFF
--- a/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
@@ -165,7 +165,7 @@ RUN pip3 install cmake==3.26.4
 RUN if [ `uname -m` = "x86_64" ]; then \
         curl -SL https://ci.opensearch.org/ci/dbc/tools/node/node-v20.18.0-linux-x64-glibc-217.tar.xz -o /node20.tar.xz; \
     else \
-        curl -SL https://ci.opensearch.org/ci/dbc/tools/node/node-v20.18.0-linux-arm64-glibc-226.tar.xz -o /node20.tar.xz; \
+        curl -SL https://ci.opensearch.org/ci/dbc/tools/node/node-v20.18.0-linux-arm64-glibc-226-libstdc++-6.0.24.tar.xz -o /node20.tar.xz; \
     fi; \
     mkdir /node_al2 && \
     tar -xf /node20.tar.xz --strip-components 1 -C /node_al2 && \


### PR DESCRIPTION
### Description
Switch AL2 arm64 with libstdc++ 6.0.24 version of node 20 binaries

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5248

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
