### PR TITLE
Switch 3.0.0-alpha1 builds back to upstream

### DIFF
--- a/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1.yml
+++ b/manifests/3.0.0-alpha1/opensearch-dashboards-3.0.0-alpha1.yml
@@ -9,7 +9,7 @@ ci:
     name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-build-v1
 components:
   - name: OpenSearch-Dashboards
-    repository: https://github.com/peterzhuamazon/OpenSearch-Dashboards.git
+    repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
     ref: main
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git


### PR DESCRIPTION
### Description
Switch 3.0.0-alpha1 builds back to upstream

### Issues Resolved
#3747
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9561 merged now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
