### PR TITLE
Fix the URL syntax when the target is a file

### DIFF
--- a/src/assemble_workflow/bundle_opensearch.py
+++ b/src/assemble_workflow/bundle_opensearch.py
@@ -6,10 +6,10 @@
 # compatible open source license.
 
 import os
+from pathlib import Path
 
 from assemble_workflow.bundle import Bundle
 from manifests.build_manifest import BuildComponent
-from pathlib import Path
 from system.os import current_platform
 
 

--- a/src/assemble_workflow/bundle_opensearch.py
+++ b/src/assemble_workflow/bundle_opensearch.py
@@ -9,6 +9,7 @@ import os
 
 from assemble_workflow.bundle import Bundle
 from manifests.build_manifest import BuildComponent
+from pathlib import Path
 from system.os import current_platform
 
 
@@ -20,5 +21,6 @@ class BundleOpenSearch(Bundle):
     def install_plugin(self, plugin: BuildComponent) -> None:
         tmp_path = self._copy_component(plugin, "plugins")
         cli_path = os.path.join(self.min_dist.archive_path, "bin", self.install_plugin_script)
-        self._execute(f"{cli_path} install --batch file:{tmp_path}")
+        uri = Path(tmp_path).as_uri()
+        self._execute(f"{cli_path} install --batch {uri}")
         super().install_plugin(plugin)

--- a/tests/tests_assemble_workflow/test_bundle_opensearch.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch.py
@@ -8,6 +8,7 @@
 import os
 import unittest
 import zipfile
+from pathlib import Path
 from unittest.mock import MagicMock, Mock, call, patch
 
 from assemble_workflow.bundle_opensearch import BundleOpenSearch
