### PR TITLE
Remove obsolete compose version specifier

### DIFF
--- a/docker/release/dockercomposefiles/docker-compose-1.x.yml
+++ b/docker/release/dockercomposefiles/docker-compose-1.x.yml
@@ -1,5 +1,4 @@
 ---
-version: '3'
 services:
   opensearch-node1:
     image: opensearchproject/opensearch:1

--- a/docker/release/dockercomposefiles/docker-compose-2.x.yml
+++ b/docker/release/dockercomposefiles/docker-compose-2.x.yml
@@ -1,5 +1,4 @@
 ---
-version: '3'
 services:
   opensearch-node1:
     image: opensearchproject/opensearch:2

--- a/docker/release/dockercomposefiles/docker-compose-default.x.yml
+++ b/docker/release/dockercomposefiles/docker-compose-default.x.yml
@@ -1,5 +1,4 @@
 ---
-version: '3'
 services:
   opensearch-node1:
     image: opensearchproject/opensearch:latest


### PR DESCRIPTION
### Description

Version specifier for docker compose is obsolete. See: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete

See this PR to collect changes across opensearch-project repos: https://github.com/opensearch-project/documentation-website/pull/8606
