### PR TITLE
Optimize version check by adding pattern matching for branches

### DIFF
--- a/src/manifests_workflow/input_manifests.py
+++ b/src/manifests_workflow/input_manifests.py
@@ -102,7 +102,7 @@ class InputManifests(Manifests):
             branches = [b for b in valid_branches if not any(b == o or b.startswith((f"{o}-", f"{o}/")) for o in legacy_branches) and b not in branches_to_ignore]
             # TODO: Remove
             logging.info(f"Checking {self.name} {sorted(branches)} branches")
-            logging.info(f"Ignoring {self.name} {sorted(set(all_branches) - set(branches))} branches as they are legacy")
+            logging.info(f"Ignoring {self.name} {sorted(set(all_branches) - set(branches))} branches as they are legacy or do not match the required pattern.")
 
             for branch in branches:
                 repo_path = os.path.join(work_dir.name, self.name.replace(" ", ""), branch)


### PR DESCRIPTION
### Description
Only allow exact pattern matched branches to be checkout for generating new manifests based on version.
This skips irrelevant branches in core repos such as development branches, PR revert branches, etc. 

From logs:
```
2025-12-22 19:07:34 INFO     Checking OpenSearch ['2.18', '2.19', '2.x', '3.0', '3.1', '3.2', '3.3', '3.4', 'main'] branches
2025-12-22 19:07:34 INFO     Ignoring OpenSearch ['1.0', '1.1', '1.2', '1.3', '1.x', '14435-refactor-range-agg-optimization', '2.0', '2.1', '2.10', '2.11', '2.12', '2.13', '2.14', '2.15', '2.16', '2.17', '2.2', '2.3', '2.4', '2.5', '2.5-transfer', '2.6', '2.7', '2.8', '2.9', '3.0.0-before-alpha1'] branches as they are legacy
```

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch selection to allow only the main branch or branches matching numeric version patterns (e.g., 3.1, 3.x, 3.3-alpha1) while excluding legacy branches; logging updated to clarify when branches are skipped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->