### PR TITLE
Switch publish min windows to use bat

### DIFF
--- a/jenkins/opensearch/publish-min-snapshots.jenkinsfile
+++ b/jenkins/opensearch/publish-min-snapshots.jenkinsfile
@@ -203,7 +203,7 @@ pipeline {
                         script {
                             retry(3) {
                                 echo("Switching to Java ${env.javaVersionNumber} on Windows Docker Container")
-                                sh("scoop reset `scoop list jdk | cut -d ' ' -f1 | grep ${env.javaVersionNumber} | head -1`")
+                                bat("bash -c \"scoop reset `scoop list jdk | cut -d ' ' -f1 | grep ${env.javaVersionNumber} | head -1`\"")
                                 buildManifest(
                                     componentName: "OpenSearch",
                                     inputManifest: "manifests/${INPUT_MANIFEST}",

--- a/tests/jenkins/jenkinsjob-regression-files/opensearch/publish-min-snapshots.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/opensearch/publish-min-snapshots.jenkinsfile.txt
@@ -258,7 +258,7 @@
             publish-min-snapshots.script(groovy.lang.Closure)
                publish-min-snapshots.retry(3, groovy.lang.Closure)
                   publish-min-snapshots.echo(Switching to Java 21 on Windows Docker Container)
-                  publish-min-snapshots.sh(scoop reset `scoop list jdk | cut -d ' ' -f1 | grep 21 | head -1`)
+                  publish-min-snapshots.bat(bash -c "scoop reset `scoop list jdk | cut -d ' ' -f1 | grep 21 | head -1`")
                   publish-min-snapshots.buildManifest({componentName=OpenSearch, inputManifest=manifests/3.0.0/opensearch-3.0.0.yml, platform=windows, architecture=x64, distribution=zip, snapshot=true})
                      buildManifest.legacySCM(groovy.lang.Closure)
                      buildManifest.library({identifier=jenkins@11.0.1, retriever=null})


### PR DESCRIPTION
### Description
Switch publish min windows to use bat

### Issues Resolved
```
sh: C:/Users/Administrator/jenkins/workspace/publish-opensearch-min-snapshots@tmp/durable-31e80786/script.sh.copy: No such file or directory

script returned exit code 1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
