### PR TITLE
temporarily disable incremental build feature for windows

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -838,7 +838,7 @@ pipeline {
                                     architecture: 'x64',
                                     distribution: 'zip',
                                     continueOnError: params.CONTINUE_ON_ERROR,
-                                    incremental: params.INCREMENTAL,
+                                    incremental: 'false',
                                     previousBuildId: params.PREVIOUS_BUILD_ID
                                 )
                                 String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -849,7 +849,7 @@ pipeline {
                                     architecture: 'x64',
                                     distribution: 'zip',
                                     continueOnError: params.CONTINUE_ON_ERROR,
-                                    incremental: params.INCREMENTAL,
+                                    incremental: 'false',
                                     previousBuildId: params.PREVIOUS_BUILD_ID
                                 )
                                 String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)


### PR DESCRIPTION
### Description
temporarily disable incremental build feature for windows. The regular builds still work as expected. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
