### PR TITLE
Set vex notice to off in docker scan

### DIFF
--- a/jenkins/docker/docker-scan.jenkinsfile
+++ b/jenkins/docker/docker-scan.jenkinsfile
@@ -20,6 +20,7 @@ pipeline {
     environment {
         TRIVY_DB_REPOSITORY = 'public.ecr.aws/aquasecurity/trivy-db'
         TRIVY_JAVA_DB_REPOSITORY = 'public.ecr.aws/aquasecurity/trivy-java-db'
+        TRIVY_DISABLE_VEX_NOTICE = true
     }
     parameters {
         string(


### PR DESCRIPTION
### Description
Set vex notice to off in docker scan

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
