### PR TITLE
Update macos runners

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-14  # arm64
-          - macos-13  # x64
+          - macos-15  # arm64
+          - macos-15-intel  # x64
     runs-on: ${{ matrix.os }}
     env:
       PYTHON_VERSION: 3.9


### PR DESCRIPTION
### Description
Update macos runners following https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
