### PR TITLE
Update distribution build to use libs 8.2.1 and fix incremental builds with qualifier

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@7.3.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@8.2.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@7.3.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@8.2.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION


### Description
Update distribution build to use libs 8.2.1 and fix incremental builds with qualifier

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
