### PR TITLE
 Remove snapshot builds for 3.5.1 and 3.6.0 

### DIFF
--- a/jenkins/opensearch/publish-min-snapshots.jenkinsfile
+++ b/jenkins/opensearch/publish-min-snapshots.jenkinsfile
@@ -31,9 +31,7 @@ pipeline {
         parameterizedCron '''
             H */4 * * * %INPUT_MANIFEST=3.6.1/opensearch-3.6.1.yml
             H */4 * * * %INPUT_MANIFEST=3.7.0/opensearch-3.7.0.yml
-            H */4 * * * %INPUT_MANIFEST=3.5.1/opensearch-3.5.1.yml
             H */4 * * * %INPUT_MANIFEST=2.19.6/opensearch-2.19.6.yml
-            H */4 * * * %INPUT_MANIFEST=3.6.0/opensearch-3.6.0.yml
         '''
     }
     parameters {


### PR DESCRIPTION
### Description
 Remove snapshot builds for 3.5.1 and 3.6.0 

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
