### PR TITLE
Included qualifier value in bundle and build manifests

### DIFF
--- a/src/assemble_workflow/bundle_recorder.py
+++ b/src/assemble_workflow/bundle_recorder.py
@@ -22,6 +22,7 @@ class BundleRecorder:
         self.build_id = build.id
         self.bundle_location = bundle_location
         self.version = build.version
+        self.qualifier = build.qualifier
         self.distribution = build.distribution
         self.package_name = self.__get_package_name(build)
         self.artifacts_dir = artifacts_dir
@@ -40,6 +41,7 @@ class BundleRecorder:
         parts = [
             build.filename,
             build.version,
+            build.qualifier,
             build.platform,
             build.architecture,
         ]
@@ -73,12 +75,13 @@ class BundleRecorder:
         self.get_manifest().to_file(manifest_path)
 
     class BundleManifestBuilder:
-        def __init__(self, build_id: str, name: str, version: str, platform: str, architecture: str, distribution: str, location: str) -> None:
+        def __init__(self, build_id: str, name: str, version: str, qualifier: str, platform: str, architecture: str, distribution: str, location: str) -> None:
             self.data: Dict[str, Any] = {}
             self.data["build"] = {}
             self.data["build"]["id"] = build_id
             self.data["build"]["name"] = name
             self.data["build"]["version"] = str(version)
+            self.date["build"]["qualifier"] = qualifier
             self.data["build"]["platform"] = platform
             self.data["build"]["architecture"] = architecture
             self.data["build"]["distribution"] = distribution if distribution else "tar"

--- a/src/build_workflow/build_incremental.py
+++ b/src/build_workflow/build_incremental.py
@@ -30,10 +30,10 @@ class BuildIncremental:
         stable_input_manifest = input_manifest.stable()
         stable_input_manifest_version = (
             stable_input_manifest.build.version
-            if not stable_input_manifest.build.qualifier
-            else f"{stable_input_manifest.build.version}-{stable_input_manifest.build.qualifier}"
         )
-        if previous_build_manifest.build.version != stable_input_manifest_version:
+        stable_input_manifest_qualifier = stable_input_manifest.build.qualifier
+        if (previous_build_manifest.build.version != stable_input_manifest_version) or \
+        (previous_build_manifest.build.qualifier != stable_input_manifest_qualifier):
             logging.info("The version of previous build manifest doesn't match the current input manifest. Rebuilding Core.")
             return [input_manifest.build.name.replace(" ", "-")]
         components = []

--- a/src/manifests/build_manifest.py
+++ b/src/manifests/build_manifest.py
@@ -60,6 +60,7 @@ class BuildManifest(ComponentManifest['BuildManifest', 'BuildComponents']):
                 "id": {"required": True, "type": "string"},
                 "name": {"required": True, "type": "string"},
                 "version": {"required": True, "type": "string"},
+                "qualifier": {"type": "string"}
             },
         },
         "schema-version": {"required": True, "type": "string", "allowed": ["1.2"]},
@@ -104,6 +105,7 @@ class BuildManifest(ComponentManifest['BuildManifest', 'BuildComponents']):
         def __init__(self, data: dict) -> None:
             self.name: str = data["name"]
             self.version: str = data["version"]
+            self.qualifier: str = data.get('qualifier', None)
             self.platform: str = data["platform"]
             self.architecture: str = data["architecture"]
             self.distribution: str = data.get('distribution', None)
@@ -113,6 +115,7 @@ class BuildManifest(ComponentManifest['BuildManifest', 'BuildComponents']):
             return {
                 "name": self.name,
                 "version": self.version,
+                "qualifier": self.qualifier,
                 "platform": self.platform,
                 "architecture": self.architecture,
                 "distribution": self.distribution,

--- a/src/manifests/bundle_manifest.py
+++ b/src/manifests/bundle_manifest.py
@@ -47,6 +47,7 @@ class BundleManifest(ComponentManifest['BundleManifest', 'BundleComponents']):
                 "location": {"required": True, "type": "string"},
                 "name": {"required": True, "type": "string"},
                 "version": {"required": True, "type": "string"},
+                "qualifier": {"type": "string"}
             },
         },
         "schema-version": {"required": True, "type": "string", "allowed": ["1.1"]},
