### PR TITLE
Allow parameters to DISABLE_INSTALL_DEMO_CONFIG, DISABLE_SECURITY_PLUGIN, DISABLE_SECURITY_DASHBOARDS_PLUGIN in deb/rpm artifacts in 3.7+

### DIFF
--- a/scripts/pkg/build_templates/2.x/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/2.x/opensearch-dashboards/deb/debian/postinst
@@ -19,6 +19,17 @@ data_dir=/var/lib/opensearch-dashboards
 log_dir=/var/log/opensearch-dashboards
 pid_dir=/var/run/opensearch-dashboards
 
+# Starting 3.7, allow disable security dashboards plugin with parameter
+if [ "$DISABLE_SECURITY_DASHBOARDS_PLUGIN" = "true" ]; then
+    ${product_dir}/bin/opensearch-dashboards-plugin remove securityDashboards
+
+    # Remove all security related parameters as well as changing HTTPS to HTTP
+    # Temporary fix before security-dashboards plugin implement a parameter to disable the plugin entirely
+    # https://github.com/opensearch-project/security-dashboards-plugin/issues/896
+    UPDATED_CONFIG=`cat ${config_dir}/opensearch_dashboards.yml | sed "/^opensearch_security/d" | sed "s/https/http/g"`
+    echo "$UPDATED_CONFIG" > ${config_dir}/opensearch_dashboards.yml
+fi
+
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then
     systemctl daemon-reload

--- a/scripts/pkg/build_templates/2.x/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
+++ b/scripts/pkg/build_templates/2.x/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
@@ -84,6 +84,16 @@ exit 0
 %post
 set -e
 chown -R root:%{name} %{config_dir}
+# Starting 3.7, allow disable security dashboards plugin with parameter
+if [ "$DISABLE_SECURITY_DASHBOARDS_PLUGIN" = "true" ]; then
+    %{product_dir}/bin/opensearch-dashboards-plugin remove securityDashboards
+
+    # Remove all security related parameters as well as changing HTTPS to HTTP
+    # Temporary fix before security-dashboards plugin implement a parameter to disable the plugin entirely
+    # https://github.com/opensearch-project/security-dashboards-plugin/issues/896
+    UPDATED_CONFIG=`cat %{config_dir}/opensearch_dashboards.yml | sed "/^opensearch_security/d" | sed "s/https/http/g"`
+    echo "$UPDATED_CONFIG" > %{config_dir}/opensearch_dashboards.yml
+fi
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then
     systemctl daemon-reload

--- a/scripts/pkg/build_templates/2.x/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/2.x/opensearch/deb/debian/postinst
@@ -20,9 +20,17 @@ log_dir=/var/log/opensearch
 pid_dir=/var/run/opensearch
 
 # Apply Security Settings
-if [ -d ${product_dir}/plugins/opensearch-security ]; then
+# Starting 3.7, allow disable demo config and security plugin with parameter
+if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]; then
     bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
 fi
+
+if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
+    UPDATED_CONFIG=`cat ${config_dir}/opensearch.yml | sed "/^plugins.security.disabled/d"`
+    echo "$UPDATED_CONFIG" > ${config_dir}/opensearch.yml
+    echo "plugins.security.disabled: true" >> ${config_dir}/opensearch.yml
+fi
+
 # Apply PerformanceAnalyzer Settings
 chmod a+rw /tmp
 if ! grep -q '## OpenSearch Performance Analyzer' ${config_dir}/jvm.options; then
@@ -81,7 +89,11 @@ else
     echo "### You can start opensearch service by executing"
     echo " sudo systemctl start opensearch.service"
 
-    if [ -d ${product_dir}/plugins/opensearch-security ]; then
+    if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
+        echo "### Security plugin is DISABLED, update parameter: ${config_dir}/opensearch.yml"
+    fi
+
+    if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]; then
         echo "### Create opensearch demo certificates in ${config_dir}/"
         echo " See demo certs creation log in ${log_dir}/install_demo_configuration.log"
     fi

--- a/scripts/pkg/build_templates/2.x/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/2.x/opensearch/rpm/opensearch.rpm.spec
@@ -98,8 +98,15 @@ exit 0
 %post
 set -e
 # Apply Security Settings
