### PR TITLE
add node.attr.knn_cb_tier to 2.20.0 & 3.0.0-alpha1

### DIFF
--- a/manifests/2.20.0/opensearch-2.20.0-test.yml
+++ b/manifests/2.20.0/opensearch-2.20.0-test.yml
@@ -78,6 +78,7 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
+        node.attr.knn_cb_tier: integ
         path.repo:
           - /tmp
   - name: ml-commons

--- a/manifests/3.0.0-alpha1/opensearch-3.0.0-alpha1-test.yml
+++ b/manifests/3.0.0-alpha1/opensearch-3.0.0-alpha1-test.yml
@@ -84,6 +84,7 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
+        node.attr.knn_cb_tier: integ
         path.repo:
           - /tmp
     smoke-test:


### PR DESCRIPTION
### Description

Recently support was added for a node-level circuit breaker in k-nn which requires a cluster-level setting to be defined in the integration test. Since Jenkins spins up a independent cluster these settings were not picked up and need to be defined in the yml file. 

### Issues Resolved

Similar to #5387 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
