### PR TITLE
Sort the build recorder on plugin list so plugins can be installed by order

### DIFF
--- a/scripts/components/core-plugins-sandbox/build.sh
+++ b/scripts/components/core-plugins-sandbox/build.sh
@@ -72,6 +72,7 @@ pwd
 ../../gradlew assemble -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier=$QUALIFIER -Dsandbox.enabled=true -PrustRelease -Pcrypto.standard=FIPS-140-3
 
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
+INSTALL_ORDER=1
 mkdir -p $OUTPUT/plugins
 for plugin in ./*; do
   PLUGIN_NAME=$(basename "$plugin")
@@ -84,7 +85,11 @@ for plugin in ./*; do
        [ "$PLUGIN_NAME" = "dsl-query-executor" ] ||
        [ "$PLUGIN_NAME" = "parquet-data-format" ]; then
       PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME-$VERSION.zip"`
-      cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/plugins/
+      if [ "$PLUGIN_NAME" = "analytics-engine" ]; then
+        PLUGIN_NAME=$INSTALL_ORDER-$PLUGIN_NAME
+        INSTALL_ORDER=$((INSTALL_ORDER + 1))
+      fi
+      cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT}"/plugins/"$PLUGIN_NAME-$VERSION.zip"
     else
       echo "Ignore $PLUGIN_NAME as it is not in the required list"
     fi

--- a/src/build_workflow/builder_from_source.py
+++ b/src/build_workflow/builder_from_source.py
@@ -60,7 +60,7 @@ class BuilderFromSource(Builder):
         artifacts_path = os.path.join(self.git_repo.working_directory, self.output_path)
         for artifact_type in ["maven", "dist", "plugins", "libs", "core-plugins"]:
             for dir, _, files in os.walk(os.path.join(artifacts_path, artifact_type)):
-                for file_name in files:
+                for file_name in sorted(files):
                     absolute_path = os.path.join(dir, file_name)
                     relative_path = os.path.relpath(absolute_path, artifacts_path)
                     build_recorder.record_artifact(self.component.name, artifact_type, relative_path, absolute_path)

--- a/tests/tests_build_workflow/test_builder_from_source.py
+++ b/tests/tests_build_workflow/test_builder_from_source.py
@@ -210,6 +210,44 @@ class TestBuilderFromSource(unittest.TestCase):
         else:
             return []
 
+    def mock_os_walk_unsorted(self, artifact_path: str) -> List[Any]:
+        if artifact_path.endswith(os.path.join("dir", "builds", "plugins")):
+            return [["plugins", [], ["plugin-c.zip", "plugin-a.zip", "plugin-b.zip"]]]
+        else:
+            return []
+
+    @patch("os.walk")
+    @patch("build_workflow.builder_from_source.GitRepository")
+    def test_export_artifacts_sorted(self, mock_git_repo: Mock, mock_walk: Mock) -> None:
+        build_recorder = MagicMock()
+        mock_git_repo.return_value = MagicMock(working_directory="dir")
+        mock_walk.side_effect = self.mock_os_walk_unsorted
+        self.builder.checkout("dir")
+        self.builder.export_artifacts(build_recorder)
+        self.assertEqual(build_recorder.record_artifact.call_count, 3)
+        build_recorder.record_artifact.assert_has_calls(
+            [
+                call(
+                    "sample_component",
+                    "plugins",
+                    os.path.relpath(os.path.join("plugins", "plugin-a.zip"), os.path.join("dir", "artifacts")),
+                    os.path.join("plugins", "plugin-a.zip"),
+                ),
+                call(
+                    "sample_component",
+                    "plugins",
+                    os.path.relpath(os.path.join("plugins", "plugin-b.zip"), os.path.join("dir", "artifacts")),
+                    os.path.join("plugins", "plugin-b.zip"),
+                ),
+                call(
+                    "sample_component",
+                    "plugins",
+                    os.path.relpath(os.path.join("plugins", "plugin-c.zip"), os.path.join("dir", "artifacts")),
+                    os.path.join("plugins", "plugin-c.zip"),
+                ),
+            ]
+        )
+
     @patch("os.walk")
     @patch("build_workflow.builder_from_source.GitRepository")
     def test_export_artifacts(self, mock_git_repo: Mock, mock_walk: Mock) -> None:


### PR DESCRIPTION


### Description
Sort the build recorder on plugin list so plugins can be installed by order

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5810

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
