### PR TITLE
add path.repo to KNN for 2.20 and 3.0.0-alpha1

### DIFF
--- a/manifests/2.20.0/opensearch-2.20.0-test.yml
+++ b/manifests/2.20.0/opensearch-2.20.0-test.yml
@@ -77,6 +77,9 @@ components:
       test-configs:
         - with-security
         - without-security
+      additional-cluster-configs:
+        path.repo:
+          - /tmp
   - name: ml-commons
     integ-test:
       test-configs:

--- a/manifests/3.0.0-alpha1/opensearch-3.0.0-alpha1-test.yml
+++ b/manifests/3.0.0-alpha1/opensearch-3.0.0-alpha1-test.yml
@@ -83,6 +83,9 @@ components:
       test-configs:
         - with-security
         - without-security
+      additional-cluster-configs:
+        path.repo:
+          - /tmp
     smoke-test:
       test-spec: k-NN.yml
   - name: ml-commons


### PR DESCRIPTION
### Description
The 3.0.0-alpha1 release build was failing KNN integ tests https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/9442/pipeline/139. Specifically the RestoreSnapshotIT test. There is a prior PR https://github.com/opensearch-project/opensearch-build/pull/5286 that fixed this error for 2.19 release, so this PR adds the same fix for 2.20 and 3.0.0-alpha1.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
