### PR TITLE
Update op-setup.sh to skip ppc64le arch

### DIFF
--- a/docker/ci/config/op-setup.sh
+++ b/docker/ci/config/op-setup.sh
@@ -31,6 +31,10 @@ case $PLATFORM-$ARCH in
     linux-aarch64|linux-arm64)
         ARCH_FINAL="arm64"
         ;;
+    linux-ppc64le)
+        echo "PPC64LE is not supported at the moment"
+        exit 0
+        ;;
     darwin-x86_64|darwin-arm64)
         brew install 1password-cli
         exit 0


### PR DESCRIPTION
### Description
Update op-setup.sh to skip ppc64le arch

### Issues Resolved
https://build.ci.opensearch.org/job/docker-build/7001/console
https://github.com/opensearch-project/opensearch-build/issues/5535

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
