### PR TITLE
Disable query-insights test in deb/rpm as they dont support multi-node

### DIFF
--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -162,9 +162,9 @@ pipeline {
                         // Due to inability to install multiple versions of deb/rpm packages on the same EC2 host.
                         // CCR plugin remoteIntegTest are failing in deb and rpm distribution due to multiple clusters are not forming.(Issue-https://github.com/opensearch-project/opensearch-build/issues/4610)
                         // A multi-cluster setup is needed. TODO: Explore multi-cluster setup solutions.
-                        // Temporarily Skipping integTest for cross-cluster-replication component when running on deb and rpm distribution.
-                        if ((distribution.equals('rpm') || distribution.equals('deb')) && component_check.equals('cross-cluster-replication')) {
-                            echo "Skipping integTest for ${distribution} distribution for cross-cluster-replication"
+                        // Temporarily Skipping integTest for cross-cluster-replication query-insights component when running on deb and rpm distribution.
+                        if ((distribution.equals('rpm') || distribution.equals('deb')) && (component_check.equals('cross-cluster-replication') || component_check.equals('query-insights'))) {
+                            echo "Skipping integTest for ${distribution} distribution for cross-cluster-replication, query-insights"
                             componentList -= component_check
                         }
                     }


### PR DESCRIPTION
### Description
Disable query-insights test in deb/rpm as they dont support multi-node

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
