### PR TITLE
Update PR reviewer to use fixed docker image tag on v0.32

### DIFF
--- a/.github/workflows/code-diff-reviewer.yml
+++ b/.github/workflows/code-diff-reviewer.yml
@@ -73,7 +73,7 @@ jobs:
         # Temporary fix due to pr-agent not lock to the specific docker image in github tag
         # Causing PRs like this to break bedrock integration:
         # https://github.com/qodo-ai/pr-agent/pull/2278
-        uses: peterzhuamazon/pr-agent@v0.32-fix-docker
+        uses: peterzhuamazon/pr-agent@4708eba6e61e9bcff9e90162e91b758076c62d1b
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           github_action_config.auto_review: true


### PR DESCRIPTION
### Description
Update PR reviewer to use fixed docker image tag on v0.32

### Issues Resolved
```
"Error during LLM inference: litellm.APIConnectionError: BedrockException - {\"Message\":\"Invalid API Key format: Must start with pre-defined prefix\"}\n"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