@@ -82,6 +83,7 @@ class BundleManifest(ComponentManifest['BundleManifest', 'BundleComponents']):
         def __init__(self, data: Dict[str, str]) -> None:
             self.name = data["name"]
             self.version = data["version"]
+            self.qualifier = data.get('qualifier', None)
             self.platform = data["platform"]
             self.architecture = data["architecture"]
             self.distribution: str = data.get('distribution', None)
@@ -92,6 +94,7 @@ class BundleManifest(ComponentManifest['BundleManifest', 'BundleComponents']):
             return {
                 "name": self.name,
                 "version": self.version,
+                "qualifier": self.qualifier,
                 "platform": self.platform,
                 "architecture": self.architecture,
                 "distribution": self.distribution,

--- a/src/report_workflow/test_report_runner.py
+++ b/src/report_workflow/test_report_runner.py
@@ -57,6 +57,7 @@ class TestReportRunner:
     def update_data(self) -> dict:
         self.test_report_data["name"] = self.product_name
         self.test_report_data["version"] = self.bundle_manifest.build.version
+        self.test_report_data["qualifier"] = self.bundle_manifest.build.qualifier
         self.test_report_data["platform"] = self.bundle_manifest.build.platform
         self.test_report_data["architecture"] = self.bundle_manifest.build.architecture
         self.test_report_data["distribution"] = self.bundle_manifest.build.distribution
@@ -105,7 +106,8 @@ class TestReportRunner:
         if self.test_type == "integ-test":
             config_names = [config for config in test_component.__to_dict__().get(self.test_type)["test-configs"]]
         elif self.test_type == "smoke-test":
-            config_names = self.get_spec_path(self.test_report_data["version"], test_component.__to_dict__().get(self.test_type)["test-spec"])
+            config_names = self.get_spec_path(self.test_report_data["version"] + (("-" + self.test_report_data["qualifier"]) 
+                                                                                  if self.test_report_data["qualifier"] else None), test_component.__to_dict__().get(self.test_type)["test-spec"])
         logging.info(f"Configs for {component_name} on {self.test_type} are {config_names}")
         for config in config_names:
             config_dict = {
@@ -151,6 +153,7 @@ class TestReportRunner:
                 "schema-version": "1.1",
                 "name": "",
                 "version": "",
+                "qualifier": "",
                 "platform": "",
                 "architecture": "",
                 "distribution": "",

--- a/src/run_manifests.py
+++ b/src/run_manifests.py
@@ -20,7 +20,8 @@ def main() -> int:
     if args.action == "list":
         for klass in args.manifests:
             for manifest in klass().values():
-                logging.info(f"{manifest.build.name} {manifest.build.version}")
+                logging.info(f"{manifest.build.name} {manifest.build.version + (("-" + manifest.build.qualifier) 
+                                                                                  if manifest.build.qualifier else None)}")
     elif args.action == "update":
         for klass in args.manifests:
             klass().update(keep=args.keep)

--- a/src/run_releasenotes_check.py
+++ b/src/run_releasenotes_check.py
@@ -33,7 +33,9 @@ def main() -> int:
         manifests.append(InputManifest.from_file(input_manifests))
 
     if len(args.manifest) == 2:
-        if manifests[0].build.version != manifests[1].build.version:
+        if manifests[0].build.version + (("-" + manifests[0].build.qualifier) 
+                    if manifests[0].build.qualifier else None) != manifests[1].build.version + (("-" + manifests[1].build.qualifier) 
+                    if manifests[1].build.qualifier else None) :
             raise ValueError("OS and OSD manifests must be provided for the same release version")
         elif manifests[0].build.name == manifests[1].build.name:
             raise ValueError("Both manifests are for the same product, OS and OSD manifests must be provided")
@@ -41,7 +43,8 @@ def main() -> int:
         raise ValueError("Only two manifests, OS and OSD, can be provided")
 
     #  Assuming that the OS and OSD manifests will be provided for the same release version
-    BUILD_VERSION = manifests[0].build.version
+    BUILD_VERSION = manifests[0].build.version + (("-" + manifests[0].build.qualifier) 
+                    if manifests[0].build.qualifier else None) 
 
     table_filename = f"{BASE_FILE_PATH}/release_notes_table-{BUILD_VERSION}.md"
     urls_filename = f"{BASE_FILE_PATH}/release_notes_urls-{BUILD_VERSION}.txt"

--- a/src/test_workflow/benchmark_test/benchmark_create_cluster.py
+++ b/src/test_workflow/benchmark_test/benchmark_create_cluster.py
@@ -104,10 +104,11 @@ class BenchmarkCreateCluster(BenchmarkTestCluster):
             suffix = self.args.stack_suffix
 
         if self.manifest:
-            self.args.distribution_version = self.manifest.build.version
+            self.args.distribution_version = self.manifest.build.version + (("-" + self.manifest.build.qualifier) 
+                                                                                  if self.manifest.build.qualifier else None)
             artifact_url = self.manifest.build.location if isinstance(self.manifest, BundleManifest) else \
-                f"https://artifacts.opensearch.org/snapshots/core/opensearch/{self.manifest.build.version}/opensearch-min-" \
-                f"{self.manifest.build.version}-linux-{self.manifest.build.architecture}-latest.tar.gz"
+                f"https://artifacts.opensearch.org/snapshots/core/opensearch/{self.args.distribution_version}/opensearch-min-" \
+                f"{self.args.distribution_version}-linux-{self.manifest.build.architecture}-latest.tar.gz"
         else:
             artifact_url = self.args.distribution_url.strip()
 

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch.py
@@ -109,7 +109,8 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
         if os.path.exists(script):
             if len(cluster_endpoints) == 1:
                 single_data_node = cluster_endpoints[0].data_nodes[0]
-                cmd = f"bash {script} -b {single_data_node.endpoint} -p {single_data_node.port} -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
+                cmd = f"bash {script} -b {single_data_node.endpoint} -p {single_data_node.port} -s {str(security).lower()} -v {self.bundle_manifest.build.version + (("-" + self.bundle_manifest.build.qualifier) 
+                                                                                  if self.bundle_manifest.build.qualifier else None)}"
             else:
                 endpoints_list = []
                 for cluster_details in cluster_endpoints:
