### PR TITLE
Bump pull request action version to v6

### DIFF
--- a/.github/workflows/os-increment-plugin-versions.yml
+++ b/.github/workflows/os-increment-plugin-versions.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Create Pull Request
         if: ${{ matrix.entry.repo != 'OpenSearch' }}
         id: cpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.github_app_token.outputs.token }}
           committer: opensearch-ci-bot <opensearch-infra@amazon.com>

--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -146,7 +146,7 @@ jobs:
         if: ${{ matrix.entry.repo != 'OpenSearch-Dashboards' && matrix.entry.repo
           != 'opensearch-dashboards-functional-test' }}
         id: cpr
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.github_app_token.outputs.token }}
           committer: opensearch-ci-bot <opensearch-infra@amazon.com>
@@ -169,7 +169,7 @@ jobs:
       - name: Create Pull Request for opensearch-dashboards-functional-test
         if: ${{ matrix.entry.repo == 'opensearch-dashboards-functional-test' }}
         id: cprft
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.github_app_token.outputs.token }}
           committer: opensearch-ci-bot <opensearch-infra@amazon.com>


### PR DESCRIPTION
### Description
Seeing below error for existing version increment pull requests:
https://github.com/opensearch-project/opensearch-build/actions/runs/14697489232/job/41241212076#step:10:519
```
   Attempting creation of pull request
  A pull request already exists for opensearch-project:create-pull-request/3.0.0-SNAPSHOT
  Fetching existing pull request
  Attempting update of pull request
  Error: Cannot read properties of undefined (reading 'number')
```
It was fixed in v6 https://github.com/peter-evans/create-pull-request/issues/2790

This ensure that PR stays up to date and pushing commits will also run the CI regularly. 

### Issues Resolved
part of https://github.com/opensearch-project/automation-app/issues/37

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
