### PR TITLE
Add release chore to create and compile release notes

### DIFF
--- a/jenkins/release-workflows/release-chores.jenkinsfile
+++ b/jenkins/release-workflows/release-chores.jenkinsfile
@@ -53,7 +53,7 @@ parameters {
                     } else if (RELEASE_CHORE == "checkCodeCoverage") {
                     return ["check", "notify"]
                     } else if (RELEASE_CHORE == "checkReleaseNotes") {
-                    return ["check", "notify"]
+                    return ["check", "create", "compile", "notify"]
                     } else if (RELEASE_CHORE == "checkReleaseIssues") {
                     return ["check", "create"]
                     } else if (RELEASE_CHORE == "checkDocumentationPullRequests") {
@@ -155,20 +155,52 @@ parameters {
             }
             steps {
                 script {
-                    if (params.GIT_LOG_DATE.isEmpty()) {
-                        currentBuild.result = 'ABORTED'
-                        error('GIT_LOG_DATE parameter cannot be empty for checkReleaseNotes')
+                    switch(params.ACTION) {
+                        case 'check':
+                            echo "Checking release notes"
+                            checkAndNotifyReleaseNotes()
+                            break
+                        case 'create':
+                            if (params.GIT_LOG_DATE.isEmpty()) {
+                                currentBuild.result = 'ABORTED'
+                                error('GIT_LOG_DATE parameter cannot be empty for checkReleaseNotes')
+                            }
+                            echo "Creating release notes for all components by triggering release-notes-generate job"
+                            build job: 'release-notes-generate', 
+                            propagate: true,
+                            wait: true,
+                            parameters: [
+                                string(name: 'INPUT_MANIFEST', value: "${params.RELEASE_VERSION}/opensearch-${params.RELEASE_VERSION}.yml"),
+                                string(name: 'GIT_LOG_DATE', value: "${params.GIT_LOG_DATE}")
+                            ]
+
+                            build job: 'release-notes-generate', 
+                            propagate: true,
+                            wait: true,
+                            parameters: [
+                                string(name: 'INPUT_MANIFEST', value: "${params.RELEASE_VERSION}/opensearch-dashboards-${params.RELEASE_VERSION}.yml"),
+                                string(name: 'GIT_LOG_DATE', value: "${params.GIT_LOG_DATE}")
+                            ]
+                            break
+                        case 'compile':
+                            echo "Creating consolidated release notes by triggering release-notes-tracker job"
+                            build job: 'release-notes-tracker', 
+                            propagate: true,
+                            wait: true,
+                            parameters: [
+                                string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),
+                                string(name: 'ACTION', value: 'compile'),
+                                string(name: 'GIT_LOG_DATE', value: "${params.GIT_LOG_DATE}")
+                            ]
+                            break
+                        case 'notify':
+                            echo "Notifying release notes"
+                            checkAndNotifyReleaseNotes()
+                            break
+                        default:
+                            currentBuild.result = 'ABORTED'
+                            error("Unknown action ${params.ACTION} for checkReleaseNotes")
                     }
-                    sh """
-                        #!/bin/bash
-                        set +e
-                        ./release_notes.sh check manifests/${params.RELEASE_VERSION}/opensearch-${params.RELEASE_VERSION}.yml manifests/${params.RELEASE_VERSION}/opensearch-dashboards-${params.RELEASE_VERSION}.yml --date ${params.GIT_LOG_DATE} --output ${WORKSPACE}/table.md
-                    """
-                    checkReleaseNotes(
-                        version: "${params.RELEASE_VERSION}",
-                        dataTable: "${WORKSPACE}/table.md",
-                        action: "${params.ACTION}"
-                        )
                 }
             }
         }
@@ -243,4 +275,21 @@ parameters {
             }
         }
     }
