### PR TITLE
Change tj-actions/changed-files usage from sha to latest version

### DIFF
--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Get changed manifest files
-        uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
         id: list-changed-manifests
         with:
           files: manifests/**/opensearch*.yml


### PR DESCRIPTION
### Description
Change tj-actions/changed-files usage from sha to latest [version](https://github.com/tj-actions/changed-files/releases)

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/5400

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
