### PR TITLE
Validate distribution while building RC

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -148,6 +148,9 @@ pipeline {
                     paramType.each { key, value ->
                         verifyParameterPlatformDistribution(key, value)
                     }
+
+                    def inputManifestObj = lib.jenkins.InputManifest.new(readYaml(file: "manifests/${INPUT_MANIFEST}"))
+                    env.version = inputManifestObj.build.version
                 }
             }
         }
@@ -953,6 +956,9 @@ pipeline {
         success {
             node(AGENT_LINUX_X64) {
                 script {
+                    if (params.RC_NUMBER.toInteger() > 0) {
+                        triggerDistributionValidationWorkflow(env.version)
+                    }
                     postCleanup()
                 }
             }
@@ -1006,6 +1012,22 @@ def triggerBWCTests(String buildManifestUrl, String platform, String distributio
                     string(name: 'AGENT_LABEL', value: AGENT_LINUX_X64)
                 ]
     }
+}
+
+def triggerDistributionValidationWorkflow(String version) {
+    def triggerValidationWorkflow =
+            build job: 'distribution-validation',
+            propagate: true,
+            wait: true,
+            parameters: [
+                string(name: 'VERSION', value: version),
+                string(name: 'OS_BUILD_NUMBER', value: 'latest'),
+                string(name: 'OSD_BUILD_NUMBER', value: BUILD_NUMBER),
+                string(name: 'OPTIONAL_ARGS', value: 'using-staging-artifact-only'),
+                string(name: 'DOCKER_SOURCE', value: 'dockerhub'),
+                string(name: 'PROJECTS', value: 'Both'),
+                string(name: 'ARTIFACT_TYPE', value: 'staging')
+            ]
 }
 
 def verifyParameterPlatformDistribution(String paramName, String allowedValue) {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -148,6 +148,9 @@ pipeline {
                     paramType.each { key, value ->
                         verifyParameterPlatformDistribution(key, value)
                     }
+
+                    def inputManifestObj = lib.jenkins.InputManifest.new(readYaml(file: "manifests/${INPUT_MANIFEST}"))
+                    env.version = inputManifestObj.build.version
                 }
             }
         }
@@ -914,6 +917,9 @@ pipeline {
         success {
             node(AGENT_LINUX_X64) {
                 script {
+                    if (params.RC_NUMBER.toInteger() > 0) {
+                        triggerDistributionValidationWorkflow(env.version)
+                    }
                     postCleanup()
                 }
             }
@@ -967,6 +973,21 @@ def triggerBWCTests(String buildManifestUrl, String platform, String distributio
                     string(name: 'AGENT_LABEL', value: AGENT_LINUX_X64)
                 ]
     }
+}
+
+def triggerDistributionValidationWorkflow(String version) {
+    def triggerValidationWorkflow =
+            build job: 'distribution-validation',
+            propagate: true,
+            wait: true,
+            parameters: [
+                string(name: 'VERSION', value: version),
+                string(name: 'OS_BUILD_NUMBER', value: BUILD_NUMBER),
+                string(name: 'OPTIONAL_ARGS', value: 'using-staging-artifact-only'),
+                string(name: 'DOCKER_SOURCE', value: 'dockerhub'),
+                string(name: 'PROJECTS', value: 'opensearch'),
+                string(name: 'ARTIFACT_TYPE', value: 'staging')
+            ]
 }
 
 def verifyParameterPlatformDistribution(String paramName, String allowedValue) {


### PR DESCRIPTION
### Description
When the given build is a release candidate build, it should be validated before declaring the workflow as successful. This chnage adds the step to do so. 

### Issues Resolved
part of https://github.com/opensearch-project/opensearch-build/issues/5022 https://github.com/opensearch-project/opensearch-build/issues/5171

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
