### PR TITLE
Fix release notes naming convention for individual components

### DIFF
--- a/src/release_notes_workflow/release_notes.py
+++ b/src/release_notes_workflow/release_notes.py
@@ -108,7 +108,8 @@ class ReleaseNotes:
                 ai_generator = AIReleaseNotesGenerator(
                     args=args,
                 )
-                filename: str = f"{product}{release_notes.filename}" if component.name in ['OpenSearch', 'OpenSearch-Dashboards'] else f"{product}-{component.name}{release_notes.filename}"
+                repo_name = component.repository.split("/")[-1].split('.')[0]
+                filename: str = f"{product}{release_notes.filename}" if component.name in ['OpenSearch', 'OpenSearch-Dashboards'] else f"opensearch-{repo_name}{release_notes.filename}"
 
                 if os.path.isfile(changelog_path):
                     with open(changelog_path, 'r') as f:

--- a/tests/tests_release_notes_workflow/test_release_notes.py
+++ b/tests/tests_release_notes_workflow/test_release_notes.py
@@ -183,3 +183,66 @@ class TestReleaseNotes(unittest.TestCase):
         self.assertIn("Implement feature X", call_args)
         # Verify flaky-test commit was filtered out
         self.assertNotIn("Fix flaky test", call_args)
+
+    @patch('release_notes_workflow.release_notes.TemporaryDirectory')
+    @patch('release_notes_workflow.release_notes.GitRepository')
+    @patch('release_notes_workflow.release_notes.ReleaseNotesComponents')
+    @patch('release_notes_workflow.release_notes.AIReleaseNotesGenerator')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('os.getcwd')
+    def test_filename_generation(self, mock_getcwd: MagicMock, mock_file_open: MagicMock, mock_isfile: MagicMock,
+                              mock_ai_generator_class: MagicMock, mock_release_notes_components: MagicMock,
+                              mock_git_repo: MagicMock, mock_temp_dir: MagicMock) -> None:
+        """Test the filename generation logic for release notes, specifically the updated repo name extraction."""
+        # Setup mocks
+        mock_getcwd.return_value = os.path.join("test", "dir")
+        mock_temp_dir_instance = Mock()
+        mock_temp_dir_instance.name = os.path.join("tmp", "test")
+        mock_temp_dir.return_value.__enter__.return_value = mock_temp_dir_instance
+
+        mock_repo = Mock()
+        mock_repo.dir = os.path.join("tmp", "test", "test-component")
+        mock_git_repo.return_value.__enter__.return_value = mock_repo
+
+        mock_release_notes = Mock()
+        mock_release_notes.filename = ".release-notes-2.0.0.md"
+        mock_release_notes_components.from_component.return_value = mock_release_notes
+
+        mock_ai_generator = Mock()
+        mock_ai_generator.generate_release_notes.return_value = "Generated release notes"
+        mock_ai_generator_class.return_value = mock_ai_generator
+
+        mock_isfile.return_value = True
+
+        # Create test components with different repository URLs
+        # Normal component (not OpenSearch or OpenSearch-Dashboards)
+        component_normal = InputComponentFromSource({
+            "name": "common-utils",
+            "repository": "https://github.com/opensearch-project/common-utils.git",
+            "ref": "main"
+        })
+
+        # OpenSearch core component
+        component_core = InputComponentFromSource({
+            "name": "OpenSearch",
+            "repository": "https://github.com/opensearch-project/OpenSearch.git",
+            "ref": "main"
+        })
+
+        # Test with normal component
+        self.release_notes.generate(self.mock_args, component_normal, "2.0.0", "", "opensearch")
+
+        # Check that the file was opened with the correct filename
+        # Should use repo name format: opensearch-common-utils.release-notes-2.0.0.md
+        mock_file_open.assert_called_with(os.path.join("test", "dir", "release-notes", "opensearch-common-utils.release-notes-2.0.0.md"), "w")
+
+        # Reset mocks for next test
+        mock_file_open.reset_mock()
+
+        # Test with OpenSearch core component
+        self.release_notes.generate(self.mock_args, component_core, "2.0.0", "", "opensearch")
+
+        # Check that the file was opened with the correct filename format for core components
+        # Should use format: opensearch.release-notes-2.0.0.md
+        mock_file_open.assert_called_with(os.path.join("test", "dir", "release-notes", "opensearch.release-notes-2.0.0.md"), "w")


### PR DESCRIPTION
### Description
Fixes release notes naming convention for AI generated release notes. See issue for more details.
Also adds associated test for filename

### Issues Resolved
resolves https://github.com/opensearch-project/opensearch-build/issues/5721

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
