### PR TITLE
Update curl to support sigv4 on almalinux8 images

### DIFF
--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
@@ -31,7 +31,6 @@ curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-l
 tar -xvf curl.tar.xz
 mv -v curl /usr/local/bin/curl
 rm -v curl.tar.xz
-curl --version
 
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
@@ -24,6 +24,15 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
     dnf update -y && \
     dnf install -y which curl git gnupg2 tar net-tools procps-ng python39 python39-devel python39-pip zip unzip jq
 
+# Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
+# https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
+# https://curl.se/changes.html#7_75_0
+curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz
+tar -xvf curl.tar.xz
+mv -v curl /usr/local/bin/curl
+rm -v curl.tar.xz
+curl --version
+
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \
     useradd -u 1000 -g 1000 -d $CONTAINER_USER_HOME $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
@@ -31,7 +31,6 @@ curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-l
 tar -xvf curl.tar.xz
 mv -v curl /usr/local/bin/curl
 rm -v curl.tar.xz
-curl --version
 
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
@@ -24,6 +24,15 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
     dnf update -y && \
     dnf install -y which curl git gnupg2 tar net-tools procps-ng python39 python39-devel python39-pip zip unzip jq
 
+# Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
+# https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
+# https://curl.se/changes.html#7_75_0
+curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz
+tar -xvf curl.tar.xz
+mv -v curl /usr/local/bin/curl
+rm -v curl.tar.xz
+curl --version
+
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \
     useradd -u 1000 -g 1000 -d $CONTAINER_USER_HOME $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
@@ -97,7 +97,6 @@ curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-l
 tar -xvf curl.tar.xz
 mv -v curl /usr/local/bin/curl
 rm -v curl.tar.xz
-curl --version
 
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
@@ -90,6 +90,15 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
     dnf update -y && \
     dnf install -y which curl git gnupg2 tar net-tools procps-ng python39 python39-devel python39-pip zip unzip
 
+# Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
+# https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
+# https://curl.se/changes.html#7_75_0
+curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz
+tar -xvf curl.tar.xz
+mv -v curl /usr/local/bin/curl
+rm -v curl.tar.xz
+curl --version
+
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \
     useradd -u 1000 -g 1000 -d $CONTAINER_USER_HOME $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
@@ -105,7 +105,6 @@ curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-l
 tar -xvf curl.tar.xz
 mv -v curl /usr/local/bin/curl
 rm -v curl.tar.xz
-curl --version
 
 # Create user group
 RUN dnf install -y sudo && \

--- a/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
@@ -98,6 +98,15 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
     dnf update -y && \
     dnf install -y which curl git gnupg2 tar net-tools procps-ng python39 python39-devel python39-pip zip unzip jq
 
+# Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
+# https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
+# https://curl.se/changes.html#7_75_0
+curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz
+tar -xvf curl.tar.xz
+mv -v curl /usr/local/bin/curl
+rm -v curl.tar.xz
+curl --version
+
 # Create user group
 RUN dnf install -y sudo && \
     groupadd -g 1000 $CONTAINER_USER && \


### PR DESCRIPTION
### Description
Update curl to support sigv4 on almalinux8 images

### Issues Resolved
Old:
```
curl: option --aws-sigv4: is unknown
curl: try 'curl --help' or 'curl --manual' for more information
Index does not exist. Creating...
```

New:
```
     --aws-sigv4 <provider1[:provider2[:region[:service]]]> Use AWS V4 signature authentication
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
