### PR TITLE
updated docker, jenkins with latest tag on opensearchstaging

### DIFF
--- a/docker/release/build-image-multi-arch.sh
+++ b/docker/release/build-image-multi-arch.sh
@@ -12,12 +12,14 @@ set -e
 
 # Import libs
 . ../../lib/shell/file_management.sh
+. ../../lib/shell/version_management.sh
 
 # Variable
 OLDIFS=$IFS
 BUILDER_NUM=`date +%s`
 BUILDER_NAME="multiarch_${BUILDER_NUM}"
 DIR=""
+TAG_LATEST=false
 
 function usage() {
     echo ""
@@ -34,6 +36,7 @@ function usage() {
     echo ""
     echo "Optional arguments:"
     echo -e "-t TARBALL\tSpecify multiple opensearch or opensearch-dashboards tarballs, use the same order as the input for '-a' param, e.g. 'opensearch-1.0.0-linux-x64.tar.gz,opensearch-1.0.0-linux-arm64.tar.gz'. You still need to specify the version - this tool does not attempt to parse the filename."
+    echo -e "-l\t\tTag the built image as :latest if this version is the highest semver tag in the repository. Uses the Docker Hub API to compare existing tags. Only applies to GA releases; skip for snapshots or patch backports where a newer minor already exists."
     echo -e "-n NOTES\tSpecify Pipeline Notes of the run, defaults to None."
     echo -e "-h\t\tPrint this message."
     echo "--------------------------------------------------------------------------"
@@ -50,7 +53,7 @@ function cleanup_all() {
     cleanup_docker_buildx
     File_Delete $DIR
 }
-while getopts ":ht:n:v:f:p:a:r:" arg; do
+while getopts ":ht:n:v:f:p:a:r:l" arg; do
     case $arg in
         h)
             usage
@@ -76,6 +79,9 @@ while getopts ":ht:n:v:f:p:a:r:" arg; do
             ;;
         r)
             REPOSITORY=$OPTARG
+            ;;
+        l)
+            TAG_LATEST=true
             ;;
         :)
             echo "-${OPTARG} requires an argument"
@@ -172,7 +178,17 @@ else
     ls -l $DIR
 fi
 
+# Determine image tags for the build
+REGISTRY_NAME="${REPOSITORY%%/*}"
+IMAGE_NAME="${REPOSITORY##*/}"
+IMAGE_TAGS="-t ${REPOSITORY}:${VERSION}"
+
+if [ "$TAG_LATEST" = true ]; then
+    if is_latest_version "$REGISTRY_NAME" "$IMAGE_NAME" "$VERSION"; then
+        IMAGE_TAGS="$IMAGE_TAGS -t ${REPOSITORY}:latest"
+    fi
+fi
+
 # Build multi-arch images
 PLATFORMS=`echo "${ARCHITECTURE_ARRAY[@]/#/linux/}" | sed 's/x64/amd64/g;s/ /,/g'` && echo PLATFORMS $PLATFORMS
-docker buildx build --platform $PLATFORMS --build-arg VERSION=$VERSION --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` --build-arg NOTES=$NOTES -t ${REPOSITORY}:${VERSION} -f $DOCKERFILE --push $DIR
-
+docker buildx build --platform $PLATFORMS --build-arg VERSION=$VERSION --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` --build-arg NOTES=$NOTES $IMAGE_TAGS -f $DOCKERFILE --push $DIR

--- a/docker/release/build-image-single-arch.sh
+++ b/docker/release/build-image-single-arch.sh
@@ -13,6 +13,9 @@ set -e
 
 # Import libs
 . ../../lib/shell/file_management.sh
