### PR TITLE
Make sure dedupe issue workflow is locked to repo

### DIFF
--- a/.github/workflows/issue-dedupe.yml
+++ b/.github/workflows/issue-dedupe.yml
@@ -15,9 +15,11 @@ on:
 jobs:
   detect-issue:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.repository == 'opensearch-project/opensearch-build') ||
       (github.event_name == 'issues' &&
-       github.event.issue.user.type != 'Bot')
+       github.event.issue.user.type != 'Bot' &&
+       github.repository == 'opensearch-project/opensearch-build')
     uses: opensearch-project/opensearch-build/.github/workflows/issue-dedupe-detect.yml@main
     permissions:
       contents: read
@@ -30,7 +32,7 @@ jobs:
       grace_days: ${{ vars.DUPLICATE_GRACE_DAYS || '7' }}
 
   auto-close-issue:
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' && github.repository == 'opensearch-project/opensearch-build'
     uses: opensearch-project/opensearch-build/.github/workflows/issue-dedupe-autoclose.yml@main
     permissions:
       issues: write


### PR DESCRIPTION
### Description
Make sure dedupe issue workflow is locked to repo

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5912

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
