### PR TITLE
Update docker image to add missed RUN keyword

### DIFF
--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
@@ -27,10 +27,10 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
 # Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
 # https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
 # https://curl.se/changes.html#7_75_0
-curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz
-tar -xvf curl.tar.xz
-mv -v curl /usr/local/bin/curl
-rm -v curl.tar.xz
+RUN curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz && \
+    tar -xvf curl.tar.xz && \
+    mv -v curl /usr/local/bin/curl && \
+    rm -v curl.tar.xz
 
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
@@ -27,10 +27,10 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
 # Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
 # https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
 # https://curl.se/changes.html#7_75_0
-curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz
-tar -xvf curl.tar.xz
-mv -v curl /usr/local/bin/curl
-rm -v curl.tar.xz
+RUN curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz && \
+    tar -xvf curl.tar.xz && \
+    mv -v curl /usr/local/bin/curl && \
+    rm -v curl.tar.xz
 
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
@@ -93,10 +93,10 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
 # Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
 # https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
 # https://curl.se/changes.html#7_75_0
-curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz
-tar -xvf curl.tar.xz
-mv -v curl /usr/local/bin/curl
-rm -v curl.tar.xz
+RUN curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz && \
+    tar -xvf curl.tar.xz && \
+    mv -v curl /usr/local/bin/curl && \
+    rm -v curl.tar.xz
 
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
@@ -101,10 +101,10 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
 # Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
 # https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
 # https://curl.se/changes.html#7_75_0
-curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz
-tar -xvf curl.tar.xz
-mv -v curl /usr/local/bin/curl
-rm -v curl.tar.xz
+RUN curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz && \
+    tar -xvf curl.tar.xz && \
+    mv -v curl /usr/local/bin/curl && \
+    rm -v curl.tar.xz
 
 # Create user group
 RUN dnf install -y sudo && \


### PR DESCRIPTION
### Description
Update docker image to add missed RUN keyword

### Issues Resolved
```
build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile:30
--------------------
  28 |     # https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
  29 |     # https://curl.se/changes.html#7_75_0
  30 | >>> curl -SL [https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname](https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-%60uname) -m`-8.6.0.tar.xz -o curl.tar.xz
  31 |     tar -xvf curl.tar.xz
  32 |     mv -v curl /usr/local/bin/curl
--------------------
ERROR: failed to solve: dockerfile parse error on line 30: unknown instruction: curl
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
