### PR TITLE
Update release notes workflows to support qualifier and update gradle check lib 8.2.3

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@7.3.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@8.2.3', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -50,7 +50,7 @@ pipeline {
         choice(
             name: 'AGENT_LABEL',
             description: 'Choose which jenkins agent to run gradle check on',
-            choices: ['Jenkins-Agent-Ubuntu2004-X64-M58xlarge-Single-Host', 'Jenkins-Agent-Ubuntu2404-X64-M58xlarge-Single-Host', 'Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host'],
+            choices: ['Jenkins-Agent-Ubuntu2404-X64-M58xlarge-Single-Host', 'Jenkins-Agent-Windows2019-X64-C524xlarge-Single-Host'],
         )
     }
     triggers {

--- a/src/release_notes_workflow/release_notes.py
+++ b/src/release_notes_workflow/release_notes.py
@@ -31,7 +31,7 @@ class ReleaseNotes:
                 if (component.name == 'OpenSearch' or component.name == 'OpenSearch-Dashboards' or component.name == 'notifications-core') and self.action_type == 'compile':
                     continue
                 if hasattr(component, "repository"):
-                    table_result.append(self.check(component, manifest.build.version))  # type: ignore[arg-type]
+                    table_result.append(self.check(component, manifest.build.version, manifest.build.qualifier))  # type: ignore[arg-type]
 
         # Sort table_result based on Repo column
         table_result.sort(key=lambda x: (x[0], x[1]) if len(x) > 1 else x[0])
@@ -50,7 +50,7 @@ class ReleaseNotes:
         )
         return writer
 
-    def check(self, component: InputComponentFromSource, build_version: str) -> List:
+    def check(self, component: InputComponentFromSource, build_version: str, build_qualifier: str) -> List:
         results = []
         with TemporaryDirectory(chdir=True) as work_dir:
             results.append(component.name)
@@ -62,7 +62,7 @@ class ReleaseNotes:
                     component.working_directory,
             ) as repo:
                 logging.debug(f"Checked out {component.name} into {repo.dir}")
-                release_notes = ReleaseNotesComponents.from_component(component, build_version, repo.dir)
+                release_notes = ReleaseNotesComponents.from_component(component, build_version, build_qualifier, repo.dir)
                 commits = repo.log(self.date)
                 if len(commits) > 0:
                     last_commit = commits[-1]

--- a/src/release_notes_workflow/release_notes_component.py
+++ b/src/release_notes_workflow/release_notes_component.py
@@ -13,9 +13,10 @@ from manifests.input_manifest import InputComponentFromSource
 
 class ReleaseNotesComponent:
 
-    def __init__(self, component: InputComponentFromSource, build_version: str, root: str) -> None:
+    def __init__(self, component: InputComponentFromSource, build_version: str, build_qualifier: str, root: str) -> None:
         self.component = component
         self.build_version = build_version
+        self.build_qualifier = f'-{build_qualifier}' if build_qualifier else ''
         self.root = root
 
     @property
@@ -53,7 +54,7 @@ class ReleaseNotesOpenSearch(ReleaseNotesComponent):
 
     @property
     def filename(self) -> str:
-        release_notes_filename = f'.release-notes-{self.build_version}.md'
+        release_notes_filename = f'.release-notes-{self.build_version}{self.build_qualifier}.md'
         return release_notes_filename
 
 
@@ -61,15 +62,15 @@ class ReleaseNotesOpenSearchPlugin(ReleaseNotesComponent):
 
     @property
     def filename(self) -> str:
-        release_notes_filename = f'.release-notes-{self.build_version}.0.md'
+        release_notes_filename = f'.release-notes-{self.build_version}.0{self.build_qualifier}.md'
         return release_notes_filename
 
 
 class ReleaseNotesComponents:
 
     @classmethod
