### PR TITLE
Temp resolve path.repo not found issues on k-NN

### DIFF
--- a/scripts/components/k-NN/integtest.sh
+++ b/scripts/components/k-NN/integtest.sh
@@ -102,4 +102,9 @@ fi
 USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
 PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 
+# This will be added after 3.0.0 to k-NN repo directly
+# As of now it is a temp measure to avoid building another Release Candidate
+# while re-running test with a different configurations that is customizable
+sed -i 's|^[[:space:]]\+task\.systemProperty\s*"tests\.path\.repo".*|    task.systemProperty "tests.path.repo", System.getProperty("tests.path.repo", "${buildDir}/testSnapshotFolder")|' build.gradle
+sed -i 's|^[[:space:]]\+systemProperty\s*"tests\.path\.repo".*|    systemProperty "tests.path.repo", System.getProperty("tests.path.repo", "${buildDir}/testSnapshotFolder")|' build.gradle
 ./gradlew integTest -Dtests.path.repo=/tmp -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.clustername="opensearch-integrationtest" -Dhttps=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD --console=plain

--- a/scripts/components/k-NN/integtest.sh
+++ b/scripts/components/k-NN/integtest.sh
@@ -105,6 +105,14 @@ PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 # This will be added after 3.0.0 to k-NN repo directly
 # As of now it is a temp measure to avoid building another Release Candidate
 # while re-running test with a different configurations that is customizable
-sed -i 's|^[[:space:]]\+task\.systemProperty\s*"tests\.path\.repo".*|    task.systemProperty "tests.path.repo", System.getProperty("tests.path.repo", "${buildDir}/testSnapshotFolder")|' build.gradle
-sed -i 's|^[[:space:]]\+systemProperty\s*"tests\.path\.repo".*|    systemProperty "tests.path.repo", System.getProperty("tests.path.repo", "${buildDir}/testSnapshotFolder")|' build.gradle
-./gradlew integTest -Dtests.path.repo=/tmp -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.clustername="opensearch-integrationtest" -Dhttps=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD --console=plain
+if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "win32" ]; then
+    echo "In Windows, need to set tests.path.repo to logs dir in OPENSEARCH_HOME"
+    REPO_PATH=`cygpath -w $(realpath "../1/local-test-cluster/opensearch-$OPENSEARCH_VERSION/logs")`
+    echo "Set new tests.path.repo to $REPO_PATH"
+    sed -i 's|^[[:space:]]\+task\.systemProperty\s*"tests\.path\.repo".*|    task.systemProperty "tests.path.repo", System.getProperty("tests.path.repo", "${buildDir}/testSnapshotFolder")|' build.gradle
+    sed -i 's|^[[:space:]]\+systemProperty\s*"tests\.path\.repo".*|    systemProperty "tests.path.repo", System.getProperty("tests.path.repo", "${buildDir}/testSnapshotFolder")|' build.gradle
+    ./gradlew integTest -Dtests.path.repo="$REPO_PATH" -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.clustername="opensearch-integrationtest" -Dhttps=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD --console=plain
+
+else
+    ./gradlew integTest -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.clustername="opensearch-integrationtest" -Dhttps=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD --console=plain
+fi

