### PR TITLE
Ubuntu2404 lock python3.9 to 3.9.23 on arm64 to avoid version mismatch

### DIFF
--- a/docker/ci/dockerfiles/current/build.ubuntu2404.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.ubuntu2404.opensearch.x64.arm64.dockerfile
@@ -46,8 +46,12 @@ RUN mkdir -p /usr/local/lib/docker/cli-plugins && \
     ln -s /usr/local/lib/docker/cli-plugins/docker-compose /usr/local/bin/docker-compose
 
 # Install python, update awscli to v2 due to lib conflicts on urllib3 v1 vs v2
-RUN apt-get update -y && apt-get install -y python3.9-full python3.9-dev && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 100 && \
+# 20251024: mismatch versions between 3.9.23 and 3.9.24 on arm64, temporarily force old versions on all python3.9 pkgs
+#           https://github.com/deadsnakes/issues/issues/330
+RUN if [ `uname -m` = "aarch64" ]; then apt-get update -y && apt-get install -y python3.9-full=3.9.23* python3.9-dev=3.9.23* libpython3.9-testsuite=3.9.23*; \
+    else apt-get update -y && apt-get install -y python3.9-full python3.9-dev; fi
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 100 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.9 100 && \
     update-alternatives --set python3 /usr/bin/python3.9 && \
     update-alternatives --set python /usr/bin/python3.9 && \

--- a/docker/ci/dockerfiles/current/test.ubuntu2404.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.ubuntu2404.systemd-base.x64.arm64.dockerfile
@@ -116,8 +116,12 @@ RUN apt-get update -y && apt-get upgrade -y && apt-get install -y curl git gnupg
     apt-get clean -y
 
 # Install python, update awscli to v2 due to lib conflicts on urllib3 v1 vs v2
-RUN apt-get update -y && apt-get install -y python3.9-full python3.9-dev && \
-    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 100 && \
+# 20251024: mismatch versions between 3.9.23 and 3.9.24 on arm64, temporarily force old versions on all python3.9 pkgs
+#           https://github.com/deadsnakes/issues/issues/330
+RUN if [ `uname -m` = "aarch64" ]; then apt-get update -y && apt-get install -y python3.9-full=3.9.23* python3.9-dev=3.9.23* libpython3.9-testsuite=3.9.23*; \
+    else apt-get update -y && apt-get install -y python3.9-full python3.9-dev; fi
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 100 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.9 100 && \
     update-alternatives --set python3 /usr/bin/python3.9 && \
     update-alternatives --set python /usr/bin/python3.9 && \


### PR DESCRIPTION
### Description
Ubuntu2404 lock python3.9 to 3.9.23 on arm64 to avoid version mismatch

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/5802
https://github.com/deadsnakes/issues/issues/330

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
