### PR TITLE
Fix ref and switch propogate to false

### DIFF
--- a/jenkins/release-workflows/release-chores.jenkinsfile
+++ b/jenkins/release-workflows/release-chores.jenkinsfile
@@ -167,7 +167,7 @@ parameters {
                             }
                             echo "Creating release notes for all components by triggering release-notes-generate job"
                             build job: 'release-notes-generate', 
-                            propagate: true,
+                            propagate: false,
                             wait: true,
                             parameters: [
                                 string(name: 'INPUT_MANIFEST', value: "${params.RELEASE_VERSION}/opensearch-${params.RELEASE_VERSION}.yml"),
@@ -175,7 +175,7 @@ parameters {
                             ]
 
                             build job: 'release-notes-generate', 
-                            propagate: true,
+                            propagate: false,
                             wait: true,
                             parameters: [
                                 string(name: 'INPUT_MANIFEST', value: "${params.RELEASE_VERSION}/opensearch-dashboards-${params.RELEASE_VERSION}.yml"),
@@ -185,7 +185,7 @@ parameters {
                         case 'compile':
                             echo "Creating consolidated release notes by triggering release-notes-tracker job"
                             build job: 'release-notes-tracker', 
-                            propagate: true,
+                            propagate: false,
                             wait: true,
                             parameters: [
                                 string(name: 'RELEASE_VERSION', value: "${params.RELEASE_VERSION}"),

--- a/jenkins/release-workflows/release-notes-generate.jenkinsfile
+++ b/jenkins/release-workflows/release-notes-generate.jenkinsfile
@@ -109,6 +109,7 @@ pipeline {
                                                         }
                                                         withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) {
                                                             def refParam = params.REF ? "--ref ${REF}" : ""
+                                                            def ref = params.REF ?: componentObj.ref
                                                             sh """
                                                                 #!/bin/bash
                                                                 set +e
@@ -121,7 +122,7 @@ pipeline {
                                                                     COMPONENT_REPO_URL="${componentObj.repository}"
                                                                     REPO_NAME=\$(basename "\${COMPONENT_REPO_URL}" .git)
 
-                                                                    git clone -b ${componentObj.ref} "\${COMPONENT_REPO_URL}"
+                                                                    git clone -b ${ref} "\${COMPONENT_REPO_URL}"
                                                                     cd "\${REPO_NAME}"
                                                                     git ls-remote --heads origin release-chores/release-notes-${version} | grep -q release-chores/release-notes-${version}
                                                                     if [ \$? -ne 0 ]; then

--- a/tests/jenkins/TestReleaseChores.groovy
+++ b/tests/jenkins/TestReleaseChores.groovy
@@ -144,8 +144,8 @@ class TestReleaseChores extends BuildPipelineTest {
         addParam('GIT_LOG_DATE', '2025-03-19')
         runScript('jenkins/release-workflows/release-chores.jenkinsfile')
         def callStack = helper.getCallStack()
-        assertCallStack().contains('release-chores.build({job=release-notes-generate, propagate=true, wait=true, parameters=[null, null]})')
-        assertCallStack().contains('release-chores.build({job=release-notes-generate, propagate=true, wait=true, parameters=[null, null]})')
+        assertCallStack().contains('release-chores.build({job=release-notes-generate, propagate=false, wait=true, parameters=[null, null]})')
+        assertCallStack().contains('release-chores.build({job=release-notes-generate, propagate=false, wait=true, parameters=[null, null]})')
     }
 
     @Test
@@ -156,7 +156,7 @@ class TestReleaseChores extends BuildPipelineTest {
         addParam('GIT_LOG_DATE', '2025-03-19')
         runScript('jenkins/release-workflows/release-chores.jenkinsfile')
         def callStack = helper.getCallStack()
-        assertCallStack().contains('release-chores.build({job=release-notes-tracker, propagate=true, wait=true, parameters=[null, null, null]})')
+        assertCallStack().contains('release-chores.build({job=release-notes-tracker, propagate=false, wait=true, parameters=[null, null, null]})')
     }
 
     @Test


### PR DESCRIPTION
### Description
The reference in the release notes creation should be either taken from parameter or manifest. This PR fixes the hard coding. 
Also switches the propagation to false in order to continue workflow run for consecutive workflows. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