+. ../../lib/shell/version_management.sh
+
+TAG_LATEST=false
 
 function usage() {
     echo ""
@@ -25,15 +28,17 @@ function usage() {
     echo -e "-f DOCKERFILE\tSpecify the dockerfile full path, e.g. dockerfile/opensearch.al2.dockerfile."
     echo -e "-p PRODUCT\tSpecify the product, e.g. opensearch or opensearch-dashboards, make sure this is the name of your config folder and the name of your .tgz defined in dockerfile."
     echo -e "-a ARCHITECTURE\tSpecify one and only one architecture, e.g. x64 or arm64."
+    echo -e "-r REPOSITORY\tSpecify the docker repository name in the format of '<Docker Hub RepoName>/<Docker Image Name>', e.g. 'opensearchstaging/opensearch'."
     echo ""
     echo "Optional arguments:"
     echo -e "-t TARBALL\tSpecify a local opensearch or opensearch-dashboards tarball. You still need to specify the version - this tool does not attempt to parse the filename."
+    echo -e "-l\t\tTag the built image as :latest if this version is the highest semver tag in the repository. Uses the Docker Hub API to compare existing tags. Only applies to GA releases; skip for snapshots or patch backports where a newer minor already exists."
     echo -e "-n NOTES\tSpecify Pipeline Notes of the run, defaults to None."
     echo -e "-h\t\tPrint this message."
     echo "--------------------------------------------------------------------------"
 }
 
-while getopts ":ht:n:v:f:p:a:" arg; do
+while getopts ":ht:n:v:f:p:a:r:l" arg; do
     case $arg in
         h)
             usage
@@ -57,6 +62,12 @@ while getopts ":ht:n:v:f:p:a:" arg; do
         a)
             ARCHITECTURE=$OPTARG
             ;;
+        r)
+            REPOSITORY=$OPTARG
+            ;;
+        l)
+            TAG_LATEST=true
+            ;;
         :)
             echo "-${OPTARG} requires an argument"
             usage
@@ -70,8 +81,8 @@ while getopts ":ht:n:v:f:p:a:" arg; do
 done
 
 # Validate the required parameters to present
-if [ -z "$VERSION" ] || [ -z "$DOCKERFILE" ] || [ -z "$PRODUCT" ] || [ -z "$ARCHITECTURE" ]; then
-  echo "You must specify '-v VERSION', '-f DOCKERFILE', '-p PRODUCT', '-a ARCHITECTURE'"
+if [ -z "$VERSION" ] || [ -z "$DOCKERFILE" ] || [ -z "$PRODUCT" ] || [ -z "$ARCHITECTURE" ] || [ -z "$REPOSITORY" ]; then
+  echo "You must specify '-v VERSION', '-f DOCKERFILE', '-p PRODUCT', '-a ARCHITECTURE', '-r REPOSITORY'"
   usage
   exit 1
 else
@@ -123,6 +134,14 @@ else
 fi
 
 # Docker build
