### PR TITLE
Add nightly and on-demand gRPC benchmark triggers for OpenSearch 3.x

### DIFF
--- a/jenkins/opensearch/benchmark-pull-request.jenkinsfile
+++ b/jenkins/opensearch/benchmark-pull-request.jenkinsfile
@@ -195,7 +195,7 @@ pipeline {
                     [key: 'EXCLUDE_TASKS', value: '$.EXCLUDE_TASKS'],
                     [key: 'INCLUDE_TASKS', value: '$.INCLUDE_TASKS'],
                     [key: 'CAPTURE_NODE_STAT', value: '$.CAPTURE_NODE_STAT'],
-                    [key: 'TELEMETRY_PARAMS', value: '$.TELEMETRY_PARAMS'],
+                    [key: 'TELEMETRY_PARAMS', value: '$.TELEMETRY_PARAMS']
                 ],
                 tokenCredentialId: 'jenkins-pr-benchmark-generic-webhook-token',
                 causeString: 'Triggered by comment on PR on OpenSearch core repository',


### PR DESCRIPTION
**Description**
This PR enables automated nightly benchmarking for the gRPC transport layer (Bulk and Search workloads) on OpenSearch 3.5.0  . It also supports on-demand gRPC tests via GitHub comments.

Related: https://github.com/opensearch-project/OpenSearch/issues/19750

**Changes**
     1)Added nightly cron schedules for grpc_bulk (2:00 AM) and grpc_search (3:00 AM) in benchmark-test.jenkinsfile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).