### PR TITLE
Add exit criteria chores

### DIFF
--- a/jenkins/release-workflows/release-chores.jenkinsfile
+++ b/jenkins/release-workflows/release-chores.jenkinsfile
@@ -6,7 +6,7 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-lib = library(identifier: 'jenkins@8.4.3', retriever: modernSCM([
+lib = library(identifier: 'jenkins@9.1.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -33,7 +33,7 @@ parameters {
         randomName: 'choice-parameter-338807851658059',
         script: groovyScript(
             fallbackScript: [classpath: [], oldScript: '', sandbox: true, script: 'return ["Unknown chore"]'],
-            script: [classpath: [], oldScript: '', sandbox: true, script: '''return [ "checkReleaseOwners", "checkDocumentation", "checkCodeCoverage", "checkReleaseNotes", "checkReleaseIssues", "addRcDetailsComment" ]'''])
+            script: [classpath: [], oldScript: '', sandbox: true, script: '''return [ "checkReleaseOwners", "checkDocumentation", "checkCodeCoverage", "checkReleaseNotes", "checkReleaseIssues", "addRcDetailsComment", "checkDocumentationPullRequests", "checkIntegTestResultsOverview" ]'''])
         )
         reactiveChoice(
             name: 'ACTION',
@@ -56,6 +56,10 @@ parameters {
                     return ["check", "notify"]
                     } else if (RELEASE_CHORE == "checkReleaseIssues") {
                     return ["check", "create"]
+                    } else if (RELEASE_CHORE == "checkDocumentationPullRequests") {
+                    return ["check"]
+                    } else if (RELEASE_CHORE == "checkIntegTestResultsOverview") {
+                    return ["check"]
                     } else if (RELEASE_CHORE == "addRcDetailsComment") {
                     return ["add"]
                     }
@@ -180,6 +184,33 @@ parameters {
                             "manifests/${params.RELEASE_VERSION}/opensearch-dashboards-${params.RELEASE_VERSION}.yml"
                             ],
                         action: "${params.ACTION}",
+                        )
+                }
+            }
+        }
+        stage('checkDocumentationPullRequests') {
+            when {
+                expression { params.RELEASE_CHORE == 'checkDocumentationPullRequests' }
+            }
+            steps {
+                script {
+                    checkDocumentationPullRequests(
+                        version: "${params.RELEASE_VERSION}"
+                        )
+                }
+            }
+        }
+        stage('checkIntegTestResultsOverview') {
+            when {
+                expression { params.RELEASE_CHORE == 'checkIntegTestResultsOverview' }
+            }
+            steps {
+                script {
+                    checkIntegTestResultsOverview(
+                        inputManifest: [
+                            "manifests/${params.RELEASE_VERSION}/opensearch-${params.RELEASE_VERSION}.yml",
+                            "manifests/${params.RELEASE_VERSION}/opensearch-dashboards-${params.RELEASE_VERSION}.yml"
+                            ]
                         )
                 }
             }

--- a/tests/jenkins/TestReleaseChores.groovy
+++ b/tests/jenkins/TestReleaseChores.groovy
@@ -25,7 +25,7 @@ class TestReleaseChores extends BuildPipelineTest {
     void setUp() {
         helper.registerSharedLibrary(
             library().name('jenkins')
-                .defaultVersion('8.4.3')
+                .defaultVersion('9.1.1')
                 .allowOverride(true)
                 .implicit(true)
                 .targetPath('vars')
@@ -58,7 +58,7 @@ class TestReleaseChores extends BuildPipelineTest {
         addParam('ACTION', 'check')
         runScript('jenkins/release-workflows/release-chores.jenkinsfile')
         def callStack = helper.getCallStack()
-        assertCallStack().contains('release-chores.groovyScript({fallbackScript={classpath=[], oldScript=, sandbox=true, script=return ["Unknown chore"]}, script={classpath=[], oldScript=, sandbox=true, script=return [ "checkReleaseOwners", "checkDocumentation", "checkCodeCoverage", "checkReleaseNotes", "checkReleaseIssues", "addRcDetailsComment" ]}})',
+        assertCallStack().contains('release-chores.groovyScript({fallbackScript={classpath=[], oldScript=, sandbox=true, script=return ["Unknown chore"]}, script={classpath=[], oldScript=, sandbox=true, script=return [ "checkReleaseOwners", "checkDocumentation", "checkCodeCoverage", "checkReleaseNotes", "checkReleaseIssues", "addRcDetailsComment", "checkDocumentationPullRequests", "checkIntegTestResultsOverview" ]}})',
         'release-chores.activeChoice({name=RELEASE_CHORE, choiceType=PT_SINGLE_SELECT, description=Release chore to carry out, filterLength=1, filterable=false, randomName=choice-parameter-338807851658059, script=null})',
         'release-chores.groovyScript({fallbackScript={classpath=[], oldScript=, sandbox=true, script= return ["Unknown action"]}, script={classpath=[], oldScript=, sandbox=true, script=if (RELEASE_CHORE == "checkReleaseOwners") {\n' +
                 '                    return ["check", "request", "assign" ]\n' +
@@ -70,6 +70,10 @@ class TestReleaseChores extends BuildPipelineTest {
                 '                    return ["check", "notify"]\n' +
                 '                    } else if (RELEASE_CHORE == "checkReleaseIssues") {\n' +
                 '                    return ["check", "create"]\n' +
+                '                    } else if (RELEASE_CHORE == "checkDocumentationPullRequests") {\n' +
+                '                    return ["check"]\n' +
+                '                    } else if (RELEASE_CHORE == "checkIntegTestResultsOverview") {\n' +
+                '                    return ["check"]\n' +
                 '                    } else if (RELEASE_CHORE == "addRcDetailsComment") {\n' +
                 '                    return ["add"]\n' +
                 '                    }\n' +
@@ -128,7 +132,7 @@ class TestReleaseChores extends BuildPipelineTest {
     }
 
     @Test
-    public void testStageToLibMappingCheckReleaseIssuess() {
+    public void testStageToLibMappingCheckReleaseIssues() {
         addParam('RELEASE_VERSION', '3.0.0-beta1')
         addParam('RELEASE_CHORE', 'checkReleaseIssues')
         addParam('ACTION', 'check')
@@ -136,6 +140,17 @@ class TestReleaseChores extends BuildPipelineTest {
         def callStack = helper.getCallStack()
         assertCallStack().contains('release-chores.stage(checkReleaseIssues, groovy.lang.Closure)')
         assertCallStack().contains('release-chores.checkReleaseIssues({version=3.0.0-beta1, inputManifest=[manifests/3.0.0-beta1/opensearch-3.0.0-beta1.yml, manifests/3.0.0-beta1/opensearch-dashboards-3.0.0-beta1.yml], action=check})')
+    }
+
+    @Test
+    public void testStageToLibMappingCheckDocumentationPullRequests() {
+        addParam('RELEASE_VERSION', '3.0.0-beta1')
+        addParam('RELEASE_CHORE', 'checkDocumentationPullRequests')
+        addParam('ACTION', 'check')
+            runScript('jenkins/release-workflows/release-chores.jenkinsfile')
+        def callStack = helper.getCallStack()
+        assertCallStack().contains('release-chores.stage(checkDocumentationPullRequests, groovy.lang.Closure)')
+        assertCallStack().contains('release-chores.checkDocumentationPullRequests({version=3.0.0-beta1})')
     }
 
     def getCommandExecutions(methodName, command) {


### PR DESCRIPTION
### Description
Adds below tasks to the release chores:

1. [checkDocumentationPullRequests](https://github.com/opensearch-project/opensearch-build-libraries/blob/main/vars/checkDocumentationPullRequests.groovy)
2. [checkIntegTestResultsOverview](https://github.com/opensearch-project/opensearch-build-libraries/blob/main/vars/checkIntegTestResultsOverview.groovy)

### Issues Resolved
resolves #5432 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
