### PR TITLE
fix: Revert 2-node topology for query-insights integ tests

### DIFF
--- a/manifests/3.6.0/opensearch-3.6.0-test.yml
+++ b/manifests/3.6.0/opensearch-3.6.0-test.yml
@@ -189,9 +189,6 @@ components:
         - without-security
   - name: query-insights
     integ-test:
-      topology:
-        - cluster_name: cluster
-          data_nodes: 2
       test-configs:
         - with-security
         - without-security


### PR DESCRIPTION
### Description

The 2-node topology causes CI runners to fail to start the OpenSearch cluster before the test harness connects, resulting in Connection refused errors across all integ tests. The REST integ tests do not require a 2-node external cluster.

Similar to #5942.


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
