### PR TITLE
Bundle native library into sandbox plugin zips and wire library path at startup

### DIFF
--- a/scripts/components/core-plugins-sandbox/build.sh
+++ b/scripts/components/core-plugins-sandbox/build.sh
@@ -71,6 +71,19 @@ pwd
 
 ../../gradlew assemble -Dbuild.snapshot="$SNAPSHOT" -Dbuild.version_qualifier=$QUALIFIER -Dsandbox.enabled=true -PrustRelease -Pcrypto.standard=FIPS-140-3
 
+# Determine native lib path and extension
+[ -z "$PLATFORM" ] && PLATFORM=$(uname -s | awk '{print tolower($0)}')
+LIB_EXT="so"
+if [[ "$PLATFORM" == "darwin" ]]; then LIB_EXT="dylib"; fi
+NATIVE_LIB="../../sandbox/libs/dataformat-native/rust/target/release/libopensearch_native.${LIB_EXT}"
+
+if [ ! -f "$NATIVE_LIB" ]; then
+    echo "Error: Native library not found at $NATIVE_LIB"
+    exit 1
+fi
+
+NATIVE_LIB_PLUGINS="analytics-backend-datafusion parquet-data-format"
+
 [ -z "$OUTPUT" ] && OUTPUT=artifacts
 INSTALL_ORDER=1
 mkdir -p $OUTPUT/plugins
