### PR TITLE
Remove 12.13.0 cypress due to installation error and not being used

### DIFF
--- a/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.ppc64le.dockerfile
@@ -46,8 +46,8 @@ WORKDIR $CONTAINER_USER_HOME
 # nvm environment variables
 ENV NVM_DIR $CONTAINER_USER_HOME/.nvm
 ENV NODE_VERSION 20.18.3
-ENV CYPRESS_VERSION 12.13.0
-ARG CYPRESS_VERSION_LIST="5.6.0 9.5.4 12.13.0"
+ENV CYPRESS_VERSION 9.5.4
+ARG CYPRESS_VERSION_LIST="5.6.0 9.5.4"
 ENV CYPRESS_LOCATION $CONTAINER_USER_HOME/.cache/Cypress/$CYPRESS_VERSION
 ENV CYPRESS_LOCATION_954 $CONTAINER_USER_HOME/.cache/Cypress/9.5.4
 # install nvm
@@ -66,7 +66,7 @@ COPY --chown=$CONTAINER_USER:$CONTAINER_USER config/yarn-version.sh /tmp
 RUN npm install -g yarn@`/tmp/yarn-version.sh main`
 # Add legacy cypress@5.6.0 for 1.x line
 # Add legacy cypress@9.5.4 for pre-2.8.0 releases
-# Add latest cypress@12.13.0 for post-2.8.0 releases
+# Add latest cypress@12.13.0 for post-2.8.0 releases, disable in 3.2.0 release due to install error https://github.com/cypress-io/cypress/issues/4595
 RUN for cypress_version in $CYPRESS_VERSION_LIST; do npm install -g cypress@$cypress_version && npm cache verify; done
 
 # Need root to get pass the build due to chrome sandbox needs to own by the root
@@ -111,7 +111,7 @@ RUN groupadd -g 1000 $CONTAINER_USER && \
 COPY --from=linux_stage_0 --chown=$CONTAINER_USER:$CONTAINER_USER $CONTAINER_USER_HOME $CONTAINER_USER_HOME
 ENV NVM_DIR $CONTAINER_USER_HOME/.nvm
 ENV NODE_VERSION 20.18.3
-ENV CYPRESS_VERSION 12.13.0
+ENV CYPRESS_VERSION 9.5.4
 ENV CYPRESS_LOCATION $CONTAINER_USER_HOME/.cache/Cypress/$CYPRESS_VERSION
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH

--- a/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.ppc64le.dockerfile
@@ -54,8 +54,8 @@ WORKDIR $CONTAINER_USER_HOME
 # nvm environment variables
 ENV NVM_DIR $CONTAINER_USER_HOME/.nvm
 ENV NODE_VERSION 20.18.3
-ENV CYPRESS_VERSION 12.13.0
-ARG CYPRESS_VERSION_LIST="5.6.0 9.5.4 12.13.0"
+ENV CYPRESS_VERSION 9.5.4
+ARG CYPRESS_VERSION_LIST="5.6.0 9.5.4"
 ENV CYPRESS_LOCATION $CONTAINER_USER_HOME/.cache/Cypress/$CYPRESS_VERSION
 ENV CYPRESS_LOCATION_954 $CONTAINER_USER_HOME/.cache/Cypress/9.5.4
 # install nvm
@@ -74,7 +74,7 @@ COPY --chown=$CONTAINER_USER:$CONTAINER_USER config/yarn-version.sh /tmp
 RUN npm install -g yarn@`/tmp/yarn-version.sh main`
 # Add legacy cypress@5.6.0 for 1.x line
 # Add legacy cypress@9.5.4 for pre-2.8.0 releases
-# Add latest cypress@12.13.0 for post-2.8.0 releases
+# Add latest cypress@12.13.0 for post-2.8.0 releases, disable in 3.2.0 release due to install error https://github.com/cypress-io/cypress/issues/4595
 RUN for cypress_version in $CYPRESS_VERSION_LIST; do npm install -g cypress@$cypress_version && npm cache verify; done
 
 # Need root to get pass the build due to chrome sandbox needs to own by the root
@@ -129,7 +129,7 @@ RUN dnf install -y sudo && \
 COPY --from=linux_stage_0 --chown=$CONTAINER_USER:$CONTAINER_USER $CONTAINER_USER_HOME $CONTAINER_USER_HOME
 ENV NVM_DIR $CONTAINER_USER_HOME/.nvm
 ENV NODE_VERSION 20.18.3
-ENV CYPRESS_VERSION 12.13.0
+ENV CYPRESS_VERSION 9.5.4
 ENV CYPRESS_LOCATION $CONTAINER_USER_HOME/.cache/Cypress/$CYPRESS_VERSION
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH

--- a/docker/ci/dockerfiles/current/test.ubuntu2404.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.ubuntu2404.systemd-base.x64.arm64.dockerfile
@@ -58,8 +58,8 @@ WORKDIR $CONTAINER_USER_HOME
 # nvm environment variables
 ENV NVM_DIR $CONTAINER_USER_HOME/.nvm
 ENV NODE_VERSION 20.18.3
-ENV CYPRESS_VERSION 12.13.0
-ARG CYPRESS_VERSION_LIST="5.6.0 9.5.4 12.13.0"
+ENV CYPRESS_VERSION 9.5.4
+ARG CYPRESS_VERSION_LIST="5.6.0 9.5.4"
 ENV CYPRESS_LOCATION $CONTAINER_USER_HOME/.cache/Cypress/$CYPRESS_VERSION
 ENV CYPRESS_LOCATION_954 $CONTAINER_USER_HOME/.cache/Cypress/9.5.4
 # install nvm
@@ -78,7 +78,7 @@ COPY --chown=$CONTAINER_USER:$CONTAINER_USER config/yarn-version.sh /tmp
 RUN npm install -g yarn@`/tmp/yarn-version.sh main`
 # Add legacy cypress@5.6.0 for 1.x line
 # Add legacy cypress@9.5.4 for pre-2.8.0 releases
-# Add latest cypress@12.13.0 for post-2.8.0 releases
+# Add latest cypress@12.13.0 for post-2.8.0 releases, disable in 3.2.0 release due to install error https://github.com/cypress-io/cypress/issues/4595
 RUN for cypress_version in $CYPRESS_VERSION_LIST; do npm install -g cypress@$cypress_version && npm cache verify; done
 
 # Need root to get pass the build due to chrome sandbox needs to own by the root
@@ -145,7 +145,7 @@ RUN apt-get install -y sudo && \
 COPY --from=linux_stage_0 --chown=$CONTAINER_USER:$CONTAINER_USER $CONTAINER_USER_HOME $CONTAINER_USER_HOME
 ENV NVM_DIR $CONTAINER_USER_HOME/.nvm
 ENV NODE_VERSION 20.18.3
-ENV CYPRESS_VERSION 12.13.0
+ENV CYPRESS_VERSION 9.5.4
 ENV CYPRESS_LOCATION $CONTAINER_USER_HOME/.cache/Cypress/$CYPRESS_VERSION
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH


### PR DESCRIPTION
### Description
Remove 12.13.0 cypress due to installation error and not being used.

### Issues Resolved
https://build.ci.opensearch.org/job/docker-build/7296/console
https://github.com/cypress-io/cypress/issues/4595
https://github.com/opensearch-project/opensearch-build/issues/5595

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