-docker build --build-arg VERSION=$VERSION --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` --build-arg NOTES=$NOTES -f $DOCKERFILE $DIR -t opensearchproject/$PRODUCT:$VERSION
-docker tag opensearchproject/$PRODUCT:$VERSION opensearchproject/$PRODUCT:latest
+docker build --build-arg VERSION=$VERSION --build-arg BUILD_DATE=`date -u +%Y-%m-%dT%H:%M:%SZ` --build-arg NOTES=$NOTES -f $DOCKERFILE $DIR -t ${REPOSITORY}:${VERSION}
 
+# Conditionally tag and push :latest based on version comparison
+if [ "$TAG_LATEST" = true ]; then
+    REGISTRY_NAME="${REPOSITORY%%/*}"
+    IMAGE_NAME="${REPOSITORY##*/}"
+    if is_latest_version "$REGISTRY_NAME" "$IMAGE_NAME" "$VERSION"; then
+        docker tag ${REPOSITORY}:${VERSION} ${REPOSITORY}:latest
+        docker push ${REPOSITORY}:latest
+    fi
+fi

--- a/jenkins/docker/docker-build.jenkinsfile
+++ b/jenkins/docker/docker-build.jenkinsfile
@@ -56,6 +56,11 @@ pipeline {
             description: 'Build docker image on which operating system.',
             choices: ['linux', 'windows'],
         )
+        booleanParam(
+            name: 'TAG_LATEST',
+            defaultValue: false,
+            description: 'If true, appends -l to the build script so the image is also tagged as :latest when this version is the highest semver in the staging registry. Should only be enabled for GA release builds, not snapshots or patch backports.'
+        )
     }
     stages {
         stage('Parameters Check') {
@@ -82,17 +87,21 @@ pipeline {
                 script {
                     echo 'The docker-build workflow will only push docker images to staging, please use docker-copy to move the image to other repositories'
                     checkout([$class: 'GitSCM', branches: [[name: "${DOCKER_BUILD_GIT_REPOSITORY_REFERENCE}" ]], userRemoteConfigs: [[url: "${DOCKER_BUILD_GIT_REPOSITORY}" ]]])
+                    def buildCommand = DOCKER_BUILD_SCRIPT_WITH_COMMANDS
+                    if (TAG_LATEST.toBoolean()) {
+                        buildCommand += ' -l'
+                    }
                     echo "Account: dockerhub staging"
                     withSecrets(secrets: secret_dockerhub_staging){
                         if (isUnix()){
                             sh """
                                 set -e
                                 set +x
-                                docker logout && echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin && eval $DOCKER_BUILD_SCRIPT_WITH_COMMANDS
+                                docker logout && echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin && eval ${buildCommand}
                             """
                         } else {
                             bat"""
-                                bash -c "set -e && set +x && docker logout && echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin && eval $DOCKER_BUILD_SCRIPT_WITH_COMMANDS"
+                                bash -c "set -e && set +x && docker logout && echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin && eval ${buildCommand}"
                             """
                         }
                     }

--- a/lib/shell/version_management.sh
+++ b/lib/shell/version_management.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# This is a library of all version management related functions.
+# Source this file in your scripts:
+#   . path/to/lib/shell/version_management.sh
+
+# Determines whether the given version is the highest published semver tag
+# for the specified image in a Docker Hub registry.
+#
+# Queries hub.docker.com/v2/repositories/<registry>/<image>/tags, filters
+# results to strict X.Y.Z shaped tags only, and compares using sort -V.
+# Tags like "latest", "2", "2.15.0.3910", or snapshot suffixes are excluded.
+#
+# Usage:
+#   is_latest_version <registry> <image> <version>
+#
+# Arguments:
+#   registry  Docker Hub organization name, e.g. "opensearchstaging"
+#   image     Docker image name, e.g. "opensearch"
+#   version   Semver string to evaluate, e.g. "2.15.0"
+#
+# Returns:
+#   0 if <version> is >= the highest existing semver tag, or no semver tags exist
+#   1 if a higher semver tag already exists in the registry
+#
+function is_latest_version() {
+    local registry="$1"
+    local image="$2"
+    local version="$3"
+
+    if [ -z "$registry" ] || [ -z "$image" ] || [ -z "$version" ]; then
+        echo "Error: is_latest_version requires <registry> <image> <version>" >&2
+        return 1
+    fi
+
+    local api_url="https://hub.docker.com/v2/repositories/${registry}/${image}/tags?page_size=100"
+    local all_tags=()
+    local next_url="$api_url"
+
+    echo "Querying Docker Hub for existing tags of ${registry}/${image} ..."
+
+    while [ -n "$next_url" ] && [ "$next_url" != "null" ]; do
+        local response
+        response=$(curl -sf --max-time 30 "$next_url" 2>/dev/null) || {
+            echo "Warning: Unable to reach Docker Hub API at ${next_url}. Assuming ${version} is latest." >&2
+            return 0
+        }
+
+        # Extract tag names from JSON response
+        local page_tags
+        page_tags=$(echo "$response" | grep -o '"name":"[^"]*"' | sed 's/"name":"//;s/"$//')
+        while IFS= read -r tag; do
+            [ -n "$tag" ] && all_tags+=("$tag")
+        done <<< "$page_tags"
+
+        # Extract next page URL, unescaping \u0026 -> &
+        next_url=$(echo "$response" | grep -o '"next":"[^"]*"' | sed 's/"next":"//;s/"$//;s/\\u0026/\&/g')
+    done
+
+    # Filter to strict semver X.Y.Z only — excludes "latest", "2", "2.15.0.3910", snapshots, etc.
+    local semver_tags=()
+    for tag in "${all_tags[@]}"; do
+        if [[ "$tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            semver_tags+=("$tag")
+        fi
+    done
+
+    if [ ${#semver_tags[@]} -eq 0 ]; then
+        echo "No existing semver tags found for ${registry}/${image}. Treating ${version} as latest."
+        return 0
+    fi
+
+    # Include the candidate version and find the highest using version-aware sort
+    semver_tags+=("$version")
+    local highest
+    highest=$(printf '%s\n' "${semver_tags[@]}" | sort -V | tail -n1)
+
+    if [ "$highest" = "$version" ]; then
+        echo "${version} is the highest semver tag for ${registry}/${image} — will tag as :latest"
+        return 0
+    else
+        echo "${version} is NOT the highest semver tag for ${registry}/${image} (highest existing: ${highest}) — skipping :latest"
+        return 1
+    fi
+}

--- a/tests/jenkins/TestDockerBuild.groovy
+++ b/tests/jenkins/TestDockerBuild.groovy
@@ -47,6 +47,7 @@ class TestDockerBuild extends BuildPipelineTest {
         binding.setVariable('DOCKER_PASSWORD', dockerPassword)
         binding.setVariable('DOCKER_BUILD_SCRIPT_WITH_COMMANDS', dockerBuildScriptwithCommands)
         binding.setVariable('DOCKER_BUILD_OS', dockerBuildOS)
+        binding.setVariable('TAG_LATEST', false)
         helper.registerAllowedMethod('isUnix', [], { true })
         helper.registerAllowedMethod("withSecrets", [Map, Closure], { args, closure ->
             closure.delegate = delegate
@@ -78,6 +79,50 @@ class TestDockerBuild extends BuildPipelineTest {
 
         // Make sure dockerBuildOS is deciding agent_node docker_nodes docker_args correctly
         assertCallStack().contains("docker-build.echo(Executing on agent [docker:[alwaysPull:true, args:-u root -v /var/run/docker.sock:/var/run/docker.sock, containerPerStageRoot:false, label:Jenkins-Agent-Ubuntu2404-X64-M52xlarge-Docker-Builder, image:opensearchstaging/ci-runner:ubuntu2404-x64-docker-buildx0.9.1-qemu8.2-v1, reuseNode:false, registryUrl:https://public.ecr.aws/, stages:[:]]])")
+
+        // Verify -l flag is NOT appended when TAG_LATEST is false
+        def commandsWithLatestFlag = getCommands('docker').findAll {
+            shCommand -> shCommand.contains(' -l')
+        }
+        assertThat(commandsWithLatestFlag.size(), equalTo(0))
+
+        printCallStack()
+    }
+
+    @Test
+    public void DockerBuildWithTagLatestEnabled() {
+        binding.setVariable('TAG_LATEST', true)
+
+        runScript("jenkins/docker/docker-build.jenkinsfile")
+
+        assertJobStatusSuccess()
+
+        // Verify -l flag IS appended to the build command when TAG_LATEST is true
+        def dockerCommandWithLatest = getCommands('docker').findAll {
+            shCommand -> shCommand.contains('docker logout && echo dockerPassword | docker login -u dockerUsername --password-stdin && eval bash docker/ci/build-image-multi-arch.sh -v <TAG_NAME> -f <DOCKERFILE PATH> -l')
+        }
+        assertThat(dockerCommandWithLatest.size(), equalTo(1))
+
+        // Validate the docker-build.sh is called with correct predefined credential
+        assertCallStack().contains("docker-build.echo(Account: dockerhub staging)")
+
+        printCallStack()
+    }
+
+    @Test
+    public void DockerBuildWithTagLatestDisabled() {
+        binding.setVariable('TAG_LATEST', false)
+
+        runScript("jenkins/docker/docker-build.jenkinsfile")
+
+        assertJobStatusSuccess()
+
+        // Verify -l flag is NOT appended when TAG_LATEST is explicitly false
+        def dockerCommandWithoutLatest = getCommands('docker').findAll {
+            shCommand -> shCommand.contains('docker logout && echo dockerPassword | docker login -u dockerUsername --password-stdin && eval bash docker/ci/build-image-multi-arch.sh -v <TAG_NAME> -f <DOCKERFILE PATH>')
+                      && !shCommand.contains(' -l')
+        }
+        assertThat(dockerCommandWithoutLatest.size(), equalTo(1))
 
         printCallStack()
     }

--- a/tests/shell/test_version_management.sh
+++ b/tests/shell/test_version_management.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+# Unit tests for lib/shell/version_management.sh
+# Run from the repo root: bash tests/shell/test_version_management.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+. "$REPO_ROOT/lib/shell/version_management.sh"
+
+PASS=0
+FAIL=0
+
+function assert_equals() {
+    local test_name="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "PASS: $test_name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $test_name — expected '$expected', got '$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+function assert_returns() {
+    local test_name="$1"
+    local expected_rc="$2"
+    shift 2
+    "$@" > /dev/null 2>&1
+    local actual_rc=$?
+    assert_equals "$test_name" "$expected_rc" "$actual_rc"
+}
+
+# ---------------------------------------------------------------------------
+# Override curl so tests never hit the network.
+# MOCK_TAGS_RESPONSE controls what the fake API returns.
+# ---------------------------------------------------------------------------
+MOCK_TAGS_RESPONSE=""
+
+function curl() {
+    # Ignore all curl flags/args and just return the mocked response
+    echo "$MOCK_TAGS_RESPONSE"
+    return 0
+}
+export -f curl
+
+# Build a minimal Docker Hub API JSON response for a list of tag names
+function make_tags_response() {
+    local tags_json=""
+    for tag in "$@"; do
+        [ -n "$tags_json" ] && tags_json="$tags_json,"
+        tags_json="${tags_json}{\"name\":\"${tag}\"}"
+    done
+    echo "{\"count\":$#,\"next\":null,\"results\":[${tags_json}]}"
+}
+
+# ---------------------------------------------------------------------------
+# Test: missing arguments
+# ---------------------------------------------------------------------------
+function test_missing_arguments() {
+    is_latest_version "" "opensearch" "2.15.0" > /dev/null 2>&1
+    local rc=$?
+    assert_equals "missing_registry_returns_error" "1" "$rc"
+
+    is_latest_version "opensearchstaging" "" "2.15.0" > /dev/null 2>&1
+    rc=$?
+    assert_equals "missing_image_returns_error" "1" "$rc"
+
+    is_latest_version "opensearchstaging" "opensearch" "" > /dev/null 2>&1
+    rc=$?
+    assert_equals "missing_version_returns_error" "1" "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Test: no existing tags — treat candidate as latest
+# ---------------------------------------------------------------------------
+function test_no_existing_tags() {
+    MOCK_TAGS_RESPONSE=$(make_tags_response)
+    is_latest_version "opensearchstaging" "opensearch" "2.15.0" > /dev/null 2>&1
+    assert_equals "no_existing_tags_returns_0" "0" "$?"
+}
+
+# ---------------------------------------------------------------------------
+# Test: candidate is the highest version
+# ---------------------------------------------------------------------------
+function test_candidate_is_highest() {
+    MOCK_TAGS_RESPONSE=$(make_tags_response "2.14.0" "2.13.0" "1.3.3")
+    is_latest_version "opensearchstaging" "opensearch" "2.15.0" > /dev/null 2>&1
+    assert_equals "candidate_higher_than_all_existing_returns_0" "0" "$?"
+}
+
+# ---------------------------------------------------------------------------
+# Test: candidate equals the current highest (idempotent re-run)
+# ---------------------------------------------------------------------------
+function test_candidate_equals_highest() {
+    MOCK_TAGS_RESPONSE=$(make_tags_response "2.15.0" "2.14.0" "1.3.3")
+    is_latest_version "opensearchstaging" "opensearch" "2.15.0" > /dev/null 2>&1
+    assert_equals "candidate_equals_highest_existing_returns_0" "0" "$?"
+}
+
+# ---------------------------------------------------------------------------
+# Test: a higher version already exists — do not tag latest
+# ---------------------------------------------------------------------------
+function test_higher_version_exists() {
+    MOCK_TAGS_RESPONSE=$(make_tags_response "2.15.0" "2.14.0" "1.3.3")
+    is_latest_version "opensearchstaging" "opensearch" "1.3.3" > /dev/null 2>&1
+    assert_equals "lower_version_than_existing_returns_1" "1" "$?"
+}
+
+function test_patch_backport_not_latest() {
+    MOCK_TAGS_RESPONSE=$(make_tags_response "2.15.0" "2.14.1" "2.14.0" "1.3.3")
+    is_latest_version "opensearchstaging" "opensearch" "2.14.1" > /dev/null 2>&1
+    assert_equals "patch_backport_lower_than_current_major_returns_1" "1" "$?"
+}
+
+# ---------------------------------------------------------------------------
+# Test: non-semver tags are filtered out (latest, major-only, build-suffixed)
+# ---------------------------------------------------------------------------
+function test_non_semver_tags_ignored() {
+    # Only non-semver tags exist — should treat candidate as latest
+    MOCK_TAGS_RESPONSE=$(make_tags_response "latest" "2" "3" "2.15.0.3910" "2.15.0-SNAPSHOT")
+    is_latest_version "opensearchstaging" "opensearch" "2.15.0" > /dev/null 2>&1
+    assert_equals "non_semver_tags_filtered_out_returns_0" "0" "$?"
+}
+
+function test_mixed_tags_only_semver_compared() {
+    # Mix of semver and non-semver; 2.14.0 is the highest real semver
+    MOCK_TAGS_RESPONSE=$(make_tags_response "latest" "2" "2.14.0" "2.14.0.1234" "2.14.0-SNAPSHOT")
+    is_latest_version "opensearchstaging" "opensearch" "2.15.0" > /dev/null 2>&1
+    assert_equals "only_semver_compared_candidate_wins_returns_0" "0" "$?"
+}
+
+# ---------------------------------------------------------------------------
+# Test: API unreachable — default to true (conservative)
+# ---------------------------------------------------------------------------
+function test_api_unreachable() {
+    # Override curl to simulate failure
+    function curl() { return 1; }
+    export -f curl
+
+    is_latest_version "opensearchstaging" "opensearch" "2.15.0" > /dev/null 2>&1
+    assert_equals "api_unreachable_defaults_to_latest_returns_0" "0" "$?"
+
+    # Restore working curl mock
+    function curl() { echo "$MOCK_TAGS_RESPONSE"; return 0; }
+    export -f curl
+}
+
+# ---------------------------------------------------------------------------
+# Test: pagination — tags span multiple pages
+# ---------------------------------------------------------------------------
+function test_pagination() {
+    # Simulate page 1 pointing to page 2
+    local page2_url="https://hub.docker.com/v2/repositories/opensearchstaging/opensearch/tags?page=2"
+    local page1="{\"count\":2,\"next\":\"${page2_url}\",\"results\":[{\"name\":\"2.14.0\"}]}"
+    local page2="{\"count\":2,\"next\":null,\"results\":[{\"name\":\"2.15.0\"}]}"
+
+    call_count=0
+    function curl() {
+        call_count=$((call_count + 1))
+        if [ "$call_count" -eq 1 ]; then
+            echo "$page1"
+        else
+            echo "$page2"
+        fi
+        return 0
+    }
+    export -f curl
+
+    # 2.15.0 is already the highest — candidate 2.15.0 should equal it → return 0
+    is_latest_version "opensearchstaging" "opensearch" "2.15.0" > /dev/null 2>&1
+    assert_equals "pagination_reads_all_pages_highest_equals_candidate_returns_0" "0" "$?"
+
+    # 2.14.0 is lower than the paginated 2.15.0 → return 1
+    is_latest_version "opensearchstaging" "opensearch" "2.14.0" > /dev/null 2>&1
+    assert_equals "pagination_reads_all_pages_higher_tag_found_returns_1" "1" "$?"
+
+    # Restore default mock
+    function curl() { echo "$MOCK_TAGS_RESPONSE"; return 0; }
+    export -f curl
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+test_missing_arguments
+test_no_existing_tags
+test_candidate_is_highest
+test_candidate_equals_highest
+test_higher_version_exists
+test_patch_backport_not_latest
+test_non_semver_tags_ignored
+test_mixed_tags_only_semver_compared
+test_api_unreachable
+test_pagination
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
### Description
- opensearchstaging/opensearch:latest was resolving to 1.3.3 because the docker build pipeline never updated the :latest tag in the staging registry.
- Root causes:
 1. build-image-multi-arch.sh only ever pushed ${REPOSITORY}:${VERSION} — the :latest tag was never written to opensearchstaging at build time.                                                     
 3. build-image-single-arch.sh had the inverse bug and it unconditionally tagged :latest but hardcoded opensearchproject (production), not opensearchstaging, and had no version guard, meaning a patch backport build could have wrongly overwritten a newer :latest. 
- The production promotion pipeline such as promote-docker-ecr.jenkinsfile correctly applies :latest to opensearchproject during release, but nothing ever kept opensearchstaging:latest current.  
### Issues Resolved
- #5927 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