-    def from_component(self, component: InputComponentFromSource, build_version: str, root: str) -> ReleaseNotesComponent:
+    def from_component(self, component: InputComponentFromSource, build_version: str, build_qualifier: str, root: str) -> ReleaseNotesComponent:
         if component.name == 'OpenSearch' or component.name == 'OpenSearch-Dashboards':
-            return ReleaseNotesOpenSearch(component, build_version, root)
+            return ReleaseNotesOpenSearch(component, build_version, build_qualifier, root)
         else:
-            return ReleaseNotesOpenSearchPlugin(component, build_version, root)
+            return ReleaseNotesOpenSearchPlugin(component, build_version, build_qualifier, root)

--- a/tests/data/opensearch-test-main-qualifier.yml
+++ b/tests/data/opensearch-test-main-qualifier.yml
@@ -1,0 +1,17 @@
+---
+schema-version: '1.1'
+build:
+  name: OpenSearch
+  version: '1.0'
+  qualifier: alpha1
+ci:
+  image:
+    name: opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3
+    args: -e JAVA_HOME=/opt/java/openjdk-17
+components:
+  - name: OpenSearch-test
+    repository: https://github.com/opensearch-project/OpenSearch.git
+    ref: main
+    checks:
+      - gradle:publish
+      - gradle:properties:version

--- a/tests/tests_release_notes_workflow/test_release_note_multiple_manifest.py
+++ b/tests/tests_release_notes_workflow/test_release_note_multiple_manifest.py
@@ -23,12 +23,18 @@ class TestReleaseNotes(unittest.TestCase):
 
     def setUp(self) -> None:
         OPENSEARCH_MANIFEST = os.path.realpath(os.path.join(TestReleaseNotes.MANIFESTS, "opensearch-test-main.yml"))
+        OPENSEARCH_MANIFEST_QUALIFIER = os.path.realpath(os.path.join(TestReleaseNotes.MANIFESTS, "opensearch-test-main-qualifier.yml"))
         DASHBOARDS_MANIFEST = os.path.realpath(
             os.path.join(TestReleaseNotes.MANIFESTS, "opensearch-dashboards-test-main.yml"))
         self.opensearch_manifest = InputManifest.from_file(open(OPENSEARCH_MANIFEST))
+        self.opensearch_manifest_qualifier = InputManifest.from_file(open(OPENSEARCH_MANIFEST_QUALIFIER))
         self.dashboards_manifest = InputManifest.from_file(open(DASHBOARDS_MANIFEST))
         self.build_version = self.opensearch_manifest.build.version
+        self.build_qualifier = self.opensearch_manifest.build.qualifier
+        self.build_with_qualifier_version = self.opensearch_manifest_qualifier.build.version
+        self.build_with_qualifier_qualifier = self.opensearch_manifest_qualifier.build.qualifier
         self.release_notes = ReleaseNotes([self.opensearch_manifest, self.dashboards_manifest], "2022-07-26", "compile")
