### PR TITLE
Add LTR into 3.0.0 manifests

### DIFF
--- a/manifests/3.0.0/opensearch-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-3.0.0-test.yml
@@ -73,11 +73,11 @@ components:
         - without-security
 
   - name: opensearch-learning-to-rank-base
-      integ-test:
-        test-configs:
-          - with-security
-          - without-security
-          
+    integ-test:
+      test-configs:
+        - with-security
+        - without-security
+
   - name: ml-commons
     integ-test:
       test-configs:

--- a/manifests/3.0.0/opensearch-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-3.0.0-test.yml
@@ -72,6 +72,12 @@ components:
         - with-security
         - without-security
 
+  - name: opensearch-learning-to-rank-base
+      integ-test:
+        test-configs:
+          - with-security
+          - without-security
+          
   - name: ml-commons
     integ-test:
       test-configs:

--- a/manifests/3.0.0/opensearch-3.0.0.yml
+++ b/manifests/3.0.0/opensearch-3.0.0.yml
@@ -23,6 +23,17 @@ components:
     checks:
       - gradle:publish
       - gradle:properties:version
+  - name: opensearch-learning-to-rank-base
+    repository: https://github.com/opensearch-project/opensearch-learning-to-rank-base
+    ref: main
+    platforms:
+      - linux
+      - windows
+    checks:
+      - gradle:publish
+      - gradle:properties:version
+    depends_on:
+      - common-utils
   - name: opensearch-remote-metadata-sdk
     repository: https://github.com/opensearch-project/opensearch-remote-metadata-sdk.git
     ref: main


### PR DESCRIPTION
### Description
Adds the [opensearch-learning-to-rank-base](https://github.com/opensearch-project/opensearch-learning-to-rank-base) plugin to the 3.0 manifest files.

The plugin was released in 2.19, now that the plugin supports build against jdk 23 adding it to 3.0.0 manifests files.

PR for 2.19 manifests update: #5245

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
