### PR TITLE
Remove skip on OSD repo

### DIFF
--- a/src/run_releasenotes_check.py
+++ b/src/run_releasenotes_check.py
@@ -239,13 +239,9 @@ def main() -> int:
         for manifest in manifests:
             product: str = 'opensearch' if manifest.build.name == 'OpenSearch' else 'opensearch-dashboards'
             for component in manifest.components.select(focus=components, platform='linux'):
-                if component.name != 'OpenSearch-Dashboards':
-                    component.ref = args.ref if args.ref is not None else component.ref  # type: ignore[attr-defined]
-                    logging.info(f"Components: {component.name}")
-                    release_notes.generate(args, component, manifest.build.version, manifest.build.qualifier, product)  # type: ignore[arg-type]
-                else:
-                    logging.info("Not executing for OpenSearch Dashboards as they have a running changelog file with all the past version releases "
-                                 "and this will exceed the token limit and cause repeted timeout calls to AWS")
+                component.ref = args.ref if args.ref is not None else component.ref  # type: ignore[attr-defined]
+                logging.info(f"Components: {component.name}")
+                release_notes.generate(args, component, manifest.build.version, manifest.build.qualifier, product)  # type: ignore[arg-type]
     return 0
 
 


### PR DESCRIPTION
### Description
#6041 enables release notes generation for the OSD repo, but the `run_releasenotes_check.py` has an explicit check that skips over `OpenSearch-Dashboards`. This PR updates the check so that it will run the release note generator script on OSD.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
