### PR TITLE
Fix release chore bugs for rc comment and release issue queries

### DIFF
--- a/jenkins/release-workflows/release-chores.jenkinsfile
+++ b/jenkins/release-workflows/release-chores.jenkinsfile
@@ -6,7 +6,7 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-lib = library(identifier: 'jenkins@8.4.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@8.4.2', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))

--- a/tests/jenkins/TestReleaseChores.groovy
+++ b/tests/jenkins/TestReleaseChores.groovy
@@ -25,7 +25,7 @@ class TestReleaseChores extends BuildPipelineTest {
     void setUp() {
         helper.registerSharedLibrary(
             library().name('jenkins')
-                .defaultVersion('8.4.1')
+                .defaultVersion('8.4.2')
                 .allowOverride(true)
                 .implicit(true)
                 .targetPath('vars')


### PR DESCRIPTION
### Description
Fix release chore bugs for rc comment and release issue queries. See the details in release https://github.com/opensearch-project/opensearch-build-libraries/releases/tag/8.4.2

### Issues Resolved
https://github.com/opensearch-project/opensearch-build-libraries/issues/643

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
