### PR TITLE
Update AL2 x64 build image to have both gcc10 and gcc12

### DIFF
--- a/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.al2.opensearch.x64.arm64.dockerfile
@@ -103,6 +103,12 @@ RUN ln -sfn /usr/local/bin/python3.9 /usr/bin/python3 && \
 # Only x64 requires gcc 12+ for k-NN avx512_spr fp16 feature
 # https://github.com/opensearch-project/opensearch-build/issues/5226
 # Due to cross-compilation being too slow on arm64, it will stay on gcc 10 for the time being
+# nmslib needs gcc 10 while faiss needs gcc 12+
+# https://github.com/opensearch-project/k-NN/issues/2484#issuecomment-2640950082
+RUN yum install -y gcc10* && \
+    mv -v /usr/bin/gcc /usr/bin/gcc7-gcc && \
+    mv -v /usr/bin/g++ /usr/bin/gcc7-g++ && \
+    mv -v /usr/bin/gfortran /usr/bin/gcc7-gfortran
 RUN if [ `uname -m` = "x86_64" ]; then \
         curl -SL https://ci.opensearch.org/ci/dbc/tools/gcc/gcc-12.4.0.tar.gz -o gcc12.tgz && \
         tar -xzf gcc12.tgz && cd gcc-12.4.0 && \
@@ -116,10 +122,6 @@ RUN if [ `uname -m` = "x86_64" ]; then \
         ln -sfn libstdc++.so.6.0.24 libstdc++.so.6 && \
         rm -v libstdc++.so.6.0.30* ; \
     else \
-        yum install -y gcc10* && \
-        mv -v /usr/bin/gcc /usr/bin/gcc7-gcc && \
-        mv -v /usr/bin/g++ /usr/bin/gcc7-g++ && \
-        mv -v /usr/bin/gfortran /usr/bin/gcc7-gfortran && \
         update-alternatives --install /usr/bin/gcc gcc $(which gcc10-gcc) 1 && \
         update-alternatives --install /usr/bin/g++ g++ $(which gcc10-g++) 1 && \
         update-alternatives --install /usr/bin/gfortran gfortran $(which gcc10-gfortran) 1; \


### PR DESCRIPTION
### Description
Update AL2 x64 build image to have both gcc10 and gcc12

### Issues Resolved
Closes https://github.com/opensearch-project/k-NN/issues/2484

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
