### PR TITLE
Update version increment workflow to remove main/3.x updates

### DIFF
--- a/.github/workflows/os-increment-plugin-versions.yml
+++ b/.github/workflows/os-increment-plugin-versions.yml
@@ -53,9 +53,6 @@ jobs:
           - {repo: opensearch-remote-metadata-sdk}
           - {repo: opensearch-learning-to-rank-base}
         branch:
-          - 2.x
-          - main
-          - '2.18'
           - '2.19'
           - '2.20'
         exclude:

--- a/.github/workflows/os-increment-plugin-versions.yml
+++ b/.github/workflows/os-increment-plugin-versions.yml
@@ -53,8 +53,8 @@ jobs:
           - {repo: opensearch-remote-metadata-sdk}
           - {repo: opensearch-learning-to-rank-base}
         branch:
+          - '2.x'
           - '2.19'
-          - '2.20'
         exclude:
           - {entry: {repo: geospatial}, branch: '1.3'}
           - {entry: {repo: neural-search}, branch: '1.3'}

--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -43,8 +43,8 @@ jobs:
           - {repo: opensearch-dashboards-functional-test}
           - {repo: query-insights-dashboards}
         branch:
+          - '2.x'
           - '2.19'
-          - '2.20'
     steps:
       - name: Check out OpenSearch Dashboards repo
         uses: actions/checkout@v3

--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -43,9 +43,6 @@ jobs:
           - {repo: opensearch-dashboards-functional-test}
           - {repo: query-insights-dashboards}
         branch:
-          - 2.x
-          - main
-          - '2.18'
           - '2.19'
           - '2.20'
     steps:


### PR DESCRIPTION
### Description
Update version increment workflow to remove main/3.x updates

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747
As of now 3.x version increment are crafted specifically to support qualifiers with a lot of tweaks from plugin side.
Disable this for now until after GA so we do not receive PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
