### PR TITLE
Bump to node24 based action versions

### DIFF
--- a/.github/workflows/automatic-merges.yml
+++ b/.github/workflows/automatic-merges.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'opensearch-project/opensearch-build'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: find-triggering-pr
         uses: peternied/find-triggering-pr@v1
@@ -50,7 +50,7 @@ jobs:
     if: github.repository == 'opensearch-project/opensearch-build'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: find-triggering-pr
         uses: peternied/find-triggering-pr@v1

--- a/.github/workflows/code-diff-analyzer.yml
+++ b/.github/workflows/code-diff-analyzer.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ env.diff_analyzer != '5' && env.diff_analyzer != '9' }}
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.BEDROCK_ACCESS_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/code-diff-reviewer.yml
+++ b/.github/workflows/code-diff-reviewer.yml
@@ -64,7 +64,7 @@ jobs:
           fi
       - name: Configure AWS credentials
         if: ${{ env.skip_diff_reviewer != 'true' }}
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.BEDROCK_ACCESS_ROLE }}
           aws-region: us-east-1

--- a/.github/workflows/create-release-issues.yml
+++ b/.github/workflows/create-release-issues.yml
@@ -38,7 +38,7 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
       - name: Checkout Build repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check if build repo release issue exists
         id: check_if_build_repo_issue_exists
         uses: actions-cool/issues-helper@v3
@@ -84,7 +84,7 @@ jobs:
           token: ${{ steps.github_app_token.outputs.token }}
           title-includes: '[RELEASE] Release version ${{ inputs.version }}'
       - name: Checkout Build repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Replace Placeholders
         if: steps.check_if_plugin_repo_issue_exists.outputs.issues == '[]'
         run: |

--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -11,7 +11,7 @@ jobs:
   dockerfile-lint-test_ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: jbergstroem/hadolint-gh-action@v1
         with:
           dockerfile: 'docker/ci/dockerfiles/current/*.dockerfile'
@@ -20,7 +20,7 @@ jobs:
   dockerfile-lint-test_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: jbergstroem/hadolint-gh-action@v1
         with:
           dockerfile: 'docker/release/dockerfiles/*.dockerfile'

--- a/.github/workflows/get-ci-image-tag.yml
+++ b/.github/workflows/get-ci-image-tag.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           crane-release: v0.15.2
       - name: Checkout opensearch-build repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: 'opensearch-project/opensearch-build'
           ref: ${{ inputs.build_ref }}

--- a/.github/workflows/groovy-tests.yml
+++ b/.github/workflows/groovy-tests.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'temurin'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Run Tests
         run: |
           ./gradlew test --info

--- a/.github/workflows/issue-dedupe-detect.yml
+++ b/.github/workflows/issue-dedupe-detect.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.BEDROCK_ACCESS_ROLE_ISSUE_DEDUPE }}
           aws-region: us-east-1

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -7,6 +7,6 @@ jobs:
   license-header-checker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Add License Header
         run: npx @kt3k/license-checker

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: lychee Link Checker
         id: lychee
         uses: lycheeverse/lychee-action@v2.0.2

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Get changed manifest files
         uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
         id: list-changed-manifests
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.list-changed-manifests.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Check JDK Version
         run: |
           java_version=`cat ${{ matrix.manifest }} | yq -r .ci.image.args | grep -Eo '[0-9]+' || echo ''`
