### PR TITLE
Add code to trigger nightly playgrounds after each RC build

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -988,6 +988,17 @@ pipeline {
                 script {
                     if (params.RC_NUMBER.toInteger() > 0) {
                         triggerDistributionValidationWorkflow(env.revision)
+                        triggerNightlyPlayground()
+                    }
+                    postCleanup()
+                }
+            }
+        }
+        unstable {
+            node(AGENT_LINUX_X64) {
+                script {
+                    if (params.RC_NUMBER.toInteger() > 0) {
+                        triggerNightlyPlayground()
                     }
                     postCleanup()
                 }
@@ -1058,6 +1069,20 @@ def triggerDistributionValidationWorkflow(String version) {
                 string(name: 'PROJECTS', value: 'Both'),
                 string(name: 'ARTIFACT_TYPE', value: 'staging')
             ]
+}
+
+def triggerNightlyPlayground() {
+    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+        println("Triggering nightly playground workflow.")
+        try {
+            sh(
+                script: "gh workflow run nightly-playground-trigger.yml -R opensearch-project/opensearch-devops --ref main",
+                returnStdout: true
+            )
+        } catch (Exception ex) {
+            println("Error in triggering nightly playground workflow. ${ex.getMessage()}")
+        }
+    }
 }
 
 def verifyParameterPlatformDistribution(String paramName, String allowedValue) {

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -999,6 +999,17 @@ pipeline {
                 script {
                     if (params.RC_NUMBER.toInteger() > 0) {
                         triggerDistributionValidationWorkflow(env.revision)
+                        triggerNightlyPlayground()
+                    }
+                    postCleanup()
+                }
+            }
+        }
+        unstable {
+            node(AGENT_LINUX_X64) {
+                script {
+                    if (params.RC_NUMBER.toInteger() > 0) {
+                        triggerNightlyPlayground()
                     }
                     postCleanup()
                 }
@@ -1083,6 +1094,20 @@ def triggerDistributionValidationWorkflow(String version) {
                 string(name: 'PROJECTS', value: 'opensearch'),
                 string(name: 'ARTIFACT_TYPE', value: 'staging')
             ]
+}
+
+def triggerNightlyPlayground() {
+    withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
+        println("Triggering nightly playground workflow.")
+        try {
+            sh(
+                script: "gh workflow run nightly-playground-trigger.yml -R opensearch-project/opensearch-devops --ref main",
+                returnStdout: true
+            )
+        } catch (Exception ex) {
+            println("Error in triggering nightly playground workflow. ${ex.getMessage()}")
+        }
+    }
 }
 
 def verifyParameterPlatformDistribution(String paramName, String allowedValue) {


### PR DESCRIPTION
### Description
As a retrospective item, it was observed that there was a delay in nightly playgrounds deployment during releases. This PR triggers the deployment given build is a RC candidate.

### Issues Resolved
#5615 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