@@ -117,7 +118,8 @@ class IntegTestSuiteOpenSearch(IntegTestSuite):
                 endpoints_string = json.dumps(endpoints_list, indent=0, default=custom_node_endpoint_encoder).replace("\n", "")
                 cmd = f"bash {script} -e '"
                 cmd = cmd + endpoints_string + "'"
-                cmd = cmd + f" -s {str(security).lower()} -v {self.bundle_manifest.build.version}"
+                cmd = cmd + f" -s {str(security).lower()} -v {self.bundle_manifest.build.version + (("-" + self.bundle_manifest.build.qualifier) 
+                                                                                  if self.bundle_manifest.build.qualifier else None)}"
             self.repo_work_dir = os.path.join(
                 self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
             (status, stdout, stderr) = execute(cmd, self.repo_work_dir, True, False)

--- a/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/integ_test_suite_opensearch_dashboards.py
@@ -110,7 +110,8 @@ class IntegTestSuiteOpenSearchDashboards(IntegTestSuite):
             return {"endpoint": node_endpoint.endpoint, "port": node_endpoint.port, "transport": node_endpoint.transport}
         if os.path.exists(script):
             single_node = cluster_endpoints[0].data_nodes[0]
-            cmd = f"bash {script} -b {single_node.endpoint} -p {single_node.port} -s {str(security).lower()} -t {self.component.name} -v {self.bundle_manifest.build.version} -o default -r false"
+            cmd = f"bash {script} -b {single_node.endpoint} -p {single_node.port} -s {str(security).lower()} -t {self.component.name} -v {self.bundle_manifest.build.version + (("-" + self.bundle_manifest.build.qualifier) 
+                                                                                  if self.bundle_manifest.build.qualifier else None)} -o default -r false"
             self.repo_work_dir = os.path.join(
                 self.repo.dir, self.test_config.working_directory) if self.test_config.working_directory is not None else self.repo.dir
             (status, stdout, stderr) = execute(cmd, self.repo_work_dir, True, False)

