### PR TITLE
Add local cluster logs recording to smoke tests framework

### DIFF
--- a/src/test_workflow/smoke_test/smoke_test_cluster_opensearch.py
+++ b/src/test_workflow/smoke_test/smoke_test_cluster_opensearch.py
@@ -34,7 +34,6 @@ class SmokeTestClusterOpenSearch():
     ) -> None:
         self.args = args
         self.work_dir = work_dir
-        self.test_recorder = test_recorder
         self.process_handler = Process()
         self.test_manifest = TestManifest.from_path(args.test_manifest_path)
         self.product = self.test_manifest.name.lower().replace(" ", "-")
@@ -46,6 +45,8 @@ class SmokeTestClusterOpenSearch():
         self.arch = self.bundle_manifest.build.architecture
         self.dist = self.bundle_manifest.build.distribution
         self.distribution = Distributions.get_distribution(self.product, self.dist, self.version, work_dir)
+
+        self.test_recorder = test_recorder
 
     def cluster_version(self) -> str:
         return self.version
@@ -97,6 +98,20 @@ class SmokeTestClusterOpenSearch():
             logging.info(f"Cluster check fails: {e}")
             return False
 
+    def __save_local_cluster_logs__(self) -> None:
+        dest_directory = os.path.join(self.test_recorder.location, "local-cluster-logs")
+        os.makedirs(dest_directory, exist_ok=True)
+        logging.info(
+            f"Recording local cluster logs for at {dest_directory}"
+        )
+
+        self.test_recorder._generate_std_files(
+            self.process_handler.stdout_data,
+            self.process_handler.stderr_data,
+            dest_directory,
+        )
+
     def __uninstall__(self) -> None:
         self.process_handler.terminate()
+        self.__save_local_cluster_logs__()
         logging.info("Cluster is terminated.")

--- a/src/test_workflow/smoke_test/smoke_test_cluster_opensearch.py
+++ b/src/test_workflow/smoke_test/smoke_test_cluster_opensearch.py
@@ -34,6 +34,7 @@ class SmokeTestClusterOpenSearch():
     ) -> None:
         self.args = args
         self.work_dir = work_dir
+        self.test_recorder = test_recorder
         self.process_handler = Process()
         self.test_manifest = TestManifest.from_path(args.test_manifest_path)
         self.product = self.test_manifest.name.lower().replace(" ", "-")
@@ -45,8 +46,6 @@ class SmokeTestClusterOpenSearch():
         self.arch = self.bundle_manifest.build.architecture
         self.dist = self.bundle_manifest.build.distribution
         self.distribution = Distributions.get_distribution(self.product, self.dist, self.version, work_dir)
-
-        self.test_recorder = test_recorder
 
     def cluster_version(self) -> str:
         return self.version

--- a/tests/tests_test_workflow/test_smoke_workflow/smoke_test/test_smoke_test_cluster_opensearch.py
+++ b/tests/tests_test_workflow/test_smoke_workflow/smoke_test/test_smoke_test_cluster_opensearch.py
@@ -181,3 +181,28 @@ class TestSmokeTestClusterOpenSearch(unittest.TestCase):
 
         # Verify termination
         mock_process_handler.terminate.assert_called_once()
+
+    @patch("test_workflow.smoke_test.smoke_test_cluster_opensearch.Distributions.get_distribution")
+    @patch("test_workflow.smoke_test.smoke_test_cluster_opensearch.BundleManifest.from_urlpath")
+    @patch("test_workflow.smoke_test.smoke_test_cluster_opensearch.BuildManifest.from_urlpath")
+    @patch("test_workflow.smoke_test.smoke_test_cluster_opensearch.TestManifest.from_path")
+    @patch("test_workflow.smoke_test.smoke_test_cluster_opensearch.Process")
+    def test_save_local_cluster_logs(self, mock_process: Mock, mock_test_manifest: Mock,
+                                     mock_build_manifest: Mock, mock_bundle_manifest: Mock,
+                                     mock_distribution: Mock) -> None:
+        args = MagicMock()
+        test_recorder = MagicMock()
+        mock_process_handler = mock_process.return_value
+
+        # Simulate process handler outputs
+        mock_process_handler.stdout_data = "mock_stdout_data"
+        mock_process_handler.stderr_data = "mock_stderr_data"
+
+        cluster = SmokeTestClusterOpenSearch(args, "/mock/work_dir", test_recorder)
+        cluster.__save_local_cluster_logs__()
+
+        test_recorder._generate_std_files.assert_called_once_with(
+            "mock_stdout_data",
+            "mock_stderr_data",
+            os.path.join(test_recorder.location, "local-cluster-logs")
+        )


### PR DESCRIPTION
### Description
Add local cluster logs recording to smoke tests framework

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-build/issues/5320

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
