### PR TITLE
Reset 3.5.0 branch back to upstream main for OSDcore as Rspack PR merged now

### DIFF
--- a/manifests/3.5.0/opensearch-dashboards-3.5.0.yml
+++ b/manifests/3.5.0/opensearch-dashboards-3.5.0.yml
@@ -17,8 +17,8 @@ ci:
         name: opensearchstaging/ci-runner:ci-runner-windows2019-opensearch-build-v1
 components:
   - name: OpenSearch-Dashboards
-    repository: https://github.com/ruanyl/OpenSearch-Dashboards.git
-    ref: rspack
+    repository: https://github.com/opensearch-project/OpenSearch-Dashboards.git
+    ref: main
   - name: functionalTestDashboards
     repository: https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
     ref: main


### PR DESCRIPTION
This reverts commit 782b66efd524889775711f06c93df2566d954ba5.


### Description
Reset 3.5.0 branch back to upstream main for OSDcore as Rspack PR merged now

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/5897
https://github.com/opensearch-project/opensearch-build/issues/5905


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
