### PR TITLE
Debian packaging: only install demo security config upon request

### DIFF
--- a/scripts/pkg/build_templates/1.x/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/1.x/opensearch/deb/debian/postinst
@@ -21,7 +21,9 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1
+    if [ "$ENABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
+        bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1
+    fi
 fi
 
 # Apply PerformanceAnalyzer Settings
@@ -65,7 +67,7 @@ echo " sudo systemctl enable opensearch.service"
 echo "### You can start opensearch service by executing"
 echo " sudo systemctl start opensearch.service"
 
-if [ -d ${product_dir}/plugins/opensearch-security ]; then
+if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$ENABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
     echo "### Create opensearch demo certificates in ${config_dir}/"
     echo " See demo certs creation log in ${log_dir}/install_demo_configuration.log"
 fi
@@ -74,5 +76,4 @@ echo " In a future release of OpenSearch, we plan to change the permissions asso
 echo " If you are configuring tools that require read access to the OpenSearch configuration files, we recommend you add the user that runs these tools to the 'opensearch' group"
 echo " For more information, see https://github.com/opensearch-project/opensearch-build/pull/4043"
 exit 0
-
 

--- a/scripts/pkg/build_templates/2.x/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/2.x/opensearch/deb/debian/postinst
@@ -21,7 +21,9 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
+    if [ "$ENABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
+        bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
+    fi
 fi
 # Apply PerformanceAnalyzer Settings
 chmod a+rw /tmp
@@ -81,7 +83,7 @@ else
     echo "### You can start opensearch service by executing"
     echo " sudo systemctl start opensearch.service"
 
-    if [ -d ${product_dir}/plugins/opensearch-security ]; then
+    if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$ENABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
         echo "### Create opensearch demo certificates in ${config_dir}/"
         echo " See demo certs creation log in ${log_dir}/install_demo_configuration.log"
     fi
@@ -92,5 +94,4 @@ echo " In 2.13.0 and later releases of OpenSearch, we have changed the permissio
 echo " If you are configuring tools that require read access to the OpenSearch configuration files, we recommend you add the user that runs these tools to the 'opensearch' group"
 echo " For more information, see https://github.com/opensearch-project/opensearch-build/pull/4043"
 exit 0
-
 

--- a/scripts/pkg/build_templates/current/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/current/opensearch/deb/debian/postinst
@@ -21,7 +21,9 @@ pid_dir=/var/run/opensearch
 
 # Apply Security Settings
 if [ -d ${product_dir}/plugins/opensearch-security ]; then
-    bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
+    if [ "$ENABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
+        bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
+    fi
 fi
 # Apply PerformanceAnalyzer Settings
 chmod a+rw /tmp
@@ -81,7 +83,7 @@ else
     echo "### You can start opensearch service by executing"
     echo " sudo systemctl start opensearch.service"
 
-    if [ -d ${product_dir}/plugins/opensearch-security ]; then
+    if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$ENABLE_INSTALL_DEMO_CONFIG" = "true" ]; then
         echo "### Create opensearch demo certificates in ${config_dir}/"
         echo " See demo certs creation log in ${log_dir}/install_demo_configuration.log"
     fi
@@ -92,5 +94,4 @@ echo " In 2.13.0 and later releases of OpenSearch, we have changed the permissio
 echo " If you are configuring tools that require read access to the OpenSearch configuration files, we recommend you add the user that runs these tools to the 'opensearch' group"
 echo " For more information, see https://github.com/opensearch-project/opensearch-build/pull/4043"
 exit 0
-
 


### PR DESCRIPTION
As currently configured, the Debian package for OpenSearch automatically installs the security demo. If the user does not supply a password for the demo config at installation time, the package install fails and it's left in a half-installed state. (ref
https://github.com/opensearch-project/opensearch-build/pull/5554#issuecomment-3857910241 )

As suggested by @DarshitChanpura , change the default behavior so that the security demo only installs when the environment variable ENABLE_INSTALL_DEMO_CONFIG is set.

- https://github.com/opensearch-project/security/issues/4199

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
