### PR TITLE
fix: reuse PR comment in Code-Diff-Analyzer on follow-up commits

### DIFF
--- a/.github/workflows/code-diff-analyzer.yml
+++ b/.github/workflows/code-diff-analyzer.yml
@@ -280,12 +280,23 @@ jobs:
             exit 1
           fi
 
+      - name: Find existing PR Code Analyzer comment
+        if: ${{ always() && github.event_name == 'pull_request_target' && inputs.update_pr_comment_with_analyzer_report && env.diff_analyzer != '0' && env.diff_analyzer != '9' }}
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '## PR Code Analyzer'
+
       - name: Create Comment Failure Git Diff Analyzer
         if: ${{ always() && github.event_name == 'pull_request_target' && inputs.update_pr_comment_with_analyzer_report && env.diff_analyzer != '0' && env.diff_analyzer != '9' }}
         uses: peter-evans/create-or-update-comment@v5
         with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
           repository: ${{ github.repository }}
           issue-number: ${{ github.event.number }}
+          edit-mode: replace
           body: |
             ## PR Code Analyzer :exclamation:
 


### PR DESCRIPTION
## Summary

- The `Create Comment Failure Git Diff Analyzer` step in `code-diff-analyzer.yml` was calling `peter-evans/create-or-update-comment` without a `comment-id`, causing it to post a **new comment on every push** to a PR instead of updating the existing one.
- Added a `peter-evans/find-comment` step (with the same `if` condition) before the create/update step to search for an existing `## PR Code Analyzer` comment by `github-actions[bot]`.
- The found `comment-id` is passed to `create-or-update-comment` with `edit-mode: replace`, so follow-up commits update the existing comment in place — matching the behaviour of the PR Reviewer Guide comment.

## Changes

- `.github/workflows/code-diff-analyzer.yml`: added `Find existing PR Code Analyzer comment` step using `peter-evans/find-comment@v3`; wired its output `comment-id` and `edit-mode: replace` into the existing `create-or-update-comment` step.

## Test plan

- [ ] Open a test PR against a repo that uses this workflow and push a second commit — verify the analyzer comment is updated rather than duplicated.
- [ ] Verify first-run behaviour (no existing comment): `find-comment` outputs an empty `comment-id`; `create-or-update-comment` falls back to creating a new comment as before.