### PR TITLE
Change docker image with python 3.9 and JDK 11 for maven publish

### DIFF
--- a/jenkins/opensearch-maven-release/publish-to-maven.jenkinsfile
+++ b/jenkins/opensearch-maven-release/publish-to-maven.jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     agent {
         docker {
             label 'Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host'
-            image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3'
+            image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211130'
             registryUrl 'https://public.ecr.aws/'
             alwaysPull true
         }

--- a/jenkins/opensearch-maven-release/publish-to-maven.jenkinsfile
+++ b/jenkins/opensearch-maven-release/publish-to-maven.jenkinsfile
@@ -16,7 +16,8 @@ pipeline {
     agent {
         docker {
             label 'Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host'
-            image 'opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211130'
+            image 'opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3'
+            args '-e JAVA_HOME=/opt/java/openjdk-11'
             registryUrl 'https://public.ecr.aws/'
             alwaysPull true
         }

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-maven-release/publish-to-maven.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-maven-release/publish-to-maven.jenkinsfile.txt
@@ -3,7 +3,7 @@
       publish-to-maven.library({identifier=jenkins@9.0.1, retriever=null})
       publish-to-maven.pipeline(groovy.lang.Closure)
          publish-to-maven.credentials(jenkins-artifact-bucket-name)
-         publish-to-maven.echo(Executing on agent [docker:[alwaysPull:true, args:, containerPerStageRoot:false, label:Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host, image:opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211130, reuseNode:false, registryUrl:https://public.ecr.aws/, stages:[:]]])
+         publish-to-maven.echo(Executing on agent [docker:[alwaysPull:true, args:-e JAVA_HOME=/opt/java/openjdk-11, containerPerStageRoot:false, label:Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host, image:opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3, reuseNode:false, registryUrl:https://public.ecr.aws/, stages:[:]]])
          publish-to-maven.stage(sign-stage-and-release, groovy.lang.Closure)
             publish-to-maven.script(groovy.lang.Closure)
                publish-to-maven.echo(Downloading from S3.)

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-maven-release/publish-to-maven.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-maven-release/publish-to-maven.jenkinsfile.txt
@@ -3,7 +3,7 @@
       publish-to-maven.library({identifier=jenkins@9.0.1, retriever=null})
       publish-to-maven.pipeline(groovy.lang.Closure)
          publish-to-maven.credentials(jenkins-artifact-bucket-name)
-         publish-to-maven.echo(Executing on agent [docker:[alwaysPull:true, args:, containerPerStageRoot:false, label:Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host, image:opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3, reuseNode:false, registryUrl:https://public.ecr.aws/, stages:[:]]])
+         publish-to-maven.echo(Executing on agent [docker:[alwaysPull:true, args:, containerPerStageRoot:false, label:Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host, image:opensearchstaging/ci-runner:centos7-x64-arm64-jdkmulti-node10.24.1-cypress6.9.1-20211130, reuseNode:false, registryUrl:https://public.ecr.aws/, stages:[:]]])
          publish-to-maven.stage(sign-stage-and-release, groovy.lang.Closure)
             publish-to-maven.script(groovy.lang.Closure)
                publish-to-maven.echo(Downloading from S3.)


### PR DESCRIPTION
### Description
Change docker image with python 3.9 and JDK 11 for maven publish

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
