### PR TITLE
Disable welcome screen in OSD integTests

### DIFF
--- a/src/test_workflow/integ_test/service_opensearch_dashboards.py
+++ b/src/test_workflow/integ_test/service_opensearch_dashboards.py
@@ -57,8 +57,11 @@ class ServiceOpenSearchDashboards(Service):
         logging.info("Additional Config: 'server.host: 0.0.0.0'")
         self.additional_config["server.host"] = '0.0.0.0'
 
-        # Since 3.3.0, OSD core introduced experience modal: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10607
+        # Since 3.3.0, OSD core introduced experience modal and welcome screen
+        # https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10607
         # Will disable it during the test
+        logging.info("Additional Config: 'home.disableWelcomeScreen: true'")
+        self.additional_config["home.disableWelcomeScreen"] = 'true'
         logging.info("Additional Config: 'home.disableExperienceModal: true'")
         self.additional_config["home.disableExperienceModal"] = 'true'
 

--- a/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
+++ b/tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch_dashboards.py
@@ -69,7 +69,8 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
                 "script.context.field.max_compilations_rate": "1000/1m",
                 "logging.dest": os.path.join(self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log"),
                 "server.host": "0.0.0.0",
-                'home.disableExperienceModal': 'true'
+                "home.disableWelcomeScreen": "true",
+                "home.disableExperienceModal": "true"
             }
         )
         mock_file.return_value.write.assert_called_once_with(mock_dump_result)
@@ -133,7 +134,14 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         )
 
         mock_dump.assert_called_once_with({"logging.dest": os.path.join(
-            self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log"), 'server.host': '0.0.0.0', 'home.disableExperienceModal': 'true'})
+            self.work_dir,
+            "opensearch-dashboards-1.1.0",
+            "logs",
+            "opensearch_dashboards.log"),
+            "server.host": "0.0.0.0",
+            "home.disableWelcomeScreen": "true",
+            "home.disableExperienceModal": "true"}
+        )
 
         mock_file_handler_for_security.close.assert_called_once()
         mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result)
@@ -195,7 +203,14 @@ class ServiceOpenSearchDashboardsTests(unittest.TestCase):
         )
 
         mock_dump.assert_called_once_with({"logging.dest": os.path.join(
-            self.work_dir, "opensearch-dashboards-1.1.0", "logs", "opensearch_dashboards.log"), 'server.host': '0.0.0.0', 'home.disableExperienceModal': 'true'})
+            self.work_dir,
+            "opensearch-dashboards-1.1.0",
+            "logs",
+            "opensearch_dashboards.log"),
+            "server.host": "0.0.0.0",
+            "home.disableWelcomeScreen": "true",
+            "home.disableExperienceModal": "true"}
+        )
 
         mock_file_handler_for_security.close.assert_called_once()
         mock_file_handler_for_additional_config.write.assert_called_once_with(mock_dump_result)


### PR DESCRIPTION
### Description
Disable welcome screen in OSD integTests

### Issues Resolved
Follow up to https://github.com/opensearch-project/opensearch-build/pull/5755

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
