### PR TITLE
deb - Listen to DISABLE_INSTALL_DEMO_CONFIG

### DIFF
--- a/scripts/pkg/build_templates/1.x/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/1.x/opensearch/deb/debian/postinst
@@ -21,7 +21,9 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1
+    if [ ! "$DISABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
+        bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1
+    fi
 fi
 
 # Apply PerformanceAnalyzer Settings

--- a/scripts/pkg/build_templates/2.x/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/2.x/opensearch/deb/debian/postinst
@@ -21,7 +21,9 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
+    if [ ! "$DISABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
+        bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
+    fi
 fi
 # Apply PerformanceAnalyzer Settings
 chmod a+rw /tmp

--- a/scripts/pkg/build_templates/current/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/current/opensearch/deb/debian/postinst
@@ -21,7 +21,9 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
+    if [ ! "$DISABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
+        bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
+    fi
 fi
 # Apply PerformanceAnalyzer Settings
 chmod a+rw /tmp


### PR DESCRIPTION
### Description
This PR allows users installing the package on debian to request no demo config. Taken from the docker install

### Issues Resolved
- https://github.com/opensearch-project/security/issues/4199

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
