### PR TITLE
Update binaryspec for deb creation as debmake=4.3.2-1 and above introduced nodejs

### DIFF
--- a/scripts/components/OpenSearch-Dashboards/install.sh
+++ b/scripts/components/OpenSearch-Dashboards/install.sh
@@ -86,12 +86,12 @@ fi
 
 if [ "$DISTRIBUTION" = "rpm" -o "$DISTRIBUTION" = "deb" ]; then
     cp -v ../../../config/opensearch_dashboards-$MAJOR_VERSION.x.yml "$OUTPUT/../etc/opensearch-dashboards/opensearch_dashboards.yml"
-    cp -a ../../../scripts/pkg/service_templates/opensearch-dashboards/* "$OUTPUT/../"
+    cp -va ../../../scripts/pkg/service_templates/opensearch-dashboards/* "$OUTPUT/../"
 
     if [ "$MAJOR_VERSION" = "1" ]; then
-        cp -a ../../../scripts/pkg/build_templates/legacy/opensearch-dashboards/$DISTRIBUTION/* "$OUTPUT/../"
+        cp -va ../../../scripts/pkg/build_templates/legacy/opensearch-dashboards/$DISTRIBUTION/* "$OUTPUT/../"
     else
-        cp -a ../../../scripts/pkg/build_templates/current/opensearch-dashboards/$DISTRIBUTION/* "$OUTPUT/../"
+        cp -va ../../../scripts/pkg/build_templates/current/opensearch-dashboards/$DISTRIBUTION/* "$OUTPUT/../"
     fi
 else
     cp -v ../../../config/opensearch_dashboards-$MAJOR_VERSION.x.yml "$OUTPUT/config/opensearch_dashboards.yml"

--- a/src/assemble_workflow/bundle_linux_deb.py
+++ b/src/assemble_workflow/bundle_linux_deb.py
@@ -109,6 +109,10 @@ class BundleLinuxDeb:
         deb_version = build_cls.version.replace('-', '.')
         self.generate_changelog_file(ext_dest, deb_version)
 
+        # 20250316: debmake since 4.3.2-1 introduced nodejs type with auto detection of js
+        # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=954828
+        # Official update to 4.4.0-3 further replace pkg-js-tools with dh-nodejs here:
+        # https://launchpad.net/ubuntu/+source/debmake/+changelog
         bundle_cmd = " ".join(
             [
                 'debmake',
@@ -117,6 +121,7 @@ class BundleLinuxDeb:
                 '--invoke debuild',
                 f'--package {self.filename}',
                 '--native',
+                f'--binaryspec {self.filename}:bin' if self.filename == 'opensearch' else f'--binaryspec {self.filename}:nodejs',
                 '--revision 1',
                 f"--upstreamversion {deb_version}"
             ]

--- a/tests/tests_assemble_workflow/test_bundle_linux_deb.py
+++ b/tests/tests_assemble_workflow/test_bundle_linux_deb.py
@@ -56,7 +56,8 @@ class TestBundleLinuxDeb(unittest.TestCase):
 
         self.assertRaises(KeyError, lambda: os.environ['OPENSEARCH_PATH_CONF'])
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual('debmake --fullname "OpenSearch Team" --email "release@opensearch.org" --invoke debuild --package opensearch --native --revision 1 --upstreamversion 1.3.0',
+        self.assertEqual('debmake --fullname "OpenSearch Team" --email "release@opensearch.org" --invoke debuild --package opensearch --native '
+                         '--binaryspec opensearch:bin --revision 1 --upstreamversion 1.3.0',
                          args_list_deb[0][0][0])
         self.assertEqual(shutil_move_mock.call_count, 2)
         self.assertEqual(generate_changelog_file_call_mock.call_count, 1)
@@ -74,7 +75,8 @@ class TestBundleLinuxDeb(unittest.TestCase):
 
         self.assertRaises(KeyError, lambda: os.environ['OPENSEARCH_PATH_CONF'])
         self.assertEqual(check_call_mock.call_count, 1)
-        self.assertEqual('debmake --fullname "OpenSearch Team" --email "release@opensearch.org" --invoke debuild --package opensearch --native --revision 1 --upstreamversion 2.0.0.alpha1',
+        self.assertEqual('debmake --fullname "OpenSearch Team" --email "release@opensearch.org" --invoke debuild --package opensearch --native '
+                         '--binaryspec opensearch:bin --revision 1 --upstreamversion 2.0.0.alpha1',
                          args_list_deb_qualifier[0][0][0])
         self.assertEqual(shutil_move_mock.call_count, 2)
         self.assertEqual(generate_changelog_file_call_mock.call_count, 1)


### PR DESCRIPTION
### Description
Update binaryspec for deb creation as debmake=4.3.2-1 and above introduced nodejs
Note that with dh_installsystemd/13.14.1ubuntu5 the postrm script will auto add which is nice.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747

```
W: many ext = "javascript" type extension programs without matching -b set.

?: -b":nodejs, ..." missing. Continue? [Y/n]: Traceback (most recent call last):

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
