### PR TITLE
Update windows normal docker with jdk24

### DIFF
--- a/docker/ci/config/windows-setup.ps1
+++ b/docker/ci/config/windows-setup.ps1
@@ -92,7 +92,7 @@ regedit /s $zlibRegFilePath
 # Temurin jdk does not have all the versions supported on scoop, especially version 14, 20, and above
 # As of now we will mix temurin and openjdk as temurin for production has support policies for fixes and patches
 # We need to make sure we do not mis-install temurin and openjdk with the same version or the distribution build code will have issues
-$jdkVersionList = "temurin8-jdk JAVA8_HOME", "temurin11-jdk JAVA11_HOME", "openjdk14 JAVA14_HOME", "temurin17-jdk JAVA17_HOME", "temurin19-jdk JAVA19_HOME", "openjdk20 JAVA20_HOME", "temurin21-jdk JAVA21_HOME", "temurin23-jdk JAVA23_HOME"
+$jdkVersionList = "temurin8-jdk JAVA8_HOME", "temurin11-jdk JAVA11_HOME", "openjdk14 JAVA14_HOME", "temurin17-jdk JAVA17_HOME", "temurin19-jdk JAVA19_HOME", "openjdk20 JAVA20_HOME", "temurin21-jdk JAVA21_HOME", "temurin23-jdk JAVA23_HOME", "temurin24-jdk JAVA24_HOME"
 Foreach ($jdkVersion in $jdkVersionList)
 {
     $jdkVersion


### PR DESCRIPTION
### Description
Update windows normal docker with jdk24

### Issues Resolved
Resolve https://github.com/opensearch-project/opensearch-build/pull/5426

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
