### PR TITLE
update amazonlinux base image references in Dockerfiles

### DIFF
--- a/docker/release/dockerfiles/opensearch-dashboards.al2023.dockerfile
+++ b/docker/release/dockerfiles/opensearch-dashboards.al2023.dockerfile
@@ -13,7 +13,7 @@
 #   OPENSEARCH_DASHBOARDS_HOME: Optional. Specify the opensearch-dashboards root directory. Defaults to /usr/share/opensearch-dashboards.
 
 ########################### Stage 0 ########################
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS linux_stage_0
+FROM amazonlinux:2023 AS linux_stage_0
 
 ARG UID=1000
 ARG GID=1000
@@ -48,7 +48,7 @@ RUN tar -xzpf $TEMP_DIR/opensearch-dashboards-`uname -p`.tgz -C $OPENSEARCH_DASH
 
 ########################### Stage 1 ########################
 # Copy working directory to the actual release docker images
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+FROM amazonlinux:2023
 
 ARG UID=1000
 ARG GID=1000

--- a/docker/release/dockerfiles/opensearch.al2023.dockerfile
+++ b/docker/release/dockerfiles/opensearch.al2023.dockerfile
@@ -14,7 +14,7 @@
 
 
 ########################### Stage 0 ########################
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023 AS linux_stage_0
+FROM amazonlinux:2023 AS linux_stage_0
 
 ARG UID=1000
 ARG GID=1000
@@ -55,7 +55,7 @@ RUN ls -l $TEMP_DIR && \
 
 ########################### Stage 1 ########################
 # Copy working directory to the actual release docker images
-FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+FROM amazonlinux:2023
 
 ARG UID=1000
 ARG GID=1000


### PR DESCRIPTION
Replace public.ecr.aws/amazonlinux/amazonlinux:2023 with amazonlinux:2023 

### Description
The current repository appears to be no longer maintained, but Docker Hub receives regular updates.

### Issues Resolved
Closes #5915  