### PR TITLE
Update claude code action hash to support node24

### DIFF
--- a/.github/workflows/issue-dedupe-detect.yml
+++ b/.github/workflows/issue-dedupe-detect.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Run Claude Code for duplicate detection
         id: claude
-        uses: anthropics/claude-code-action@2ff1acb3ee319fa302837dad6e17c2f36c0d98ea # v1
+        uses: anthropics/claude-code-action@4c682d8b65549056a671d1be4d37ac4832e53859 # v1  # support node24
         with:
           use_bedrock: 'true'
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Update claude code action hash to support node24

### Issues Resolved
`Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
