### PR TITLE
Allow incremental build to respect version qualifier

### DIFF
--- a/src/build_workflow/build_incremental.py
+++ b/src/build_workflow/build_incremental.py
@@ -28,7 +28,12 @@ class BuildIncremental:
             return [input_manifest.build.name.replace(" ", "-")]
         previous_build_manifest = BuildManifest.from_path(build_manifest_path)
         stable_input_manifest = input_manifest.stable()
-        if previous_build_manifest.build.version != stable_input_manifest.build.version:
+        stable_input_manifest_version = (
+            stable_input_manifest.build.version
+            if not stable_input_manifest.build.qualifier
+            else f"{stable_input_manifest.build.version}-{stable_input_manifest.build.qualifier}"
+        )
+        if previous_build_manifest.build.version != stable_input_manifest_version:
             logging.info("The version of previous build manifest doesn't match the current input manifest. Rebuilding Core.")
             return [input_manifest.build.name.replace(" ", "-")]
         components = []

--- a/tests/tests_build_workflow/data/opensearch-input-3.0.0-alpha1.yml
+++ b/tests/tests_build_workflow/data/opensearch-input-3.0.0-alpha1.yml
@@ -1,0 +1,213 @@
+---
+schema-version: '1.1'
+build:
+  name: OpenSearch
+  version: 3.0.0
+  qualifier: alpha1
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1
+    args: -e JAVA_HOME=/opt/java/openjdk-23
+components:
+  - name: OpenSearch
+    repository: https://github.com/opensearch-project/OpenSearch.git
+    ref: main
+  - name: common-utils
+    repository: https://github.com/opensearch-project/common-utils.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+  - name: opensearch-learning-to-rank-base
+    repository: https://github.com/opensearch-project/opensearch-learning-to-rank-base.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+  - name: opensearch-remote-metadata-sdk
+    repository: https://github.com/opensearch-project/opensearch-remote-metadata-sdk.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+  - name: job-scheduler
+    repository: https://github.com/opensearch-project/job-scheduler.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+  - name: security
+    repository: https://github.com/opensearch-project/security.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+  - name: k-NN
+    repository: https://github.com/opensearch-project/k-NN.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+  - name: geospatial
+    repository: https://github.com/opensearch-project/geospatial.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - job-scheduler
+  - name: cross-cluster-replication
+    repository: https://github.com/opensearch-project/cross-cluster-replication.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: ml-commons
+    repository: https://github.com/opensearch-project/ml-commons.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: neural-search
+    repository: https://github.com/opensearch-project/neural-search.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - ml-commons
+      - k-NN
+  - name: notifications-core
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: main
+    working_directory: notifications
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: notifications
+    repository: https://github.com/opensearch-project/notifications.git
+    ref: main
+    working_directory: notifications
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: opensearch-observability
+    repository: https://github.com/opensearch-project/observability.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: opensearch-reports
+    repository: https://github.com/opensearch-project/reporting.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+      - job-scheduler
+  - name: sql
+    repository: https://github.com/opensearch-project/sql.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - ml-commons
+  - name: asynchronous-search
+    repository: https://github.com/opensearch-project/asynchronous-search.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: anomaly-detection
+    repository: https://github.com/opensearch-project/anomaly-detection.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+      - job-scheduler
+  - name: alerting
+    repository: https://github.com/opensearch-project/alerting.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+  - name: security-analytics
+    repository: https://github.com/opensearch-project/security-analytics.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+      - alerting
+      - job-scheduler
+  - name: index-management
+    repository: https://github.com/opensearch-project/index-management.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+      - job-scheduler
+  - name: performance-analyzer
+    repository: https://github.com/opensearch-project/performance-analyzer.git
+    ref: main
+    platforms:
+      - linux
+  - name: custom-codecs
+    repository: https://github.com/opensearch-project/custom-codecs.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+  - name: flow-framework
+    repository: https://github.com/opensearch-project/flow-framework.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - common-utils
+      - opensearch-remote-metadata-sdk
+  - name: skills
+    repository: https://github.com/opensearch-project/skills.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - job-scheduler
+      - anomaly-detection
+      - sql
+      - ml-commons
+  - name: query-insights
+    repository: https://github.com/opensearch-project/query-insights.git
+    ref: main
+    platforms:
+      - linux
+      - windows
+  - name: opensearch-system-templates
+    repository: https://github.com/opensearch-project/opensearch-system-templates.git
+    ref: main
+    platforms:
+      - linux
+      - windows

--- a/tests/tests_build_workflow/test_build_incremental.py
+++ b/tests/tests_build_workflow/test_build_incremental.py
@@ -61,7 +61,7 @@ class TestBuildIncremental(unittest.TestCase):
     @patch("manifests.input_manifest.InputManifest.stable")
     def test_no_commits_diffi_with_qualifier(self, stable_mock_input_manifest: MagicMock, mock_build_manifest: MagicMock, mock_path_exists: MagicMock) -> None:
         mock_path_exists.return_value = True
-        input_manifest_data = {'schema-version': '1.1', 'build': {'name': 'OpenSearch', 'version': '3.0.0-alpha1'},
+        input_manifest_data = {'schema-version': '1.1', 'build': {'name': 'OpenSearch', 'version': '3.0.0', 'qualifier': 'alpha1'},
                                'components': [{'name': 'OpenSearch',
                                                'repository': 'https://github.com/opensearch-project/OpenSearch.git',
                                                'ref': '91a93dacb84eae4f09decbabe54771585d42b570',


### PR DESCRIPTION
### Description
Allow incremental build to respect version qualifier

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747
https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-build-opensearch/detail/distribution-build-opensearch/10821/pipeline/77

Despite the ref is the same every component rebuild due to version mismatch as qualifier field was initially designed to be only exist in input manifest, while build / dist manifest will put it as part of the version.

```
2025-02-17 04:49:56 INFO     Adding OpenSearch because it has different commit ID and needs to be rebuilt.
```
```
2025-02-17 21:04:13 INFO     The version of previous build manifest doesn't match the current input manifest. Rebuilding Core.
2025-02-17 21:04:13 INFO     Core engine has new changes, rebuilding all components.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
