### PR TITLE
Remove dotnet from container host to avoid space issues

### DIFF
--- a/.github/workflows/get-ci-image-tag.yml
+++ b/.github/workflows/get-ci-image-tag.yml
@@ -65,7 +65,7 @@ jobs:
           fi
 
           if [[ "$PLATFORM" = "al2" ]]; then
-              CI_IMAGE_CMD="cp -a /node_al2/* /node && /node/bin/node -v && cp -a /node_al2/* /node24 && /node24/bin/node -v && ls -l / && du -sh /* && rm -rf /usr/share/dotnet/*"
+              CI_IMAGE_CMD="cp -a /node_al2/* /node && /node/bin/node -v && cp -a /node_al2/* /node24 && /node24/bin/node -v && ls -l /usr/share/dotnet && rm -rf /usr/share/dotnet/*"
               echo "ci-image-start-command=$CI_IMAGE_CMD" >> $GITHUB_OUTPUT
               CI_IMAGE_OPTIONS="--user root -v /node:/node:rw,rshared -v /node:/__e/node20:ro,rshared -v /node24:/node24:rw,rshared -v /node24:/__e/node24:ro,rshared -v /usr/share/dotnet:/usr/share/dotnet:rw,rshared"
               echo "ci-image-start-options=$CI_IMAGE_OPTIONS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description
Remove dotnet from container host to avoid space issues

### Issues Resolved
```



> Task :opensearch-ml-plugin:yamlRestTest FAILED
Exec output and error:
| Output for ./bin/opensearch-plugin:warning: no-jdk distributions that do not bundle a JDK are deprecated and will be removed in a future release
| -> Installing file:/home/ci-runner/.gradle/caches/modules-2/files-2.1/org.opensearch.plugin/opensearch-job-scheduler/3.4.0.0-SNAPSHOT/e0c382d2e412ab2978b8d81b36601feedf62b775/opensearch-job-scheduler-3.4.0.0-SNAPSHOT.zip
| -> Downloading file:/home/ci-runner/.gradle/caches/modules-2/files-2.1/org.opensearch.plugin/opensearch-job-scheduler/3.4.0.0-SNAPSHOT/e0c382d2e412ab2978b8d81b36601feedf62b775/opensearch-job-scheduler-3.4.0.0-SNAPSHOT.zip
| -> Installed opensearch-job-scheduler with folder name opensearch-job-scheduler
| -> Installing file:/__w/ml-commons/ml-commons/plugin/build/distributions/opensearch-ml-3.4.0.0-SNAPSHOT.zip
| -> Downloading file:/__w/ml-commons/ml-commons/plugin/build/distributions/opensearch-ml-3.4.0.0-SNAPSHOT.zip
| -> Failed installing file:/__w/ml-commons/ml-commons/plugin/build/distributions/opensearch-ml-3.4.0.0-SNAPSHOT.zip
| -> Rolling back opensearch-job-scheduler
| -> Rolled back opensearch-job-scheduler
| -> Rolling back file:/__w/ml-commons/ml-commons/plugin/build/distributions/opensearch-ml-3.4.0.0-SNAPSHOT.zip
| -> Rolled back file:/__w/ml-commons/ml-commons/plugin/build/distributions/opensearch-ml-3.4.0.0-SNAPSHOT.zip
| Exception in thread "main" java.io.IOException: No space left on device
| 	at java.base/sun.nio.ch.UnixFileDispatcherImpl.write0(Native Method)
| 	at java.base/sun.nio.ch.UnixFileDispatcherImpl.write(UnixFileDispatcherImpl.java:69)
| 	at java.base/sun.nio.ch.IOUtil.writeFromNativeBuffer(IOUtil.java:137)
| 	at java.base/sun.nio.ch.IOUtil.write(IOUtil.java:102)
| 	at java.base/sun.nio.ch.IOUtil.write(IOUtil.java:72)
| 	at java.base/sun.nio.ch.FileChannelImpl.write(FileChannelImpl.java:338)
| 	at java.base/sun.nio.ch.ChannelOutputStream.writeFully(ChannelOutputStream.java:68)
| 	at java.base/sun.nio.ch.ChannelOutputStream.write(ChannelOutputStream.java:105)
| 	at java.base/java.io.InputStream.transferTo(InputStream.java:797)
| 	at org.opensearch.tools.cli.plugin.InstallPluginCommand.unzip(InstallPluginCommand.java:736)
| 	at org.opensearch.tools.cli.plugin.InstallPluginCommand.execute(InstallPluginCommand.java:275)
| 	at org.opensearch.tools.cli.plugin.InstallPluginCommand.execute(InstallPluginCommand.java:251)
| 	at org.opensearch.common.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:110)
| 	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
| 	at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
| 	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
| 	at org.opensearch.cli.Command.main(Command.java:101)
| 	at org.opensearch.tools.cli.plugin.PluginCli.main(PluginCli.java:66)

> Task :opensearch-ml-plugin:jacocoTestReport
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI image startup now runs additional diagnostics and cleanup steps during initialization to aid troubleshooting and ensure a clean environment.
  * CI setup mounts host runtime components into the build container with read-write access to improve reliability and consistency of the build environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->