### PR TITLE
change release notes file name to use git repo name

### DIFF
--- a/jenkins/release-workflows/release-notes-generate.jenkinsfile
+++ b/jenkins/release-workflows/release-notes-generate.jenkinsfile
@@ -97,13 +97,15 @@ pipeline {
                                                         sh("echo ${currentComponent} with index ${currentIndex} will sleep ${currentWaitSeconds} seconds to reduce load && sleep ${currentWaitSeconds}")
                                                         unstash "release-notes-opensearch-$BUILD_NUMBER"
                                                         def componentObj = inputManifestObj.components[currentComponent]
+                                                        def repoUrl = componentObj.repository
+                                                        def repoName = repoUrl.replaceAll(/\.git$/, '').tokenize('/')[-1] // Extract repo name from URL, replaces git suffix if exists
                                                         def version = inputManifestObj.build.version
-                                                        def productName = ['opensearch': 'opensearch', 'opensearch dashboards': 'opensearch-dashboards'][product.toLowerCase()]
+                                                        def productName = 'opensearch'
                                                         def filename
                                                         if (currentComponent.toLowerCase() in ['opensearch', 'opensearch-dashboards']) {
                                                             filename = "${productName}.release-notes-${version}.md"
                                                         } else {
-                                                            filename = "${productName}-${currentComponent}.release-notes-${version}.0.md"
+                                                            filename = "${productName}-${repoName}.release-notes-${version}.0.md"
                                                         }
                                                         withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
                                                             def refParam = params.REF ? "--ref ${REF}" : ""


### PR DESCRIPTION
### Description
In release notes generate workflow change the final filename to use git repo name instead of component name from manifest and set product name to OpenSearch for all plugins including dashboards plugins. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
