### PR TITLE
Add queryInsightsDashboards to 2.19, 3.0, 3.0.0-alpha1 dashboard test manifests

### DIFF
--- a/.github/workflows/osd-release-issues.yml
+++ b/.github/workflows/osd-release-issues.yml
@@ -54,6 +54,7 @@ jobs:
           - {repo: security-dashboards-plugin}
           - {repo: dashboards-search-relevance}
           - {repo: opensearch-dashboards-functional-test}
+          - {repo: query-insights-dashboards}
         release_version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
       - name: GitHub App token

--- a/manifests/2.19.0/opensearch-dashboards-2.19.0-test.yml
+++ b/manifests/2.19.0/opensearch-dashboards-2.19.0-test.yml
@@ -98,3 +98,8 @@ components:
       test-configs:
         - with-security
         - without-security
+  - name: queryInsightsDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security

--- a/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1-test.yml
+++ b/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1-test.yml
@@ -98,3 +98,8 @@ components:
       test-configs:
         - with-security
         - without-security
+  - name: queryInsightsDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security

--- a/manifests/3.0.0/opensearch-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-3.0.0-test.yml
@@ -158,3 +158,9 @@ components:
       additional-cluster-configs:
         opensearch.experimental.feature.application_templates.enabled: true
         cluster.application_templates.enabled: true
+
+  - name: query-insights
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security

--- a/manifests/3.0.0/opensearch-dashboards-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-dashboards-3.0.0-test.yml
@@ -98,3 +98,8 @@ components:
       test-configs:
         - with-security
         - without-security
+  - name: queryInsightsDashboards
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security


### PR DESCRIPTION
### Description
- Add `queryInsightsDashboards` to 2.19 , 3.0, 3.0.0-alpha1 dashboard test manifests
- Add `query-insights-dashboards` to release issues list

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