@@ -85,6 +98,17 @@ for plugin in ./*; do
        [ "$PLUGIN_NAME" = "dsl-query-executor" ] ||
        [ "$PLUGIN_NAME" = "parquet-data-format" ]; then
       PLUGIN_ARTIFACT_BUILD_NAME=`ls "$plugin"/build/distributions/ | grep "$PLUGIN_NAME-$VERSION.zip"`
+
+      # Inject native lib into plugins that load it at runtime
+      if echo "$NATIVE_LIB_PLUGINS" | grep -qw "$PLUGIN_NAME"; then
+        PLUGIN_ZIP_PATH="$plugin/build/distributions/$PLUGIN_ARTIFACT_BUILD_NAME"
+        STAGING=$(mktemp -d)
+        mkdir -p "$STAGING/lib"
+        cp "$NATIVE_LIB" "$STAGING/lib/"
+        (cd "$STAGING" && zip -ur "$(cd - >/dev/null && pwd)/$PLUGIN_ZIP_PATH" lib)
+        rm -rf "$STAGING"
+      fi
+
       if [ "$PLUGIN_NAME" = "analytics-engine" ]; then
         PLUGIN_NAME=$INSTALL_ORDER-$PLUGIN_NAME
         INSTALL_ORDER=$((INSTALL_ORDER + 1))

--- a/scripts/startup/tar/linux/opensearch-tar-install.sh
+++ b/scripts/startup/tar/linux/opensearch-tar-install.sh
@@ -8,6 +8,8 @@ export OPENSEARCH_PATH_CONF=$OPENSEARCH_HOME/config
 cd $OPENSEARCH_HOME
 
 KNN_LIB_DIR=$OPENSEARCH_HOME/plugins/opensearch-knn/lib
+DATAFUSION_LIB_DIR=$OPENSEARCH_HOME/plugins/analytics-backend-datafusion/lib
+PARQUET_LIB_DIR=$OPENSEARCH_HOME/plugins/parquet-data-format/lib
 ##Security Plugin
 if [ -d "$OPENSEARCH_HOME/plugins/opensearch-security" ]; then
         echo -e "OpenSearch 2.12.0 onwards, the OpenSearch Security Plugin introduces a change that requires an initial password for 'admin' user. \nPlease define an environment variable 'OPENSEARCH_INITIAL_ADMIN_PASSWORD' with a strong password string. \nIf a password is not provided, the setup will quit. \nFor more details, please visit: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/tar/"
@@ -34,22 +36,25 @@ if ! grep -q '## OpenSearch Performance Analyzer' $OPENSEARCH_PATH_CONF/jvm.opti
 fi
 echo "done plugins"
 
-##Set KNN Dylib Path for macOS and *nix systems
-if echo "$OSTYPE" | grep -qi "darwin"; then
-    if echo "$JAVA_LIBRARY_PATH" | grep -q "$KNN_LIB_DIR"; then
-        echo "k-NN libraries found in JAVA_LIBRARY_PATH"
-    else
-        export JAVA_LIBRARY_PATH=$JAVA_LIBRARY_PATH:$KNN_LIB_DIR
-        echo "k-NN libraries not found in JAVA_LIBRARY_PATH. Updating path to: $JAVA_LIBRARY_PATH." 
+##Set native library paths for macOS and *nix systems
+NATIVE_LIB_DIRS="$KNN_LIB_DIR $DATAFUSION_LIB_DIR $PARQUET_LIB_DIR"
+
+for LIB_DIR in $NATIVE_LIB_DIRS; do
+    if [ ! -d "$LIB_DIR" ]; then
+        continue
     fi
-else
-    if echo "$LD_LIBRARY_PATH" | grep -q "$KNN_LIB_DIR"; then
-        echo "k-NN libraries found in LD_LIBRARY_PATH"
+    if echo "$OSTYPE" | grep -qi "darwin"; then
+        if ! echo "$JAVA_LIBRARY_PATH" | grep -q "$LIB_DIR"; then
+            export JAVA_LIBRARY_PATH=$JAVA_LIBRARY_PATH:$LIB_DIR
+            echo "Added $LIB_DIR to JAVA_LIBRARY_PATH"
+        fi
     else
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$KNN_LIB_DIR
-        echo "k-NN libraries not found in LD_LIBRARY_PATH. Updating path to: $LD_LIBRARY_PATH."
+        if ! echo "$LD_LIBRARY_PATH" | grep -q "$LIB_DIR"; then
+            export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LIB_DIR
+            echo "Added $LIB_DIR to LD_LIBRARY_PATH"
+        fi
     fi
-fi
+done
 
 ##Start OpenSearch
 echo "Starting OpenSearch"


### PR DESCRIPTION
## Summary

The DataFusion sandbox plugins depend on `libopensearch_native` (built from Rust via `sandbox/libs/dataformat-native`), but the native library was never packaged into plugin distribution zips. This caused `bin/opensearch` to crash at startup:

```
java.lang.RuntimeException: Failed to load native library 'opensearch_native'
    at NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:168)
    at NativeBridge.<clinit>(NativeBridge.java:63)
    at DataFusionService.doStart(DataFusionService.java:64)
    at DataFusionPlugin.createComponents(DataFusionPlugin.java:129)
```

`./gradlew run` worked because it explicitly sets `-Dnative.lib.path=...`, but any assembled distribution (tar/deb/rpm) failed because `NativeLibraryLoader` could not find the library through any of its three search tiers (`java.library.path`, classpath resource, `native.lib.path` sysprop).

## Changes

### `scripts/components/OpenSearch-DataFusion/build.sh`
- Add `sandbox/plugins/*` assemble and zip collection loop (previously only `plugins/*` was collected)
- For plugins that load the native lib at runtime (`analytics-backend-datafusion`, `parquet-data-format`), inject `libopensearch_native` into the plugin zip at `lib/` using `zip -ur` — same pattern as k-NN's `scripts/build.sh`
- Fail fast if the native library is not found after build

### `scripts/startup/tar/linux/opensearch-tar-install.sh`
- Add `DATAFUSION_LIB_DIR` for `plugins/analytics-backend-datafusion/lib`
- Refactor KNN-only native library path export into a loop over all native lib directories
- Skip directories that don't exist (graceful when plugin is not installed)
- Export `JAVA_LIBRARY_PATH` (macOS) or `LD_LIBRARY_PATH` (Linux) so `NativeLibraryLoader`'s tier-1 search finds the lib

## Companion Change (OpenSearch repo)

`sandbox/libs/dataformat-native/build.gradle` needs:
```gradle
assemble.dependsOn buildRustLibrary
```
Without this, the Rust native library is only built as a test dependency and won't exist when `build.sh` looks for it after assemble.

## How It Works (k-NN pattern)

```
gradlew assemble → produces plugin zip (JARs only, no native lib)
    ↓
build.sh → zip -ur injects lib/libopensearch_native.{so,dylib} into zip
    ↓
plugin install → extracts to plugins/<name>/lib/
    ↓
opensearch-tar-install.sh → exports plugins/<name>/lib/ to JAVA_LIBRARY_PATH/LD_LIBRARY_PATH
    ↓
NativeLibraryLoader tier-1 → scans java.library.path dirs → finds lib → success
```

## Test plan

- [ ] Verify `build.sh` produces sandbox plugin zips with `lib/libopensearch_native.*` inside
- [ ] Verify `opensearch-tar-install.sh` exports correct paths on both macOS and Linux
- [ ] Verify `bin/opensearch` starts successfully with all sandbox plugins installed
- [ ] Verify graceful behavior when datafusion plugin is not installed (lib dir doesn't exist, loop skips)

