### PR TITLE
Update maven publishing workflow to accommodate nexus EOL

### DIFF
--- a/jenkins/release-workflows/publish-to-maven.jenkinsfile
+++ b/jenkins/release-workflows/publish-to-maven.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@testMaven', retriever: modernSCM([
+lib = library(identifier: 'jenkins@10.0.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -62,7 +62,7 @@ pipeline {
                     publishToMaven(
                         signingArtifactsPath: "$WORKSPACE/artifacts/$ARTIFACT_PATH/opensearch/manifest.yml",
                         mavenArtifactsPath: "$WORKSPACE/artifacts/$ARTIFACT_PATH/opensearch/maven",
-                        autoPublish: false,
+                        autoPublish: true,
                         email: "${email}"
                     )
                 }

--- a/tests/jenkins/TestPublishToMaven.groovy
+++ b/tests/jenkins/TestPublishToMaven.groovy
@@ -22,7 +22,7 @@ class TestPublishToMaven extends BuildPipelineTest {
     void setUp() {
         helper.registerSharedLibrary(
             library().name('jenkins')
-                .defaultVersion('testMaven')
+                .defaultVersion('10.0.0')
                 .allowOverride(true)
                 .implicit(true)
                 .targetPath('vars')

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch-maven-release/publish-to-maven.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch-maven-release/publish-to-maven.jenkinsfile.txt
@@ -1,6 +1,6 @@
    publish-to-maven.run()
       publish-to-maven.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
-      publish-to-maven.library({identifier=jenkins@testMaven, retriever=null})
+      publish-to-maven.library({identifier=jenkins@10.0.0, retriever=null})
       publish-to-maven.pipeline(groovy.lang.Closure)
          publish-to-maven.credentials(jenkins-artifact-bucket-name)
          publish-to-maven.echo(Executing on agent [docker:[alwaysPull:true, args:-e JAVA_HOME=/opt/java/openjdk-11, containerPerStageRoot:false, label:Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host, image:opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3, reuseNode:false, registryUrl:https://public.ecr.aws/, stages:[:]]])
@@ -15,9 +15,9 @@
                publish-to-maven.echo(Signing, Staging and Publishing Maven artifacts.)
                publish-to-maven.echo(Major version is 2)
                publish-to-maven.echo(Signing email is opensearch@amazon.com)
-               publish-to-maven.publishToMaven({signingArtifactsPath=/tmp/workspace/artifacts/distribution-build-opensearch/null/null/linux/x64/tar/builds/opensearch/manifest.yml, mavenArtifactsPath=/tmp/workspace/artifacts/distribution-build-opensearch/null/null/linux/x64/tar/builds/opensearch/maven, autoPublish=false, email=opensearch@amazon.com})
+               publish-to-maven.publishToMaven({signingArtifactsPath=/tmp/workspace/artifacts/distribution-build-opensearch/null/null/linux/x64/tar/builds/opensearch/manifest.yml, mavenArtifactsPath=/tmp/workspace/artifacts/distribution-build-opensearch/null/null/linux/x64/tar/builds/opensearch/maven, autoPublish=true, email=opensearch@amazon.com})
                   publishToMaven.legacySCM(groovy.lang.Closure)
-                  publishToMaven.library({identifier=jenkins@9.6.2, retriever=null})
+                  publishToMaven.library({identifier=jenkins@10.0.0, retriever=null})
                   publishToMaven.loadCustomScript({scriptPath=publish/stage-maven-release.sh, scriptName=stage-maven-release.sh})
                      loadCustomScript.libraryResource(publish/stage-maven-release.sh)
                      loadCustomScript.writeFile({file=stage-maven-release.sh, text=#!/bin/bash
@@ -33,44 +33,51 @@
 # Name:          stage-maven-release.sh
 # Language:      Shell
 #
-# About:         Deploy opensearch artifacts to a sonatype staging repository.
+# About:         Deploy opensearch artifacts to a maven central.
 #                This script will create a new staging repository in Sonatype and stage
-#                all artifacts in the passed in directory. The folder passed as input should contain
+#                all artifacts in the passed in directory. If auto_publish is enabled, 
+#                it will publish to maven central. The folder passed as input should contain 
 #                subfolders org/opensearch to ensure artifacts are deployed under the correct groupId.
 #                Example: ./stage-maven-release.sh /maven
 #                - where maven contains /maven/org/opensearch
 #
-# Usage:         ./stage-maven-release.sh <directory>
+# Usage:         ./stage-maven-release.sh <directory> -a <true|false>
 #
 ###############################################################################################
 set -e
 
-[ -z "${1:-}" ] && {
-  usage
-}
-
 usage() {
-  echo "usage: $0 [-h] [dir]"
+  echo "usage: $0 [-h] [dir] -a <true|false>"
   echo "  dir     parent directory containing artifacts to org/opensearch namespace."
   echo "          example: dir = ~/.m2/repository where repository contains /org/opensearch"
   echo "  -h      display help"
+  echo "  -a      auto-publish to maven central after staging repository is created. Defaults to false."
   echo "Required environment variables:"
   echo "SONATYPE_USERNAME - username with publish rights to a sonatype repository"
   echo "SONATYPE_PASSWORD - password for sonatype"
+  echo "JOB_NAME - Job Name which triggered this script for tracking purposes"
   echo "BUILD_ID - Build ID from CI so we can trace where the artifacts were built"
   echo "STAGING_PROFILE_ID - Sonatype Staging profile ID"
-  echo "REPO_URL - repository URL without path, ex. https://aws.oss.sonatype.org/"
   exit 1
 }
 
-while getopts ":h" option; do
+[ -z "${1:-}" ] && {
+  usage
+  exit 1
+}
+
+while getopts ":ha:" option; do
   case $option in
   h)
     usage
     ;;
+  a)
+    auto_publish="${OPTARG:-false}"
+    ;;
   \?)
     echo "Invalid option -$OPTARG" >&2
     usage
+    exit 1
     ;;
   esac
 done
@@ -85,8 +92,8 @@ done
   exit 1
 }
 
-[ -z "${REPO_URL}" ] && {
-  echo "REPO_URL is required"
+[ -z "${JOB_NAME}" ] && {
+  echo "JOB_NAME is required"
   exit 1
 }
 
@@ -111,7 +118,6 @@ fi
 }
 
 staged_repo=$1
-auto_publish=$2
 
 workdir=$(mktemp -d)
 
@@ -131,7 +137,7 @@ function create_maven_settings() {
                             http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>nexus</id>
+      <id>central</id>
       <username>${SONATYPE_USERNAME}</username>
       <password>${SONATYPE_PASSWORD}</password>
     </server>
@@ -141,12 +147,13 @@ EOF
 }
 
 function create_staging_repository() {
+  echo "Creating staging repository."
   staging_repo_id=$(mvn --settings="${mvn_settings}" \
     org.sonatype.plugins:nexus-staging-maven-plugin:rc-open \
-    -DnexusUrl="${REPO_URL}" \
-    -DserverId=nexus \
+    -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
+    -DserverId=central \
     -DstagingProfileId="${STAGING_PROFILE_ID}" \
-    -DstagingDescription="Staging artifacts for build ${BUILD_ID}" \
+    -DstagingDescription="Staging artifacts for ${JOB_NAME}-${BUILD_ID}" \
     -DopenedRepositoryMessageFormat="opensearch-staging-repo-id=%s" |
     grep -E -o 'opensearch-staging-repo-id=.*$' | cut -d'=' -f2)
   echo "Opened staging repository ID $staging_repo_id"
@@ -156,28 +163,26 @@ create_maven_settings
 create_staging_repository
 
 echo "==========================================="
-echo "Deploying artifacts under ${artifact_path} to Staging Repository ${staging_repo_id}."
+echo "Deploying artifacts under ${staged_repo} to Staging Repository ${staging_repo_id}."
 echo "==========================================="
 
 mvn --settings="${mvn_settings}" \
   org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository \
   -DrepositoryDirectory="${staged_repo}" \
-  -DnexusUrl="${REPO_URL}" \
-  -DserverId=nexus \
+  -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
+  -DserverId=central \
   -DautoReleaseAfterClose=false \
   -DstagingProgressTimeoutMinutes=30 \
-  -DstagingProfileId="${STAGING_PROFILE_ID}" \
-  -DstagingRepositoryId="${staging_repo_id}"
+  -DstagingProfileId="${STAGING_PROFILE_ID}"
 
 echo "==========================================="
 echo "Done."
 echo "==========================================="
 
-## Below commands will be executed if the user checks AUTO_RELEASE_STAGING_TO_PROD parameter in the
-## maven-sign-release job. See https://github.com/sonatype/nexus-maven-plugins/blob/main/staging/maven-plugin/README.md
-## for command reference.
+# If auto_publish is set to true below commands will be executed See https://github.com/sonatype/nexus-maven-plugins/blob/main/staging/maven-plugin/README.md
+# for command reference.
 if [ "$auto_publish" = true ] ; then
-    export MAVEN_OPTS=--add-opens=java.base/java.util=ALL-UNNAMED ## See https://issues.sonatype.org/browse/NEXUS-31214
+    export MAVEN_OPTS=--add-opens=java.base/java.util=ALL-UNNAMED
 
     echo "==========================================="
     echo "Closing Staging Repository ${staging_repo_id}."
@@ -185,8 +190,8 @@ if [ "$auto_publish" = true ] ; then
 
     mvn --settings="${mvn_settings}" \
       org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:rc-close \
-      -DnexusUrl="${REPO_URL}" \
-      -DserverId=nexus \
+      -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
+      -DserverId=central \
       -DautoReleaseAfterClose=true \
       -DstagingProfileId="${STAGING_PROFILE_ID}" \
       -DstagingRepositoryId="${staging_repo_id}"
@@ -201,8 +206,8 @@ if [ "$auto_publish" = true ] ; then
 
     mvn --settings="${mvn_settings}" \
       org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:rc-release \
-      -DnexusUrl="${REPO_URL}" \
-      -DserverId=nexus \
+      -DnexusUrl="https://ossrh-staging-api.central.sonatype.com" \
+      -DserverId=central \
       -DstagingProfileId="${STAGING_PROFILE_ID}" \
       -DstagingRepositoryId="${staging_repo_id}"
 
@@ -232,9 +237,10 @@ fi
 
                    /tmp/workspace/opensearch-build/sign.sh /tmp/workspace/artifacts/distribution-build-opensearch/null/null/linux/x64/tar/builds/opensearch/manifest.yml --type maven --platform linux --sigtype .asc --email opensearch@amazon.com
                )
-                  publishToMaven.usernamePassword({credentialsId=jenkins-sonatype-creds, usernameVariable=SONATYPE_USERNAME, passwordVariable=SONATYPE_PASSWORD})
-                  publishToMaven.withCredentials([[SONATYPE_USERNAME, SONATYPE_PASSWORD]], groovy.lang.Closure)
-                     publishToMaven.sh(./stage-maven-release.sh /tmp/workspace/artifacts/distribution-build-opensearch/null/null/linux/x64/tar/builds/opensearch/maven false)
+                  publishToMaven.string({credentialsId=maven-central-portal-username, variable=SONATYPE_USERNAME})
+                  publishToMaven.string({credentialsId=maven-central-portal-token, variable=SONATYPE_PASSWORD})
+                  publishToMaven.withCredentials([SONATYPE_USERNAME, SONATYPE_PASSWORD], groovy.lang.Closure)
+                     publishToMaven.sh(./stage-maven-release.sh /tmp/workspace/artifacts/distribution-build-opensearch/null/null/linux/x64/tar/builds/opensearch/maven -a true)
          publish-to-maven.script(groovy.lang.Closure)
             publish-to-maven.postCleanup()
                postCleanup.cleanWs({disableDeferredWipeout=true, deleteDirs=true})


### PR DESCRIPTION
### Description
Updates maven publishing workflow to accommodate nexus EOL. Also reverts testing settings to auto-publish https://github.com/opensearch-project/opensearch-build-libraries/releases/tag/10.0.0

### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-build/issues/5550

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
