### PR TITLE
Add flowFrameworkDashboards to test manifests

### DIFF
--- a/manifests/2.19.0/opensearch-dashboards-2.19.0-test.yml
+++ b/manifests/2.19.0/opensearch-dashboards-2.19.0-test.yml
@@ -93,3 +93,8 @@ components:
         - without-security
       additional-cluster-configs:
         assistant.chat.enabled: true
+  - name: flowFrameworkDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security

--- a/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1-test.yml
+++ b/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1-test.yml
@@ -93,3 +93,8 @@ components:
         - without-security
       additional-cluster-configs:
         assistant.chat.enabled: true
+  - name: flowFrameworkDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security

--- a/manifests/3.0.0/opensearch-dashboards-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-dashboards-3.0.0-test.yml
@@ -93,3 +93,8 @@ components:
         - without-security
       additional-cluster-configs:
         assistant.chat.enabled: true
+  - name: flowFrameworkDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security


### PR DESCRIPTION
### Description
Adds `flowFrameworkDashboards` plugin to the following test manifests:
- 2.19
- 3.0
- 3.0-alpha1

The plugin is already in all of the build manifests; this just adds to the test manifests, now that the integ tests have been updated and are passing. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