@@ -193,7 +194,7 @@ class TestBundleOpenSearch(unittest.TestCase):
                 mock_check_call.assert_has_calls(
                     [
                         call(
-                            f'{install_plugin_bin} install --batch file:{os.path.join(bundle.tmp_dir.name, "opensearch-job-scheduler-1.1.0.0.zip")}',
+                            f'{install_plugin_bin} install --batch {Path(os.path.join(bundle.tmp_dir.name, "opensearch-job-scheduler-1.1.0.0.zip")).as_uri()}',
                             cwd=bundle.min_dist.archive_path,
                             shell=True,
                         ),

--- a/tests/tests_assemble_workflow/test_bundle_opensearch_windows_uri.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch_windows_uri.py
@@ -7,9 +7,13 @@
 
 import types
 from pathlib import Path
+from typing import Any, List, cast
 from unittest.mock import patch
 
 from assemble_workflow.bundle_opensearch import BundleOpenSearch
+from assemble_workflow.dist import Dist
+from manifests.build_manifest import BuildComponent, BuildManifest
+from system.temporary_directory import TemporaryDirectory
 
 
 class DummyBundle(BundleOpenSearch):
@@ -20,33 +24,43 @@ class DummyBundle(BundleOpenSearch):
 
     def __init__(self, archive_path: str, tmp_dir: Path):
         # Only set attributes used by install_plugin() and super().install_plugin()
-        self.min_dist = types.SimpleNamespace(archive_path=archive_path)
-        self.build = types.SimpleNamespace(
-            version="3.3.0",
-            platform="windows",
-            architecture="x64",
-            distribution="zip",
+        self.min_dist = cast(Dist, types.SimpleNamespace(archive_path=archive_path))
+        self.build = cast(
+            BuildManifest.Build,
+            types.SimpleNamespace(
+                version="3.3.0",
+                platform="windows",
+                architecture="x64",
+                distribution="zip",
+            ),
         )
-        self.tmp_dir = types.SimpleNamespace(name=str(tmp_dir))
+        self.tmp_dir = cast(TemporaryDirectory, types.SimpleNamespace(name=str(tmp_dir)))
         self.artifacts_dir = str(tmp_dir)
-        self._commands = []
+        self._commands: List[str] = []
 
-    def _copy_component(self, plugin, subdir):
+    def _copy_component(self, plugin: Any, subdir: str) -> str:
         # Simulate copied plugin zip path
         return str(Path(self.tmp_dir.name) / "opensearch-ltr-3.3.0.0.zip")
 
-    def _execute(self, cmd: str):
+    def _execute(self, cmd: str) -> None:
         # Capture any command invoked by install_plugin() and super().install_plugin()
         self._commands.append(cmd)
 
 
-def test_install_plugin_converts_windows_path_to_file_uri(tmp_path):
+def test_install_plugin_converts_windows_path_to_file_uri(tmp_path: Path) -> None:
     # Force windows behavior for this test to validate .bat and file:/// URI usage.
     with patch("assemble_workflow.bundle_opensearch.current_platform", return_value="windows"):
         archive_path = r"C:\0p8tp1m4\opensearch-3.3.0"
         b = DummyBundle(archive_path, tmp_path)
 
-        plugin = types.SimpleNamespace(name="opensearch-learning-to-rank-base")
+        plugin = BuildComponent({
+            "name": "opensearch-learning-to-rank-base",
+            "repository": "https://example.com/repo.git",
+            "ref": "main",
+            "commit_id": "deadbeef",
+            "artifacts": {},
+            "version": "0.0.0",
+        })
         b.install_plugin(plugin)
 
         assert b._commands, "Expected at least one command to be executed"

--- a/tests/tests_assemble_workflow/test_bundle_opensearch_windows_uri.py
+++ b/tests/tests_assemble_workflow/test_bundle_opensearch_windows_uri.py
@@ -1,0 +1,65 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+from assemble_workflow.bundle_opensearch import BundleOpenSearch
+
+
+class DummyBundle(BundleOpenSearch):
+    """
+    Minimal stub to exercise install_plugin() without running full Bundle initialization.
+    Captures executed commands for assertions.
+    """
+
+    def __init__(self, archive_path: str, tmp_dir: Path):
+        # Only set attributes used by install_plugin() and super().install_plugin()
+        self.min_dist = types.SimpleNamespace(archive_path=archive_path)
+        self.build = types.SimpleNamespace(
+            version="3.3.0",
+            platform="windows",
+            architecture="x64",
+            distribution="zip",
+        )
+        self.tmp_dir = types.SimpleNamespace(name=str(tmp_dir))
+        self.artifacts_dir = str(tmp_dir)
+        self._commands = []
+
+    def _copy_component(self, plugin, subdir):
+        # Simulate copied plugin zip path
+        return str(Path(self.tmp_dir.name) / "opensearch-ltr-3.3.0.0.zip")
+
+    def _execute(self, cmd: str):
+        # Capture any command invoked by install_plugin() and super().install_plugin()
+        self._commands.append(cmd)
+
+
+def test_install_plugin_converts_windows_path_to_file_uri(tmp_path):
+    # Force windows behavior for this test to validate .bat and file:/// URI usage.
+    with patch("assemble_workflow.bundle_opensearch.current_platform", return_value="windows"):
+        archive_path = r"C:\0p8tp1m4\opensearch-3.3.0"
+        b = DummyBundle(archive_path, tmp_path)
+
+        plugin = types.SimpleNamespace(name="opensearch-learning-to-rank-base")
+        b.install_plugin(plugin)
+
+        assert b._commands, "Expected at least one command to be executed"
+        cmd = b._commands[0]
+
+        # Must use .bat launcher on Windows
+        assert "opensearch-plugin.bat install --batch" in cmd
+
+        # Must pass a file: URI with forward slashes for the zip path (command path may use backslashes on Windows)
+        assert "file:///" in cmd
+        uri = cmd.split("--batch", 1)[1].strip()
+        assert uri.startswith("file:///")
+        assert "\\" not in uri
+
+        # Sanity: ends with expected filename
+        assert cmd.endswith("opensearch-ltr-3.3.0.0.zip")


### PR DESCRIPTION
### Description
This uses `to_uri()` in order to build the argument to the installer. This is necessary for plugin builds that happen local to a Windows build machine where the path to the artifact doesn't look like a proper URL.

### Issues Resolved
Closes #5742 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
