### PR TITLE
Add --dry-run option to AssembleArgs to support non-destructive runs

### DIFF
--- a/src/assemble_workflow/README.md
+++ b/src/assemble_workflow/README.md
@@ -28,6 +28,53 @@ The following options are available in `assemble.sh`.
 | --keep             | Do not delete the temporary working directory on both success or error. |
 | -v, --verbose      | Show more verbose output.                                               |
 
+
+### run_assemble.py Options
+
+You can also run the assembling logic directly using Python:
+
+```bash
+python src/run_assemble.py <manifest-file> [options]
+```
+
+If you're generating a manifest dynamically, you can omit the input file and use `--generate-manifest`.
+
+#### CLI Flags
+
+| Option                  | Description                                                                 |
+|--------------------------|-----------------------------------------------------------------------------|
+| `--generate-manifest`   | Generate a manifest YAML file dynamically (default filename: `manifest.yml`). |
+| `--dry-run`             | Simulate the assemble step without downloading or extracting artifacts.      |
+| `--version`             | OpenSearch version (e.g., `2.14.0`). Used with `--generate-manifest`.        |
+| `--platform`            | Target platform (`linux`, `windows`, `macos`).                              |
+| `--arch`                | Target architecture (`x64`, `arm64`).                                       |
+| `--dist`                | Distribution type (`tar`, `zip`, `rpm`).                                    |
+| `--component`           | Component name (defaults to `opensearch`).                                  |
+| `-b`, `--base-url`      | Base URL to download artifacts from.                                        |
+| `--keep`                | Do not delete the working temporary directory.                              |
+| `-v`, `--verbose`       | Enable verbose logging.                                                     |
+
+#### Examples
+
+**Assemble using an existing manifest:**
+
+```bash
+python src/run_assemble.py builds/opensearch/manifest.yml --verbose
+```
+
+**Dry run (simulate without downloading or extracting):**
+
+```bash
+python src/run_assemble.py builds/opensearch/manifest.yml --dry-run
+```
+
+**Generate a new manifest file for version 2.14.0:**
+
+```bash
+python src/run_assemble.py --generate-manifest output-manifest.yml --version 2.14.0 --platform linux --arch x64 --dist tar --component opensearch
+```
+
+
 ### Custom Install Scripts
 
 You can perform additional plugin install steps by adding an `install.sh` script. By default the tool will look for a script in [scripts/bundle-build/components](../../scripts/bundle-build/components), then default to a noop version implemented in [scripts/default/install.sh](../../scripts/default/install.sh).

--- a/src/assemble_workflow/assemble_args.py
+++ b/src/assemble_workflow/assemble_args.py
@@ -13,7 +13,14 @@ from typing import IO
 class AssembleArgs:
     manifest: IO
     keep: bool
-
+    dry_run: bool
+    generate_manifest: str
+    version: str
+    platform: str
+    arch: str
+    dist: str
+    component: str
+    
     def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="Assemble an OpenSearch Distribution")
         parser.add_argument("manifest", type=argparse.FileType("r"), help="Manifest file.")
@@ -33,9 +40,34 @@ class AssembleArgs:
             const=logging.DEBUG,
             dest="logging_level",
         )
+        parser.add_argument(
+            "--dry-run",
+            dest="dry_run",
+            action="store_true",
+            help="Run assemble logic without actually downloading or extracting.",
+        )
+        parser.add_argument(
+            "--generate-manifest",
+            nargs="?",
+            const="manifest.yml",
+            help="Generate a manifest file dynamically. Default filename is manifest.yml",
+        )
+        parser.add_argument("--version", help="Version of OpenSearch to include in the manifest.")
+        parser.add_argument("--platform", help="Target platform (linux, windows, macos).")
+        parser.add_argument("--arch", help="Target architecture (x64, arm64).")
+        parser.add_argument("--dist", help="Distribution type (tar, zip, rpm).")
+        parser.add_argument("--component", help="Component name (default: opensearch).")
+        
 
         args = parser.parse_args()
         self.logging_level = args.logging_level
         self.manifest = args.manifest
         self.keep = args.keep
         self.base_url = args.base_url
+        self.dry_run = args.dry_run
+        self.generate_manifest = args.generate_manifest
+        self.version = args.version
+        self.platform = args.platform
+        self.arch = args.arch
+        self.dist = args.dist
+        self.component = args.component


### PR DESCRIPTION
### Description

This PR adds a `--dry-run` option to the assemble tool to support non-destructive runs, allowing users to simulate the assembly process without downloading or extracting artifacts. Additionally, it introduces the capability to generate a manifest file dynamically via the `--generate-manifest` option.

With these enhancements, users can:

- Dynamically generate a manifest YAML file with customizable parameters such as version, platform, architecture, distribution, and component.
- Perform dry runs using an existing or dynamically generated manifest to validate the assemble logic safely without modifying disk or network state.

### Generate a Manifest File Dynamically

Run the following command to create a manifest file named `dry-run-manifest.yml` with your desired parameters (all optional):

**Generate a new manifest file for version 2.14.0:**

```bash
python src/run_assemble.py --generate-manifest output-manifest.yml --version 2.14.0 --platform linux --arch x64 --dist tar --component opensearch
```

Using the below command to run the assemble tool in dry-run mode with the generated manifest:

```bash
python3 src/run_assemble.py dry-run-manifest.yml --dry-run
```

Other enhancements include new command-line arguments to specify version, platform, architecture, distribution type, and component name for the manifest generation feature.

### Issues Resolved
- Adds safer testing and debugging capabilities for the assemble workflow.
- Provides dynamic manifest generation to simplify build and release workflows.
- Improves CLI usability and feature set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
