### PR TITLE
Remove parameterized cron schedules for 3.5.0 builds

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -23,8 +23,6 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H 1 * * * %INPUT_MANIFEST=3.5.0/opensearch-dashboards-3.5.0.yml;TEST_MANIFEST=3.5.0/opensearch-dashboards-3.5.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_PLATFORM=linux windows;TEST_DISTRIBUTION=tar rpm deb zip;
-            H 1 * * * %INPUT_MANIFEST=3.5.0/opensearch-3.5.0.yml;TEST_MANIFEST=3.5.0/opensearch-3.5.0-test.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_PLATFORM=linux windows;TEST_DISTRIBUTION=tar rpm deb zip;
             H 1 * * * %INPUT_MANIFEST=2.19.5/opensearch-2.19.5.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
         '''
     }


### PR DESCRIPTION
### Description
Remove 3.5.0 build cron triggers for OpenSearch and OpenSearch Dashboards

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
