### PR TITLE
Upgrade jenkins lib version to 9.6.0 for docker-re-release job

### DIFF
--- a/jenkins/docker/docker-re-release.jenkinsfile
+++ b/jenkins/docker/docker-re-release.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@6.2.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@9.6.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))

--- a/tests/jenkins/TestDockerReRelease.groovy
+++ b/tests/jenkins/TestDockerReRelease.groovy
@@ -25,7 +25,7 @@ class TestDockerReRelease extends BuildPipelineTest {
 
         helper.registerSharedLibrary(
             library().name('jenkins')
-                .defaultVersion('6.2.0')
+                .defaultVersion('9.6.0')
                 .allowOverride(true)
                 .implicit(true)
                 .targetPath('vars')

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-re-release.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-re-release.jenkinsfile.txt
@@ -1,6 +1,6 @@
    docker-re-release.run()
       docker-re-release.modernSCM({$class=GitSCMSource, remote=https://github.com/opensearch-project/opensearch-build-libraries.git})
-      docker-re-release.library({identifier=jenkins@6.2.0, retriever=null})
+      docker-re-release.library({identifier=jenkins@9.6.0, retriever=null})
       docker-re-release.pipeline(groovy.lang.Closure)
          docker-re-release.timeout({time=2, unit=HOURS})
          docker-re-release.echo(Executing on agent [label:none])
@@ -14,7 +14,7 @@
             docker-re-release.script(groovy.lang.Closure)
                docker-re-release.patchDockerImage({product=opensearch, tag=1})
                   patchDockerImage.legacySCM(groovy.lang.Closure)
-                  patchDockerImage.library({identifier=jenkins@6.2.0, retriever=null})
+                  patchDockerImage.library({identifier=jenkins@9.6.0, retriever=null})
                   patchDockerImage.sh(#!/bin/bash
     set -e
     set +x
@@ -29,7 +29,7 @@
                   InputManifest.asBoolean()
                   patchDockerImage.buildDockerImage({inputManifest=manifests/1.3.0/opensearch-1.3.0.yml, buildNumber=7756, buildGitRef=1.3.0, buildDate=20230619, buildOption=re_release_docker_image, artifactUrlX64=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.0/7756/linux/x64/tar/dist/opensearch/opensearch-1.3.0-linux-x64.tar.gz, artifactUrlArm64=https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.0/7756/linux/arm64/tar/dist/opensearch/opensearch-1.3.0-linux-arm64.tar.gz})
                      buildDockerImage.legacySCM(groovy.lang.Closure)
-                     buildDockerImage.library({identifier=jenkins@6.2.0, retriever=null})
+                     buildDockerImage.library({identifier=jenkins@9.6.0, retriever=null})
                      buildDockerImage.readYaml({file=manifests/1.3.0/opensearch-1.3.0.yml})
                      InputManifest.asBoolean()
                      buildDockerImage.echo(Triggering docker-build)


### PR DESCRIPTION
### Description
Upgrade jenkins lib version to 9.6.0 for docker-re-release job to fix the Input manifest schema change error
### Issues Resolved
https://build.ci.opensearch.org/blue/organizations/jenkins/docker-re-release/detail/docker-re-release/89/pipeline/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
