### PR TITLE
Resolve ubuntu2404 docker python3.9 cannot remove packaging 24.0 due to 3.9.25 bump

### DIFF
--- a/docker/ci/dockerfiles/current/build.ubuntu2404.opensearch.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/build.ubuntu2404.opensearch.x64.arm64.dockerfile
@@ -50,9 +50,13 @@ RUN apt-get update -y && apt-get install -y python3.9-full python3.9-dev && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 100 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.9 100 && \
     update-alternatives --set python3 /usr/bin/python3.9 && \
-    update-alternatives --set python /usr/bin/python3.9 && \
-    curl -SL https://bootstrap.pypa.io/get-pip.py | python3 - && \
-    pip3 install awscliv2==2.3.1 pipenv==2023.6.12 && \
+    update-alternatives --set python /usr/bin/python3.9
+
+# Cannot uninstall packaging 24.0
+# The package's contents are unknown: no RECORD file was found for packaging.
+RUN curl -SL https://bootstrap.pypa.io/get-pip.py | python3 - --no-deps && \
+    python3 -m pip install --upgrade --ignore-installed packaging && \
+    pip3 install awscliv2==2.3.1 pipenv==2023.6.12 cmake==3.26.4 && \
     ln -s `which awsv2` /usr/local/bin/aws && aws --install
 
 # Install aptly and required changes to debmake

--- a/docker/ci/dockerfiles/current/test.ubuntu2404.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.ubuntu2404.systemd-base.x64.arm64.dockerfile
@@ -120,8 +120,12 @@ RUN apt-get update -y && apt-get install -y python3.9-full python3.9-dev && \
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 100 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.9 100 && \
     update-alternatives --set python3 /usr/bin/python3.9 && \
-    update-alternatives --set python /usr/bin/python3.9 && \
-    curl -SL https://bootstrap.pypa.io/get-pip.py | python3 - && \
+    update-alternatives --set python /usr/bin/python3.9
+
+# Cannot uninstall packaging 24.0
+# The package's contents are unknown: no RECORD file was found for packaging.
+RUN curl -SL https://bootstrap.pypa.io/get-pip.py | python3 - --no-deps && \
+    python3 -m pip install --upgrade --ignore-installed packaging && \
     pip3 install awscliv2==2.3.1 pipenv==2023.6.12 cmake==3.26.4 && \
     ln -s `which awsv2` /usr/local/bin/aws && aws --install
 


### PR DESCRIPTION


### Description
Resolve ubuntu2404 docker python3.9 cannot remove packaging 24.0 due to 3.9.25 bump

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5905
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11080
https://github.com/opensearch-project/opensearch-build/issues/5897
https://github.com/opensearch-project/opensearch-build/pull/5934

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
