### PR TITLE
Ensure AL2 build image keep libstdc++.so.6.0.24 version

### DIFF
--- a/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
@@ -99,7 +99,7 @@ RUN ln -sfn /usr/local/bin/python3.9 /usr/bin/python3 && \
     ln -sfn /usr/local/bin/pip3.9 /usr/bin/pip3 && \
     pip3 install pip==23.1.2 && pip3 install pipenv==2023.6.12 awscli==1.32.17
 
-# Upgrade gcc, while keep libstdc++.so to older 6.0.24 version for backward compatiblity
+# Upgrade gcc, while keep libstdc++.so to older 6.0.24 version for backward compatibility
 # Only x64 requires gcc 12+ for k-NN avx512_spr fp16 feature
 # https://github.com/opensearch-project/opensearch-build/issues/5226
 # Due to cross-compilation being too slow on arm64, it will stay on gcc 10 for the time being

--- a/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
@@ -111,10 +111,10 @@ RUN if [ `uname -m` = "x86_64" ]; then \
         mkdir build && cd build && \
         ../configure --enable-languages=all --prefix=/usr --disable-multilib --disable-bootstrap && \
         make -j$(nproc) && make install && gcc --version && g++ --version && gfortran --version && \
-        cd  ../../ && rm -rf gcc12.tgz gcc-12.4.0 && \
-        ln -sfn /lib64/libstdc++.so.6 /lib64/libstdc++.so && \
-        ln -sfn /lib64/libstdc++.so.6.0.24 /lib64/libstdc++.so.6 && \
-        rm -v /lib64/libstdc++.so.6.0.30* ; \
+        cd  ../../ && rm -rf gcc12.tgz gcc-12.4.0 && cd /lib64/ && \
+        ln -sfn libstdc++.so.6 libstdc++.so && \
+        ln -sfn libstdc++.so.6.0.24 libstdc++.so.6 && \
+        rm -v libstdc++.so.6.0.30* ; \
     else \
         yum install -y gcc10* && \
         mv -v /usr/bin/gcc /usr/bin/gcc7-gcc && \

--- a/docker/release/dockerfiles/opensearch.al2023.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2023.dockerfile
@@ -85,14 +85,6 @@ ENV PATH=$PATH:$JAVA_HOME/bin:$OPENSEARCH_HOME/bin
 # Add k-NN lib directory to library loading path variable
 ENV LD_LIBRARY_PATH="$OPENSEARCH_HOME/plugins/opensearch-knn/lib"
 
-# Replace libstdc++.so.6.0.29 with libstdc++.so.6.0.30 to support k-NN avx512_spr on x64 only
-# https://github.com/opensearch-project/opensearch-build/issues/5226
-# https://github.com/opensearch-project/k-NN/issues/2484
-RUN if [ `uname -m` = "x86_64" ]; then \
-        curl -SLO https://ci.opensearch.org/ci/dbc/tools/gcc/libstdcpp/x64/libstdcpp.so.6.0.30.stripped.tar.gz && \
-        tar -xzf libstdcpp.so.6.0.30.stripped.tar.gz -C /lib64 && rm -v libstdcpp.so.6.0.30.stripped.tar.gz; \
-    fi
-
 # Change user
 USER $UID
 


### PR DESCRIPTION
### Description
Ensure AL2 build image keep libstdc++.so.6.0.24 version

### Issues Resolved
Closes https://github.com/opensearch-project/k-NN/issues/2484

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
