### PR TITLE
Fix the base branch for release notes PR

### DIFF
--- a/jenkins/release-workflows/release-notes-generate.jenkinsfile
+++ b/jenkins/release-workflows/release-notes-generate.jenkinsfile
@@ -146,7 +146,7 @@ pipeline {
                                                                             if [ -n "\$EXISTING_PR" ]; then
                                                                                 echo "Updating existing PR #\${EXISTING_PR} for component \${REPO_NAME} with new release notes."
                                                                             else
-                                                                                gh pr create --title '[AUTO] Add release notes for ${version}' --body 'Add release notes for ${version}' -H release-chores/release-notes-${version} -B main
+                                                                                gh pr create --title '[AUTO] Add release notes for ${version}' --body 'Add release notes for ${version}' -H release-chores/release-notes-${version} -B ${ref}
                                                                             fi
                                                                         fi
                                                                     else

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/release-notes-generate.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/release-notes-generate.jenkinsfile.txt
@@ -57,7 +57,7 @@
                                                                             if [ -n "$EXISTING_PR" ]; then
                                                                                 echo "Updating existing PR #${EXISTING_PR} for component ${REPO_NAME} with new release notes."
                                                                             else
-                                                                                gh pr create --title '[AUTO] Add release notes for 2.2.0' --body 'Add release notes for 2.2.0' -H release-chores/release-notes-2.2.0 -B main
+                                                                                gh pr create --title '[AUTO] Add release notes for 2.2.0' --body 'Add release notes for 2.2.0' -H release-chores/release-notes-2.2.0 -B 2.2
                                                                             fi
                                                                         fi
                                                                     else
@@ -111,7 +111,7 @@
                                                                             if [ -n "$EXISTING_PR" ]; then
                                                                                 echo "Updating existing PR #${EXISTING_PR} for component ${REPO_NAME} with new release notes."
                                                                             else
-                                                                                gh pr create --title '[AUTO] Add release notes for 2.2.0' --body 'Add release notes for 2.2.0' -H release-chores/release-notes-2.2.0 -B main
+                                                                                gh pr create --title '[AUTO] Add release notes for 2.2.0' --body 'Add release notes for 2.2.0' -H release-chores/release-notes-2.2.0 -B 2.2
                                                                             fi
                                                                         fi
                                                                     else


### PR DESCRIPTION
### Description
Fixes the base branch for release notes PR that is right now always creating against main porting all commits from ref branch.
Example: https://github.com/pulls?q=sort%3Aupdated-desc+is%3Apr+org%3Aopensearch-project+%5BAUTO%5D+Add+release+notes+for+2.19.4+is%3Aopen

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5815

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
