### PR TITLE
Allow any human user's thumbs-down to cancel duplicate auto-close

### DIFF
--- a/.github/workflows/issue-dedupe-autoclose.yml
+++ b/.github/workflows/issue-dedupe-autoclose.yml
@@ -73,11 +73,11 @@ jobs:
               const reactions = await github.rest.reactions.listForIssueComment({
                 owner, repo, comment_id: lastDupeComment.id, per_page: 100,
               });
-              const authorThumbsDown = reactions.data.some(r =>
-                r.user.id === issue.user.id && r.content === '-1'
+              const humanThumbsDown = reactions.data.some(r =>
+                r.user.type !== 'Bot' && r.content === '-1'
               );
-              if (authorThumbsDown) {
-                console.log(`  Issue author gave thumbs-down on duplicate comment, removing duplicate label`);
+              if (humanThumbsDown) {
+                console.log(`  Human user gave thumbs-down on duplicate comment, removing duplicate label`);
                 try {
                   await github.rest.issues.removeLabel({
                     owner, repo, issue_number: issue.number, name: 'duplicate',


### PR DESCRIPTION
## Summary
- The duplicate-detection comment tells users "👎 this comment to prevent auto-closure" without restricting who can do it, but the auto-close workflow only honored a thumbs-down from the issue author. Any other user's 👎 was silently ignored, which is misleading given the comment's wording.
- Loosen the check in `.github/workflows/issue-dedupe-autoclose.yml` so a thumbs-down from any non-bot user cancels the auto-close.
- This also aligns the reaction-based cancellation with the existing comment-based cancellation, which already accepts any human user (filtered only by `c.user.type !== 'Bot'`).

## Test plan
- [ ] Workflow YAML is syntactically valid (no structural change, only the filter condition was updated).
- [ ] Manually verify on a test issue that a non-author 👎 on the duplicate-detection comment removes the `duplicate` label on the next autoclose run.
- [ ] Verify that a bot 👎 (e.g., from `github-actions[bot]`) does **not** cancel the auto-close.