### PR TITLE
Run --skip-artifact-check on Jenkins with 11.6.1 libs

### DIFF
--- a/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
+++ b/jenkins/opensearch-dashboards/distribution-build.jenkinsfile
@@ -10,7 +10,7 @@
 // @job-name: distribution-build-opensearch-dashboards
 // @description: Build OpenSearch-Dashboards distribution based on the input manifest and provided parameters.
 
-lib = library(identifier: 'jenkins@11.3.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@11.6.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -105,6 +105,11 @@ pipeline {
             name: 'CONTINUE_ON_ERROR',
             description: '<Optional> Continue building the distribution even if a one or more component fails',
             defaultValue: true
+        )
+        booleanParam(
+            name: 'SKIP_ARTIFACT_CHECK',
+            description: '<Optional> Skip Artifact Check upon completing the build of a component and plugin',
+            defaultValue: false
         )
         booleanParam(
             name: 'INCREMENTAL',
@@ -224,6 +229,7 @@ pipeline {
                                 architecture: 'x64',
                                 distribution: 'tar',
                                 continueOnError: params.CONTINUE_ON_ERROR,
+                                skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                 incremental: params.INCREMENTAL,
                                 previousBuildId: params.PREVIOUS_BUILD_ID
                             )
@@ -308,6 +314,7 @@ pipeline {
                                         architecture: 'x64',
                                         distribution: 'rpm',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
                                         stashName: "build-archive-linux-x64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
@@ -343,6 +350,7 @@ pipeline {
                                         architecture: 'x64',
                                         distribution: 'rpm',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         stashName: "build-archive-linux-x64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -420,6 +428,7 @@ pipeline {
                                         architecture: 'x64',
                                         distribution: 'deb',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
                                         stashName: "build-archive-linux-x64-deb-${JOB_NAME}-${BUILD_NUMBER}"
@@ -455,6 +464,7 @@ pipeline {
                                         architecture: 'x64',
                                         distribution: 'deb',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         stashName: "build-archive-linux-x64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -530,6 +540,7 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'tar',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
                                         stashName: "build-archive-linux-arm64-tar-${JOB_NAME}-${BUILD_NUMBER}"
@@ -566,6 +577,7 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'tar',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         stashName: "build-archive-linux-arm64-tar-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
 
@@ -649,6 +661,7 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'rpm',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
                                         stashName: "build-archive-linux-arm64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
@@ -684,6 +697,7 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'rpm',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         stashName: "build-archive-linux-arm64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -761,6 +775,7 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'deb',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
                                         stashName: "build-archive-linux-arm64-deb-${JOB_NAME}-${BUILD_NUMBER}"
@@ -796,6 +811,7 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'deb',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         stashName: "build-archive-linux-arm64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -868,6 +884,7 @@ pipeline {
                                     architecture: 'x64',
                                     distribution: 'zip',
                                     continueOnError: params.CONTINUE_ON_ERROR,
+                                    skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                     incremental: false,
                                     previousBuildId: params.PREVIOUS_BUILD_ID
                                 )

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -10,7 +10,7 @@
 // @job-name: distribution-build-opensearch
 // @description: Build OpenSearch distribution based on the input manifest and provided parameters.
 
-lib = library(identifier: 'jenkins@11.3.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@11.6.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -110,6 +110,11 @@ pipeline {
             name: 'CONTINUE_ON_ERROR',
             description: '<Optional> Continue building the distribution even if a one or more component fails',
             defaultValue: true
+        )
+        booleanParam(
+            name: 'SKIP_ARTIFACT_CHECK',
+            description: '<Optional> Skip Artifact Check upon completing the build of a component and plugin',
+            defaultValue: false
         )
         booleanParam(
             name: 'INCREMENTAL',
@@ -252,6 +257,7 @@ pipeline {
                                 architecture: 'x64',
                                 distribution: 'tar',
                                 continueOnError: params.CONTINUE_ON_ERROR,
+                                skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                 incremental: params.INCREMENTAL,
                                 previousBuildId: params.PREVIOUS_BUILD_ID
                             )
@@ -336,6 +342,7 @@ pipeline {
                                         architecture: 'x64',
                                         distribution: 'rpm',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
                                         stashName: "build-archive-linux-x64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
@@ -371,6 +378,7 @@ pipeline {
                                         architecture: 'x64',
                                         distribution: 'rpm',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         stashName: "build-archive-linux-x64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -452,6 +460,7 @@ pipeline {
                                         architecture: 'x64',
                                         distribution: 'deb',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
                                         stashName: "build-archive-linux-x64-deb-${JOB_NAME}-${BUILD_NUMBER}"
@@ -487,6 +496,7 @@ pipeline {
                                         architecture: 'x64',
                                         distribution: 'deb',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         stashName: "build-archive-linux-x64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -565,6 +575,7 @@ pipeline {
                                 architecture: 'arm64',
                                 distribution: 'tar',
                                 continueOnError: params.CONTINUE_ON_ERROR,
+                                skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                 incremental: params.INCREMENTAL,
                                 previousBuildId: params.PREVIOUS_BUILD_ID
                             )
@@ -646,6 +657,7 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'rpm',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
                                         stashName: "build-archive-linux-arm64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
@@ -681,6 +693,7 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'rpm',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         stashName: "build-archive-linux-arm64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -763,6 +776,7 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'deb',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
                                         stashName: "build-archive-linux-arm64-deb-${JOB_NAME}-${BUILD_NUMBER}"
@@ -798,6 +812,7 @@ pipeline {
                                         architecture: 'arm64',
                                         distribution: 'deb',
                                         continueOnError: params.CONTINUE_ON_ERROR,
+                                        skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         stashName: "build-archive-linux-arm64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                     String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
@@ -881,6 +896,7 @@ pipeline {
                                     architecture: 'x64',
                                     distribution: 'zip',
                                     continueOnError: params.CONTINUE_ON_ERROR,
+                                    skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                     incremental: false,
                                     previousBuildId: params.PREVIOUS_BUILD_ID
                                 )

--- a/jenkins/opensearch/feature-build.jenkinsfile
+++ b/jenkins/opensearch/feature-build.jenkinsfile
@@ -10,7 +10,7 @@
 // @job-name: feature-build-opensearch
 // @description: Builds OpenSearch distribution for feature branches based on the input manifest.
 
-lib = library(identifier: 'jenkins@11.2.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@11.6.1', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -60,6 +60,11 @@ pipeline {
         booleanParam(
             name: 'CONTINUE_ON_ERROR',
             description: '<Optional> Continue building the distribution even if a one or more component fails',
+            defaultValue: true
+        )
+        booleanParam( // Note: Feature Build will always skil artifact check just so that we can install core plugins
+            name: 'SKIP_ARTIFACT_CHECK',
+            description: '<Optional> Skip Artifact Check upon completing the build of a component and plugin',
             defaultValue: true
         )
         booleanParam(
@@ -159,6 +164,7 @@ pipeline {
                                 architecture: 'x64',
                                 distribution: 'tar',
                                 continueOnError: params.CONTINUE_ON_ERROR,
+                                skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                 incremental: params.INCREMENTAL,
                                 previousBuildId: params.PREVIOUS_BUILD_ID,
                                 buildFeature: env.BUILD_FEATURE
@@ -230,6 +236,7 @@ pipeline {
                                 architecture: 'arm64',
                                 distribution: 'tar',
                                 continueOnError: params.CONTINUE_ON_ERROR,
+                                skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                 incremental: params.INCREMENTAL,
                                 previousBuildId: params.PREVIOUS_BUILD_ID,
                                 buildFeature: env.BUILD_FEATURE

--- a/jenkins/opensearch/feature-build.jenkinsfile
+++ b/jenkins/opensearch/feature-build.jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
             description: '<Optional> Continue building the distribution even if a one or more component fails',
             defaultValue: true
         )
-        booleanParam( // Note: Feature Build will always skil artifact check just so that we can install core plugins
+        booleanParam( // Note: Feature Build will always skip artifact check just so that we can install core plugins
             name: 'SKIP_ARTIFACT_CHECK',
             description: '<Optional> Skip Artifact Check upon completing the build of a component and plugin',
             defaultValue: true


### PR DESCRIPTION
### Description
Run --skip-artifact-check on Jenkins with 11.6.1 libs

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5810
Pending https://github.com/opensearch-project/opensearch-build-libraries/pull/819

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
