### PR TITLE
Enable automated release notes generation for OpenSearch-Dashboards

### DIFF
--- a/jenkins/release-workflows/release-notes-generate.jenkinsfile
+++ b/jenkins/release-workflows/release-notes-generate.jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
                         def currentIndex = component_index
                         def currentWaitSeconds = wait_seconds
 
-                        if (!(currentComponent in ['notifications-core', 'functionalTestDashboards', 'OpenSearch-Dashboards'])) {
+                        if (!(currentComponent in ['notifications-core', 'functionalTestDashboards'])) {
                             componentNotes["Release notes for ${currentComponent}"] = {
                                 timeout(time: 1, unit: 'HOURS') {
                                     node('Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host') {


### PR DESCRIPTION
### Description

Remove OpenSearch-Dashboards from the exclusion list in release-notes-generate.jenkinsfile. OSD will remove its custom changelog fragment system https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11563 and will now use the centralized release notes automation based on PR labels and commit history.      

### Issues Resolved
NA

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
