### PR TITLE
Add release@opensearch.org keyid to rpm validation

### DIFF
--- a/src/validation_workflow/rpm/validation_rpm.py
+++ b/src/validation_workflow/rpm/validation_rpm.py
@@ -117,8 +117,13 @@ class ValidateRpm(Validation, DownloadUtils):
     def validate_signature(self) -> None:
         (_, stdout, _) = execute(f'rpm -K -v {os.path.join(self.tmp_dir.path, self.filename)}', ".")
         logging.info(stdout)
-        key_list = ["Header V4 RSA/SHA512 Signature, key ID 9310d3fc", "Header SHA256 digest", "Header SHA1 digest",
-                    "Payload SHA256 digest", "V4 RSA/SHA512 Signature, key ID 9310d3fc", "MD5 digest"]
+        major_version = self.args.version.split('.')[0]
+        if int(major_version) > 2:
+            key_list = ["Header V4 RSA/SHA512 Signature, key ID 6ba2427f", "Header SHA256 digest", "Header SHA1 digest",
+                        "Payload SHA256 digest", "V4 RSA/SHA512 Signature, key ID 6ba2427f", "MD5 digest"]
+        else:
+            key_list = ["Header V4 RSA/SHA512 Signature, key ID 9310d3fc", "Header SHA256 digest", "Header SHA1 digest",
+                        "Payload SHA256 digest", "V4 RSA/SHA512 Signature, key ID 9310d3fc", "MD5 digest"]
         present_key = []
         for line in stdout.rstrip('\n').split('\n')[1:]:
             key = line.split(':')[0].strip()


### PR DESCRIPTION
### Description
Add release@opensearch.org keyid to rpm validation

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5308
https://github.com/opensearch-project/opensearch-build/issues/3747

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
