### PR TITLE
Add -e (--exclude-tasks) param to gradle-check.sh

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -70,7 +70,8 @@ pipeline {
                 [key: 'pr_title', value: '$.pr_title'],
                 [key: 'pr_number', value: '$.pr_number'],
                 [key: 'post_merge_action', value: '$.post_merge_action'],
-                [key: 'pr_owner', value: '$.pr_owner']
+                [key: 'pr_owner', value: '$.pr_owner'],
+                [key: 'exclude_tasks', value: '$.exclude_tasks', defaultValue: '']
             ],
             tokenCredentialId: 'jenkins-gradle-check-generic-webhook-token',
             causeString: 'Triggered by PR on OpenSearch core repository',
@@ -134,7 +135,8 @@ pipeline {
                                 gitRepoUrl: "${pr_from_clone_url}",
                                 gitReference: "${pr_from_sha}",
                                 bwcCheckoutAlign: "${bwc_checkout_align}",
-                                scope: "all"
+                                scope: "all",
+                                excludeTasks: "${exclude_tasks}"
                             )
                         }
                         else {
@@ -146,7 +148,8 @@ pipeline {
                                 gitRepoUrl: "${GIT_REPO_URL}",
                                 gitReference: "${GIT_REFERENCE}",
                                 bwcCheckoutAlign: "${bwc_checkout_align}",
-                                scope: "all"
+                                scope: "all",
+                                excludeTasks: "${exclude_tasks}"
                             )
                         }
 

--- a/scripts/gradle/gradle-check.sh
+++ b/scripts/gradle/gradle-check.sh
@@ -16,8 +16,9 @@ JENKINS_URL="https://build.ci.opensearch.org"
 TRIGGER_TOKEN=""
 GITHUB_USER=""
 GITHUB_TOKEN=""
+EXCLUDE_TASKS=""
 
-while getopts "u:t:p:" opt; do
+while getopts "u:t:p:e:" opt; do
   case $opt in
     t)
       TRIGGER_TOKEN="$OPTARG"
@@ -27,6 +28,9 @@ while getopts "u:t:p:" opt; do
       ;;
     p)
       GITHUB_TOKEN="$OPTARG"
+      ;;
+    e)
+      EXCLUDE_TASKS="$OPTARG"
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -59,7 +63,7 @@ TIMEPASS=0
 TIMEOUT=7200
 RESULT="null"
 PR_TITLE_NEW=`echo $pr_title | tr -dc '[:alnum:] ' | tr '[:upper:]' '[:lower:]'`
-PAYLOAD_JSON="{\"pr_from_sha\": \"$pr_from_sha\", \"pr_from_clone_url\": \"$pr_from_clone_url\", \"pr_to_clone_url\": \"$pr_to_clone_url\", \"pr_title\": \"$PR_TITLE_NEW\", \"pr_number\": \"$pr_number\", \"post_merge_action\": \"$post_merge_action\", \"pr_owner\": \"$pr_owner\"}"
+PAYLOAD_JSON="{\"pr_from_sha\": \"$pr_from_sha\", \"pr_from_clone_url\": \"$pr_from_clone_url\", \"pr_to_clone_url\": \"$pr_to_clone_url\", \"pr_title\": \"$PR_TITLE_NEW\", \"pr_number\": \"$pr_number\", \"post_merge_action\": \"$post_merge_action\", \"pr_owner\": \"$pr_owner\", \"exclude_tasks\": \"$EXCLUDE_TASKS\"}"
 
 perform_curl_and_process_with_jq() {
     local url=$1


### PR DESCRIPTION
### Description

This PR is part of a series of 3:

- https://github.com/opensearch-project/OpenSearch/pull/20946
- https://github.com/opensearch-project/opensearch-build/pull/6043
- https://github.com/opensearch-project/opensearch-build-libraries/pull/814

This PR adds a new param `-e` to gradle-check.sh so that OpenSearch core's invocation can pass a list of tasks to exclude: https://github.com/opensearch-project/OpenSearch/blob/main/.github/workflows/gradle-check.yml#L131

### Issues Resolved

Related to: https://github.com/opensearch-project/OpenSearch/issues/19378

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
