### PR TITLE
Restore osd path as it does not correctly fix windows error

### DIFF
--- a/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1.yml
+++ b/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1.yml
@@ -9,7 +9,7 @@ ci:
     name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-build-v1
 components:
   - name: OpenSearch-Dashboards
-    repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+    repository: https://github.com/peterzhuamazon/OpenSearch-Dashboards.git
     ref: main
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git

--- a/src/build_workflow/builder_from_source.py
+++ b/src/build_workflow/builder_from_source.py
@@ -21,17 +21,10 @@ Artifacts found in "<build root>/artifacts/<maven|plugins|libs|dist|core-plugins
 
 class BuilderFromSource(Builder):
     def checkout(self, work_dir: str) -> None:
-        # TODO: Reduce temp dir randomized dirname char counts or remove this after qualifier
-        # This is a temporary fix for OSD Core
-        # Due to path of node installation is longer than 200 chars and cause path not able to be removed
-        # https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9397#issuecomment-2727641857
-        # Even 'osd' would not be enough for the proper cleanup so switch to 'o' for now
-        # https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9397#issuecomment-2731257431
-        component_name = self.component.name if self.component.name != 'OpenSearch-Dashboards' else 'o'
         self.git_repo = GitRepository(
             self.component.repository,
             self.component.ref,
-            os.path.join(work_dir, component_name),
+            os.path.join(work_dir, self.component.name),
             self.component.working_directory,
         )
 

--- a/src/system/temporary_directory.py
+++ b/src/system/temporary_directory.py
@@ -42,7 +42,7 @@ class TemporaryDirectory:
         self.keep = keep
         if current_platform() == "windows":
             windows_home_dir = os.path.abspath("C:\\")  # Reduce char counts on windows path
-            self.name = tempfile.mkdtemp(dir=windows_home_dir)
+            self.name = tempfile.mkdtemp(dir=windows_home_dir, prefix='')  # Reduce char counts on windows path
         else:
             self.name = tempfile.mkdtemp()
 

--- a/tests/tests_system/test_temporary_directory.py
+++ b/tests/tests_system/test_temporary_directory.py
@@ -58,6 +58,7 @@ class TestTemporaryDirectory(unittest.TestCase):
         with TemporaryDirectory() as work_dir:
             if current_platform() == "windows":
                 windows_home_dir = os.path.abspath("C:\\")
+                self.assertTrue(not str(work_dir.path).startswith("tmp"))
                 self.assertTrue(str(work_dir.path).startswith(windows_home_dir))
             else:
                 self.assertTrue(str(work_dir.path).startswith(tempfile.gettempdir()))


### PR DESCRIPTION
### Description
Restore osd path as it does not correctly fix windows error

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3747

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
