### PR TITLE
Update manifest repopath and temp resolve osd compiling issues on windows

### DIFF
--- a/manifests/2.19.1/opensearch-2.19.1-test.yml
+++ b/manifests/2.19.1/opensearch-2.19.1-test.yml
@@ -80,8 +80,10 @@ components:
         - with-security
         - without-security
       additional-cluster-configs:
+        node.attr.knn_cb_tier: integ
         path.repo:
           - /tmp
+          - 'C:\'
     smoke-test:
       test-spec: k-NN.yml
   - name: ml-commons

--- a/manifests/2.19.1/opensearch-2.19.1.yml
+++ b/manifests/2.19.1/opensearch-2.19.1.yml
@@ -71,6 +71,8 @@ components:
       - windows
     depends_on:
       - common-utils
+      - job-scheduler
+      - opensearch-remote-metadata-sdk
   - name: neural-search
     repository: https://github.com/opensearch-project/neural-search.git
     ref: tags/2.19.1.0

--- a/manifests/2.20.0/opensearch-2.20.0-test.yml
+++ b/manifests/2.20.0/opensearch-2.20.0-test.yml
@@ -81,6 +81,7 @@ components:
         node.attr.knn_cb_tier: integ
         path.repo:
           - /tmp
+          - 'C:\'
   - name: ml-commons
     integ-test:
       test-configs:

--- a/manifests/3.0.0-alpha1/opensearch-3.0.0-alpha1-test.yml
+++ b/manifests/3.0.0-alpha1/opensearch-3.0.0-alpha1-test.yml
@@ -87,6 +87,7 @@ components:
         node.attr.knn_cb_tier: integ
         path.repo:
           - /tmp
+          - 'C:\'
     smoke-test:
       test-spec: k-NN.yml
   - name: ml-commons

--- a/src/build_workflow/builder_from_source.py
+++ b/src/build_workflow/builder_from_source.py
@@ -21,10 +21,17 @@ Artifacts found in "<build root>/artifacts/<maven|plugins|libs|dist|core-plugins
 
 class BuilderFromSource(Builder):
     def checkout(self, work_dir: str) -> None:
+        # TODO: Reduce temp dir randomized dirname char counts or remove this after qualifier
+        # This is a temporary fix for OSD Core
+        # Due to path of node installation is longer than 200 chars and cause path not able to be removed
+        # https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9397#issuecomment-2727641857
+        # Even 'osd' would not be enough for the proper cleanup so switch to 'o' for now
+        # https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9397#issuecomment-2731257431
+        component_name = self.component.name if self.component.name != 'OpenSearch-Dashboards' else 'o'
         self.git_repo = GitRepository(
             self.component.repository,
             self.component.ref,
-            os.path.join(work_dir, self.component.name),
+            os.path.join(work_dir, component_name),
             self.component.working_directory,
         )
 

--- a/src/system/temporary_directory.py
+++ b/src/system/temporary_directory.py
@@ -41,7 +41,7 @@ class TemporaryDirectory:
     def __init__(self, keep: bool = False, chdir: bool = False) -> None:
         self.keep = keep
         if current_platform() == "windows":
-            windows_home_dir = os.path.expanduser('~')
+            windows_home_dir = os.path.abspath("C:\\")  # Reduce char counts on windows path
             self.name = tempfile.mkdtemp(dir=windows_home_dir)
         else:
             self.name = tempfile.mkdtemp()

--- a/tests/tests_system/test_temporary_directory.py
+++ b/tests/tests_system/test_temporary_directory.py
@@ -57,7 +57,7 @@ class TestTemporaryDirectory(unittest.TestCase):
     def test_path_windows(self) -> None:
         with TemporaryDirectory() as work_dir:
             if current_platform() == "windows":
-                windows_home_dir = os.path.expanduser('~')
+                windows_home_dir = os.path.abspath("C:\\")
                 self.assertTrue(str(work_dir.path).startswith(windows_home_dir))
             else:
                 self.assertTrue(str(work_dir.path).startswith(tempfile.gettempdir()))


### PR DESCRIPTION
### Description
Update manifest repopath and temp resolve osd compiling issues on windows

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9397


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
