### PR TITLE
Increment version for gradle-check-flaky-test-issue-creation.jenkinsfile

### DIFF
--- a/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
+++ b/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
@@ -7,7 +7,7 @@
  * compatible open source license.
  */
 
-lib = library(identifier: 'jenkins@11.1.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@11.1.3', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Increment version for gradle-check-flaky-test-issue-creation.jenkinsfile

### Issues Resolved
https://github.com/opensearch-project/opensearch-build-libraries/releases/tag/11.1.3, this should fix the failing builds https://build.ci.opensearch.org/job/gradle-check-flaky-test-detector/.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
