### PR TITLE
add osd plugins version bump back to main branch

### DIFF
--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -43,6 +43,7 @@ jobs:
           - {repo: opensearch-dashboards-functional-test}
           - {repo: query-insights-dashboards}
         branch:
+          - 'main'
           - '3.0'
           - '2.19'
     steps:


### PR DESCRIPTION
### Description
Raised [PR](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9789) in OSD to bump version to 3.1.0, we should also resume the plugin version bump workflow

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
