### PR TITLE
Use github secrets to host BEDROCK_ACCESS_ROLE

### DIFF
--- a/.github/workflows/code-diff-analyzer.yml
+++ b/.github/workflows/code-diff-analyzer.yml
@@ -3,7 +3,7 @@ name: Code Diff Analyzer
 on:
   workflow_call:
     secrets:
-      OP_SERVICE_ACCOUNT_TOKEN:
+      BEDROCK_ACCESS_ROLE:
         required: true
     inputs:
       skip_diff_analyzer_on_push:
@@ -141,21 +141,11 @@ jobs:
           npm install -g @anthropic-ai/claude-code@stable
           pip install json-repair==0.55.2
 
-      - name: Load secret
-        if: ${{ env.diff_analyzer != '5' && env.diff_analyzer != '9' }}
-        uses: 1password/load-secrets-action@v3
-        with:
-          # Export loaded secrets as environment variables
-          export-env: true
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          BEDROCK_ACCESS_ROLE: op://opensearch-infra-secrets/aws-iam-roles/bedrock-access-role
-
       - name: Configure AWS credentials
         if: ${{ env.diff_analyzer != '5' && env.diff_analyzer != '9' }}
         uses: aws-actions/configure-aws-credentials@v5
         with:
-          role-to-assume: ${{ env.BEDROCK_ACCESS_ROLE }}
+          role-to-assume: ${{ secrets.BEDROCK_ACCESS_ROLE }}
           aws-region: us-east-1
 
       # yamllint disable


### PR DESCRIPTION
### Description
Use github secrets to host BEDROCK_ACCESS_ROLE

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5912
https://github.com/opensearch-project/OpenSearch/actions/runs/21890923264/job/63196367070?pr=20566


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
