### PR TITLE
Allow --skip-artifact-check to install core-plugin as plugin, add analytics-engine before sql in datafusion

### DIFF
--- a/feature-manifests/feature-datafusion/opensearch-3.7.0.yml
+++ b/feature-manifests/feature-datafusion/opensearch-3.7.0.yml
@@ -56,6 +56,15 @@ components:
       - job-scheduler
       - opensearch-remote-metadata-sdk
       - security
+  - name: analytics-engine
+    repository: https://github.com/opensearch-project/OpenSearch.git
+    ref: 'main'
+    working_directory: sandbox/plugins
+    platforms:
+      - linux
+      - windows
+    depends_on:
+      - OpenSearch-DataFusion
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
     ref: 'feature/mustang-ppl-integration'

--- a/scripts/components/OpenSearch-DataFusion/build.sh
+++ b/scripts/components/OpenSearch-DataFusion/build.sh
@@ -186,19 +186,19 @@ for plugin in plugins/*; do
   fi
 done
 
-echo "Building (sandbox) core plugins, save in same dir as core plugins..."
-cd sandbox/plugins
-../../gradlew assemble -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier=$QUALIFIER -Dsandbox.enabled=true -PrustRelease -Pcrypto.standard=FIPS-140-3
-cd ../../
-touch ./sandbox-core-plugins.txt
-for plugin in sandbox/plugins/*; do
-  PLUGIN_NAME=$(basename "$plugin")
-  if [ -d "$plugin" ] && [ "examples" != "$PLUGIN_NAME" ]; then
-    PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME.*$IDENTIFIER.zip"`
-    cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
-    echo $PLUGIN_ARTIFACT_BUILD_NAME >> ./sandbox-core-plugins.txt
-  fi
-done
-cp -v ./sandbox-core-plugins.txt "${OUTPUT}"/core-plugins/
-
-echo "Both core-plugins and (sandbox) core-plugins are built now"
+#echo "Building (sandbox) core plugins, save in same dir as core plugins..."
+#cd sandbox/plugins
+#../../gradlew assemble -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier=$QUALIFIER -Dsandbox.enabled=true -PrustRelease -Pcrypto.standard=FIPS-140-3
+#cd ../../
+#touch ./sandbox-core-plugins.txt
+#for plugin in sandbox/plugins/*; do
+#  PLUGIN_NAME=$(basename "$plugin")
+#  if [ -d "$plugin" ] && [ "examples" != "$PLUGIN_NAME" ]; then
+#    PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME.*$IDENTIFIER.zip"`
+#    cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
+#    echo $PLUGIN_ARTIFACT_BUILD_NAME >> ./sandbox-core-plugins.txt
+#  fi
+#done
+#cp -v ./sandbox-core-plugins.txt "${OUTPUT}"/core-plugins/
+#
+#echo "Both core-plugins and (sandbox) core-plugins are built now"

--- a/scripts/components/analytics-engine/build.sh
+++ b/scripts/components/analytics-engine/build.sh
@@ -74,21 +74,4 @@ pwd
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 mkdir -p $OUTPUT/plugins
 cp -v analytics-engine/build/distributions/analytics-engine-$VERSION.zip $OUTPUT/plugins/
-#cp -v analytics-engine/build/distributions/analytics-engine-$VERSION.zip $OUTPUT/plugins/analytics-engine-$VERSION.0.zip
 
-#echo "Building (sandbox) core plugins, save in same dir as core plugins..."
-#cd sandbox/plugins
-#../../gradlew assemble -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier=$QUALIFIER -Dsandbox.enabled=true -PrustRelease -Pcrypto.standard=FIPS-140-3
-#cd ../../
-#touch ./sandbox-core-plugins.txt
-#for plugin in sandbox/plugins/*; do
-#  PLUGIN_NAME=$(basename "$plugin")
-#  if [ -d "$plugin" ] && [ "examples" != "$PLUGIN_NAME" ]; then
-#    PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME.*$IDENTIFIER.zip"`
-#    cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
-#    echo $PLUGIN_ARTIFACT_BUILD_NAME >> ./sandbox-core-plugins.txt
-#  fi
-#done
-#cp -v ./sandbox-core-plugins.txt "${OUTPUT}"/core-plugins/
-#
-#echo "Both core-plugins and (sandbox) core-plugins are built now"

--- a/scripts/components/analytics-engine/build.sh
+++ b/scripts/components/analytics-engine/build.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+#
+# Copyright OpenSearch Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Build qualifier."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:q:s:o:p:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ ! -z "$QUALIFIER" ]] && VERSION=$VERSION-$QUALIFIER
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+pwd
+
+../../gradlew assemble -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier=$QUALIFIER -Dsandbox.enabled=true -PrustRelease -Pcrypto.standard=FIPS-140-3
+
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+mkdir -p $OUTPUT/plugins
+cp -v analytics-engine/build/distributions/analytics-engine-$VERSION.zip $OUTPUT/plugins/
+#cp -v analytics-engine/build/distributions/analytics-engine-$VERSION.zip $OUTPUT/plugins/analytics-engine-$VERSION.0.zip
+
+#echo "Building (sandbox) core plugins, save in same dir as core plugins..."
+#cd sandbox/plugins
+#../../gradlew assemble -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier=$QUALIFIER -Dsandbox.enabled=true -PrustRelease -Pcrypto.standard=FIPS-140-3
+#cd ../../
+#touch ./sandbox-core-plugins.txt
+#for plugin in sandbox/plugins/*; do
+#  PLUGIN_NAME=$(basename "$plugin")
+#  if [ -d "$plugin" ] && [ "examples" != "$PLUGIN_NAME" ]; then
+#    PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME.*$IDENTIFIER.zip"`
+#    cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/core-plugins/"$PLUGIN_ARTIFACT_BUILD_NAME"
+#    echo $PLUGIN_ARTIFACT_BUILD_NAME >> ./sandbox-core-plugins.txt
+#  fi
+#done
+#cp -v ./sandbox-core-plugins.txt "${OUTPUT}"/core-plugins/
+#
+#echo "Both core-plugins and (sandbox) core-plugins are built now"

--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -90,6 +90,13 @@ class BuildArgs:
             dest="distribution"
         )
         parser.add_argument(
+            "--skip-artifact-check",
+            dest="skip_artifact_check",
+            default=False,
+            action="store_true",
+            help="Skip artifact checks when building components and plugins.",
+        )
+        parser.add_argument(
             "--continue-on-error",
             dest="continue_on_error",
             default=False,
@@ -126,6 +133,7 @@ class BuildArgs:
         self.distribution = args.distribution
         self.script_path = sys.argv[0].replace("/src/run_build.py", "/build.sh")
         self.continue_on_error = args.continue_on_error
+        self.skip_artifact_check = args.skip_artifact_check
         self.incremental = args.incremental
 
     def component_command(self, name: str) -> str:

--- a/src/build_workflow/build_recorder.py
+++ b/src/build_workflow/build_recorder.py
@@ -38,7 +38,10 @@ class BuildRecorder:
         dest_dir = os.path.dirname(dest_file)
         os.makedirs(dest_dir, exist_ok=True)
         # Check artifact
-        BuildArtifactChecks.check(self.target, artifact_type, artifact_file)
+        if not self.target.skip_artifact_check:
+            BuildArtifactChecks.check(self.target, artifact_type, artifact_file)
+        else:
+            logging.info(f"Skipping artifact check for {component_name}: {artifact_path} (--skip-artifact-check was set)")
         # Copy the file
         shutil.copyfile(artifact_file, dest_file)
         # Notify the recorder

--- a/src/build_workflow/build_target.py
+++ b/src/build_workflow/build_target.py
@@ -22,6 +22,7 @@ class BuildTarget:
     distribution: str
     snapshot: bool
     output_dir: str
+    skip_artifact_check: bool
 
     def __init__(
         self,
@@ -35,6 +36,7 @@ class BuildTarget:
         snapshot: bool = True,
         build_id: str = None,
         output_dir: str = "artifacts",
+        skip_artifact_check: bool = False,
     ) -> None:
         self.build_id = os.getenv("BUILD_NUMBER") or build_id or uuid.uuid4().hex
         self.name = name
@@ -46,6 +48,7 @@ class BuildTarget:
         self.distribution = distribution
         self.platform = platform or current_platform()
         self.output_dir = output_dir
+        self.skip_artifact_check = skip_artifact_check
 
     @property
     def opensearch_version(self) -> str:

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -78,6 +78,7 @@ def main() -> int:
             distribution=args.distribution,
             platform=args.platform or manifest.build.platform,
             architecture=args.architecture or manifest.build.architecture,
+            skip_artifact_check=args.skip_artifact_check,
         )
 
         build_recorder = BuildRecorder(target, build_manifest) if args.incremental else BuildRecorder(target)

--- a/tests/tests_build_workflow/test_build_args.py
+++ b/tests/tests_build_workflow/test_build_args.py
@@ -129,3 +129,11 @@ class TestBuildArgs(unittest.TestCase):
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
     def test_manifest_no_lock(self) -> None:
         self.assertIsNone(BuildArgs().ref_manifest)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_skip_artifact_check_default(self) -> None:
+        self.assertFalse(BuildArgs().skip_artifact_check)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--skip-artifact-check"])
+    def test_skip_artifact_check_true(self) -> None:
+        self.assertTrue(BuildArgs().skip_artifact_check)

--- a/tests/tests_build_workflow/test_build_recorder.py
+++ b/tests/tests_build_workflow/test_build_recorder.py
@@ -20,7 +20,7 @@ from system.temporary_directory import TemporaryDirectory
 
 
 class TestBuildRecorder(unittest.TestCase):
-    def __mock(self, snapshot: bool = True) -> BuildRecorder:
+    def __mock(self, snapshot: bool = True, skip_artifact_check: bool = False) -> BuildRecorder:
         return BuildRecorder(
             BuildTarget(
                 build_id="1",
@@ -30,6 +30,7 @@ class TestBuildRecorder(unittest.TestCase):
                 platform="linux",
                 architecture="x64",
                 snapshot=snapshot,
+                skip_artifact_check=skip_artifact_check,
             )
         )
 
@@ -247,6 +248,15 @@ class TestBuildRecorder(unittest.TestCase):
         mock_plugin_check.assert_called()
         mock_copyfile.assert_called()
         mock_makedirs.assert_called()
+
+    @patch("shutil.copyfile")
+    @patch("os.makedirs")
+    def test_record_artifact_skip_artifact_check(self, mock_makedirs: Mock, mock_copyfile: Mock) -> None:
+        recorder = self.__mock(snapshot=False, skip_artifact_check=True)
+        recorder.record_component("security", MagicMock())
+        with patch.object(BuildArtifactOpenSearchCheckPlugin, "check") as mock_check:
+            recorder.record_artifact("security", "plugins", "../file1.zip", "invalid.file")
+            mock_check.assert_not_called()
 
     def test_append_component_with_existing_manifest(self) -> None:
         mock = self.__mock_with_manifest(snapshot=False)


### PR DESCRIPTION


### Description
Allow --skip-artifact-check to install core-plugin as plugin, add analytics-engine before sql in datafusion

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5810

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
