### PR TITLE
Removed dblock@ from CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dblock @peterzhuamazon @gaiksaya @rishabh6788 @zelinh @prudhvigodithi @Divyaasm @tianleh
+* @peterzhuamazon @gaiksaya @rishabh6788 @zelinh @prudhvigodithi @Divyaasm @tianleh


### PR DESCRIPTION
### Description

Removed dblock@ from CODEOWNERS. Forgot to do it as part of #5347.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
