### PR TITLE
Switch k-NN repo path to logs dir to avoid pathing issues on non-windows

### DIFF
--- a/manifests/2.19.2/opensearch-2.19.2-test.yml
+++ b/manifests/2.19.2/opensearch-2.19.2-test.yml
@@ -83,7 +83,7 @@ components:
         node.attr.knn_cb_tier: integ
         path.repo:
           - /tmp
-          - C:\
+          - logs
     smoke-test:
       test-spec: k-NN.yml
   - name: ml-commons

--- a/manifests/3.0.0/opensearch-3.0.0-test.yml
+++ b/manifests/3.0.0/opensearch-3.0.0-test.yml
@@ -87,7 +87,7 @@ components:
         node.attr.knn_cb_tier: integ
         path.repo:
           - /tmp
-          - 'C:\'
+          - logs
     smoke-test:
       test-spec: k-NN.yml
   - name: ml-commons

--- a/manifests/3.1.0/opensearch-3.1.0-test.yml
+++ b/manifests/3.1.0/opensearch-3.1.0-test.yml
@@ -87,7 +87,7 @@ components:
         node.attr.knn_cb_tier: integ
         path.repo:
           - /tmp
-          - C:\
+          - logs
     smoke-test:
       test-spec: k-NN.yml
   - name: ml-commons


### PR DESCRIPTION
### Description
Switch k-NN repo path to logs dir to avoid pathing issues on non-windows

```
java.lang.IllegalStateException: Unable to access 'path.repo' (/usr/share/opensearch/C:\)
```

### Issues Resolved
#3747

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
