### PR TITLE
Validate only docker hub in staging artifacts

### DIFF
--- a/jenkins/release-workflows/release-promotion.jenkinsfile
+++ b/jenkins/release-workflows/release-promotion.jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
                             string(name: 'ARCHITECTURE', value: 'x64 arm64'),
                             string(name: 'PLATFORM', value: 'linux windows'),
                             string(name: 'PROJECTS', value: 'opensearch'),
-                            string(name: 'DOCKER_SOURCE', value: 'Both'),
+                            string(name: 'DOCKER_SOURCE', value: 'dockerhub'),
                             string(name: 'ARTIFACT_TYPE', value: 'staging'),
                             string(name: 'OPTIONAL_ARGS', value: 'using-staging-artifact-only')
                         ]
@@ -108,7 +108,7 @@ pipeline {
                             string(name: 'ARCHITECTURE', value: 'x64 arm64'),
                             string(name: 'PLATFORM', value: 'linux windows'),
                             string(name: 'PROJECTS', value: 'Both'),
-                            string(name: 'DOCKER_SOURCE', value: 'Both'),
+                            string(name: 'DOCKER_SOURCE', value: 'dockerhub'),
                             string(name: 'ARTIFACT_TYPE', value: 'staging'),
                             string(name: 'OPTIONAL_ARGS', value: 'using-staging-artifact-only')
                         ]

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/release-promotion.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/release-promotion.jenkinsfile.txt
@@ -36,7 +36,7 @@
                release-promotion.string({name=ARCHITECTURE, value=x64 arm64})
                release-promotion.string({name=PLATFORM, value=linux windows})
                release-promotion.string({name=PROJECTS, value=Both})
-               release-promotion.string({name=DOCKER_SOURCE, value=Both})
+               release-promotion.string({name=DOCKER_SOURCE, value=dockerhub})
                release-promotion.string({name=ARTIFACT_TYPE, value=staging})
                release-promotion.string({name=OPTIONAL_ARGS, value=using-staging-artifact-only})
                release-promotion.build({job=distribution-validation, wait=true, parameters=[null, null, null, null, null, null, null, null, null, null]})


### PR DESCRIPTION

### Related issues
https://github.com/opensearch-project/opensearch-build/issues/5883

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated release promotion pipeline configuration to specify Docker source selection for artifact validation during staging operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->