### PR TITLE
Add 2-node topology configuration for query-insights integration tests

### DIFF
--- a/manifests/3.5.0/opensearch-3.5.0-test.yml
+++ b/manifests/3.5.0/opensearch-3.5.0-test.yml
@@ -187,6 +187,9 @@ components:
         - without-security
   - name: query-insights
     integ-test:
+      topology:
+        - cluster_name: cluster
+          data_nodes: 2
       test-configs:
         - with-security
         - without-security


### PR DESCRIPTION
### Description

This PR fixes failing integration tests in the query-insights plugin by adding the missing topology configuration to test manifests. The QueryInsightsClusterIT test class requires a 2-node cluster to properly test multi-node functionality, but the CI configuration was only running tests on a single node by default.

### Problem
The query-insights plugin has cluster-level integration tests that require multiple nodes:

- testCrossNodeQueryInsightsDataConsistency
- testTopQueriesNodeFiltering
- testMultiNodeDataCollectionAndAggregation

These tests were failing in CI because the test manifests lacked topology configuration, causing them to run on the default single-node setup.

### Solution
Added topology configuration to query-insights in all test manifests:

```
- name: query-insights
  integ-test:
    topology:
      - cluster_name: cluster
        data_nodes: 2
    test-configs:
      - with-security
      - without-security
 ```
This matches the pattern used by other plugins requiring multi-node clusters (e.g., cross-cluster-replication).

### Files Changed

Updated test manifest file for version 3.5.0 to include the 2-node topology configuration.

### Testing
The integration tests can now be verified with:

./gradlew ':integTest' --tests 'org.opensearch.plugin.insights.QueryInsightsClusterIT.*'


### Issues Resolved
Closes [[#5868](https://github.com/opensearch-project/opensearch-build/issues/5868)]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
