### PR TITLE
Update OSD distribution build to use new Docker Separation schema 1.2

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@9.5.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@9.6.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -21,9 +21,6 @@ pipeline {
         AGENT_LINUX_X64 = 'Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host'
         AGENT_LINUX_ARM64 = 'Jenkins-Agent-AL2023-Arm64-M6g4xlarge-Docker-Host'
         AGENT_WINDOWS_X64 = 'Jenkins-Agent-Windows2019-X64-M54xlarge-Docker-Host'
-        IMAGE_LINUX_RPM = 'opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-build-v1' // required for rpm to create digest sha256 correctly with rpm 4.12+, still define here for 1.x version as 2.x+ moved to rockylinux8, later almalinux8, already
-        IMAGE_LINUX_DEB = 'opensearchstaging/ci-runner:ci-runner-ubuntu2404-opensearch-build-v1' // required for deb to create pkg using debmake/debuild/debhelper
-        IMAGE_WINDOWS_ZIP = 'opensearchstaging/ci-runner:ci-runner-windows2019-opensearch-build-v1' // required for windows to build zip distribution
         JOB_NAME_OPENSEARCH = 'distribution-build-opensearch'
     }
     parameters {
@@ -130,7 +127,32 @@ pipeline {
                         error("Input manifest was not provided or not found at manifests/${INPUT_MANIFEST}.")
                     }
                     echo('Detect Docker Images and Related Parameters')
-                    dockerAgent = detectDockerAgent()
+                    dockerAgentLinuxTar = detectDockerAgent(
+                        distribution: "tar",
+                        platform: "linux"
+                    )
+                    dockerAgentLinuxDeb = detectDockerAgent(
+                        distribution: "deb",
+                        platform: "linux"
+                    )
+                    dockerAgentLinuxRpm = detectDockerAgent(
+                        distribution: "rpm",
+                        platform: "linux"
+                    )
+                    dockerAgentWindowsZip = detectDockerAgent(
+                        distribution: "zip",
+                        platform: "windows"
+                    )
+                    echo('Print Image Information')
+                    [
+                        linux_tar: dockerAgentLinuxTar,
+                        linux_deb: dockerAgentLinuxDeb,
+                        linux_rpm: dockerAgentLinuxRpm,
+                        windows_zip: dockerAgentWindowsZip
+                    ].each { name, agent ->
+                        echo("${name} Image: ${agent.image}, Args: ${agent.args}")
+                    }
+
                     currentBuild.description = INPUT_MANIFEST
                     paramType = [
                         'BUILD_PLATFORM': 'linux windows',
@@ -179,8 +201,8 @@ pipeline {
                     agent {
                         docker {
                             label AGENT_LINUX_X64
-                            image dockerAgent.image
-                            args dockerAgent.args
+                            image dockerAgentLinuxTar.image
+                            args dockerAgentLinuxTar.args
                             registryUrl 'https://public.ecr.aws/'
                             alwaysPull true
                         }
@@ -263,8 +285,8 @@ pipeline {
                             agent {
                                 docker {
                                     label AGENT_LINUX_X64
-                                    image dockerAgent.image
-                                    args dockerAgent.args
+                                    image dockerAgentLinuxTar.image
+                                    args dockerAgentLinuxRpm.args
                                     registryUrl 'https://public.ecr.aws/'
                                     alwaysPull true
                                 }
@@ -299,7 +321,7 @@ pipeline {
                             agent {
                                 docker {
                                     label AGENT_LINUX_X64
-                                    image IMAGE_LINUX_RPM
+                                    image dockerAgentLinuxRpm.image
                                     registryUrl 'https://public.ecr.aws/'
                                     alwaysPull true
                                 }
@@ -375,8 +397,8 @@ pipeline {
                             agent {
                                 docker {
                                     label AGENT_LINUX_X64
-                                    image dockerAgent.image
-                                    args dockerAgent.args
+                                    image dockerAgentLinuxTar.image
+                                    args dockerAgentLinuxDeb.args
                                     registryUrl 'https://public.ecr.aws/'
                                     alwaysPull true
                                 }
@@ -411,7 +433,7 @@ pipeline {
                             agent {
                                 docker {
                                     label AGENT_LINUX_X64
-                                    image IMAGE_LINUX_DEB
+                                    image dockerAgentLinuxDeb.image
                                     registryUrl 'https://public.ecr.aws/'
                                     alwaysPull true
                                 }
@@ -485,8 +507,8 @@ pipeline {
                             agent {
                                 docker {
                                     label AGENT_LINUX_X64
-                                    image dockerAgent.image
-                                    args dockerAgent.args
+                                    image dockerAgentLinuxTar.image
+                                    args dockerAgentLinuxTar.args
                                     registryUrl 'https://public.ecr.aws/'
                                     alwaysPull true
                                 }
@@ -521,8 +543,8 @@ pipeline {
                             agent {
                                 docker {
                                     label AGENT_LINUX_ARM64
-                                    image dockerAgent.image
-                                    args dockerAgent.args
+                                    image dockerAgentLinuxTar.image
+                                    args dockerAgentLinuxTar.args
                                     registryUrl 'https://public.ecr.aws/'
                                     alwaysPull true
                                 }
@@ -604,8 +626,8 @@ pipeline {
                             agent {
                                 docker {
                                     label AGENT_LINUX_X64
-                                    image dockerAgent.image
-                                    args dockerAgent.args
+                                    image dockerAgentLinuxTar.image
+                                    args dockerAgentLinuxRpm.args
                                     registryUrl 'https://public.ecr.aws/'
                                     alwaysPull true
                                 }
@@ -640,7 +662,7 @@ pipeline {
                             agent {
                                 docker {
                                     label AGENT_LINUX_ARM64
-                                    image IMAGE_LINUX_RPM
+                                    image dockerAgentLinuxRpm.image
                                     registryUrl 'https://public.ecr.aws/'
                                     alwaysPull true
                                 }
@@ -716,8 +738,8 @@ pipeline {
                             agent {
                                 docker {
                                     label AGENT_LINUX_X64
-                                    image dockerAgent.image
-                                    args dockerAgent.args
+                                    image dockerAgentLinuxTar.image
+                                    args dockerAgentLinuxDeb.args
                                     registryUrl 'https://public.ecr.aws/'
                                     alwaysPull true
                                 }
@@ -752,7 +774,7 @@ pipeline {
                             agent {
                                 docker {
                                     label AGENT_LINUX_ARM64
-                                    image IMAGE_LINUX_DEB
+                                    image dockerAgentLinuxDeb.image
                                     registryUrl 'https://public.ecr.aws/'
                                     alwaysPull true
                                 }
@@ -823,7 +845,7 @@ pipeline {
                     agent {
                         docker {
                             label AGENT_WINDOWS_X64
-                            image IMAGE_WINDOWS_ZIP
+                            image dockerAgentWindowsZip.image
                             registryUrl 'https://public.ecr.aws/'
                             alwaysPull true
                         }
@@ -904,8 +926,8 @@ pipeline {
                     agent {
                         docker {
                             label AGENT_LINUX_X64
-                            image dockerAgent.image
-                            args dockerAgent.args
+                            image dockerAgentLinuxTar.image
+                            args dockerAgentLinuxTar.args
                             registryUrl 'https://public.ecr.aws/'
                             alwaysPull true
                         }

--- a/manifests/2.19.3/opensearch-dashboards-2.19.3.yml
+++ b/manifests/2.19.3/opensearch-dashboards-2.19.3.yml
@@ -1,11 +1,20 @@
 ---
-schema-version: '1.1'
+schema-version: '1.2'
 build:
   name: OpenSearch Dashboards
   version: 2.19.3
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-build-v1
+    linux:
+      tar:
+        name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-build-v1
+      deb:
+        name: opensearchstaging/ci-runner:ci-runner-ubuntu2404-opensearch-build-v1
+      rpm:
+        name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-build-v1
+    windows:
+      zip:
+        name: opensearchstaging/ci-runner:ci-runner-windows2019-opensearch-build-v1
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git

--- a/manifests/3.1.0/opensearch-dashboards-3.1.0.yml
+++ b/manifests/3.1.0/opensearch-dashboards-3.1.0.yml
@@ -1,11 +1,20 @@
 ---
-schema-version: '1.1'
+schema-version: '1.2'
 build:
   name: OpenSearch Dashboards
   version: 3.1.0
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-build-v1
+    linux:
+      tar:
+        name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-build-v1
+      deb:
+        name: opensearchstaging/ci-runner:ci-runner-ubuntu2404-opensearch-build-v1
+      rpm:
+        name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-build-v1
+    windows:
+      zip:
+        name: opensearchstaging/ci-runner:ci-runner-windows2019-opensearch-build-v1
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git

--- a/manifests/templates/opensearch-dashboards/2.x/manifest.yml
+++ b/manifests/templates/opensearch-dashboards/2.x/manifest.yml
@@ -1,11 +1,13 @@
 ---
-schema-version: '1.1'
+schema-version: '1.2'
 build:
   name: OpenSearch Dashboards
   version: 'replace'
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-build-v1
+    linux:
+      tar:
+        name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-build-v1
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git

--- a/manifests/templates/opensearch-dashboards/3.x/manifest.yml
+++ b/manifests/templates/opensearch-dashboards/3.x/manifest.yml
@@ -1,11 +1,13 @@
 ---
-schema-version: '1.1'
+schema-version: '1.2'
 build:
   name: OpenSearch Dashboards
   version: 'replace'
 ci:
   image:
-    name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-build-v1
+    linux:
+      tar:
+        name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-build-v1
 components:
   - name: OpenSearch-Dashboards
     repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git


### PR DESCRIPTION
### Description
Update OSD distribution build to use new Docker Separation schema 1.2

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5360

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
