### PR TITLE
Add onboarding doc for smoke tests

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -53,7 +53,7 @@ Add the new plugin to the [opensearch-plugins meta](https://github.com/opensearc
 
     2. You will need to add a distinct YAML file for your plugin in the appropriate major version directory under [smoke_tests_spec](src/test_workflow/smoke_test/smoke_tests_spec) and reference the file name in the test manifest for the corresponding component. e.g. [security.yml](https://github.com/opensearch-project/opensearch-build/blob/main/src/test_workflow/smoke_test/smoke_tests_spec/default/security.yml)
 
-    3. In the YAML file, specify the API path, HTTP method, request body as parameter and heading if `Content-Type` differs from the default `application/json`. Refer to an example test definition [here](src/test_workflow/smoke_test/smoke_tests_spec/2.x/opensearch.yml) for guidance. 
+    3. In the YAML file, specify the API path, HTTP method, request body as parameter and heading if `Content-Type` differs from the default `application/json`. Refer to an example test definition [here](src/test_workflow/smoke_test/smoke_tests_spec/2.x/opensearch.yml) for guidance. Before adding APIs to the smoke tests, ensure they are already onboarded to the OpenSearch API Specification repository. For onboarding procedures, refer to the [OpenSearch API Specification Developer Guide](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md). 
 
 ## Standalone Component Onboarding
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -35,7 +35,7 @@ Add the new plugin to the [opensearch-plugins meta](https://github.com/opensearc
 
 ### Onboard to Test Workflow
 
-1. Update the test configuration file (use 1.3.0 as an example), [opensearch-1.3.0-test.yml](https://github.com/opensearch-project/opensearch-build/blob/opensearch-1.3.0/manifests/1.3.0/opensearch-1.3.0-test.yml), for a particular release, to include your plugin. This test configuration defines full suite of tests - `integ`, `bwc`, that can be run on the plugin.
+1. Update the test configuration file (use 1.3.0 as an example), [opensearch-1.3.0-test.yml](https://github.com/opensearch-project/opensearch-build/blob/opensearch-1.3.0/manifests/1.3.0/opensearch-1.3.0-test.yml), for a particular release, to include your plugin. This test configuration defines full suite of tests - `integ`, `bwc`, `smoke` that can be run on the plugin.
 
 2. For integration testing, the `test-workflow` runs integration tests available in the plugin repository. You will need to add `integ-test` config for your plugin in opensearch-1.3.0-test.yml, [example](https://github.com/opensearch-project/opensearch-build/blob/opensearch-1.3.0/manifests/1.3.0/opensearch-1.3.0-test.yml).
    
@@ -47,6 +47,13 @@ Add the new plugin to the [opensearch-plugins meta](https://github.com/opensearc
 
     1. It supports two test configs - `with-security` and `without-security`, which runs test with security plugin enabled and disabled respectively. Choose one or both depending on what your plugin integration tests support.
 
+4. For smoke testing, The test-workflow runs smoke tests defined in the [smoke_tests_spec](src/test_workflow/smoke_test/smoke_tests_spec) directory for each major OpenSearch version. The smoke tests are executed based on the API specification provided in the [OpenSearch API Specification](https://github.com/opensearch-project/opensearch-api-specification) repository.
+
+    1. The smoke test framework currently supports testing the OpenSearch distribution and its plugins. It ensures that core OpenSearch functionalities and plugin-specific APIs behave as expected before release.
+
+    2. You will need to add a distinct YAML file for your plugin in the appropriate major version directory under [smoke_tests_spec](src/test_workflow/smoke_test/smoke_tests_spec) and reference the file name in the test manifest for the corresponding component.
+
+    3. In the YAML file, specify the API path, HTTP method, request body as parameter and heading if `Content-Type` differs from the default `application/json`. Refer to an example test definition [here](src/test_workflow/smoke_test/smoke_tests_spec/2.x/opensearch.yml) for guidance. 
 
 ## Standalone Component Onboarding
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -47,11 +47,11 @@ Add the new plugin to the [opensearch-plugins meta](https://github.com/opensearc
 
     1. It supports two test configs - `with-security` and `without-security`, which runs test with security plugin enabled and disabled respectively. Choose one or both depending on what your plugin integration tests support.
 
-4. For smoke testing, The test-workflow runs smoke tests defined in the [smoke_tests_spec](src/test_workflow/smoke_test/smoke_tests_spec) directory for each major OpenSearch version. The smoke tests are executed based on the API specification provided in the [OpenSearch API Specification](https://github.com/opensearch-project/opensearch-api-specification) repository.
+4. For smoke testing, The test-workflow runs smoke tests defined in the [smoke_tests_spec](src/test_workflow/smoke_test/smoke_tests_spec) directory across all OpenSearch versions and the respective test specification files are organized by major version. The smoke tests are executed based on the API specification provided in the [OpenSearch API Specification](https://github.com/opensearch-project/opensearch-api-specification) repository.
 
-    1. The smoke test framework currently supports testing the OpenSearch distribution and its plugins. It ensures that core OpenSearch functionalities and plugin-specific APIs behave as expected before release.
+    1. The smoke test framework currently supports testing the OpenSearch distribution and its plugins. It ensures that core OpenSearch functionalities and plugin-specific APIs behave as expected when bundled into a distribution before release.
 
-    2. You will need to add a distinct YAML file for your plugin in the appropriate major version directory under [smoke_tests_spec](src/test_workflow/smoke_test/smoke_tests_spec) and reference the file name in the test manifest for the corresponding component.
+    2. You will need to add a distinct YAML file for your plugin in the appropriate major version directory under [smoke_tests_spec](src/test_workflow/smoke_test/smoke_tests_spec) and reference the file name in the test manifest for the corresponding component. e.g. [security.yml](https://github.com/opensearch-project/opensearch-build/blob/main/src/test_workflow/smoke_test/smoke_tests_spec/default/security.yml)
 
     3. In the YAML file, specify the API path, HTTP method, request body as parameter and heading if `Content-Type` differs from the default `application/json`. Refer to an example test definition [here](src/test_workflow/smoke_test/smoke_tests_spec/2.x/opensearch.yml) for guidance. 
 


### PR DESCRIPTION
### Description
Add  smoke tests framework onboarding guide for plugins.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/5223

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
