### PR TITLE
Remove ganttcharts in 3.0.0 and update deprecation notice

### DIFF
--- a/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1-test.yml
+++ b/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1-test.yml
@@ -29,11 +29,6 @@ components:
       test-configs:
         - with-security
         - without-security
-  - name: ganttChartDashboards
-    integ-test:
-      test-configs:
-        - with-security
-        - without-security
   - name: indexManagementDashboards
     integ-test:
       test-configs:

--- a/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1.yml
+++ b/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1.yml
@@ -20,9 +20,6 @@ components:
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
     ref: main
-  - name: ganttChartDashboards
-    repository: https://github.com/opensearch-project/dashboards-visualizations.git
-    ref: main
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
     ref: main

--- a/manifests/3.0.0-beta1/opensearch-dashboards-3.0.0-beta1-test.yml
+++ b/manifests/3.0.0-beta1/opensearch-dashboards-3.0.0-beta1-test.yml
@@ -29,11 +29,6 @@ components:
       test-configs:
         - with-security
         - without-security
-  - name: ganttChartDashboards
-    integ-test:
-      test-configs:
-        - with-security
-        - without-security
   - name: indexManagementDashboards
     integ-test:
       test-configs:

--- a/manifests/3.0.0-beta1/opensearch-dashboards-3.0.0-beta1.yml
+++ b/manifests/3.0.0-beta1/opensearch-dashboards-3.0.0-beta1.yml
@@ -20,9 +20,6 @@ components:
   - name: reportsDashboards
     repository: https://github.com/opensearch-project/dashboards-reporting.git
     ref: main
-  - name: ganttChartDashboards
-    repository: https://github.com/opensearch-project/dashboards-visualizations.git
-    ref: main
   - name: queryWorkbenchDashboards
     repository: https://github.com/opensearch-project/dashboards-query-workbench.git
     ref: main

--- a/release-notes/opensearch-release-notes-2.19.0.md
+++ b/release-notes/opensearch-release-notes-2.19.0.md
@@ -81,7 +81,10 @@ OpenSearch 2.19 includes the following experimental functionality. Experimental 
 #### DEPRECATION NOTICES
 
 **Deprecating support for Ubuntu Linux 20.04**
-Please note that OpenSearch will deprecate support for Ubuntu Linux 20.04 as a continuous integration build image and supported operating system in an upcoming version, as Ubuntu Linux 20.04 will reach end-of-life with standard support as of April 2025 (refer to [this notice](https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare) from Canonical Ubuntu). For a list of OpenSearch's compatible operating systems, [visit here](https://opensearch.org/docs/latest/install-and-configure/os-comp/).
+Please note that OpenSearch and OpenSearch Dashboards will deprecate support for Ubuntu Linux 20.04 as a continuous integration build image and supported operating system in an upcoming version, as Ubuntu Linux 20.04 will reach end-of-life with standard support as of April 2025 (refer to [this notice](https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare) from Canonical Ubuntu). For a list of the compatible operating systems, [visit here](https://opensearch.org/docs/latest/install-and-configure/os-comp/).
+
+**Deprecating support for Amazon Linux 2 on OpenSearch Dashboards**
+Please note that OpenSearch Dashboards will deprecate support for Amazon Linux 2 as a continuous integration build image and supported operating system in an upcoming version, as Node.js 18 will reach end-of-life with support as of April 2025 (refer to [this notice](https://nodejs.org/en/blog/announcements/v18-release-announce) from nodejs.org) and newer version of Node.js LTS version (20+) will not support runtime on Amazon Linux 2. For a list of the compatible operating systems, [visit here](https://opensearch.org/docs/latest/install-and-configure/os-comp/).
 
 **Deprecating support for features and plugins in OpenSearch 3.0.0**
 Please note that OpenSearch and OpenSearch Dashboards will deprecate support for the following features and plugins in [OpenSearch 3.0.0](https://github.com/opensearch-project/opensearch-build/issues/3747):
@@ -91,6 +94,9 @@ Please note that OpenSearch and OpenSearch Dashboards will deprecate support for
 * [Dashboards-Observability](https://github.com/opensearch-project/dashboards-observability/issues/2311): Support will be removed for legacy notebooks from observability indexes.
 * [SQL](https://github.com/opensearch-project/sql/issues/3248): OpenSearch 3.0.0 will deprecate the OpenSearch DSL format as well as several settings, remove the SparkSQL connector, and remove DELETE statement support in SQL.
 * [k-NN](https://github.com/opensearch-project/k-NN/issues/2396): OpenSearch 3.0.0 will deprecate the NMSLIB engine. Users will be advised to use the Faiss or Lucene engines instead.
+
+
+For more updates on breaking changes and deprecated/removed features in version 3.0.0, please see details in the [meta issues](https://github.com/opensearch-project/opensearch-build/issues/5243).
 
 
 ## Release Details


### PR DESCRIPTION
### Description
Remove ganttcharts in 3.0.0 and update deprecation notice

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9459
https://github.com/opensearch-project/dashboards-visualizations/issues/411

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
