### PR TITLE
Fix bedrock timeout config for AI Release Notes

### DIFF
--- a/src/release_notes_workflow/README.md
+++ b/src/release_notes_workflow/README.md
@@ -73,7 +73,6 @@ The following options are available.
 |--------------------|-------------------------------------------------------------------------|
 | --date             | Baseline date for commit analysis.                                      |
 | --component, -c    | Generate release notes for specific components only.                    |
-| --test-mode        | Run in test mode without creating PRs.                                  |
 | --output           | Saves the generated release notes to user specified file.               |
 | --ai-model         | AI model to use for analysis (default: claude-3-7-sonnet).              |
 | -v, --verbose      | Show more verbose output.                                               |

--- a/src/release_notes_workflow/release_notes_check_args.py
+++ b/src/release_notes_workflow/release_notes_check_args.py
@@ -57,7 +57,7 @@ class ReleaseNotesCheckArgs:
                             help="AWS Bedrock model ID to use for AI generation.")
         parser.add_argument("--max-tokens",
                             type=int,
-                            default=2000,
+                            default=15000,
                             help="Maximum number of tokens to generate in AI response.")
         parser.add_argument("--ref",
                             type=str,


### PR DESCRIPTION
### Description

- Increases timeout
- Changes Release Notes AI max token default to 15,000 tokens

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
