### PR TITLE
Improve AI release notes generation for OpenSearch

### DIFF
--- a/jenkins/release-workflows/release-notes-generate.jenkinsfile
+++ b/jenkins/release-workflows/release-notes-generate.jenkinsfile
@@ -151,11 +151,20 @@ pipeline {
                                                                             git add .
                                                                             git commit -sm "Add release notes for ${version}"
                                                                             git push origin release-chores/release-notes-${version} --force
+                                                                            BORDERLINE_FILE="$WORKSPACE/release-notes/${filename.replace('.md', '-borderline.md')}"
+                                                                            PR_BODY="Add release notes for ${version}"
+                                                                            if [ -f "\$BORDERLINE_FILE" ]; then
+                                                                                PR_BODY="\${PR_BODY}
+
+## Borderline Calls
+\$(cat "\$BORDERLINE_FILE")"
+                                                                            fi
                                                                             EXISTING_PR=\$(gh pr list --head release-chores/release-notes-${version} --state open --json number --jq '.[0].number')
                                                                             if [ -n "\$EXISTING_PR" ]; then
                                                                                 echo "Updating existing PR #\${EXISTING_PR} for component \${REPO_NAME} with new release notes."
+                                                                                gh pr edit "\$EXISTING_PR" --body "\$PR_BODY"
                                                                             else
-                                                                                gh pr create --title '[AUTO] Add release notes for ${version}' --body 'Add release notes for ${version}' -H release-chores/release-notes-${version} -B ${ref}
+                                                                                gh pr create --title '[AUTO] Add release notes for ${version}' --body "\$PR_BODY" -H release-chores/release-notes-${version} -B ${ref}
                                                                             fi
                                                                         fi
                                                                     else

--- a/src/git/git_commit_processor.py
+++ b/src/git/git_commit_processor.py
@@ -146,12 +146,12 @@ class GitHubCommitsProcessor:
 
         return pr_data
 
-    def get_commit_pr_info(self, owner: str, repo: str, commit: Dict) -> tuple[List[str], str]:
+    def get_commit_pr_info(self, owner: str, repo: str, commit: Dict) -> tuple[List[str], str, str]:
         """
-        Get labels and PR subject for a commit from its associated PR
+        Get labels, PR subject, and PR body for a commit from its associated PR
 
         Returns:
-            Tuple of (labels, pr_subject) where pr_subject is formatted as "Title (#PR_NUMBER)" or empty string
+            Tuple of (labels, pr_subject, pr_body) where pr_subject is formatted as "Title (#PR_NUMBER)" or empty string
         """
         # Try to get PR number from commit message
         pr_number = self._extract_pr_number_from_commit(commit)
@@ -169,9 +169,10 @@ class GitHubCommitsProcessor:
                 labels = [label["name"] for label in pr_details.get("labels", [])]
                 pr_title = pr_details.get("title", "").strip()
                 pr_subject = f"{pr_title} (#{pr_number})" if pr_title else f"(#{pr_number})"
-                return labels, pr_subject
+                pr_body = pr_details.get("body", "") or ""
+                return labels, pr_subject, pr_body
 
-        return [], ""
+        return [], "", ""
 
     def get_commits_with_labels(self, owner: str, repo: str, since_date: str,
                                 until_date: str = None, branch: str = None) -> List[Dict]:
@@ -216,11 +217,12 @@ class GitHubCommitsProcessor:
 
         def process_commit(commit: Dict) -> Dict:
             message = commit["commit"]["message"].replace('\n', ' ').replace('\r', ' ').strip()
-            labels, pr_subject = self.get_commit_pr_info(owner, repo, commit)
+            labels, pr_subject, pr_body = self.get_commit_pr_info(owner, repo, commit)
             return {
                 "Message": message,
                 "Labels": labels,
-                "PullRequestSubject": pr_subject
+                "PullRequestSubject": pr_subject,
+                "PullRequestBody": pr_body
             }
 
         with ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/src/llms/prompts.py
+++ b/src/llms/prompts.py
@@ -55,7 +55,7 @@ AI_RELEASE_NOTES_PROMPT_COMMIT = """I need you to generate OpenSearch component 
      * "refactor" or "refactoring" → Refactoring
 
 2. **Fallback Message Analysis:**
-   - If no labels match, analyze the Message content and PullRequestSubject to determine the appropriate category following below guidelines:
+   - If no labels match, analyze the Message content, PullRequestSubject, and PR Description to determine the appropriate category following below guidelines:
     * Features: A change that introduce a net new unit of functionality of a software system that satisfies a requirement,
     represents a design decision, and provides a potential configuration option. As for improvement on existing features,
     use the Enhancement category. As for fixes on existing features, use the Bug Fixes category.
@@ -79,7 +79,9 @@ AI_RELEASE_NOTES_PROMPT_COMMIT = """I need you to generate OpenSearch component 
    - Do not add the pull request that has title starting with "[AUTO] Increment version to".
 
 4. **Entry Format:**
-   - Use PullRequestSubject as the main content for each entry
+   - Use the PullRequestSubject and PR Description as input, but rewrite each entry as a concise, clear one-line
+     summary. The target audience is end-users, operators, and system administrators — not developers.
+     Do not simply copy the PR subject verbatim; improve clarity and consistency.
    - Extract PR number from PullRequestSubject (format: (#123))
    - Format: `* <description> ([#<number>]({repository_url}/pull/<number>))`
    - Always use asterisk (*) for bullet points
@@ -101,10 +103,127 @@ AI_RELEASE_NOTES_PROMPT_COMMIT = """I need you to generate OpenSearch component 
    - Format as: `([#<number>]({repository_url}/pull/<number>))`
    - Example: `([#456](https://github.com/opensearch-project/anomaly-detection/pull/456))`
 
-7. **Important Notes:
+7. **Important Notes:**
    - Every commit should be categorized into exactly one category
    - If you cannot determine the appropriate category from labels OR content analysis, place the entry in an "Unknown" category
    - Do not skip any commits - every entry must appear somewhere in the release notes
    - Prioritize Message over PullRequestSubject for determining category when using fallback analysis
+
+8. **Borderline Calls:**
+   After the release notes, add a section starting with `<!-- BORDERLINE_CALLS` and ending with `-->`.
+   Inside this HTML comment, list any judgment calls where the categorization or inclusion decision was debatable.
+   For each, reference the PR number and briefly explain the decision and alternatives. Example:
+   ```
+   <!-- BORDERLINE_CALLS
+   - #1234: Placed in **Enhancements** — could also be **Bug Fixes** since it changes existing behavior to fix a usability issue.
+   - #5678: Placed in **Maintenance** — borderline with **Infrastructure**, chose Maintenance because it's a dependency update.
+   -->
+   ```
+   If there are no borderline calls, omit this section entirely.
+
+Generate the release notes in proper OpenSearch format:"""
+
+AI_RELEASE_NOTES_PROMPT_COMMIT_OPENSEARCH = """I need you to generate OpenSearch component release notes from commit data. Please follow the OpenSearch release notes format exactly.
+
+**Component Information:**
+- Component Name: {component_name}
+- Version: {version}
+- Repository URL: {repository_url}
+
+**Commit Data:**
+{commits_text}
+
+**Instructions:**
+
+1. **Content filtering — apply BEFORE categorization:**
+   - Do not add the pull request that has title starting with "[AUTO] Increment version to".
+   - Do not add any PR with the `skip-changelog` label, regardless of content.
+   - Exclude any commit/revert pairs as the net result is no change.
+   - **Exclude the following non-user-facing changes:**
+     * Test additions, modifications, fixes, or refactoring (including flaky test fixes, new integration tests,
+       test infrastructure improvements, and test cleanup). A PR whose description says "Add test for X" or
+       "Cleanup X in tests" is non-user-facing even if the underlying feature is user-facing.
+     * Build and CI changes: GitHub Actions version bumps (e.g. actions/setup-java, actions/upload-artifact,
+       peter-evans/create-pull-request, lycheeverse/lychee-action, tj-actions/*), Gradle build changes,
+       Docker base image updates, CI pipeline configuration.
+     * Dependency bumps that only affect test fixtures or build tooling (e.g. bumps under /test/fixtures/,
+       /buildSrc/, or test-only libraries like wiremock).
+     * Release machinery: changelog fixes, release notes commits, README edits.
+     * Internal code refactoring that does not change any user-facing behavior, API, or configuration.
+       This includes deprecation warning fixes, code cleanup, and removing unused internal code/plugins.
+     * Maintainer list changes.
+     * Incremental PRs for a larger feature (these should already have one entry from the main PR).
+   - A PR matching an exclusion rule above must be excluded even if its labels would match a category.
+   - Use the commit message, PR description, and labels to make this judgment.
+   - When uncertain whether a change is user-facing, **include it** — a human reviewer can remove it later.
+
+2. **Categorization — only for PRs that survive filtering:**
+   - First, check if any labels match these categories (case-insensitive, partial matches allowed):
+     * "breaking change" or "breaking" → Breaking Changes
+     * "feature" or "feat" → Features
+     * "enhancement" or "improve" → Enhancements
+     * "bug" or "fix" or "bugfix" → Bug Fixes
+     * "maintenance" or "version" or "support" → Maintenance
+   - If no labels match, analyze the Message content, PullRequestSubject, and PR Description to determine
+     the appropriate category:
+     * Features: A net new unit of functionality that satisfies a requirement, represents a design decision,
+       and provides a potential configuration option. For improvements on existing features, use Enhancements.
+       For fixes on existing features, use Bug Fixes.
+     * Enhancements: Improves the performance, usability, or reliability of an existing feature without
+       changing its core functionality.
+     * Bug Fixes: Resolves an issue or defect in the software.
+     * Maintenance: Routine upkeep such as dependency updates that ship in the distribution.
+   - Do not use "Infrastructure", "Documentation", or "Refactoring" as categories. Changes that would
+     belong to those categories should have been excluded by the filtering step.
+
+3. **Entry Format:**
+   - Use the PullRequestSubject and PR Description as input, but rewrite each entry as a concise, clear one-line
+     summary. The target audience is OpenSearch users — end-users, operators, and system administrators — not developers.
+     Do not simply copy the PR subject verbatim; improve clarity and consistency.
+   - Extract PR number from PullRequestSubject (format: (#123))
+   - Format: `* <description> ([#<number>]({repository_url}/pull/<number>))`
+   - Always use asterisk (*) for bullet points
+   - Always wrap PR links in parentheses
+   - Make sure first character of each entry is capitalized.
+   - Group related commits into a single entry when appropriate (e.g., multiple PRs implementing parts of the same
+     feature, or a series of dependency bumps for the same library).
+
+4. **Output Requirements:**
+   - The main heading with ## should be "version number Release Notes" (e.g., For version 3.2.0 ## Version 3.2.0
+   Release Notes followed by a blank line and then "Compatible with OpenSearch and OpenSearch Dashboards
+   version <version number>" followed by content)
+   - Generate markdown with ### headers for each category
+   - Only include categories that have entries
+   - Sort categories in this order: Breaking Changes, Features, Enhancements, Bug Fixes, Maintenance
+   - Each entry should be a single line with proper PR link formatting
+
+5. **PR Link Format:**
+   - Extract PR number from PullRequestSubject
+   - Format as: `([#<number>]({repository_url}/pull/<number>))`
+   - Example: `([#456](https://github.com/opensearch-project/OpenSearch/pull/456))`
+
+6. **Important Notes:**
+   - If you cannot determine the appropriate category from labels OR content analysis, place the entry in an "Unknown" category
+   - Prioritize Message over PullRequestSubject for determining category when using fallback analysis
+
+7. **Borderline Calls:**
+   After the release notes, add a section starting with `<!-- BORDERLINE_CALLS` and ending with `-->`.
+   Inside this HTML comment, list any judgment calls where the categorization, inclusion, or exclusion decision
+   was debatable. For each, reference the PR number and briefly explain the decision and alternatives. Examples:
+   - A PR labeled `bug` that reads more like a behavioral change
+   - Grouping multiple PRs into a single entry
+   - Including a PR that could reasonably be considered non-user-facing
+   - Excluding a PR that could reasonably be considered user-facing
+   - Choosing one category over another when both fit
+
+   Format:
+   ```
+   <!-- BORDERLINE_CALLS
+   - #1234: Excluded as non-user-facing (test fix) — but it changes test infrastructure that plugin authors rely on, so could be included under Infrastructure.
+   - #5678: Placed in **Enhancements** — could also be **Bug Fixes** since it changes existing behavior to fix a usability issue.
+   - #9012 + #9013: Grouped into one entry — both implement parts of the same feature.
+   -->
+   ```
+   If there are no borderline calls, omit this section entirely.
 
 Generate the release notes in proper OpenSearch format:"""

--- a/src/release_notes_workflow/release_notes.py
+++ b/src/release_notes_workflow/release_notes.py
@@ -7,14 +7,15 @@
 
 import logging
 import os
-from typing import List
+import re
+from typing import List, Tuple
 
 from pytablewriter import MarkdownTableWriter
 
 from git.git_commit_processor import GitHubCommitsProcessor
 from git.git_repository import GitRepository
 from llms.ai_release_notes_generator import AIReleaseNotesGenerator
-from llms.prompts import AI_RELEASE_NOTES_PROMPT_CHANGELOG, AI_RELEASE_NOTES_PROMPT_COMMIT
+from llms.prompts import AI_RELEASE_NOTES_PROMPT_CHANGELOG, AI_RELEASE_NOTES_PROMPT_COMMIT, AI_RELEASE_NOTES_PROMPT_COMMIT_OPENSEARCH
 from manifests.input_manifest import InputComponentFromSource, InputManifest
 from release_notes_workflow.release_notes_check_args import ReleaseNotesCheckArgs
 from release_notes_workflow.release_notes_component import ReleaseNotesComponents
@@ -29,6 +30,16 @@ class ReleaseNotes:
         self.action_type = action_type
         self.token = os.getenv('GITHUB_TOKEN')
         self.filter_commits = ['flaky-test', 'testing', 'skip-changelog']
+
+    @staticmethod
+    def _extract_borderline_calls(raw: str) -> Tuple[str, str]:
+        """Extract borderline calls HTML comment from LLM output, returning (release_notes, borderline_calls)."""
+        match = re.search(r'<!-- BORDERLINE_CALLS\s*\n(.*?)-->', raw, re.DOTALL)
+        if match:
+            borderline = match.group(1).strip()
+            release_notes = raw[:match.start()].rstrip() + "\n"
+            return release_notes, borderline
+        return raw, ""
 
     def table(self) -> MarkdownTableWriter:
         table_result = []
@@ -135,11 +146,18 @@ class ReleaseNotes:
                             message = commit.get("Message", "")
                             labels = commit.get("Labels", [])
                             pr_subject = commit.get("PullRequestSubject", "")
+                            pr_body = commit.get("PullRequestBody", "")
 
                             commits_text += f"{i}. PR Subject: {pr_subject}\n"
                             commits_text += f"   Message: {message}\n"
-                            commits_text += f"   Labels: {', '.join(labels) if labels else 'None'}\n\n"
-                        prompt = AI_RELEASE_NOTES_PROMPT_COMMIT.format(
+                            commits_text += f"   Labels: {', '.join(labels) if labels else 'None'}\n"
+                            if pr_body:
+                                # Truncate very long PR bodies to avoid exceeding token limits
+                                truncated_body = pr_body[:2000] + "..." if len(pr_body) > 2000 else pr_body
+                                commits_text += f"   PR Description: {truncated_body}\n"
+                            commits_text += "\n"
+                        commit_prompt = AI_RELEASE_NOTES_PROMPT_COMMIT_OPENSEARCH if component.name == 'OpenSearch' else AI_RELEASE_NOTES_PROMPT_COMMIT
+                        prompt = commit_prompt.format(
                             component_name=component.name,
                             version=build_version,
                             repository_url=component.repository.removesuffix('.git'),
@@ -150,5 +168,10 @@ class ReleaseNotes:
                         logging.warning(f"No commits found for {component.name} since {baseline_date}")
 
         if release_notes_raw:
+            release_notes_content, borderline_calls = self._extract_borderline_calls(release_notes_raw)
             with open(os.path.join(os.getcwd(), 'release-notes', filename), 'w') as f:
-                f.write(release_notes_raw)
+                f.write(release_notes_content)
+            if borderline_calls:
+                borderline_filename = filename.replace('.md', '-borderline.md')
+                with open(os.path.join(os.getcwd(), 'release-notes', borderline_filename), 'w') as f:
+                    f.write(borderline_calls)

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/release-notes-generate.jenkinsfile.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/release-notes-generate.jenkinsfile.txt
@@ -53,11 +53,20 @@
                                                                             git add .
                                                                             git commit -sm "Add release notes for 2.2.0"
                                                                             git push origin release-chores/release-notes-2.2.0 --force
+                                                                            BORDERLINE_FILE="/tmp/workspace/release-notes/opensearch.release-notes-2.2.0-borderline.md"
+                                                                            PR_BODY="Add release notes for 2.2.0"
+                                                                            if [ -f "$BORDERLINE_FILE" ]; then
+                                                                                PR_BODY="${PR_BODY}
+
+## Borderline Calls
+$(cat "$BORDERLINE_FILE")"
+                                                                            fi
                                                                             EXISTING_PR=$(gh pr list --head release-chores/release-notes-2.2.0 --state open --json number --jq '.[0].number')
                                                                             if [ -n "$EXISTING_PR" ]; then
                                                                                 echo "Updating existing PR #${EXISTING_PR} for component ${REPO_NAME} with new release notes."
+                                                                                gh pr edit "$EXISTING_PR" --body "$PR_BODY"
                                                                             else
-                                                                                gh pr create --title '[AUTO] Add release notes for 2.2.0' --body 'Add release notes for 2.2.0' -H release-chores/release-notes-2.2.0 -B 2.2
+                                                                                gh pr create --title '[AUTO] Add release notes for 2.2.0' --body "$PR_BODY" -H release-chores/release-notes-2.2.0 -B 2.2
                                                                             fi
                                                                         fi
                                                                     else
@@ -107,11 +116,20 @@
                                                                             git add .
                                                                             git commit -sm "Add release notes for 2.2.0"
                                                                             git push origin release-chores/release-notes-2.2.0 --force
+                                                                            BORDERLINE_FILE="/tmp/workspace/release-notes/opensearch-sql.release-notes-2.2.0.0-borderline.md"
+                                                                            PR_BODY="Add release notes for 2.2.0"
+                                                                            if [ -f "$BORDERLINE_FILE" ]; then
+                                                                                PR_BODY="${PR_BODY}
+
+## Borderline Calls
+$(cat "$BORDERLINE_FILE")"
+                                                                            fi
                                                                             EXISTING_PR=$(gh pr list --head release-chores/release-notes-2.2.0 --state open --json number --jq '.[0].number')
                                                                             if [ -n "$EXISTING_PR" ]; then
                                                                                 echo "Updating existing PR #${EXISTING_PR} for component ${REPO_NAME} with new release notes."
+                                                                                gh pr edit "$EXISTING_PR" --body "$PR_BODY"
                                                                             else
-                                                                                gh pr create --title '[AUTO] Add release notes for 2.2.0' --body 'Add release notes for 2.2.0' -H release-chores/release-notes-2.2.0 -B 2.2
+                                                                                gh pr create --title '[AUTO] Add release notes for 2.2.0' --body "$PR_BODY" -H release-chores/release-notes-2.2.0 -B 2.2
                                                                             fi
                                                                         fi
                                                                     else

--- a/tests/tests_git/test_git_commit_processor.py
+++ b/tests/tests_git/test_git_commit_processor.py
@@ -130,11 +130,12 @@ class TestGitHubCommitsProcessor(unittest.TestCase):
         mock_extract_pr.return_value = 123
         mock_get_pr_details.return_value = {
             "title": "Fix bug",
-            "labels": [{"name": "bug"}, {"name": "critical"}]
+            "labels": [{"name": "bug"}, {"name": "critical"}],
+            "body": "This fixes a critical bug"
         }
 
         commit = {"sha": "abc123", "commit": {"message": "Fix bug (#123)"}}
-        labels, pr_subject = self.processor.get_commit_pr_info("owner", "repo", commit)
+        labels, pr_subject, pr_body = self.processor.get_commit_pr_info("owner", "repo", commit)
 
         self.assertEqual(labels, ["bug", "critical"])
         self.assertEqual(pr_subject, "Fix bug (#123)")
@@ -152,7 +153,7 @@ class TestGitHubCommitsProcessor(unittest.TestCase):
         }
 
         commit = {"sha": "def456", "commit": {"message": "Add new feature"}}
-        labels, pr_subject = self.processor.get_commit_pr_info("owner", "repo", commit)
+        labels, pr_subject, pr_body = self.processor.get_commit_pr_info("owner", "repo", commit)
 
         self.assertEqual(labels, ["enhancement"])
         self.assertEqual(pr_subject, "Add feature (#456)")
@@ -165,7 +166,7 @@ class TestGitHubCommitsProcessor(unittest.TestCase):
 
         with patch.object(self.processor, '_get_pr_from_commit_api', return_value=None):
             commit = {"sha": "xyz789", "commit": {"message": "Direct commit"}}
-            labels, pr_subject = self.processor.get_commit_pr_info("owner", "repo", commit)
+            labels, pr_subject, pr_body = self.processor.get_commit_pr_info("owner", "repo", commit)
 
             self.assertEqual(labels, [])
             self.assertEqual(pr_subject, "")
@@ -256,10 +257,10 @@ class TestGitHubCommitsProcessor(unittest.TestCase):
         ]
 # Mock the PR info retrieval
         mock_get_pr_info.side_effect = [
-            (["bug"], "Fix bug (#123)"),
-            (["enhancement"], "Add feature (#456)"),
-            (["documentation"], "123 Numeric prefix (#789)"),
-            ([], "Empty message (#012)")
+            (["bug"], "Fix bug (#123)", "Bug fix description"),
+            (["enhancement"], "Add feature (#456)", "Feature description"),
+            (["documentation"], "123 Numeric prefix (#789)", "Doc description"),
+            ([], "Empty message (#012)", "")
         ]
         test_data = [
             {"Message": "Fix bug", "Labels": ["bug"]},

--- a/tests/tests_release_notes_workflow/test_release_notes.py
+++ b/tests/tests_release_notes_workflow/test_release_notes.py
@@ -89,6 +89,7 @@ class TestReleaseNotes(unittest.TestCase):
         mock_ai_generator = MagicMock()
         mock_ai_generator_class.return_value = mock_ai_generator
         mock_ai_generator.process.return_value = {"success": True}
+        mock_ai_generator.generate_release_notes.return_value = "## Release Notes\nTest content"
 
         # Create ReleaseNotes instance
         release_notes = ReleaseNotes([self.manifest_file], "2025-06-24", "generate")
@@ -151,17 +152,20 @@ class TestReleaseNotes(unittest.TestCase):
             {
                 "Message": "Fix critical bug in search",
                 "Labels": ["bug", "critical"],
-                "PullRequestSubject": "Fix search functionality"
+                "PullRequestSubject": "Fix search functionality",
+                "PullRequestBody": "Fixes a critical search bug"
             },
             {
                 "Message": "Add new feature X",
                 "Labels": ["enhancement"],
-                "PullRequestSubject": "Implement feature X"
+                "PullRequestSubject": "Implement feature X",
+                "PullRequestBody": "Adds feature X"
             },
             {
                 "Message": "Flaky test fix",
                 "Labels": ["flaky-test"],  # This should be filtered out
-                "PullRequestSubject": "Fix flaky test"
+                "PullRequestSubject": "Fix flaky test",
+                "PullRequestBody": ""
             }
         ]
         mock_commits_processor.get_commit_details.return_value = mock_commits
@@ -283,7 +287,7 @@ class TestReleaseNotes(unittest.TestCase):
 
         # Mock commits
         mock_commits_processor = Mock()
-        mock_commits = [{"Message": "Test commit", "Labels": ["enhancement"], "PullRequestSubject": "Test PR"}]
+        mock_commits = [{"Message": "Test commit", "Labels": ["enhancement"], "PullRequestSubject": "Test PR", "PullRequestBody": "Test description"}]
         mock_commits_processor.get_commit_details.return_value = mock_commits
         mock_github_commits_class.return_value = mock_commits_processor
 
@@ -299,3 +303,108 @@ class TestReleaseNotes(unittest.TestCase):
         call_args = mock_ai_generator.generate_release_notes.call_args[0][0]
         self.assertIn("Test PR", call_args)
         self.assertIn("Test commit", call_args)
+
+    def test_extract_borderline_calls_with_comment(self) -> None:
+        raw = "## Release Notes\nSome content\n<!-- BORDERLINE_CALLS\nCall 1\nCall 2\n-->"
+        notes, borderline = ReleaseNotes._extract_borderline_calls(raw)
+        self.assertEqual(notes, "## Release Notes\nSome content\n")
+        self.assertEqual(borderline, "Call 1\nCall 2")
+
+    def test_extract_borderline_calls_without_comment(self) -> None:
+        raw = "## Release Notes\nJust normal content"
+        notes, borderline = ReleaseNotes._extract_borderline_calls(raw)
+        self.assertEqual(notes, raw)
+        self.assertEqual(borderline, "")
+
+    def test_extract_borderline_calls_empty_comment(self) -> None:
+        raw = "## Release Notes\n<!-- BORDERLINE_CALLS\n-->"
+        notes, borderline = ReleaseNotes._extract_borderline_calls(raw)
+        self.assertEqual(notes, "## Release Notes\n")
+        self.assertEqual(borderline, "")
+
+    @patch('release_notes_workflow.release_notes.TemporaryDirectory')
+    @patch('release_notes_workflow.release_notes.GitRepository')
+    @patch('release_notes_workflow.release_notes.ReleaseNotesComponents')
+    @patch('release_notes_workflow.release_notes.AIReleaseNotesGenerator')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('os.getcwd')
+    def test_generate_writes_borderline_file(self, mock_getcwd: MagicMock, mock_file_open: MagicMock, mock_isfile: MagicMock,
+                                             mock_ai_generator_class: MagicMock, mock_release_notes_components: MagicMock,
+                                             mock_git_repo: MagicMock, mock_temp_dir: MagicMock) -> None:
+        """Test that borderline calls are extracted and written to a separate file."""
+        mock_getcwd.return_value = os.path.join("test", "dir")
+        mock_temp_dir_instance = Mock()
+        mock_temp_dir_instance.name = os.path.join("tmp", "test")
+        mock_temp_dir.return_value.__enter__.return_value = mock_temp_dir_instance
+
+        mock_repo = Mock()
+        mock_repo.dir = os.path.join("tmp", "test", "test-component")
+        mock_git_repo.return_value.__enter__.return_value = mock_repo
+
+        mock_release_notes = Mock()
+        mock_release_notes.filename = ".release-notes-1.0.md"
+        mock_release_notes_components.from_component.return_value = mock_release_notes
+
+        mock_ai_generator = Mock()
+        mock_ai_generator.generate_release_notes.return_value = (
+            "## Release Notes\nReal content\n"
+            "<!-- BORDERLINE_CALLS\nBorderline item 1\nBorderline item 2\n-->"
+        )
+        mock_ai_generator_class.return_value = mock_ai_generator
+
+        mock_isfile.return_value = True
+
+        self.release_notes.generate(self.mock_args, self.component, self.build_version, self.build_qualifier, 'opensearch')
+
+        # Verify two files were written
+        write_calls = [c for c in mock_file_open.call_args_list if len(c[0]) > 1 and c[0][1] == 'w']
+        self.assertEqual(len(write_calls), 2)
+
+        # Main release notes file
+        self.assertIn("opensearch-url.release-notes-1.0.md", write_calls[0][0][0])
+        # Borderline file
+        self.assertIn("opensearch-url.release-notes-1.0-borderline.md", write_calls[1][0][0])
+
+        # Verify content written to each file
+        handle = mock_file_open()
+        write_args = [c[0][0] for c in handle.write.call_args_list]
+        self.assertIn("## Release Notes\nReal content\n", write_args)
+        self.assertIn("Borderline item 1\nBorderline item 2", write_args)
+
+    @patch('release_notes_workflow.release_notes.TemporaryDirectory')
+    @patch('release_notes_workflow.release_notes.GitRepository')
+    @patch('release_notes_workflow.release_notes.ReleaseNotesComponents')
+    @patch('release_notes_workflow.release_notes.AIReleaseNotesGenerator')
+    @patch('os.path.isfile')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('os.getcwd')
+    def test_generate_no_borderline_file_when_absent(self, mock_getcwd: MagicMock, mock_file_open: MagicMock, mock_isfile: MagicMock,
+                                                     mock_ai_generator_class: MagicMock, mock_release_notes_components: MagicMock,
+                                                     mock_git_repo: MagicMock, mock_temp_dir: MagicMock) -> None:
+        """Test that no borderline file is created when LLM output has no borderline comment."""
+        mock_getcwd.return_value = os.path.join("test", "dir")
+        mock_temp_dir_instance = Mock()
+        mock_temp_dir_instance.name = os.path.join("tmp", "test")
+        mock_temp_dir.return_value.__enter__.return_value = mock_temp_dir_instance
+
+        mock_repo = Mock()
+        mock_repo.dir = os.path.join("tmp", "test", "test-component")
+        mock_git_repo.return_value.__enter__.return_value = mock_repo
+
+        mock_release_notes = Mock()
+        mock_release_notes.filename = ".release-notes-1.0.md"
+        mock_release_notes_components.from_component.return_value = mock_release_notes
+
+        mock_ai_generator = Mock()
+        mock_ai_generator.generate_release_notes.return_value = "## Release Notes\nClean output"
+        mock_ai_generator_class.return_value = mock_ai_generator
+
+        mock_isfile.return_value = True
+
+        self.release_notes.generate(self.mock_args, self.component, self.build_version, self.build_qualifier, 'opensearch')
+
+        # Only one file should be written (no borderline file)
+        write_calls = [c for c in mock_file_open.call_args_list if len(c[0]) > 1 and c[0][1] == 'w']
+        self.assertEqual(len(write_calls), 1)
+        self.assertNotIn("borderline", write_calls[0][0][0])


### PR DESCRIPTION
- Fetch PR body from GitHub API and include it (truncated to 2000 chars) in the commit data sent to the LLM for better categorization and filtering decisions.

- Add OpenSearch-specific prompt that filters non-user-facing changes (test additions, CI action bumps, test fixture deps, internal refactoring, release machinery) before categorization. Removes Infrastructure/Documentation/Refactoring categories that contradicted the exclusion policy. Only Breaking Changes, Features, Enhancements, Bug Fixes, and Maintenance categories are used.

- Add borderline calls section: the LLM appends an HTML comment documenting debatable inclusion/exclusion/categorization decisions. This is extracted from the LLM output and written to a separate -borderline.md file.

- Update Jenkinsfile to include borderline calls in the PR description when creating or updating release notes PRs. Also fix the existing PR path to update the PR body via gh pr edit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
