### PR TITLE
Revert "[3.5.0] Manifest Commit Lock with action UPDATE_TO_RECENT_COMMITS"

### DIFF
--- a/manifests/3.5.0/opensearch-3.5.0.yml
+++ b/manifests/3.5.0/opensearch-3.5.0.yml
@@ -79,7 +79,7 @@ components:
       - common-utils
   - name: ml-commons
     repository: https://github.com/opensearch-project/ml-commons.git
-    ref: 19dae23d89a0d54ea9f4186a1213613ed8e21abe
+    ref: a7f848d116562997cfc5275e5bd284750716be6b
     platforms:
       - linux
       - windows


### PR DESCRIPTION
Reverts opensearch-project/opensearch-build#5970