### PR TITLE
Add Smoke test for neural search plugin

### DIFF
--- a/manifests/3.1.0/opensearch-3.1.0-test.yml
+++ b/manifests/3.1.0/opensearch-3.1.0-test.yml
@@ -109,6 +109,8 @@ components:
       test-configs:
         - with-security
         - without-security
+    smoke-test:
+      test-spec: neural-search.yml
   - name: notifications
     working-directory: notifications
     integ-test:

--- a/src/test_workflow/smoke_test/smoke_tests_spec/default/neural-search.yml
+++ b/src/test_workflow/smoke_test/smoke_tests_spec/default/neural-search.yml
@@ -1,0 +1,20 @@
+---
+info:
+  title: OpenSearch neural-search plugin smoke tests
+  version: default
+name: neural-search
+paths:
+  /_cluster/settings:
+    PUT:
+      parameters:
+        - persistent:
+            plugins.neural_search.stats_enabled: true
+  /_plugins/_neural/stats:
+    GET:
+      parameters: []
+  /_plugins/_neural/stats?flat_stat_paths=true&include_metadata=true:
+    GET:
+      parameters: []
+  /_plugins/_neural/stats/text_embedding_executions:
+    GET:
+      parameters: []


### PR DESCRIPTION
### Description
This PR add changes to onboard smoke test for neural-search plugin

### Issues Resolved
https://github.com/opensearch-project/neural-search/issues/1186

### Test

```
./test.sh smoke-test manifests/3.0.0/opensearch-3.0.0-test.yml --component neural-search --paths opensearch=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/3.0.0/11061/linux/x64/tar


2025-05-20 10:00:17 INFO     | neural-search        | /_cluster/settings PUT | PASS  |
2025-05-20 10:00:17 INFO     | neural-search        | /_plugins/_neural/stats GET | PASS  |
2025-05-20 10:00:17 INFO     | neural-search        | /_plugins/_neural/stats/text_embedding_executions GET | PASS  |
2025-05-20 10:00:17 INFO     | neural-search        | /_plugins/_neural/stats?flat_stat_paths=true&include_metadata=true GET | PASS  |

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
