### PR TITLE
Add code diff analyzer github action to be re-used by others

### DIFF
--- a/.github/workflows/code-diff-analyzer.yml
+++ b/.github/workflows/code-diff-analyzer.yml
@@ -14,7 +14,19 @@ on:
         required: false
         type: string
         default: 'skip-diff-analyzer'
-      update_pr_comment_with_analyzer_report:  # Only take if event is pull_request_target
+      # all = every mode
+      # report = analyze diff to find malicious code
+      # TODO: review = analyze diff to suggest code improvement
+      diff_analyzer_mode:
+        required: false
+        type: string
+        default: 'report'
+      update_pr_comment_with_analyzer_report:  # Only update if event is pull_request_target
+        required: false
+        type: boolean
+        default: false
+      # TODO: Implement review
+      update_pr_conversation_with_analyzer_review:  # Only update if event is pull_request_target
         required: false
         type: boolean
         default: false


### PR DESCRIPTION
### Description
Add code diff analyzer github action to be re-used by others
Example: https://github.com/peterzhuamazon/OpenSearch/pull/2#issuecomment-3844667108
Pre-requisite to https://github.com/opensearch-project/OpenSearch/pull/20504

* Note: this is early stage and only review for malicious code. We can extend it to also review on code enhancement just like other AI review tools, through bedrock.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5912

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
