### PR TITLE
Reset jdk to 21 for test manifests and windows runner

### DIFF
--- a/docker/ci/config/windows-setup.ps1
+++ b/docker/ci/config/windows-setup.ps1
@@ -105,8 +105,8 @@ Foreach ($jdkVersion in $jdkVersionList)
     [System.Environment]::SetEnvironmentVariable($jdkArray[1], "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)
     java -version
 }
-# Switch to temurin11-jdk as it is the widest supported version to build OpenSearch
-scoop reset temurin11-jdk
+# Switch to temurin21-jdk as 3.0.0 is baselined to 21
+scoop reset temurin21-jdk
 $JAVA_HOME_TEMP = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::User).replace("\", "/")
 $JAVA_HOME_TEMP
 [System.Environment]::SetEnvironmentVariable('JAVA_HOME', "$JAVA_HOME_TEMP", [System.EnvironmentVariableTarget]::User)

--- a/manifests/3.0.0-alpha1/opensearch-3.0.0-alpha1-test.yml
+++ b/manifests/3.0.0-alpha1/opensearch-3.0.0-alpha1-test.yml
@@ -4,7 +4,7 @@ name: OpenSearch
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1
-    args: -e JAVA_HOME=/opt/java/openjdk-23
+    args: -e JAVA_HOME=/opt/java/openjdk-21
 components:
   - name: OpenSearch
     integ-test:

--- a/manifests/3.0.0-beta1/opensearch-3.0.0-beta1-test.yml
+++ b/manifests/3.0.0-beta1/opensearch-3.0.0-beta1-test.yml
@@ -4,7 +4,7 @@ name: OpenSearch
 ci:
   image:
     name: opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1
-    args: -e JAVA_HOME=/opt/java/openjdk-23
+    args: -e JAVA_HOME=/opt/java/openjdk-21
 components:
   - name: OpenSearch
     integ-test:


### PR DESCRIPTION
### Description
Reset jdk to 21 for test manifests and windows runner

### Issues Resolved
#3747

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