--- a/src/test_workflow/integ_test/local_test_cluster.py
+++ b/src/test_workflow/integ_test/local_test_cluster.py
@@ -52,7 +52,8 @@ class LocalTestCluster(TestCluster):
         self.dependency_installer = dependency_installer
 
         self.service_opensearch = ServiceOpenSearch(
-            self.manifest.build.version,
+            self.manifest.build.version + (("-" + self.manifest.build.qualifier) 
+                                                    if self.manifest.build.qualifier else None),
             self.manifest.build.distribution,
             self.additional_cluster_config,
             self.security_enabled,

--- a/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/local_test_cluster_opensearch_dashboards.py
@@ -56,7 +56,8 @@ class LocalTestClusterOpenSearchDashboards(TestCluster):
         self.dependency_installer_opensearch_dashboards = dependency_installer_opensearch_dashboards
 
         self.service_opensearch = ServiceOpenSearch(
-            self.manifest_opensearch.build.version,
+            self.manifest_opensearch.build.version + (("-" + self.manifest_opensearch.build.qualifier) 
+                                                    if self.manifest_opensearch.build.qualifier else None),
             self.manifest_opensearch.build.distribution,
             {},
             self.security_enabled,
@@ -64,7 +65,8 @@ class LocalTestClusterOpenSearchDashboards(TestCluster):
             self.work_dir)
 
         self.service_opensearch_dashboards = ServiceOpenSearchDashboards(
-            self.manifest_opensearch_dashboards.build.version,
+            self.manifest_opensearch_dashboards.build.version + (("-" + self.manifest_opensearch_dashboards.build.qualifier) 
+                                                    if self.manifest_opensearch_dashboards.build.qualifier else None),
             self.manifest_opensearch_dashboards.build.distribution,
             self.additional_cluster_config,
             self.security_enabled,

--- a/src/test_workflow/perf_test/perf_test_cluster.py
+++ b/src/test_workflow/perf_test/perf_test_cluster.py
@@ -111,7 +111,8 @@ class PerfTestCluster(TestCluster):
     def wait_for_processing(self, tries: int = 3, delay: int = 15, backoff: int = 2) -> None:
         password = 'admin'
         if self.manifest:
-            if semver.compare(self.manifest.build.version, '2.12.0') != -1:
+            if semver.compare(self.manifest.build.version + (("-" + self.manifest.build.qualifier) 
+                                                    if self.manifest.build.qualifier else None), '2.12.0') != -1:
                 password = 'myStrongPassword123!'
 
         # Should be invoked only if the endpoint is public.

--- a/src/test_workflow/smoke_test/smoke_test_cluster_opensearch.py
+++ b/src/test_workflow/smoke_test/smoke_test_cluster_opensearch.py
@@ -41,7 +41,8 @@ class SmokeTestClusterOpenSearch():
         self.path = args.paths.get(self.product)
         self.build_manifest = BuildManifest.from_urlpath(os.path.join(self.path, "builds", f"{self.product}", "manifest.yml"))
         self.bundle_manifest = BundleManifest.from_urlpath(os.path.join(self.path, "dist", f"{self.product}", "manifest.yml"))
-        self.version = self.bundle_manifest.build.version
+        self.version = self.bundle_manifest.build.version + (("-" + self.bundle_manifest.build.qualifier) 
+                                                    if self.bundle_manifest.build.qualifier else None)
         self.platform = self.bundle_manifest.build.platform
         self.arch = self.bundle_manifest.build.architecture
         self.dist = self.bundle_manifest.build.distribution


### PR DESCRIPTION
### Description
Currently, the input manifest schema has a qualifier attribute which is not included in the bundle and build manifests. Now whenever the versions of the build and bundle manifest are used in the workflow, the qualifier is also appended to the version of the build or bundle manifests for those cases. Additionally, the schema for the build and bundle manifests will keep track of a qualifier value. 

### Issues Resolved
#5386 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
