### PR TITLE
add testSnapshotFolder to path.repo

### DIFF
--- a/manifests/2.19.0/opensearch-2.19.0-test.yml
+++ b/manifests/2.19.0/opensearch-2.19.0-test.yml
@@ -77,6 +77,9 @@ components:
       test-configs:
         - with-security
         - without-security
+      additional-cluster-configs:
+        path.repo:
+          - /tmp
   - name: ml-commons
     integ-test:
       test-configs:


### PR DESCRIPTION
### Description
The 2.19 release build was failing KNN integ tests https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/9318/pipeline/90. Specifically the `RestoreSnapshotIT` test. There is a prior PR https://github.com/opensearch-project/k-NN/pull/2461 that added fixes to this test by adding a path to `path.repo`. The current failure is related to that change. This PR attempts to fix it.

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
