### PR TITLE
Pass module scope param to gradle check

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -130,7 +130,8 @@ pipeline {
                             runGradleCheck(
                                 gitRepoUrl: "${pr_from_clone_url}",
                                 gitReference: "${pr_from_sha}",
-                                bwcCheckoutAlign: "${bwc_checkout_align}"
+                                bwcCheckoutAlign: "${bwc_checkout_align}",
+                                scope: "all"
                             )
                         }
                         else {
@@ -141,7 +142,8 @@ pipeline {
                             runGradleCheck(
                                 gitRepoUrl: "${GIT_REPO_URL}",
                                 gitReference: "${GIT_REFERENCE}",
-                                bwcCheckoutAlign: "${bwc_checkout_align}"
+                                bwcCheckoutAlign: "${bwc_checkout_align}",
+                                scope: "all"
                             )
                         }
 


### PR DESCRIPTION
### Description
Pass module scope param to gradle check to gradle check job. Set it to default all to build all modules.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
