### PR TITLE
Add job-scheduler dependency for sql component in 3.7.0 manifest

### DIFF
--- a/manifests/3.7.0/opensearch-3.7.0.yml
+++ b/manifests/3.7.0/opensearch-3.7.0.yml
@@ -148,6 +148,7 @@ components:
     depends_on:
       - ml-commons
       - geospatial
+      - job-scheduler
   - name: asynchronous-search
     repository: https://github.com/opensearch-project/asynchronous-search.git
     ref: main


### PR DESCRIPTION
## Summary
- Add `job-scheduler` to `depends_on` for the `sql` component in the 3.7.0 manifest
- The sql plugin depends on job-scheduler but it was missing from the manifest dependency declaration
- Ref: https://github.com/opensearch-project/sql/issues/3632#issuecomment-2903027126