### PR TITLE
Add gradle_check_command webhook parameter

### DIFF
--- a/jenkins/gradle/gradle-check.jenkinsfile
+++ b/jenkins/gradle/gradle-check.jenkinsfile
@@ -76,7 +76,8 @@ pipeline {
                 [key: 'pr_title', value: '$.pr_title'],
                 [key: 'pr_number', value: '$.pr_number'],
                 [key: 'post_merge_action', value: '$.post_merge_action'],
-                [key: 'pr_owner', value: '$.pr_owner']
+                [key: 'pr_owner', value: '$.pr_owner'],
+                [key: 'gradle_check_command', value: '$.gradle_check_command']
             ],
             tokenCredentialId: 'jenkins-gradle-check-generic-webhook-token',
             causeString: 'Triggered by PR on OpenSearch core repository',
@@ -95,6 +96,15 @@ pipeline {
         stage('Run Gradle Check') {
             steps {
                 script {
+
+                    // Use webhook value if provided, otherwise fall back to pipeline parameter default
+                    if (binding.hasVariable('gradle_check_command') && gradle_check_command?.trim()) {
+                        env.GRADLE_CHECK_COMMAND = gradle_check_command
+                    }
+
+                    if (!(env.GRADLE_CHECK_COMMAND ==~ /^[a-zA-Z0-9\-._=: \/*#]+$/)) {
+                        error("Invalid GRADLE_CHECK_COMMAND '${env.GRADLE_CHECK_COMMAND}': contains disallowed characters")
+                    }
 
                     sh """
                         set +x

--- a/scripts/gradle/gradle-check.sh
+++ b/scripts/gradle/gradle-check.sh
@@ -17,7 +17,9 @@ TRIGGER_TOKEN=""
 GITHUB_USER=""
 GITHUB_TOKEN=""
 
-while getopts "u:t:p:" opt; do
+GRADLE_CHECK_COMMAND=""
+
+while getopts "u:t:p:c:" opt; do
   case $opt in
     t)
       TRIGGER_TOKEN="$OPTARG"
@@ -27,6 +29,9 @@ while getopts "u:t:p:" opt; do
       ;;
     p)
       GITHUB_TOKEN="$OPTARG"
+      ;;
+    c)
+      GRADLE_CHECK_COMMAND="$OPTARG"
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -59,7 +64,7 @@ TIMEPASS=0
 TIMEOUT=7200
 RESULT="null"
 PR_TITLE_NEW=`echo $pr_title | tr -dc '[:alnum:] ' | tr '[:upper:]' '[:lower:]'`
-PAYLOAD_JSON="{\"pr_from_sha\": \"$pr_from_sha\", \"pr_from_clone_url\": \"$pr_from_clone_url\", \"pr_to_clone_url\": \"$pr_to_clone_url\", \"pr_title\": \"$PR_TITLE_NEW\", \"pr_number\": \"$pr_number\", \"post_merge_action\": \"$post_merge_action\", \"pr_owner\": \"$pr_owner\"}"
+PAYLOAD_JSON="{\"pr_from_sha\": \"$pr_from_sha\", \"pr_from_clone_url\": \"$pr_from_clone_url\", \"pr_to_clone_url\": \"$pr_to_clone_url\", \"pr_title\": \"$PR_TITLE_NEW\", \"pr_number\": \"$pr_number\", \"post_merge_action\": \"$post_merge_action\", \"pr_owner\": \"$pr_owner\", \"gradle_check_command\": \"$GRADLE_CHECK_COMMAND\"}"
 
 perform_curl_and_process_with_jq() {
     local url=$1


### PR DESCRIPTION
My previous PR only added a pipeline parameter. I need a webhook parameter to be able to start this job from the OpenSearch GitHub Action.

This also adds validation to the gradle check command to reject invalid characters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
