### PR TITLE
Fix reporting workflow for special characters

### DIFF
--- a/src/report_workflow/test_report_runner.py
+++ b/src/report_workflow/test_report_runner.py
@@ -7,6 +7,7 @@
 
 import logging
 import os
+import re
 import typing
 import urllib.request
 from typing import Any
@@ -184,7 +185,7 @@ class TestReportRunner:
                 paths = data.get('paths', {})
                 for api_requests, api_details in paths.items():
                     for method in api_details.keys():
-                        api_path = '_'.join([method, api_requests.replace("/", "_")])
+                        api_path = '_'.join([method, re.sub(r'[^a-zA-Z0-9]', '_', api_requests)])
                         logging.info(f"api_path is {api_path}")
                         api_paths.append(api_path)
                 break


### PR DESCRIPTION
### Description
Fix reporting workflow for special characters as it shows `URL_NOT_AVAILABLE` Tested in local. Works as expected

### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-build/issues/5577

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