+}
+
+def checkAndNotifyReleaseNotes() {
+        if (params.GIT_LOG_DATE.isEmpty()) {
+            currentBuild.result = 'ABORTED'
+            error('GIT_LOG_DATE parameter cannot be empty for checkReleaseNotes')
+        }                    
+        sh """
+            #!/bin/bash
+            set +e
+            ./release_notes.sh check manifests/${params.RELEASE_VERSION}/opensearch-${params.RELEASE_VERSION}.yml manifests/${params.RELEASE_VERSION}/opensearch-dashboards-${params.RELEASE_VERSION}.yml --date ${params.GIT_LOG_DATE} --output ${WORKSPACE}/table.md
+        """
+        checkReleaseNotes(
+            version: "${params.RELEASE_VERSION}",
+            dataTable: "${WORKSPACE}/table.md",
+            action: "${params.ACTION}"
+            )
 }

--- a/jenkins/release-workflows/release-notes-generate.jenkinsfile
+++ b/jenkins/release-workflows/release-notes-generate.jenkinsfile
@@ -47,7 +47,6 @@ pipeline {
         )
         string(
             name: 'REF',
-            defaultValue: 'main',
             description: 'Override input component github repo ref, defaults to provided in input manifest file',
             trim: true
         )

--- a/tests/jenkins/TestReleaseChores.groovy
+++ b/tests/jenkins/TestReleaseChores.groovy
@@ -71,7 +71,7 @@ class TestReleaseChores extends BuildPipelineTest {
                 '                    } else if (RELEASE_CHORE == "checkCodeCoverage") {\n' +
                 '                    return ["check", "notify"]\n' +
                 '                    } else if (RELEASE_CHORE == "checkReleaseNotes") {\n' +
-                '                    return ["check", "notify"]\n' +
+                '                    return ["check", "create", "compile", "notify"]\n' +
                 '                    } else if (RELEASE_CHORE == "checkReleaseIssues") {\n' +
                 '                    return ["check", "create"]\n' +
                 '                    } else if (RELEASE_CHORE == "checkDocumentationPullRequests") {\n' +
@@ -137,11 +137,34 @@ class TestReleaseChores extends BuildPipelineTest {
     }
 
     @Test
+    public void testCheckReleaseNotesCreation() {
+        addParam('RELEASE_VERSION', '3.0.0-beta1')
+        addParam('RELEASE_CHORE', 'checkReleaseNotes')
+        addParam('ACTION', 'create')
+        addParam('GIT_LOG_DATE', '2025-03-19')
+        runScript('jenkins/release-workflows/release-chores.jenkinsfile')
+        def callStack = helper.getCallStack()
+        assertCallStack().contains('release-chores.build({job=release-notes-generate, propagate=true, wait=true, parameters=[null, null]})')
+        assertCallStack().contains('release-chores.build({job=release-notes-generate, propagate=true, wait=true, parameters=[null, null]})')
+    }
+
+    @Test
+    public void testCheckReleaseNotesCompilation() {
+        addParam('RELEASE_VERSION', '3.0.0-beta1')
+        addParam('RELEASE_CHORE', 'checkReleaseNotes')
+        addParam('ACTION', 'compile')
+        addParam('GIT_LOG_DATE', '2025-03-19')
+        runScript('jenkins/release-workflows/release-chores.jenkinsfile')
+        def callStack = helper.getCallStack()
+        assertCallStack().contains('release-chores.build({job=release-notes-tracker, propagate=true, wait=true, parameters=[null, null, null]})')
+    }
+
+    @Test
     public void testStageToLibMappingCheckReleaseIssues() {
         addParam('RELEASE_VERSION', '3.0.0-beta1')
         addParam('RELEASE_CHORE', 'checkReleaseIssues')
         addParam('ACTION', 'check')
-            runScript('jenkins/release-workflows/release-chores.jenkinsfile')
+        runScript('jenkins/release-workflows/release-chores.jenkinsfile')
         def callStack = helper.getCallStack()
         assertCallStack().contains('release-chores.stage(checkReleaseIssues, groovy.lang.Closure)')
         assertCallStack().contains('release-chores.checkReleaseIssues({version=3.0.0-beta1, inputManifest=[manifests/3.0.0-beta1/opensearch-3.0.0-beta1.yml, manifests/3.0.0-beta1/opensearch-dashboards-3.0.0-beta1.yml], action=check})')


### PR DESCRIPTION
### Description
Add release chore to create and compile release notes. Also removes default value for creation that was not matching its description

### Issues Resolved
#5693 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
