### PR TITLE
Bump docker build to 6 hours timeout

### DIFF
--- a/jenkins/docker/docker-build.jenkinsfile
+++ b/jenkins/docker/docker-build.jenkinsfile
@@ -29,7 +29,7 @@ def secret_dockerhub_staging = [
 
 pipeline {
     options {
-        timeout(time: 5, unit: 'HOURS')
+        timeout(time: 6, unit: 'HOURS')
     }
     agent none
     parameters {

--- a/tests/jenkins/jenkinsjob-regression-files/docker/docker-build.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/docker/docker-build.jenkinsfile.txt
@@ -1,6 +1,6 @@
    docker-build.run()
       docker-build.pipeline(groovy.lang.Closure)
-         docker-build.timeout({time=5, unit=HOURS})
+         docker-build.timeout({time=6, unit=HOURS})
          docker-build.echo(Executing on agent [label:none])
          docker-build.stage(Parameters Check, groovy.lang.Closure)
             docker-build.script(groovy.lang.Closure)


### PR DESCRIPTION
### Description
Bump docker build to 6 hours timeout
https://build.ci.opensearch.org/job/docker-build/7486/console

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/19314

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
