### PR TITLE
Support module split and generate individual coverage reports in gradle check task

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -158,7 +158,7 @@ pipeline {
                 }
                 always {
                     sh '''
-                        mkdir -p codeCoverage
+                        rm -rf codeCoverage && mkdir -p codeCoverage
 
                         for file in $(find search/server/build/reports/jacoco/ -name '*.xml'); do
                             cp -v "$file" codeCoverage/

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -143,7 +143,8 @@ pipeline {
                             runGradleCheck(
                                 gitRepoUrl: "${GIT_REPO_URL}",
                                 gitReference: "${GIT_REFERENCE}",
-                                bwcCheckoutAlign: "${bwc_checkout_align}"
+                                bwcCheckoutAlign: "${bwc_checkout_align}",
+                                scope: "all"
                             )
                         }
 

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -158,7 +158,7 @@ pipeline {
                 }
                 always {
                     sh '''
-                        rm -rf codeCoverage && mkdir -p codeCoverage/
+                        rm -rf codeCoverage && mkdir -p codeCoverage
 
                         for file in $(find search/server/build/reports/jacoco/ -name '*.xml'); do
                             cp -v "$file" codeCoverage/

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -158,7 +158,7 @@ pipeline {
                 }
                 always {
                     sh '''
-                        rm -rf codeCoverage && mkdir -p codeCoverage
+                        rm -rf codeCoverage && mkdir -p codeCoverage/
 
                         for file in $(find search/server/build/reports/jacoco/ -name '*.xml'); do
                             cp -v "$file" codeCoverage/

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -158,11 +158,11 @@ pipeline {
                 }
                 always {
                     sh '''
-                    mkdir codeCoverage
+                        mkdir codeCoverage
 
-                    for file in $(find search/server/build/reports/jacoco/ -name '*.xml'); do
-                        cp -v "$file" codeCoverage/
-                    done
+                        for file in $(find search/server/build/reports/jacoco/ -name '*.xml'); do
+                            cp -v "$file" codeCoverage/
+                        done
                     '''
                     junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
                     archiveArtifacts artifacts: 'codeCoverage/**', onlyIfSuccessful: true

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -67,7 +67,8 @@ pipeline {
                 [key: 'pr_title', value: '$.pr_title'],
                 [key: 'pr_number', value: '$.pr_number'],
                 [key: 'post_merge_action', value: '$.post_merge_action'],
-                [key: 'pr_owner', value: '$.pr_owner']
+                [key: 'pr_owner', value: '$.pr_owner'],
+                [key: 'module_name', value: '$.module_name']
             ],
             tokenCredentialId: 'jenkins-gradle-check-generic-webhook-token',
             causeString: 'Triggered by PR on OpenSearch core repository',
@@ -130,7 +131,8 @@ pipeline {
                             runGradleCheck(
                                 gitRepoUrl: "${pr_from_clone_url}",
                                 gitReference: "${pr_from_sha}",
-                                bwcCheckoutAlign: "${bwc_checkout_align}"
+                                bwcCheckoutAlign: "${bwc_checkout_align}",
+                                scope: "${module_name}"
                             )
                         }
                         else {
@@ -154,9 +156,15 @@ pipeline {
                     archiveArtifacts artifacts: '**/build/heapdump/*.hprof', allowEmptyArchive: true
                 }
                 always {
-                    sh ("cp -v `find search/build/reports/jacoco/ -name '*.xml' | head -n 1` codeCoverage.xml || echo")
+                    sh '''
+                    mkdir codeCoverage
+
+                    for file in $(find search/server/build/reports/jacoco/ -name '*.xml'); do
+                        cp -v "$file" codeCoverage/
+                    done
+                    '''
                     junit allowEmptyResults: true, testResults: '**/build/test-results/**/*.xml'
-                    archiveArtifacts artifacts: 'codeCoverage.xml', onlyIfSuccessful: true
+                    archiveArtifacts artifacts: 'codeCoverage/**', onlyIfSuccessful: true
                     script {
                         def invokedBy
                         def pullRequest

--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -158,7 +158,7 @@ pipeline {
                 }
                 always {
                     sh '''
-                        mkdir codeCoverage
+                        mkdir -p codeCoverage
 
                         for file in $(find search/server/build/reports/jacoco/ -name '*.xml'); do
                             cp -v "$file" codeCoverage/

--- a/scripts/gradle/gradle-check.sh
+++ b/scripts/gradle/gradle-check.sh
@@ -59,7 +59,7 @@ TIMEPASS=0
 TIMEOUT=7200
 RESULT="null"
 PR_TITLE_NEW=`echo $pr_title | tr -dc '[:alnum:] ' | tr '[:upper:]' '[:lower:]'`
-PAYLOAD_JSON="{\"pr_from_sha\": \"$pr_from_sha\", \"pr_from_clone_url\": \"$pr_from_clone_url\", \"pr_to_clone_url\": \"$pr_to_clone_url\", \"pr_title\": \"$PR_TITLE_NEW\", \"pr_number\": \"$pr_number\", \"post_merge_action\": \"$post_merge_action\", \"pr_owner\": \"$pr_owner\"}"
+PAYLOAD_JSON="{\"pr_from_sha\": \"$pr_from_sha\", \"pr_from_clone_url\": \"$pr_from_clone_url\", \"pr_to_clone_url\": \"$pr_to_clone_url\", \"pr_title\": \"$PR_TITLE_NEW\", \"pr_number\": \"$pr_number\", \"post_merge_action\": \"$post_merge_action\", \"pr_owner\": \"$pr_owner\", \"module_name\": \"$module_name\"}"
 
 perform_curl_and_process_with_jq() {
     local url=$1
@@ -145,7 +145,8 @@ fi
 echo "Please check jenkins url for logs: $WORKFLOW_URL"
 echo "Result: $RESULT"
 if [ "$RESULT" == "SUCCESS" ] || [ "$RESULT" == "UNSTABLE" ]; then
-    echo "Get codeCoverage.xml" && curl -SLO ${WORKFLOW_URL}artifact/codeCoverage.xml --user ${GITHUB_USER}:${GITHUB_TOKEN}
+    echo "Get Coverage reports" && curl -SLO ${WORKFLOW_URL}artifact/codeCoverage/*zip*/codeCoverage.zip --user ${GITHUB_USER}:${GITHUB_TOKEN}
+    unzip -o codeCoverage.zip
 else
     exit 1
 fi


### PR DESCRIPTION
### Description
1. Support server module and other modules split from the gradle check tasks
2. Archive all the coverage reports generated during the run.
3. Gradle script changes to support the feature

### Issues Resolved
Addresses build side changes for the meta issue https://github.com/opensearch-project/OpenSearch/issues/19378

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
