### PR TITLE
Ignore 1.x branch for manifest check

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -85,7 +85,7 @@ class InputManifests(Manifests):
 
             # ignore branches that are legacy/outdated and not maintained anymore
             # get possible legacy branches based on legacy manifests, then cross check with current branches from current manifests
-            # ex: 1.0 failed due to certain dependencies not available anymore: https://github.com/avast/gradle-docker-compose-plugin/issues/446
+            branches_to_ignore = ["1.x"]
             all_manifests = set(InputManifests.files(self.prefix))
             legacy_manifests = {m for m in all_manifests if "legacy-manifests" in m}
             legacy_branches = {".".join(m.split(os.sep)[-2].rsplit(".", 1)[:-1]) for m in legacy_manifests}
@@ -97,7 +97,7 @@ class InputManifests(Manifests):
 
             # check out and build #main, 1.x, etc.
             all_branches = sorted(min_klass.branches())
-            branches = [b for b in all_branches if not any(b == o or b.startswith((f"{o}-", f"{o}/")) for o in legacy_branches)]
+            branches = [b for b in all_branches if not any(b == o or b.startswith((f"{o}-", f"{o}/")) for o in legacy_branches) and b not in branches_to_ignore]
             # TODO: Remove
             logging.info(f"Checking {self.name} {sorted(branches)} branches")
             logging.info(f"Ignoring {self.name} {sorted(set(all_branches) - set(branches))} branches as they are legacy")


### PR DESCRIPTION
### Description
Ignore 1.x branch for manifest check as the branch is not maintained anymore and needs outdated java version

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated branch filtering to exclude the "1.x" branch from workflow processing. Enhanced legacy branch detection and exclusion logic to ensure workflow operations only run on supported branches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->