### PR TITLE
Revert "Update OSB version to use latest"

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_test_suite_execute.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_suite_execute.py
@@ -43,7 +43,7 @@ class BenchmarkTestSuiteExecute(BenchmarkTestSuite):
 
         if self.args.benchmark_config:
             self.command += f" -v {self.args.benchmark_config}:/opensearch-benchmark/.benchmark/benchmark.ini"
-        self.command += f" opensearchproject/opensearch-benchmark:latest run --workload={self.args.workload} " \
+        self.command += f" opensearchproject/opensearch-benchmark:1.15.0 execute-test --workload={self.args.workload} " \
                         f"--pipeline=benchmark-only --target-hosts={self.endpoint}"
 
         if self.args.workload_params:
@@ -82,10 +82,10 @@ class BenchmarkTestSuiteExecute(BenchmarkTestSuite):
     def convert(self) -> None:
         with TemporaryDirectory() as work_dir:
             subprocess.check_call(f"docker cp docker-container-{self.args.stack_suffix}:opensearch-benchmark"
-                                  f"/test-runs/. {str(work_dir.path)}", cwd=os.getcwd(), shell=True)
+                                  f"/test_executions/. {str(work_dir.path)}", cwd=os.getcwd(), shell=True)
             subprocess.check_call(f"docker cp docker-container-{self.args.stack_suffix}:opensearch-benchmark"
                                   f"/final_result.md {str(work_dir.path)}", cwd=os.getcwd(), shell=True)
-            file_path = glob.glob(os.path.join(str(work_dir.path), "*", "test_run.json"))
+            file_path = glob.glob(os.path.join(str(work_dir.path), "*", "test_execution.json"))
             final_results_file = glob.glob(os.path.join(str(work_dir.path), "final_result.md"))
             shutil.copy(file_path[0], os.path.join('/tmp', f"test_execution_{self.args.stack_suffix}.json"))
             shutil.copy(final_results_file[0], os.path.join('/tmp', f"final_result_{self.args.stack_suffix}.md"))

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_suite.py
@@ -19,7 +19,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
     def setUp(self, **kwargs: Any) -> None:
         with patch('test_workflow.integ_test.utils.get_password') as mock_get_password:
             self.args = Mock()
-            self.args.command = 'run'
+            self.args.command = 'execute-test'
             self.args.insecure = True
             self.args.sigv4 = False
             self.args.workload = "nyc_taxis"
@@ -49,7 +49,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
             test_suite.execute()
         self.assertEqual(mock_check_call.call_count, 2)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:latest run '
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.15.0 execute-test '
                          f'--workload=nyc_taxis --pipeline=benchmark-only --target-hosts=abc.com:80 --client-options="timeout:300" --results-file=final_result.md')
 
     @patch('test_workflow.benchmark_test.benchmark_test_suite_execute.subprocess.check_call')
@@ -63,7 +63,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         mock_check_call.assert_called_with(
             f"docker rm -f docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:latest run'
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.15.0 execute-test'
                          f' --workload=nyc_taxis --pipeline=benchmark-only '
                          f'--target-hosts=abc.com:443 '
                          f'--client-options="timeout:300,use_ssl:true,verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'myStrongPassword123!\'" --results-file=final_result.md')
@@ -79,7 +79,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         mock_check_call.assert_called_with(
             f"docker rm -f docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:latest run '
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.15.0 execute-test '
                          '--workload=nyc_taxis --pipeline=benchmark-only '
                          '--target-hosts=abc.com:443 --client-options="timeout:300,use_ssl:true,'
                          'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'" --results-file=final_result.md')
@@ -100,7 +100,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} '
                          '-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN '
-                         'opensearchproject/opensearch-benchmark:latest run '
+                         'opensearchproject/opensearch-benchmark:1.15.0 execute-test '
                          '--workload=nyc_taxis --pipeline=benchmark-only '
                          '--target-hosts=abc.com:443 --client-options="timeout:300,amazon_aws_log_in:session,'
                          f'region:{self.args.region},service:{self.args.service}" --results-file=final_result.md')
@@ -122,7 +122,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:latest run '
+                         'opensearchproject/opensearch-benchmark:1.15.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -143,7 +143,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:latest run '
+                         'opensearchproject/opensearch-benchmark:1.15.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -165,7 +165,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:latest run '
+                         'opensearchproject/opensearch-benchmark:1.15.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -189,7 +189,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         self.assertEqual(test_suite.command,
                          f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                          '/opensearch-benchmark/.benchmark/benchmark.ini '
-                         'opensearchproject/opensearch-benchmark:latest run '
+                         'opensearchproject/opensearch-benchmark:1.15.0 execute-test '
                          '--workload=nyc_taxis '
                          '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                          '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -212,7 +212,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
                 f"docker rm -f docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
             self.assertEqual(test_suite.command, f'docker run --name docker-container-{test_suite.args.stack_suffix} -v /home/test/benchmark.ini:'
                                                  '/opensearch-benchmark/.benchmark/benchmark.ini '
-                                                 'opensearchproject/opensearch-benchmark:latest run '
+                                                 'opensearchproject/opensearch-benchmark:1.15.0 execute-test '
                                                  '--workload=nyc_taxis '
                                                  '--pipeline=benchmark-only --target-hosts=abc.com:80 '
                                                  '--workload-params \'{"number_of_replicas":"1"}\' '
@@ -235,7 +235,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
         mock_check_call.assert_called_with(
             f"docker rm -f docker-container-{test_suite.args.stack_suffix}", cwd=os.getcwd(), shell=True)
         self.assertEqual(test_suite.command,
-                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:latest run '
+                         f'docker run --name docker-container-{test_suite.args.stack_suffix} opensearchproject/opensearch-benchmark:1.15.0 execute-test '
                          '--workload=nyc_taxis --pipeline=benchmark-only '
                          '--target-hosts=abc.com:443 --client-options="timeout:300,use_ssl:true,'
                          'verify_certs:false,basic_auth_user:\'admin\',basic_auth_password:\'admin\'" --results-file=final_result.md')
@@ -265,7 +265,7 @@ class TestBenchmarkTestSuite(unittest.TestCase):
                 mock_glob.return_value = ['/mock/test_execution.json', '/mock/final_result.md']
                 test_suite.convert()
                 mock_temp_directory.assert_called_once()
-            mock_check_call.assert_any_call(f"docker cp docker-container-{test_suite.args.stack_suffix}:opensearch-benchmark/test-runs/. /mock/temp/dir", cwd=os.getcwd(), shell=True)
+            mock_check_call.assert_any_call(f"docker cp docker-container-{test_suite.args.stack_suffix}:opensearch-benchmark/test_executions/. /mock/temp/dir", cwd=os.getcwd(), shell=True)
             mock_check_call.assert_any_call(f"docker cp docker-container-{test_suite.args.stack_suffix}:opensearch-benchmark/final_result.md /mock/temp/dir", cwd=os.getcwd(), shell=True)
 
             mock_open.assert_called_once_with("/mock/test_execution.json")


### PR DESCRIPTION
Reverts opensearch-project/opensearch-build#5925
The renaming of `test-execution-timestamp` to `test-run-timestamp` is breaking all the dashboards. 