### PR TITLE
Ensure curl is using the scoop version

### DIFF
--- a/docker/ci/config/windows-setup.ps1
+++ b/docker/ci/config/windows-setup.ps1
@@ -22,6 +22,9 @@ iex "& {$(irm https://raw.githubusercontent.com/peterzhuamazon/scoop-Install/ref
 # Use static path in environment variable
 scoop config no_junction true
 
+# Install curl (to avoid ssl stall issues later on)
+scoop install curl
+
 # Install git
 scoop install git
 git --version
@@ -182,6 +185,7 @@ yarn --version
 #     volta install "cypress@$cypressVersion"
 #     cypress --version
 # }
+
 $userenv2 = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User)
 $nodePathFixed = "C:\\Users\\ContainerAdministrator\\scoop\\persist\\volta\\appdata\\bin"
 [System.Environment]::SetEnvironmentVariable("PATH", $userenv2 + ";$nodePathFixed", [System.EnvironmentVariableTarget]::User)


### PR DESCRIPTION
### Description
Ensure curl is using the scoop version

### Issues Resolved
Windows default curl and mingw bundled curl have issues handling ssl at times.
https://github.com/opensearch-project/opensearch-build/issues/5595

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
