### PR TITLE
Add release-chores workflow

### DIFF
--- a/jenkins/release-workflows/release-chores.jenkinsfile
+++ b/jenkins/release-workflows/release-chores.jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
         stage('Parameter check') {
             steps {
                 script {
-                    if (!(RELEASE_VERSION && RELEASE_CHORE)) {
+                    if (!(params.RELEASE_VERSION && params.RELEASE_CHORE)) {
                         error('Required parameters are missing. Please provide the mandatory arguments RELEASE_VERSION and RELEASE_CHORE')
                     }
                 }

--- a/jenkins/release-workflows/release-chores.jenkinsfile
+++ b/jenkins/release-workflows/release-chores.jenkinsfile
@@ -7,9 +7,9 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@refactor-classes', retriever: modernSCM([
+lib = library(identifier: 'jenkins@8.2.0', retriever: modernSCM([
     $class: 'GitSCMSource',
-    remote: 'https://github.com/gaiksaya/opensearch-build-libraries.git',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
 
 pipeline {

--- a/jenkins/release-workflows/release-chores.jenkinsfile
+++ b/jenkins/release-workflows/release-chores.jenkinsfile
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+lib = library(identifier: 'jenkins@refactor-classes', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/gaiksaya/opensearch-build-libraries.git',
+]))
+
+pipeline {
+    options {
+            timeout(time: 1, unit: 'HOURS')
+    }
+    agent {
+        docker {
+            label 'Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host'
+            image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3'
+            registryUrl 'https://public.ecr.aws/'
+            alwaysPull true
+        }
+    }
+    parameters {
+        string(
+            name: 'RELEASE_VERSION',
+            description: "Required: On-going release version, e.g. 2.0.0",
+            trim: true
+        )
+        string(
+            name: 'RELEASE_CHORE',
+            description: "Required: What release chore you wanna do? e.g: 'add_rc_details_comment'",
+            trim: true
+        )
+    }
+    stages {
+        stage('Parameter check') {
+            steps {
+                script {
+                    if (!(RELEASE_VERSION && RELEASE_CHORE)) {
+                        error('Required parameters are missing. Please provide the mandatory arguments RELEASE_VERSION and RELEASE_CHORE')
+                    }
+                }
+            }
+        }
+        stage('Add RC details comment') {
+            when {
+                expression { params.RELEASE_CHORE == 'add_rc_details_comment' }
+            }
+            steps {
+                script {
+                    addRcDetailsComment(
+                        version: "${params.RELEASE_VERSION}"
+                        )
+                }
+            }
+        }
+    }
+    post() {
+        always {
+            script {
+                postCleanup()
+            }
+        }
+    }
+}

--- a/jenkins/release-workflows/release-chores.jenkinsfile
+++ b/jenkins/release-workflows/release-chores.jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     agent {
         docker {
             label 'Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host'
-            image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3'
+            image 'opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1'
             registryUrl 'https://public.ecr.aws/'
             alwaysPull true
         }

--- a/jenkins/release-workflows/release-chores.jenkinsfile
+++ b/jenkins/release-workflows/release-chores.jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
                 }
             }
         }
-        stage('Add RC details comment') {
+        stage('Add RC details and Docker Scan comment') {
             when {
                 expression { params.RELEASE_CHORE == 'add_rc_details_comment' }
             }

--- a/tests/jenkins/TestReleaseChores.groovy
+++ b/tests/jenkins/TestReleaseChores.groovy
@@ -10,10 +10,8 @@
 import jenkins.tests.BuildPipelineTest
 import org.junit.Before
 import org.junit.Test
-import org.yaml.snakeyaml.Yaml
 
 import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
-import static org.hamcrest.CoreMatchers.equalTo
 import static org.hamcrest.CoreMatchers.hasItem
 import static org.hamcrest.MatcherAssert.assertThat
 

--- a/tests/jenkins/TestReleaseChores.groovy
+++ b/tests/jenkins/TestReleaseChores.groovy
@@ -27,11 +27,11 @@ class TestReleaseChores extends BuildPipelineTest {
     void setUp() {
         helper.registerSharedLibrary(
             library().name('jenkins')
-                .defaultVersion('refactor-classes')
+                .defaultVersion('8.2.0')
                 .allowOverride(true)
                 .implicit(true)
                 .targetPath('vars')
-                .retriever(gitSource('https://github.com/gaiksaya/opensearch-build-libraries.git'))
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
                 .build()
             )
 

--- a/tests/jenkins/TestReleaseChores.groovy
+++ b/tests/jenkins/TestReleaseChores.groovy
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import jenkins.tests.BuildPipelineTest
+import org.junit.Before
+import org.junit.Test
+import org.yaml.snakeyaml.Yaml
+
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.MatcherAssert.assertThat
+
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
+
+class TestReleaseChores extends BuildPipelineTest {
+
+    @Override
+    @Before
+    void setUp() {
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('refactor-classes')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/gaiksaya/opensearch-build-libraries.git'))
+                .build()
+            )
+
+        super.setUp()
+    }
+
+    @Test
+    public void testVerifyParameters() {
+        addParam('RELEASE_VERSION', '')
+        addParam('RELEASE_CHORE', 'add_rc_details_comment')
+        runScript('jenkins/release-workflows/release-chores.jenkinsfile')
+        assertThat(getCommandExecutions('error', ''), hasItem('Required parameters are missing. Please provide the mandatory arguments RELEASE_VERSION and RELEASE_CHORE'))
+    }
+
+    def getCommandExecutions(methodName, command) {
+        def shCommands = helper.callStack.findAll {
+            call ->
+                call.methodName == methodName
+        }.
+        collect {
+            call ->
+                callArgsToString(call)
+        }.findAll {
+            shCommand ->
+                shCommand.contains(command)
+        }
+        return shCommands
+    }
+}


### PR DESCRIPTION
### Description
This workflow will host all the minute release chores that are run manually today starting with adding rc details to the GH issue as a comment, checking the docker scan results. Sample [comment](https://github.com/gaiksaya/opensearch-build/issues/49#issuecomment-2654985673). 
The future plan is to enhance this workflow to add more chores such as checking release notes and updating entrance criteria accordingly, updating exit criterias, etc.

### Issues Resolved
closes https://github.com/opensearch-project/opensearch-build/issues/5022

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
