### PR TITLE
Temporarily set file size limit before moving from -p to --file as parameter allows only 100kb inputs

### DIFF
--- a/.github/workflows/code-diff-analyzer.yml
+++ b/.github/workflows/code-diff-analyzer.yml
@@ -49,7 +49,7 @@ jobs:
     env:
       AWS_REGION: 'us-east-1'
       CLAUDE_CODE_USE_BEDROCK: '1'
-      CLAUDE_CODE_MAX_INPUT_TOKENS: '150000'
+      CLAUDE_CODE_MAX_INPUT_TOKENS: '100000'
       CLAUDE_CODE_MAX_OUTPUT_TOKENS: '4096'
       MAX_THINKING_TOKENS: '1024'
       DIFF_CONTENT_PATH: 'git_diff_content.txt'
@@ -107,12 +107,11 @@ jobs:
             "https://api.github.com/repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}" > $DIFF_CONTENT_PATH
 
           DIFF_SIZE=$(cat $DIFF_CONTENT_PATH | wc -c)
-          DIFF_TOKEN_EST=$((DIFF_SIZE / 3))
-          echo "Check diff size of '$DIFF_SIZE' with token number '$DIFF_TOKEN_EST' over max token limit '$CLAUDE_CODE_MAX_INPUT_TOKENS'"
-          if [ "$DIFF_TOKEN_EST" -gt "$CLAUDE_CODE_MAX_INPUT_TOKENS" ]; then
-            echo "Diff too large, requires skip by maintainers after manual review"
+          echo "Check diff size of '$DIFF_SIZE' max token limit '$CLAUDE_CODE_MAX_INPUT_TOKENS'"
+          if [ "$DIFF_SIZE" -ge "$CLAUDE_CODE_MAX_INPUT_TOKENS" ]; then
+            echo "Diff too large, reduce your PR size or requires skip by maintainers after manual review"
             echo "diff_analyzer=5" >> $GITHUB_ENV
-            echo "diff_report='Diff too large, requires skip by maintainers after manual review'" >> $GITHUB_ENV
+            echo "diff_report='Diff too large, reduce your PR size or requires skip by maintainers after manual review'" >> $GITHUB_ENV
             exit 1
           fi
           echo "-------------------------------------------------------"


### PR DESCRIPTION


### Description
Temporarily set file size limit before moving from -p to --file as parameter allows only 100kb inputs

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5912

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