@@ -48,11 +48,11 @@ jobs:
           echo "JAVA_VERSION=$java_version" >> "$GITHUB_ENV"
       - name: Set Up JDK ${{ env.JAVA_VERSION }}
         if: ${{ env.JAVA_VERSION }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Pipenv and Dependencies

--- a/.github/workflows/os-increment-plugin-versions.yml
+++ b/.github/workflows/os-increment-plugin-versions.yml
@@ -61,7 +61,7 @@ jobs:
           - '3.7'
     steps:
       - name: Check out OpenSearch repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: opensearch-project/OpenSearch
           ref: ${{ matrix.branch }}
@@ -77,14 +77,14 @@ jobs:
           OPENSEARCH_JAVA_VERSION_NUMBER=`curl -sSfL https://raw.githubusercontent.com/opensearch-project/opensearch-build/refs/heads/main/manifests/$OS_VERSION/opensearch-$OS_VERSION.yml | yq -r '.ci.image.linux.tar.args' | grep -oE 'openjdk-[0-9]*' | awk -F'-' '{ print $NF }'`
           echo "OPENSEARCH_JAVA_VERSION=$OPENSEARCH_JAVA_VERSION_NUMBER" >> $GITHUB_ENV
       - name: Set up JDK ${{ env.OPENSEARCH_JAVA_VERSION }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.OPENSEARCH_JAVA_VERSION }}
           distribution: 'temurin'
           cache: gradle
       - name: Check out plugin repo
         if: ${{ matrix.entry.repo != 'OpenSearch' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: opensearch-project/${{ matrix.entry.repo }}
           ref: ${{ matrix.branch }}

--- a/.github/workflows/os-release-issues.yml
+++ b/.github/workflows/os-release-issues.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       versions_matrix: ${{ steps.set-matrix.outputs.versions }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: set-matrix
         # produces a list of major.minor versions only, no patch versions e.g. ["1.4.0","2.10.0","2.6.0","2.7.0","2.8.0","2.9.0","3.0.0"]
         run: echo "versions=$(ls manifests/**/opensearch*.yml | cut -d'/' -f2 | grep '0$' | grep -v '[0-9]0$' | sort | uniq | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -24,7 +24,7 @@ jobs:
     outputs:
       version_components_matrix: ${{ steps.get-all-components.outputs.combined_matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: get-all-components
         run: |

--- a/.github/workflows/osd-increment-plugin-versions.yml
+++ b/.github/workflows/osd-increment-plugin-versions.yml
@@ -50,20 +50,20 @@ jobs:
           - '3.7'
     steps:
       - name: Check out OpenSearch Dashboards repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: opensearch-project/OpenSearch-Dashboards
           ref: ${{ matrix.branch }}
           path: OpenSearch-Dashboards
       - name: Check out plugin repo
         if: ${{ matrix.entry.repo != 'OpenSearch-Dashboards' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: opensearch-project/${{ matrix.entry.repo }}
           ref: ${{ matrix.branch }}
           path: OpenSearch-Dashboards/plugins/${{ matrix.entry.repo }}
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: './OpenSearch-Dashboards/.nvmrc'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/osd-release-issues.yml
+++ b/.github/workflows/osd-release-issues.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       versions_matrix: ${{ steps.set-matrix.outputs.versions }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: set-matrix
         # produces a list of major.minor versions only, no patch versions e.g. ["1.4.0","2.10.0","2.6.0","2.7.0","2.8.0","2.9.0","3.0.0"]
         run: echo "versions=$(ls manifests/**/opensearch-dashboards*.yml | cut -d'/' -f2 | grep '0$' | grep -v '[0-9]0$' | sort | uniq | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
@@ -24,7 +24,7 @@ jobs:
     outputs:
       version_components_matrix: ${{ steps.get-all-components.outputs.combined_matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: get-all-components
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -19,7 +19,7 @@ jobs:
   publish-wiki:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: Andrew-Chen-Wang/github-wiki-action@v4
         with:
           path: docs/

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       PYTHON_VERSION: 3.9
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v6
         with:
@@ -50,7 +50,7 @@ jobs:
     env:
       PYTHON_VERSION: 3.9
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v6
         with:
@@ -91,7 +91,7 @@ jobs:
     steps:
       - name: Run start commands
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Pipenv and Dependencies
         run: |
           pipenv install
@@ -108,7 +108,7 @@ jobs:
         run: |
           pipenv run coverage run -m pytest --cov=./ --cov-report=xml
           sed -i 's|<source>.*</source>|<source>opensearch-build</source>|' coverage.xml
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: coverage-report-${{ matrix.os }}
           path: ./coverage.xml
@@ -117,7 +117,7 @@ jobs:
     needs: python-tests-linux
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           name: coverage-report-ubuntu-24.04
           path: ./

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Pipenv and Dependencies
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
@@ -122,7 +122,7 @@ jobs:
           name: coverage-report-ubuntu-24.04
           path: ./
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - id: set-matrix
         # produces a list of versions, e.g. ["1.0.0","1.0.0","1.0.1","1.1.0","1.2.0","2.0.0"]
         run: echo "::set-output name=matrix::$(ls manifests/**/opensearch*.yml | cut -d'/' -f2 | sort | uniq | jq -R -s -c 'split("\n")[:-1]')"
@@ -24,7 +24,7 @@ jobs:
       matrix:
         release_version: ${{ fromJson(needs.list-manifest-versions.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Create release issue
         uses: dblock/create-a-github-issue@v3.0.0
         id: release-issue

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -9,9 +9,9 @@ jobs:
     env:
       PYTHON_VERSION: 3.9.12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Pipenv and Dependencies


### PR DESCRIPTION
### Description
Bump to node24 based action versions

### Issues Resolved
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
