### PR TITLE
Increase docker-build timeout to 150 minutes

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -897,7 +897,7 @@ pipeline {
                         }
                     }
                     options {
-                        timeout(time: 90, unit: 'MINUTES')
+                        timeout(time: 2, unit: 'HOURS')
                     }
                     agent {
                         docker {

--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -897,7 +897,7 @@ pipeline {
                         }
                     }
                     options {
-                        timeout(time: 2, unit: 'HOURS')
+                        timeout(time: 150, unit: 'MINUTES')
                     }
                     agent {
                         docker {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -857,7 +857,7 @@ pipeline {
                         }
                     }
                     options {
-                        timeout(time: 2, unit: 'HOURS')
+                        timeout(time: 150, unit: 'MINUTES')
                     }
                     agent {
                         docker {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -857,7 +857,7 @@ pipeline {
                         }
                     }
                     options {
-                        timeout(time: 90, unit: 'MINUTES')
+                        timeout(time: 2, unit: 'HOURS')
                     }
                     agent {
                         docker {


### PR DESCRIPTION
### Description
Increase docker-build timeout to 150 minutes
### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
