### PR TITLE
Fix template placeholder dates

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -62,21 +62,21 @@ Release blog is ready | :red_circle: |   |
 - [ ] [Component Release Issue](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#component-release-issues).
 - [ ] [Release Campaigns](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#release-campaigns).
 
-### [Version Increment](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#version-increment) - _Ends __REPLACE_RELEASE-minus-10-days__
+### [Version Increment](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#version-increment) - _Ends __REPLACE_RELEASE-minus-20-days__
 
 - [ ] [Core Version Increment](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#core-version-increment).
 - [ ] [Components Version Increment](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#components-version-increment).
 
-### [Feature Freeze](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#code-complete-and-feature-freeze) - _Ends __REPLACE_RELEASE-minus-12-days__
+### [Feature Freeze](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#code-complete-and-feature-freeze) - _Ends __REPLACE_RELEASE-minus-15-days__
 
 - [ ] OpenSearch / OpenSearch-Dashboards core and components teams finalize their features.
 
-### [Code Complete](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#code-complete-and-feature-freeze) - _Ends __REPLACE_RELEASE-minus-10-days___
+### [Code Complete](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#code-complete-and-feature-freeze) - _Ends __REPLACE_RELEASE-minus-14-days___
 
 - [ ] Mark this as done once the [Code Complete](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#code-complete-and-feature-freeze) is reviewed.
 - [ ] Create/Verify pull requests to add each component to relase input [manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-{{ env.VERSION }}.yml) and [manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml](/opensearch-project/opensearch-build/tree/main/manifests/{{ env.VERSION }}/opensearch-dashboards-{{ env.VERSION }}.yml).
 
-### [Release Branch, Release Candidate Creation and Testing](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#release-candidate-creation-and-testing) - _Ends __REPLACE_RELEASE-minus-6-days___
+### [Release Branch, Release Candidate Creation and Testing](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#release-candidate-creation-and-testing) - _Ends __REPLACE_RELEASE-minus-14-days___
 
 - [ ] [Core Release Branch](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#core).
 - [ ] [Components Release Branch](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#components).
@@ -96,7 +96,7 @@ Release blog is ready | :red_circle: |   |
 - [ ] Post the benchmark-tests
 - [ ] Longevity tests do not show any issues.
 
-### [Pre Release](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#pre-release) - _Ends __REPLACE_RELEASE-minus-1-days___
+### [Pre Release](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#pre-release) - _Ends __REPLACE_RELEASE-minus-1-day___
 
 - [ ] [Release Labeled Issues](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#release-labeled-issues).
 - [ ] [Go or No-Go](https://github.com/opensearch-project/opensearch-build/wiki/Releasing-the-Distribution#go-or-no-go).


### PR DESCRIPTION
### Description
The dates mentioned on https://opensearch.org/releases/ do not match the release template dates. 
Fixing it in this PR. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
