### PR TITLE
Enforce docker build with tag when RC is built

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -151,7 +151,10 @@ pipeline {
                     paramType.each { key, value ->
                         verifyParameterPlatformDistribution(key, value)
                     }
-
+                    if (params.RC_NUMBER.toInteger() > 0) {
+                        echo 'This is a release candidate build, enforcing build_docker_with_build_number_tag'
+                        BUILD_DOCKER = 'build_docker_with_build_number_tag'
+                    }
                     def inputManifestObj = lib.jenkins.InputManifest.new(readYaml(file: "manifests/${INPUT_MANIFEST}"))
                     env.version = inputManifestObj.build.version
                 }
@@ -883,7 +886,7 @@ pipeline {
                         beforeAgent true
                         allOf {
                             expression {
-                                params.BUILD_DOCKER != 'do_not_build_docker'
+                                BUILD_DOCKER != 'do_not_build_docker'
                             }
                             expression {
                                 params.BUILD_PLATFORM.contains('linux')

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -152,7 +152,10 @@ pipeline {
                     paramType.each { key, value ->
                         verifyParameterPlatformDistribution(key, value)
                     }
-
+                    if (params.RC_NUMBER.toInteger() > 0) {
+                        echo 'This is a release candidate build, enforcing build_docker_with_build_number_tag'
+                        BUILD_DOCKER = 'build_docker_with_build_number_tag'
+                    }
                     def inputManifestObj = lib.jenkins.InputManifest.new(readYaml(file: "manifests/${INPUT_MANIFEST}"))
                     env.version = inputManifestObj.build.version
                 }
@@ -846,10 +849,10 @@ pipeline {
                         beforeAgent true
                         allOf {
                             expression {
-                                params.BUILD_DOCKER != 'do_not_build_docker'
+                                BUILD_DOCKER != 'do_not_build_docker'
                             }
                             expression {
-                                        params.BUILD_PLATFORM.contains('linux')
+                                params.BUILD_PLATFORM.contains('linux')
                             }
                         }
                     }


### PR DESCRIPTION
### Description
With a release candidate is being build, it is essential to build docker with tag in order to differentiate regular build from RC one. This PR enforces that.
Also value of `params.` is immutable. Hence, using env variable instead. Tested all scenarios in beta and it works as expected. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5022

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
