### PR TITLE
Skipping DWZ as too few files for multifile optimization in DEB generation

### DIFF
--- a/scripts/pkg/build_templates/current/opensearch-dashboards/deb/debian/rules
+++ b/scripts/pkg/build_templates/current/opensearch-dashboards/deb/debian/rules
@@ -22,6 +22,9 @@ override_dh_builddeb:
 override_dh_gencontrol:
 	dh_gencontrol -- -DLicense=Apache-2.0
 
+override_dh_dwz:
+	echo "Skipping DWZ: Too few files for multifile optimization"
+
 #override_dh_auto_install:
 #	dh_auto_install -- prefix=/usr
 

--- a/scripts/pkg/build_templates/current/opensearch/deb/debian/rules
+++ b/scripts/pkg/build_templates/current/opensearch/deb/debian/rules
@@ -22,6 +22,9 @@ override_dh_builddeb:
 override_dh_gencontrol:
 	dh_gencontrol -- -DLicense=Apache-2.0
 
+override_dh_dwz:
+	echo "Skipping DWZ: Too few files for multifile optimization"
+
 #override_dh_auto_install:
 #	dh_auto_install -- prefix=/usr
 


### PR DESCRIPTION

### Description
Skipping DWZ as too few files for multifile optimization in DEB generation

Resolve: https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-build-opensearch/detail/distribution-build-opensearch/10751/pipeline/1373/
```
dwz: Too few files for multifile optimization
```

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5152

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
