### PR TITLE
Bump gh cli version

### DIFF
--- a/docker/ci/config/gh-setup.sh
+++ b/docker/ci/config/gh-setup.sh
@@ -19,7 +19,7 @@ for entry in "${PLATFORM_LIST[@]}"; do
     fi
 done
 ARCH=`uname -m`
-VERSION="2.42.0"
+VERSION="2.55.0"
 
 # ppc64le specific
 function gh_install_ppc64le {


### PR DESCRIPTION
### Description
In order to be able to use --json option in gh cli for https://github.com/opensearch-project/opensearch-build/issues/5501
need to upgrade gh cli version to atleast 2.53.0

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