+        self.release_notes_qualifier = ReleaseNotes([self.opensearch_manifest_qualifier, self.dashboards_manifest], "2022-07-26", "compile")
         self.opensearch_component = InputComponentFromSource(
             {"name": "OpenSearch-test", "repository": "url", "ref": "ref"})
         self.dashboards_component = InputComponentFromSource(
@@ -37,16 +43,24 @@ class TestReleaseNotes(unittest.TestCase):
     @patch("subprocess.check_output", return_value=''.encode())
     @patch("subprocess.check_call")
     def test_check(self, *mocks: Any) -> None:
-        self.assertEqual(self.release_notes.check(self.opensearch_component, self.build_version),
+        self.assertEqual(self.release_notes.check(self.opensearch_component, self.build_version, self.build_qualifier),
                          ['OpenSearch-test', '[ref]', None, None, False, None])
-        self.assertEqual(self.release_notes.check(self.dashboards_component, self.build_version),
+        self.assertEqual(self.release_notes.check(self.dashboards_component, self.build_version, self.build_qualifier),
+                         ['OpenSearch-Dashboards-test', '[ref]', None, None, False, None])
+
+    @patch("subprocess.check_output", return_value=''.encode())
+    @patch("subprocess.check_call")
+    def test_check_qualifier(self, *mocks: Any) -> None:
+        self.assertEqual(self.release_notes_qualifier.check(self.opensearch_component, self.build_version, self.build_with_qualifier_qualifier),
+                         ['OpenSearch-test', '[ref]', None, None, False, None])
+        self.assertEqual(self.release_notes_qualifier.check(self.dashboards_component, self.build_version, self.build_with_qualifier_qualifier),
                          ['OpenSearch-Dashboards-test', '[ref]', None, None, False, None])
 
     @patch("subprocess.check_output", return_value=''.encode())
     @patch("subprocess.check_call")
     def test_table(self, *mocks: Any) -> None:
-        self.release_notes.check(self.opensearch_component, self.build_version)
-        self.release_notes.check(self.dashboards_component, self.build_version)
+        self.release_notes.check(self.opensearch_component, self.build_version, self.build_qualifier)
+        self.release_notes.check(self.dashboards_component, self.build_version, self.build_qualifier)
         self.release_notes.table()
 
         self.assertEqual(self.release_notes.table()._table_name.strip(),
@@ -54,5 +68,20 @@ class TestReleaseNotes(unittest.TestCase):
         self.assertEqual(self.release_notes.table().headers,
                          ['Repo', 'Branch', 'CommitID', 'Commit Date', 'Release Notes Exists', 'URL'])
         self.assertEqual(self.release_notes.table().value_matrix,
+                         [['OpenSearch-Dashboards-test', '[main]', None, None, False, None],
+                          ['OpenSearch-test', '[main]', None, None, False, None]])
+
+    @patch("subprocess.check_output", return_value=''.encode())
+    @patch("subprocess.check_call")
+    def test_table_qualifier(self, *mocks: Any) -> None:
+        self.release_notes_qualifier.check(self.opensearch_component, self.build_with_qualifier_version, self.build_with_qualifier_qualifier)
+        self.release_notes_qualifier.check(self.dashboards_component, self.build_with_qualifier_version, self.build_with_qualifier_qualifier)
+        self.release_notes_qualifier.table()
+
+        self.assertEqual(self.release_notes_qualifier.table()._table_name.strip(),
+                         'Core Components CommitID(after 2022-07-26) & Release Notes info')
+        self.assertEqual(self.release_notes_qualifier.table().headers,
+                         ['Repo', 'Branch', 'CommitID', 'Commit Date', 'Release Notes Exists', 'URL'])
+        self.assertEqual(self.release_notes_qualifier.table().value_matrix,
                          [['OpenSearch-Dashboards-test', '[main]', None, None, False, None],
                           ['OpenSearch-test', '[main]', None, None, False, None]])

--- a/tests/tests_release_notes_workflow/test_release_notes_component.py
+++ b/tests/tests_release_notes_workflow/test_release_notes_component.py
@@ -23,7 +23,7 @@ class TestReleaseNotesComponent(unittest.TestCase):
             return "release-notes-2.0.0.md"
 
     def setUp(self) -> None:
-        self.release_notes_component = self.MyReleaseNotesComponent(MagicMock(), "2.2.0", "path")
+        self.release_notes_component = self.MyReleaseNotesComponent(MagicMock(), "2.2.0", "", "path")
 
     def test_path(self) -> None:
         self.assertEqual(self.release_notes_component.path, os.path.join("path", "release-notes"))
@@ -52,30 +52,62 @@ class TestReleaseNotesComponent(unittest.TestCase):
 class TestReleaseNotesOpenSearch(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.release_notes_component = ReleaseNotesOpenSearch(MagicMock(), "2.2.0", "path")
+        self.release_notes_component = ReleaseNotesOpenSearch(MagicMock(), "2.2.0", "", "path")
 
     def test_filename(self) -> None:
         self.assertEqual(self.release_notes_component.filename, ".release-notes-2.2.0.md")
 
 
+class TestReleaseNotesOpenSearchQualifier(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.release_notes_component = ReleaseNotesOpenSearch(MagicMock(), "2.2.0", "alpha1", "path")
+
+    def test_filename(self) -> None:
+        self.assertEqual(self.release_notes_component.filename, ".release-notes-2.2.0-alpha1.md")
+
+
 class TestReleaseNotesOpenSearchPlugin(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.release_notes_component = ReleaseNotesOpenSearchPlugin(MagicMock(), "2.2.0", "path")
+        self.release_notes_component = ReleaseNotesOpenSearchPlugin(MagicMock(), "2.2.0", "", "path")
 
     def test_filename(self) -> None:
         self.assertEqual(self.release_notes_component.filename, ".release-notes-2.2.0.0.md")
 
 
+class TestReleaseNotesOpenSearchPluginQualifier(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.release_notes_component = ReleaseNotesOpenSearchPlugin(MagicMock(), "2.2.0", "alpha1", "path")
+
+    def test_filename(self) -> None:
+        self.assertEqual(self.release_notes_component.filename, ".release-notes-2.2.0.0-alpha1.md")
+
+
 class TestComponentsReleaseNotes(unittest.TestCase):
 
     def test_from_component(self) -> None:
-        self.assertIsInstance(ReleaseNotesComponents.from_component(MagicMock(), "2.2.0", "path"), ReleaseNotesComponent)
+        self.assertIsInstance(ReleaseNotesComponents.from_component(MagicMock(), "2.2.0", "", "path"), ReleaseNotesComponent)
 
     def test_from_component_open_search(self) -> None:
         test_component_opensearch = InputComponentFromSource({"name": "OpenSearch", "repository": "url", "ref": "ref"})
-        self.assertIsInstance(ReleaseNotesComponents.from_component(test_component_opensearch, "2.2.0", "path"), ReleaseNotesOpenSearch)
+        self.assertIsInstance(ReleaseNotesComponents.from_component(test_component_opensearch, "2.2.0", "", "path"), ReleaseNotesOpenSearch)
 
     def test_from_component_open_search_plugin(self) -> None:
         test_component_plugin = InputComponentFromSource({"name": "common-utils", "repository": "url", "ref": "ref"})
-        self.assertIsInstance(ReleaseNotesComponents.from_component(test_component_plugin, "2.2.0", "path"), ReleaseNotesOpenSearchPlugin)
+        self.assertIsInstance(ReleaseNotesComponents.from_component(test_component_plugin, "2.2.0", "", "path"), ReleaseNotesOpenSearchPlugin)
+
+
+class TestComponentsReleaseNotesQualifier(unittest.TestCase):
+
+    def test_from_component(self) -> None:
+        self.assertIsInstance(ReleaseNotesComponents.from_component(MagicMock(), "2.2.0", "alpha1", "path"), ReleaseNotesComponent)
+
+    def test_from_component_open_search(self) -> None:
+        test_component_opensearch = InputComponentFromSource({"name": "OpenSearch", "repository": "url", "ref": "ref"})
+        self.assertIsInstance(ReleaseNotesComponents.from_component(test_component_opensearch, "2.2.0", "alpha1", "path"), ReleaseNotesOpenSearch)
+
+    def test_from_component_open_search_plugin(self) -> None:
+        test_component_plugin = InputComponentFromSource({"name": "common-utils", "repository": "url", "ref": "ref"})
+        self.assertIsInstance(ReleaseNotesComponents.from_component(test_component_plugin, "2.2.0", "alpha1", "path"), ReleaseNotesOpenSearchPlugin)


### PR DESCRIPTION


### Description
Update release notes workflows to support qualifier and update gradle check lib 8.2.3

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747
https://build.ci.opensearch.org/job/gradle-check/54277/console

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
