### PR TITLE
Fix the OpenSearch version increment workflow

### DIFF
--- a/.github/workflows/os-increment-plugin-versions.yml
+++ b/.github/workflows/os-increment-plugin-versions.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Get JDK version
         run: |
           OS_VERSION=${{ env.OPENSEARCH_VERSION_NUMBER }}
-          OPENSEARCH_JAVA_VERSION_NUMBER=`curl -sSfL https://raw.githubusercontent.com/opensearch-project/opensearch-build/refs/heads/main/manifests/$OS_VERSION/opensearch-$OS_VERSION.yml | yq -r '.ci.image.args' | grep -oE 'openjdk-[0-9]*' | awk -F'-' '{ print $NF }'`
+          OPENSEARCH_JAVA_VERSION_NUMBER=`curl -sSfL https://raw.githubusercontent.com/opensearch-project/opensearch-build/refs/heads/main/manifests/$OS_VERSION/opensearch-$OS_VERSION.yml | yq -r '.ci.image.linux.tar.args' | grep -oE 'openjdk-[0-9]*' | awk -F'-' '{ print $NF }'`
           echo "OPENSEARCH_JAVA_VERSION=$OPENSEARCH_JAVA_VERSION_NUMBER" >> $GITHUB_ENV
       - name: Set up JDK ${{ env.OPENSEARCH_JAVA_VERSION }}
         uses: actions/setup-java@v4


### PR DESCRIPTION
### Description
Workflows fail to detect the java version https://github.com/opensearch-project/opensearch-build/actions/runs/15837880212.

### Issues Resolved
This PR uses `ci.image.linux.tar.args` to detect the java version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
