### PR TITLE
Reduce bedrock calls slightly to prepare for more repositories

### DIFF
--- a/.github/workflows/code-diff-reviewer.yml
+++ b/.github/workflows/code-diff-reviewer.yml
@@ -87,7 +87,7 @@ jobs:
           pr_reviewer.enable_review_labels_effort: false
           pr_code_suggestions.max_history_len: 5  # max number of history of previous suggestions in same persistent comment
           pr_code_suggestions.max_number_of_calls: 3  # max number of chunks to cut PR, make X number of calls per commit on PR, each 32000 token
-          pr_code_suggestions.num_code_suggestions_per_chunk: 3  # max number of suggestions per chunk
+          pr_code_suggestions.num_code_suggestions_per_chunk: 4  # max number of suggestions per chunk
           pr_code_suggestions.enable_chat_in_code_suggestions: false  # only for app
           pr_code_suggestions.commitable_code_suggestions: false  # Too much similar changes on every push
           pr_code_suggestions.apply_suggestions_checkbox: false


### PR DESCRIPTION
### Description
Reduce bedrock calls slightly to prepare for more repositories

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5912

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
