### PR TITLE
Update rustlib copy location to exactly opensearch-<version>/lib/rust

### DIFF
--- a/scripts/components/OpenSearch-DataFusion/install.sh
+++ b/scripts/components/OpenSearch-DataFusion/install.sh
@@ -121,5 +121,5 @@ fi
 if [ "$MAJOR_VERSION" -ge "3" ]; then
   echo "Setting datafusion rustlib..."
   mkdir -p "$OUTPUT/../lib/rust"
-  cp -v ../../../$DISTRIBUTION/builds/opensearch/dist/libopensearch_native.* "$OUTPUT/../lib/rust"
+  cp -v ../../../$DISTRIBUTION/builds/opensearch/dist/libopensearch_native.* "$OUTPUT/lib/rust"
 fi


### PR DESCRIPTION
### Description
Update rustlib copy location to exactly opensearch-<version>/lib/rust

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5810

`‘../../../tar/builds/opensearch/dist/libopensearch_native.so’ -> ‘/tmp/tmpozgrz1am/opensearch-3.7.0/../lib/rust/libopensearch_native.so’`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
