### PR TITLE
Relink ca-certs as curl binary is pointing to ubuntu version

### DIFF
--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
@@ -27,10 +27,13 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
 # Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
 # https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
 # https://curl.se/changes.html#7_75_0
-RUN curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz && \
+RUN ARCH=`uname -m`; \
+    if [ "$ARCH" = "ppc64le"]; then ARCH=powerpc64le; fi; \
+    curl -SfL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-$ARCH-8.6.0.tar.xz -o curl.tar.xz && \
     tar -xvf curl.tar.xz && \
     mv -v curl /usr/local/bin/curl && \
-    rm -v curl.tar.xz
+    rm -v curl.tar.xz && \
+    cd /etc/ssl/certs && ln -s ca-bundle.crt ca-certificates.crt
 
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/build.almalinux8.opensearch.x64.arm64.ppc64le.dockerfile
@@ -27,10 +27,13 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
 # Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
 # https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
 # https://curl.se/changes.html#7_75_0
-RUN curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz && \
+RUN ARCH=`uname -m`; \
+    if [ "$ARCH" = "ppc64le"]; then ARCH=powerpc64le; fi; \
+    curl -SfL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-$ARCH-8.6.0.tar.xz -o curl.tar.xz && \
     tar -xvf curl.tar.xz && \
     mv -v curl /usr/local/bin/curl && \
-    rm -v curl.tar.xz
+    rm -v curl.tar.xz && \
+    cd /etc/ssl/certs && ln -s ca-bundle.crt ca-certificates.crt
 
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
@@ -93,10 +93,13 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
 # Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
 # https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
 # https://curl.se/changes.html#7_75_0
-RUN curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz && \
+RUN ARCH=`uname -m`; \
+    if [ "$ARCH" = "ppc64le"]; then ARCH=powerpc64le; fi; \
+    curl -SfL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-$ARCH-8.6.0.tar.xz -o curl.tar.xz && \
     tar -xvf curl.tar.xz && \
     mv -v curl /usr/local/bin/curl && \
-    rm -v curl.tar.xz
+    rm -v curl.tar.xz && \
+    cd /etc/ssl/certs && ln -s ca-bundle.crt ca-certificates.crt
 
 # Create user group
 RUN groupadd -g 1000 $CONTAINER_USER && \

--- a/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
@@ -101,10 +101,13 @@ RUN dnf clean all && dnf install -y 'dnf-command(config-manager)' && \
 # Replace default curl 7.61.1 on Almalinux8 with 7.75+ version to support aws-sigv4
 # https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64
 # https://curl.se/changes.html#7_75_0
-RUN curl -SL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-`uname -m`-8.6.0.tar.xz -o curl.tar.xz && \
+RUN ARCH=`uname -m`; \
+    if [ "$ARCH" = "ppc64le"]; then ARCH=powerpc64le; fi; \
+    curl -SfL https://github.com/stunnel/static-curl/releases/download/8.6.0-1/curl-linux-$ARCH-8.6.0.tar.xz -o curl.tar.xz && \
     tar -xvf curl.tar.xz && \
     mv -v curl /usr/local/bin/curl && \
-    rm -v curl.tar.xz
+    rm -v curl.tar.xz && \
+    cd /etc/ssl/certs && ln -s ca-bundle.crt ca-certificates.crt
 
 # Create user group
 RUN dnf install -y sudo && \


### PR DESCRIPTION
### Description
Relink ca-certs as curl binary is pointing to ubuntu version

### Issues Resolved
```
#21 30.71 + curl -SL https://github.com/mikefarah/yq/releases/download/v4.27.2/yq_linux_amd64 -o /usr/bin/yq
#21 30.71   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#21 30.71                                  Dload  Upload   Total   Spent    Left  Speed
#21 30.71 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
#21 30.72 curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