-if [ -d %{product_dir}/plugins/opensearch-security ]; then
+# Starting 3.7, allow disable demo config and security plugin with parameter
+if [ -d %{product_dir}/plugins/opensearch-security ] && [ "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]; then
     sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > %{log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in %{log_dir}/install_demo_configuration.log" && exit 1)
+fi
+
+if [ -d %{product_dir}/plugins/opensearch-security ] && [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
+    UPDATED_CONFIG=`cat %{config_dir}/opensearch.yml | sed "/^plugins.security.disabled/d"`
+    echo "$UPDATED_CONFIG" > %{config_dir}/opensearch.yml
+    echo "plugins.security.disabled: true" >> %{config_dir}/opensearch.yml
 fi
 chown -R %{name}:%{name} %{config_dir}
 chown -R %{name}:%{name} %{log_dir}
@@ -134,7 +141,11 @@ echo " sudo systemctl daemon-reload"
 echo " sudo systemctl enable opensearch.service"
 echo "### You can start opensearch service by executing"
 echo " sudo systemctl start opensearch.service"
-if [ -d %{product_dir}/plugins/opensearch-security ]; then
+if [ -d %{product_dir}/plugins/opensearch-security ] && [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
+    echo "### Security plugin is DISABLED, update parameter: %{config_dir}/opensearch.yml"
+fi
+
+if [ -d %{product_dir}/plugins/opensearch-security ] && [ "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]; then
     echo "### Create opensearch demo certificates in %{config_dir}/"
     echo " See demo certs creation log in %{log_dir}/install_demo_configuration.log"
 fi

--- a/scripts/pkg/build_templates/current/opensearch-dashboards/deb/debian/postinst
+++ b/scripts/pkg/build_templates/current/opensearch-dashboards/deb/debian/postinst
@@ -19,6 +19,17 @@ data_dir=/var/lib/opensearch-dashboards
 log_dir=/var/log/opensearch-dashboards
 pid_dir=/var/run/opensearch-dashboards
 
+# Starting 3.7, allow disable security dashboards plugin with parameter
+if [ "$DISABLE_SECURITY_DASHBOARDS_PLUGIN" = "true" ]; then
+    ${product_dir}/bin/opensearch-dashboards-plugin remove securityDashboards
+
+    # Remove all security related parameters as well as changing HTTPS to HTTP
+    # Temporary fix before security-dashboards plugin implement a parameter to disable the plugin entirely
+    # https://github.com/opensearch-project/security-dashboards-plugin/issues/896
+    UPDATED_CONFIG=`cat ${config_dir}/opensearch_dashboards.yml | sed "/^opensearch_security/d" | sed "s/https/http/g"`
+    echo "$UPDATED_CONFIG" > ${config_dir}/opensearch_dashboards.yml
+fi
+
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then
     systemctl daemon-reload

--- a/scripts/pkg/build_templates/current/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
+++ b/scripts/pkg/build_templates/current/opensearch-dashboards/rpm/opensearch-dashboards.rpm.spec
@@ -84,6 +84,16 @@ exit 0
 %post
 set -e
 chown -R root:%{name} %{config_dir}
+# Starting 3.7, allow disable security dashboards plugin with parameter
+if [ "$DISABLE_SECURITY_DASHBOARDS_PLUGIN" = "true" ]; then
+    %{product_dir}/bin/opensearch-dashboards-plugin remove securityDashboards
+
+    # Remove all security related parameters as well as changing HTTPS to HTTP
+    # Temporary fix before security-dashboards plugin implement a parameter to disable the plugin entirely
+    # https://github.com/opensearch-project/security-dashboards-plugin/issues/896
+    UPDATED_CONFIG=`cat %{config_dir}/opensearch_dashboards.yml | sed "/^opensearch_security/d" | sed "s/https/http/g"`
+    echo "$UPDATED_CONFIG" > %{config_dir}/opensearch_dashboards.yml
+fi
 # Reload systemctl daemon
 if command -v systemctl > /dev/null; then
     systemctl daemon-reload

--- a/scripts/pkg/build_templates/current/opensearch/deb/debian/postinst
+++ b/scripts/pkg/build_templates/current/opensearch/deb/debian/postinst
@@ -20,9 +20,17 @@ log_dir=/var/log/opensearch
 pid_dir=/var/run/opensearch
 
 # Apply Security Settings
-if [ -d ${product_dir}/plugins/opensearch-security ]; then
+# Starting 3.7, allow disable demo config and security plugin with parameter
+if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]; then
     bash ${product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > ${log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in ${log_dir}/install_demo_configuration.log" && exit 1)
 fi
+
+if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
+    UPDATED_CONFIG=`cat ${config_dir}/opensearch.yml | sed "/^plugins.security.disabled/d"`
+    echo "$UPDATED_CONFIG" > ${config_dir}/opensearch.yml
+    echo "plugins.security.disabled: true" >> ${config_dir}/opensearch.yml
+fi
+
 # Apply PerformanceAnalyzer Settings
 chmod a+rw /tmp
 if ! grep -q '## OpenSearch Performance Analyzer' ${config_dir}/jvm.options; then
@@ -81,7 +89,11 @@ else
     echo "### You can start opensearch service by executing"
     echo " sudo systemctl start opensearch.service"
 
-    if [ -d ${product_dir}/plugins/opensearch-security ]; then
+    if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
+        echo "### Security plugin is DISABLED, update parameter: ${config_dir}/opensearch.yml"
+    fi
+
+    if [ -d ${product_dir}/plugins/opensearch-security ] && [ "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]; then
         echo "### Create opensearch demo certificates in ${config_dir}/"
         echo " See demo certs creation log in ${log_dir}/install_demo_configuration.log"
     fi

--- a/scripts/pkg/build_templates/current/opensearch/rpm/opensearch.rpm.spec
+++ b/scripts/pkg/build_templates/current/opensearch/rpm/opensearch.rpm.spec
@@ -98,8 +98,15 @@ exit 0
 %post
 set -e
 # Apply Security Settings
-if [ -d %{product_dir}/plugins/opensearch-security ]; then
+# Starting 3.7, allow disable demo config and security plugin with parameter
+if [ -d %{product_dir}/plugins/opensearch-security ] && [ "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]; then
     sh %{product_dir}/plugins/opensearch-security/tools/install_demo_configuration.sh -y -i -s > %{log_dir}/install_demo_configuration.log 2>&1 || (echo "ERROR: Something went wrong during demo configuration installation. Please see the logs in %{log_dir}/install_demo_configuration.log" && exit 1)
+fi
+
+if [ -d %{product_dir}/plugins/opensearch-security ] && [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
+    UPDATED_CONFIG=`cat %{config_dir}/opensearch.yml | sed "/^plugins.security.disabled/d"`
+    echo "$UPDATED_CONFIG" > %{config_dir}/opensearch.yml
+    echo "plugins.security.disabled: true" >> %{config_dir}/opensearch.yml
 fi
 chown -R %{name}:%{name} %{config_dir}
 chown -R %{name}:%{name} %{log_dir}
@@ -134,7 +141,11 @@ echo " sudo systemctl daemon-reload"
 echo " sudo systemctl enable opensearch.service"
 echo "### You can start opensearch service by executing"
 echo " sudo systemctl start opensearch.service"
-if [ -d %{product_dir}/plugins/opensearch-security ]; then
+if [ -d %{product_dir}/plugins/opensearch-security ] && [ "$DISABLE_SECURITY_PLUGIN" = "true" ]; then
+    echo "### Security plugin is DISABLED, update parameter: %{config_dir}/opensearch.yml"
+fi
+
+if [ -d %{product_dir}/plugins/opensearch-security ] && [ "$DISABLE_INSTALL_DEMO_CONFIG" != "true" ]; then
     echo "### Create opensearch demo certificates in %{config_dir}/"
     echo " See demo certs creation log in %{log_dir}/install_demo_configuration.log"
 fi


### PR DESCRIPTION


### Description
Initial update of behavior in 2.12 via: https://github.com/opensearch-project/security/issues/3916
Deb/Rpm changes in: https://github.com/opensearch-project/opensearch-build/pull/4332
Requested in https://github.com/opensearch-project/security/issues/4199
Thanks to:
https://github.com/opensearch-project/opensearch-build/pull/5554
https://github.com/opensearch-project/opensearch-build/pull/6124

This change will take effect in the next 3.7 and might need more testing later to be certain.

### Issues Resolved
Resolves https://github.com/opensearch-project/security/issues/4199

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