--- a/scripts/components/k-NN/integtest.sh
+++ b/scripts/components/k-NN/integtest.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+
+set -e
+
+function usage() {
+    echo ""
+    echo "This script is used to run integration tests for plugin installed on a remote OpenSearch/Dashboards cluster."
+    echo "--------------------------------------------------------------------------"
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Required arguments:"
+    echo "None"
+    echo ""
+    echo "Optional arguments:"
+    echo -e "-b BIND_ADDRESS\t, defaults to localhost | 127.0.0.1, can be changed to any IP or domain name for the cluster location."
+    echo -e "-p BIND_PORT\t, defaults to 9200 or 5601 depends on OpenSearch or Dashboards, can be changed to any port for the cluster location."
+    echo -e "-s SECURITY_ENABLED\t(true | false), defaults to true. Specify the OpenSearch/Dashboards have security enabled or not."
+    echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
+    echo -e "-v OPENSEARCH_VERSION\t, no defaults"
+    echo -e "-n SNAPSHOT\t, defaults to false"
+    echo -e "-h\tPrint this message."
+    echo "--------------------------------------------------------------------------"
+}
+
+while getopts ":hb:p:s:c:v:n:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        b)
+            BIND_ADDRESS=$OPTARG
+            ;;
+        p)
+            BIND_PORT=$OPTARG
+            ;;
+        s)
+            SECURITY_ENABLED=$OPTARG
+            ;;
+        c)
+            CREDENTIAL=$OPTARG
+            ;;
+        v)
+            OPENSEARCH_VERSION=$OPTARG
+            ;;
+        n)
+            SNAPSHOT=$OPTARG
+            ;;
+        :)
+            echo "-${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${OPTARG}"
+            exit 1
+            ;;
+    esac
+done
+
+
+if [ -z "$BIND_ADDRESS" ]
+then
+  BIND_ADDRESS="localhost"
+fi
+
+if [ -z "$BIND_PORT" ]
+then
+  BIND_PORT="9200"
+fi
+
+if [ -z "$SECURITY_ENABLED" ]
+then
+  SECURITY_ENABLED="true"
+fi
+
+if [ -z "$SNAPSHOT" ]
+then
+  SNAPSHOT="false"
+fi
+
+OPENSEARCH_REQUIRED_VERSION="2.12.0"
+if [ -z "$CREDENTIAL" ]
+then
+  # Starting in 2.12.0, security demo configuration script requires an initial admin password
+  COMPARE_VERSION=`echo $OPENSEARCH_REQUIRED_VERSION $OPENSEARCH_VERSION | tr ' ' '\n' | sort -V | uniq | head -n 1`
+  if [ "$COMPARE_VERSION" != "$OPENSEARCH_REQUIRED_VERSION" ]; then
+    CREDENTIAL="admin:admin"
+  else
+    CREDENTIAL="admin:myStrongPassword123!"
+  fi
+fi
+
+USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
+PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
+
+./gradlew integTest -Dtests.path.repo=/tmp -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.clustername="opensearch-integrationtest" -Dhttps=$SECURITY_ENABLED -Duser=$USERNAME -Dpassword=$PASSWORD --console=plain


### PR DESCRIPTION
### Description
Temp resolve path.repo not found issues on k-NN

Will move the script to k-NN repo once 3.0.0 is released to public to avoid building new RCs.

```
2> REPRODUCE WITH: gradlew ':integTest' --tests "org.opensearch.knn.integ.DerivedSourceIT.testDerivedSource_whenSegrepLocal_thenDisabled" -Dtests.seed=3D5D0C854DD4AA88 -Dtests.security.manager=false -Dtests.locale=dua-Latn-CM -Dtests.timezone=Asia/Novokuznetsk -Druntime.java=21

  2> org.opensearch.client.ResponseException: method [PUT], host [http://localhost:9200/], URI [_snapshot/repo?verify=true], status line [HTTP/1.1 500 Internal Server Error]

    {"error":{"root_cause":[{"type":"repository_exception","reason":"[repo] location [C:\\5iv84bze\\k-NN\\build/testSnapshotFolder] doesn't match any of the locations specified by path.repo"}],"type":"repository_exception","reason":"[repo] failed to create repository","caused_by":{"type":"repository_exception","reason":"[repo] location [C:\\5iv84bze\\k-NN\\build/testSnapshotFolder] doesn't match any of the locations specified by path.repo"}},"status":500}

        at __randomizedtesting.SeedInfo.seed([3D5D0C854DD4AA88:95AB786E87274F6D]:0)

        at app//org.opensearch.client.RestClient.convertResponse(RestClient.java:501)

        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:384)

        at app//org.opensearch.client.RestClient.performRequest(RestClient.java:359)

        at app//org.opensearch.test.rest.OpenSearchRestTestCase.registerRepository(OpenSearchRestTestCase.java:1097)

        at app//org.opensearch.knn.integ.DerivedSourceIT.setUp(DerivedSourceIT.java:42)

  2> REPRODUCE WITH: gradlew ':integTest' --tests "org.opensearch.knn.integ.DerivedSourceIT.testNes
```

Reason being k-NN is hardcoding the tests.path.repo to https://github.com/opensearch-project/k-NN/blob/3.0/build.gradle#L443, and the folder is not available in opensearch.yml during test.

Therefore, override it when running integTest on Jenkins.

### Issues Resolved
#3747 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
