### PR TITLE
Update test manifest to use ubuntu systemd image

### DIFF
--- a/manifests/2.19.3/opensearch-2.19.3-test.yml
+++ b/manifests/2.19.3/opensearch-2.19.3-test.yml
@@ -8,7 +8,7 @@ ci:
         name: opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1
         args: '-e JAVA_HOME=/opt/java/openjdk-21 -u 1000 --cpus 4 -m 16g'
       deb:
-        name: opensearchstaging/ci-runner:ci-runner-ubuntu2404-opensearch-build-v1
+        name: opensearchstaging/ci-runner:ci-runner-ubuntu2404-systemd-base-integtest-v1
         args: '-e JAVA_HOME=/opt/java/openjdk-21 --entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 16g'
       rpm:
         name: opensearchstaging/ci-runner:ci-runner-almalinux8-systemd-base-integtest-v1

--- a/manifests/2.19.3/opensearch-dashboards-2.19.3-test.yml
+++ b/manifests/2.19.3/opensearch-dashboards-2.19.3-test.yml
@@ -8,7 +8,7 @@ ci:
         name: opensearchstaging/ci-runner-almalinux8-opensearch-dashboards-integtest-v1
         args: '-u 1000 --cpus 4 -m 16g -e BROWSER_PATH=electron'
       deb:
-        name: opensearchstaging/ci-runner:ci-runner-ubuntu2404-opensearch-build-v1
+        name: opensearchstaging/ci-runner:ci-runner-ubuntu2404-systemd-base-integtest-v1
         args: '--entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 16g -e BROWSER_PATH=electron'
       rpm:
         name: opensearchstaging/ci-runner:ci-runner-almalinux8-systemd-base-integtest-v1

--- a/manifests/3.2.0/opensearch-3.2.0-test.yml
+++ b/manifests/3.2.0/opensearch-3.2.0-test.yml
@@ -8,7 +8,7 @@ ci:
         name: opensearchstaging/ci-runner:ci-runner-al2-opensearch-build-v1
         args: '-e JAVA_HOME=/opt/java/openjdk-24 -u 1000 --cpus 4 -m 16g'
       deb:
-        name: opensearchstaging/ci-runner:ci-runner-ubuntu2404-opensearch-build-v1
+        name: opensearchstaging/ci-runner:ci-runner-ubuntu2404-systemd-base-integtest-v1
         args: '-e JAVA_HOME=/opt/java/openjdk-24 --entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw --cgroupns=host --cpus 4 -m 16g'
       rpm:
         name: opensearchstaging/ci-runner:ci-runner-almalinux8-systemd-base-integtest-v1


### PR DESCRIPTION
### Description
Update test manifest to use ubuntu systemd image

### Issues Resolved
```
2025-07-17 20:51:24 INFO     deb installation requires sudo, script will exit if current user does not have sudo access

/bin/sh: 1: sudo: not found

2025-07-17 20:51:24 INFO     Removing /tmp/tmpty2k1fj0

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
