### PR TITLE
Skip version increment PR for already incremented dashboards plugins

### DIFF
--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -183,7 +183,7 @@ jobs:
             opensearch_dashboards.json
             package.json
       - name: Create Pull Request for opensearch-dashboards-functional-test
-        if: ${{ matrix.entry.repo == 'opensearch-dashboards-functional-test' && steps.version_check.outputs.already_incremented == 'false' }}
+        if: ${{ matrix.entry.repo == 'opensearch-dashboards-functional-test' }}
         id: cprft
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
### Description

The aim of this PR is to avoid autocut PRs like this: https://github.com/opensearch-project/security-dashboards-plugin/pull/2380

Currently, the version increment automation will sometimes open blank PRs for already incremented repos. This PR skips creating a PR if it detects that a dashboards plugin has already been incremented.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
