### PR TITLE
Allow sandbox plugins to join normal core-plugins on s3 with datafusion

### DIFF
--- a/scripts/components/OpenSearch-DataFusion/build.sh
+++ b/scripts/components/OpenSearch-DataFusion/build.sh
@@ -171,7 +171,7 @@ echo "Copying artifact to ${OUTPUT}/dist"
 [[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
 ARTIFACT_BUILD_NAME=`ls distribution/$TYPE/$TARGET/build/distributions/ | grep "opensearch-min.*$SUFFIX.$EXT"`
 mkdir -p "${OUTPUT}/dist"
-cp distribution/$TYPE/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/dist/$ARTIFACT_BUILD_NAME
+cp -v distribution/$TYPE/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/dist/$ARTIFACT_BUILD_NAME
 
 echo "Building core plugins..."
 mkdir -p "${OUTPUT}/core-plugins"
@@ -182,6 +182,23 @@ for plugin in plugins/*; do
   PLUGIN_NAME=$(basename "$plugin")
   if [ -d "$plugin" ] && [ "examples" != "$PLUGIN_NAME" ]; then
     PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME.*$IDENTIFIER.zip"`
-    cp "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
+    cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
   fi
 done
+
+echo "Building (sandbox) core plugins, save in same dir as core plugins..."
+cd sandbox/plugins
+../../gradlew assemble -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier=$QUALIFIER -Dsandbox.enabled=true -PrustRelease -Pcrypto.standard=FIPS-140-3
+cd ../../
+touch ./sandbox-core-plugins.txt
+for plugin in sandbox/plugins/*; do
+  PLUGIN_NAME=$(basename "$plugin")
+  if [ -d "$plugin" ] && [ "examples" != "$PLUGIN_NAME" ]; then
+    PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME.*$IDENTIFIER.zip"`
+    cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
+    echo $PLUGIN_ARTIFACT_BUILD_NAME >> ./sandbox-core-plugins.txt
+  fi
+done
+cp -v ./sandbox-core-plugins.txt "${OUTPUT}"/core-plugins/
+
+echo "Both core-plugins and (sandbox) core-plugins are built now"

--- a/scripts/components/OpenSearch/build.sh
+++ b/scripts/components/OpenSearch/build.sh
@@ -171,7 +171,7 @@ echo "Copying artifact to ${OUTPUT}/dist"
 [[ "$SNAPSHOT" == "true" ]] && IDENTIFIER="-SNAPSHOT"
 ARTIFACT_BUILD_NAME=`ls distribution/$TYPE/$TARGET/build/distributions/ | grep "opensearch-min.*$SUFFIX.$EXT"`
 mkdir -p "${OUTPUT}/dist"
-cp distribution/$TYPE/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/dist/$ARTIFACT_BUILD_NAME
+cp -v distribution/$TYPE/$TARGET/build/distributions/$ARTIFACT_BUILD_NAME "${OUTPUT}"/dist/$ARTIFACT_BUILD_NAME
 
 echo "Building core plugins..."
 mkdir -p "${OUTPUT}/core-plugins"
@@ -182,6 +182,6 @@ for plugin in plugins/*; do
   PLUGIN_NAME=$(basename "$plugin")
   if [ -d "$plugin" ] && [ "examples" != "$PLUGIN_NAME" ]; then
     PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME.*$IDENTIFIER.zip"`
-    cp "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
+    cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
   fi
 done


### PR DESCRIPTION
### Description
Allow sandbox plugins to join normal core-plugins on s3 with datafusion

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5810

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
