### PR TITLE
Ensure scripted pipeline also pull latest docker images

### DIFF
--- a/jenkins/opensearch-dashboards/integ-test.jenkinsfile
+++ b/jenkins/opensearch-dashboards/integ-test.jenkinsfile
@@ -245,6 +245,7 @@ pipeline {
                               timeout(time: 3, unit: 'HOURS') {
                                 node(AGENT_LABEL) {
                                   docker.withRegistry('https://public.ecr.aws/') {
+                                    docker.image(docker_images["$distribution"]).pull() // always pull latest
                                     docker.image(docker_images["$distribution"]).inside(docker_args["$distribution"]) {
                                       try {
                                         stage("${local_component}-ci-group-${ciNum}") {

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -215,6 +215,7 @@ pipeline {
                             timeout(time: 2, unit: 'HOURS') {
                                 node(AGENT_LABEL) {
                                     docker.withRegistry('https://public.ecr.aws/') {
+                                        docker.image(docker_images["$distribution"]).pull() // always pull latest
                                         docker.image(docker_images["$distribution"]).inside(docker_args["$distribution"]) {
                                             try {
                                                 stage("${local_component}") {

--- a/jenkins/validate-artifacts/validate-artifacts.jenkinsfile
+++ b/jenkins/validate-artifacts/validate-artifacts.jenkinsfile
@@ -233,6 +233,7 @@ pipeline {
                                         }
                                     } else {
                                         node(agent_nodes["${local_platform}_${local_architecture}"]) {
+                                            docker.image(docker_images["$local_distribution"]).pull() // always pull latest
                                             docker.withRegistry('https://public.ecr.aws/') {
                                                 docker.image(docker_images["$local_distribution"]).inside(docker_args["$local_distribution"]) {
                                                     try {


### PR DESCRIPTION
### Description
Ensure scripted pipeline also pull latest docker images.
Scripted language docs: https://github.com/jenkinsci/docker-workflow-plugin/tree/docker-workflow-1.12/demo

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
