### PR TITLE
Enable release notes automation for OpenSearch-Dashboards

### DIFF
--- a/jenkins/release-workflows/release-notes-generate.jenkinsfile
+++ b/jenkins/release-workflows/release-notes-generate.jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
                         def currentIndex = component_index
                         def currentWaitSeconds = wait_seconds
 
-                        if (!(currentComponent in ['notifications-core', 'functionalTestDashboards', 'OpenSearch-Dashboards'])) {
+                        if (!(currentComponent in ['notifications-core', 'functionalTestDashboards'])) {
                             componentNotes["Release notes for ${currentComponent}"] = {
                                 timeout(time: 1, unit: 'HOURS') {
                                     node('Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host') {


### PR DESCRIPTION
## Summary
This PR enables automatic AI-powered release notes generation for the OpenSearch-Dashboards repository.

## Changes
- Removed `OpenSearch-Dashboards` from the exclusion list in `release-notes-generate.jenkinsfile`
- The Jenkins workflow will now generate release notes for OpenSearch-Dashboards alongside other components

## Background
Currently, the `release-notes-generate` Jenkins workflow excludes OpenSearch-Dashboards from automated release notes generation. This PR removes that exclusion to enable the same automated release notes workflow that other OpenSearch components use.

## Impact
With this change, the release-notes-generate workflow will:
- Generate AI-powered release notes for OpenSearch-Dashboards based on commit history or CHANGELOG.md
- Automatically create PRs to the OpenSearch-Dashboards repository with generated release notes
- Streamline the release process for OpenSearch-Dashboards maintainers

## Testing
- The change only modifies the component exclusion list
- No new logic or functionality is added
- The existing workflow logic will handle OpenSearch-Dashboards the same way it handles other components

🤖 Generated with [Claude Code](https://claude.com/claude-code)