### PR TITLE
Upgrade version to lib version to 9.6.0 in release chores workflow

### DIFF
--- a/jenkins/release-workflows/release-chores.jenkinsfile
+++ b/jenkins/release-workflows/release-chores.jenkinsfile
@@ -6,7 +6,7 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-lib = library(identifier: 'jenkins@9.1.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@9.6.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))

--- a/tests/jenkins/TestReleaseChores.groovy
+++ b/tests/jenkins/TestReleaseChores.groovy
@@ -25,7 +25,7 @@ class TestReleaseChores extends BuildPipelineTest {
     void setUp() {
         helper.registerSharedLibrary(
             library().name('jenkins')
-                .defaultVersion('9.1.1')
+                .defaultVersion('9.6.0')
                 .allowOverride(true)
                 .implicit(true)
                 .targetPath('vars')


### PR DESCRIPTION
### Description
Upgrade version to lib version to 9.6.0 in release chores workflow
### Issues Resolved
https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-release-chores/detail/distribution-release-chores/75/pipeline

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
