### PR TITLE
Add missing RC parameter in smoke test trigger

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -1065,7 +1065,8 @@ def triggerSmokeTests(String buildManifestUrl, String platform, String distribut
                 wait: false,
                 parameters: [
                     string(name: 'TEST_MANIFEST', value: TEST_MANIFEST),
-                    string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl)
+                    string(name: 'BUILD_MANIFEST_URL', value: buildManifestUrl),
+                    string(name: 'RC_NUMBER', value: RC_NUMBER)
                 ]
     }
 }


### PR DESCRIPTION
### Description
Add missing RC parameter in smoke test trigger

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
