### PR TITLE
Remove adding major.x version to version increment workflows

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -224,14 +224,10 @@ class InputManifests(Manifests):
                 data = yaml.load(f)
 
             version_entry = []
-            major_version_entry = version.split(".")[0] + ".x"
             minor_version_entry = version.rsplit(".", 1)[0]
             if minor_version_entry not in data["jobs"]["plugin-version-increment-sync"]["strategy"]["matrix"]["branch"]:
                 logging.info(f"Adding {minor_version_entry} to {workflow_file}")
                 version_entry.append(minor_version_entry)
-            if major_version_entry not in data["jobs"]["plugin-version-increment-sync"]["strategy"]["matrix"]["branch"]:
-                logging.info(f"Adding {major_version_entry} to {workflow_file}")
-                version_entry.append(major_version_entry)
 
             if version_entry:
                 branch_list = list(data["jobs"]["plugin-version-increment-sync"]["strategy"]["matrix"]["branch"])


### PR DESCRIPTION
### Description
With more simplified branching strategy introduced [recently](https://github.com/opensearch-project/.github/blob/main/RELEASING.md#branching), `major.x` branch is not created anymore. Hence refactoring the code to remove the related changes. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
