### PR TITLE
Add smoke test for geospatial plugin

### DIFF
--- a/manifests/2.19.3/opensearch-2.19.3-test.yml
+++ b/manifests/2.19.3/opensearch-2.19.3-test.yml
@@ -59,6 +59,8 @@ components:
       test-configs:
         - with-security
         - without-security
+    smoke-test:
+      test-spec: geospatial.yml
   - name: index-management
     integ-test:
       build-dependencies:

--- a/manifests/3.1.0/opensearch-3.1.0-test.yml
+++ b/manifests/3.1.0/opensearch-3.1.0-test.yml
@@ -63,6 +63,8 @@ components:
       test-configs:
         - with-security
         - without-security
+    smoke-test:
+      test-spec: geospatial.yml
   - name: index-management
     integ-test:
       build-dependencies:

--- a/src/test_workflow/smoke_test/smoke_tests_spec/2.x/geospatial.yml
+++ b/src/test_workflow/smoke_test/smoke_tests_spec/2.x/geospatial.yml
@@ -1,0 +1,60 @@
+---
+info:
+  title: OpenSearch geospatial plugin smoke tests
+  version: 2.x
+name: geospatial
+paths:
+  /_plugins/geospatial/geojson/_upload:
+    PUT:
+      parameters:
+        - index: national_parks_test
+          field: boundary
+          type: geo_shape
+          data:
+            - type: Feature
+              geometry:
+                type: Polygon
+                coordinates:
+                  - - - 100.0
+                      - 0.0
+                    - - 101.0
+                      - 0.0
+                    - - 101.0
+                      - 1.0
+                    - - 100.0
+                      - 1.0
+                    - - 100.0
+                      - 0.0
+              properties:
+                name: Yosemite Valley
+                type: National Park
+                state: California
+            - type: Feature
+              geometry:
+                type: LineString
+                coordinates:
+                  - - 106.0
+                    - 6.0
+                  - - 106.1
+                    - 6.1
+                  - - 106.2
+                    - 6.2
+                  - - 106.3
+                    - 6.3
+              properties:
+                name: Grand Canyon Trail
+                type: Hiking Trail
+                difficulty: Moderate
+  /_plugins/geospatial/_upload/stats:
+    GET:
+      parameters: []
+  /_plugins/geospatial/ip2geo/datasource/test-datasource:
+    PUT:
+      parameters:
+        - endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
+          update_interval_in_days: 5
+    GET:
+      parameters: []
+  /_plugins/geospatial/ip2geo/datasource:
+    GET:
+      parameters: []

--- a/src/test_workflow/smoke_test/smoke_tests_spec/default/geospatial.yml
+++ b/src/test_workflow/smoke_test/smoke_tests_spec/default/geospatial.yml
@@ -1,0 +1,60 @@
+---
+info:
+  title: OpenSearch geospatial plugin smoke tests
+  version: default
+name: geospatial
+paths:
+  /_plugins/geospatial/geojson/_upload:
+    PUT:
+      parameters:
+        - index: national_parks_test
+          field: boundary
+          type: geo_shape
+          data:
+            - type: Feature
+              geometry:
+                type: Polygon
+                coordinates:
+                  - - - 100.0
+                      - 0.0
+                    - - 101.0
+                      - 0.0
+                    - - 101.0
+                      - 1.0
+                    - - 100.0
+                      - 1.0
+                    - - 100.0
+                      - 0.0
+              properties:
+                name: Yosemite Valley
+                type: National Park
+                state: California
+            - type: Feature
+              geometry:
+                type: LineString
+                coordinates:
+                  - - 106.0
+                    - 6.0
+                  - - 106.1
+                    - 6.1
+                  - - 106.2
+                    - 6.2
+                  - - 106.3
+                    - 6.3
+              properties:
+                name: Grand Canyon Trail
+                type: Hiking Trail
+                difficulty: Moderate
+  /_plugins/geospatial/_upload/stats:
+    GET:
+      parameters: []
+  /_plugins/geospatial/ip2geo/datasource/test-datasource:
+    PUT:
+      parameters:
+        - endpoint: https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json
+          update_interval_in_days: 5
+    GET:
+      parameters: []
+  /_plugins/geospatial/ip2geo/datasource:
+    GET:
+      parameters: []


### PR DESCRIPTION
### Description

This PR add changes to onboard smoke test for geospatial plugin

### Issues Resolved
[724](https://github.com/opensearch-project/geospatial/issues/724)

### Test

```
./test.sh smoke-test manifests/2.19.3/opensearch-2.19.3-test.yml --component geospatial --paths opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.19.3/11066/linux/x64/tar


2025-05-16 13:04:54 INFO     | geospatial           | /_plugins/geospatial/_upload/stats GET | PASS  |
2025-05-16 13:04:54 INFO     | geospatial           | /_plugins/geospatial/geojson/_upload PUT | PASS  |
2025-05-16 13:04:54 INFO     | geospatial           | /_plugins/geospatial/ip2geo/datasource GET | PASS  |
2025-05-16 13:04:54 INFO     | geospatial           | /_plugins/geospatial/ip2geo/datasource/test-datasource GET | PASS  |
2025-05-16 13:04:54 INFO     | geospatial           | /_plugins/geospatial/ip2geo/datasource/test-datasource PUT | PASS  |


```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
