### PR TITLE
Using node20 to override node24 on github runner

### DIFF
--- a/.github/workflows/get-ci-image-tag.yml
+++ b/.github/workflows/get-ci-image-tag.yml
@@ -65,9 +65,9 @@ jobs:
           fi
 
           if [[ "$PLATFORM" = "al2" ]]; then
-              CI_IMAGE_CMD="cp -a /node_al2/* /node && /node/bin/node -v"
+              CI_IMAGE_CMD="cp -a /node_al2/* /node && /node/bin/node -v && cp -a /node_al2/* /node24 && /node24/bin/node -v"
               echo "ci-image-start-command=$CI_IMAGE_CMD" >> $GITHUB_OUTPUT
-              CI_IMAGE_OPTIONS="--user root -v /node:/node:rw,rshared -v /node:/__e/node20:ro,rshared"
+              CI_IMAGE_OPTIONS="--user root -v /node:/node:rw,rshared -v /node:/__e/node20:ro,rshared -v /node24:/node24:rw,rshared -v /node24:/__e/node24:ro,rshared"
               echo "ci-image-start-options=$CI_IMAGE_OPTIONS" >> $GITHUB_OUTPUT
           else
               CI_IMAGE_CMD="echo pass"


### PR DESCRIPTION
### Description
Using node20 to override node24 on github runner, support multiple v5 action upgrades by github.
https://github.com/opensearch-project/job-scheduler/actions/runs/17776011934/job/50523797065?pr=818

### Issues Resolved
Resolves: https://github.com/opensearch-project/opensearch-build/issues/5178

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
