### PR TITLE
Add an option to build components in parallel

### DIFF
--- a/src/build_workflow/build_args.py
+++ b/src/build_workflow/build_args.py
@@ -103,6 +103,15 @@ class BuildArgs:
             action="store_true",
             help="Do not fail the distribution build on any plugin component failure.",
         )
+        parser.add_argument(
+            "--parallel",
+            dest="parallel",
+            type=int,
+            nargs='?',
+            const=4,
+            default=None,
+            help="Build components in parallel using a dependency graph. Optionally specify max workers (default: 4).",
+        )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
             "-c",
@@ -135,6 +144,7 @@ class BuildArgs:
         self.continue_on_error = args.continue_on_error
         self.skip_artifact_check = args.skip_artifact_check
         self.incremental = args.incremental
+        self.parallel = args.parallel
 
     def component_command(self, name: str) -> str:
         return " ".join(

--- a/src/build_workflow/build_graph.py
+++ b/src/build_workflow/build_graph.py
@@ -1,0 +1,95 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import logging
+import threading
+from collections import defaultdict
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from typing import Callable, Dict, List, Optional, Set
+
+
+class BuildGraph:
+    """
+    Manages a dependency graph of build components and executes them
+    in parallel respecting dependency ordering.
+    """
+
+    def __init__(self, max_workers: int = 4) -> None:
+        self.max_workers = max_workers
+        self.dependencies: Dict[str, Set[str]] = defaultdict(set)
+        self.dependents: Dict[str, Set[str]] = defaultdict(set)
+        self.components: List[str] = []
+
+    def add_component(self, name: str, depends_on: Optional[List[str]] = None) -> None:
+        self.components.append(name)
+        if depends_on:
+            for dep in depends_on:
+                if dep in self.components:
+                    self.dependencies[name].add(dep)
+                    self.dependents[dep].add(name)
+
+    def execute_parallel(
+        self,
+        build_fn: Callable[[str], None],
+        critical_components: List[str],
+        continue_on_error: bool = False,
+    ) -> List[str]:
+        """
+        Execute builds in parallel respecting dependencies.
+        All components are submitted immediately but each waits for its
+        dependencies to complete before starting its build.
+
+        Returns a list of failed component names.
+        """
+        failed: List[str] = []
+        lock = threading.Lock()
+        completed_event: Dict[str, threading.Event] = {name: threading.Event() for name in self.components}
+
+        def wait_for_deps(name: str) -> bool:
+            for dep in self.dependencies[name]:
+                completed_event[dep].wait()
+                with lock:
+                    if dep in failed:
+                        return False
+            return True
+
+        def run_component(name: str) -> str:
+            if not wait_for_deps(name):
+                with lock:
+                    failed.append(name)
+                    completed_event[name].set()
+                logging.info(f"Skipping {name} because a dependency failed.")
+                return name
+
+            try:
+                build_fn(name)
+                completed_event[name].set()
+                return ""
+            except Exception:
+                with lock:
+                    failed.append(name)
+                    completed_event[name].set()
+                if not continue_on_error and name in critical_components:
+                    raise
+                return name
+
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            futures: Dict[Future, str] = {}
+
+            for name in self.components:
+                future = executor.submit(run_component, name)
+                futures[future] = name
+
+            for future in as_completed(futures):
+                try:
+                    future.result()
+                except Exception:
+                    if not continue_on_error:
+                        executor.shutdown(wait=False, cancel_futures=True)
+                        raise
+
+        return failed

--- a/src/build_workflow/build_graph.py
+++ b/src/build_workflow/build_graph.py
@@ -35,7 +35,7 @@ class BuildGraph:
     def execute_parallel(
         self,
         build_fn: Callable[[str], None],
-        critical_components: List[str],
+        required_components: List[str],
         continue_on_error: bool = False,
     ) -> List[str]:
         """
@@ -73,7 +73,7 @@ class BuildGraph:
                 with lock:
                     failed.append(name)
                     completed_event[name].set()
-                if not continue_on_error and name in critical_components:
+                if not continue_on_error or name in required_components:
                     raise
                 return name
 
@@ -88,8 +88,7 @@ class BuildGraph:
                 try:
                     future.result()
                 except Exception:
-                    if not continue_on_error:
-                        executor.shutdown(wait=False, cancel_futures=True)
-                        raise
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    raise
 
         return failed

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -9,9 +9,11 @@
 import logging
 import os
 import sys
+import threading
 import uuid
 
 from build_workflow.build_args import BuildArgs
+from build_workflow.build_graph import BuildGraph
 from build_workflow.build_incremental import BuildIncremental
 from build_workflow.build_recorder import BuildRecorder
 from build_workflow.build_target import BuildTarget
@@ -21,6 +23,8 @@ from manifests.input_manifest import InputManifest
 from paths.build_output_dir import BuildOutputDir
 from system import console
 from system.temporary_directory import TemporaryDirectory
+
+CRITICAL_COMPONENTS = ['OpenSearch', 'job-scheduler', 'common-utils', 'OpenSearch-Dashboards']
 
 
 def main() -> int:
@@ -85,29 +89,90 @@ def main() -> int:
 
         logging.info(f"Building {manifest.build.name} ({target.architecture}) into {target.output_dir}")
 
-        for component in manifest.components.select(focus=components, platform=target.platform):
-            logging.info(f"Building {component.name}")
+        if args.parallel:
+            failed_plugins = _build_parallel(manifest, target, build_recorder, work_dir.name, args, components)
+        else:
+            for component in manifest.components.select(focus=components, platform=target.platform):
+                logging.info(f"Building {component.name}")
 
-            builder = Builders.builder_from(component, target)
-            try:
-                builder.checkout(work_dir.name)
-                builder.build(build_recorder)
-                builder.export_artifacts(build_recorder)
-                logging.info(f"Successfully built {component.name}")
-            except Exception as e:
-                logging.error(f"ERROR: {e}")
-                logging.error(f"Error building {component.name}, retry with: {args.component_command(component.name)}")
-                if args.continue_on_error and component.name not in ['OpenSearch', 'job-scheduler', 'common-utils', 'OpenSearch-Dashboards']:
-                    failed_plugins.append(component.name)
-                    continue
-                else:
-                    raise
+                builder = Builders.builder_from(component, target)
+                try:
+                    builder.checkout(work_dir.name)
+                    builder.build(build_recorder)
+                    builder.export_artifacts(build_recorder)
+                    logging.info(f"Successfully built {component.name}")
+                except Exception as e:
+                    logging.error(f"ERROR: {e}")
+                    logging.error(f"Error building {component.name}, retry with: {args.component_command(component.name)}")
+                    if args.continue_on_error and component.name not in CRITICAL_COMPONENTS:
+                        failed_plugins.append(component.name)
+                        continue
+                    else:
+                        raise
 
         build_recorder.write_manifest()
     if len(failed_plugins) > 0:
         logging.error(f"Failed plugins are {failed_plugins}")
     logging.info("Done.")
     return 0
+
+
+def _build_parallel(manifest: InputManifest, target: BuildTarget, build_recorder: BuildRecorder, work_dir: str, args: BuildArgs, components: list) -> list:
+    recorder_lock = threading.Lock()
+
+    selected_components = list(manifest.components.select(focus=components, platform=target.platform))
+    component_map = {c.name: c for c in selected_components}
+    selected_names = set(component_map.keys())
+
+    # OpenSearch core must build first — it publishes build-tools and artifacts
+    # to Maven local that ALL plugins depend on implicitly.
+    core_name = manifest.build.name.replace(" ", "-")
+    if core_name in component_map:
+        core_component = component_map[core_name]
+        logging.info(f"Building {core_component.name}")
+        builder = Builders.builder_from(core_component, target)
+        try:
+            builder.checkout(work_dir)
+            builder.build(build_recorder)
+            builder.export_artifacts(build_recorder)
+            logging.info(f"Successfully built {core_component.name}")
+        except Exception as e:
+            logging.error(f"ERROR: {e}")
+            logging.error(f"Error building {core_component.name}, retry with: {args.component_command(core_component.name)}")
+            raise
+
+    # Now build remaining components in parallel
+    remaining_components = [c for c in selected_components if c.name != core_name]
+
+    graph = BuildGraph(max_workers=args.parallel)
+
+    for component in remaining_components:
+        deps = getattr(component, 'depends_on', None) or []
+        graph.add_component(component.name, [d for d in deps if d in selected_names and d != core_name])
+
+    def build_component(name: str) -> None:
+        component = component_map[name]
+        logging.info(f"Building {component.name}")
+
+        builder = Builders.builder_from(component, target)
+        builder.checkout(work_dir)
+        builder.build(build_recorder)
+        with recorder_lock:
+            builder.export_artifacts(build_recorder)
+        logging.info(f"Successfully built {component.name}")
+
+    failed = graph.execute_parallel(
+        build_fn=build_component,
+        critical_components=CRITICAL_COMPONENTS,
+        continue_on_error=args.continue_on_error,
+    )
+
+    if not args.continue_on_error:
+        critical_failures = [f for f in failed if f in CRITICAL_COMPONENTS]
+        if critical_failures:
+            raise Exception(f"Critical component(s) failed: {critical_failures}")
+
+    return [f for f in failed if f not in CRITICAL_COMPONENTS]
 
 
 if __name__ == "__main__":

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -9,7 +9,6 @@
 import logging
 import os
 import sys
-import threading
 import uuid
 
 from build_workflow.build_args import BuildArgs
@@ -118,7 +117,6 @@ def main() -> int:
 
 
 def _build_parallel(manifest: InputManifest, target: BuildTarget, build_recorder: BuildRecorder, work_dir: str, args: BuildArgs, components: list) -> list:
-    recorder_lock = threading.Lock()
 
     selected_components = list(manifest.components.select(focus=components, platform=target.platform))
     component_map = {c.name: c for c in selected_components}
@@ -156,8 +154,7 @@ def _build_parallel(manifest: InputManifest, target: BuildTarget, build_recorder
         builder = Builders.builder_from(component, target)
         builder.checkout(work_dir)
         builder.build(build_recorder)
-        with recorder_lock:
-            builder.export_artifacts(build_recorder)
+        builder.export_artifacts(build_recorder)
         logging.info(f"Successfully built {component.name}")
 
     failed = graph.execute_parallel(

--- a/src/run_build.py
+++ b/src/run_build.py
@@ -24,7 +24,7 @@ from paths.build_output_dir import BuildOutputDir
 from system import console
 from system.temporary_directory import TemporaryDirectory
 
-CRITICAL_COMPONENTS = ['OpenSearch', 'job-scheduler', 'common-utils', 'OpenSearch-Dashboards']
+REQUIRED_COMPONENTS = ['OpenSearch', 'job-scheduler', 'common-utils', 'OpenSearch-Dashboards']
 
 
 def main() -> int:
@@ -104,7 +104,7 @@ def main() -> int:
                 except Exception as e:
                     logging.error(f"ERROR: {e}")
                     logging.error(f"Error building {component.name}, retry with: {args.component_command(component.name)}")
-                    if args.continue_on_error and component.name not in CRITICAL_COMPONENTS:
+                    if args.continue_on_error and component.name not in REQUIRED_COMPONENTS:
                         failed_plugins.append(component.name)
                         continue
                     else:
@@ -124,8 +124,7 @@ def _build_parallel(manifest: InputManifest, target: BuildTarget, build_recorder
     component_map = {c.name: c for c in selected_components}
     selected_names = set(component_map.keys())
 
-    # OpenSearch core must build first — it publishes build-tools and artifacts
-    # to Maven local that ALL plugins depend on implicitly.
+    # Core engines must build first
     core_name = manifest.build.name.replace(" ", "-")
     if core_name in component_map:
         core_component = component_map[core_name]
@@ -163,16 +162,15 @@ def _build_parallel(manifest: InputManifest, target: BuildTarget, build_recorder
 
     failed = graph.execute_parallel(
         build_fn=build_component,
-        critical_components=CRITICAL_COMPONENTS,
+        required_components=REQUIRED_COMPONENTS,
         continue_on_error=args.continue_on_error,
     )
 
-    if not args.continue_on_error:
-        critical_failures = [f for f in failed if f in CRITICAL_COMPONENTS]
-        if critical_failures:
-            raise Exception(f"Critical component(s) failed: {critical_failures}")
+    required_component_failures = [f for f in failed if f in REQUIRED_COMPONENTS]
+    if required_component_failures:
+        raise Exception(f"Required component(s) failed: {required_component_failures}")
 
-    return [f for f in failed if f not in CRITICAL_COMPONENTS]
+    return [f for f in failed if f not in REQUIRED_COMPONENTS]
 
 
 if __name__ == "__main__":

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -457,3 +457,97 @@ class TestRunBuild(unittest.TestCase):
 
         mock_recorder.assert_called_once()
         mock_recorder.return_value.write_manifest.assert_called()
+
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "-p", "linux", "--parallel"])
+    @patch("run_build.Builders.builder_from", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.TemporaryDirectory")
+    def test_main_parallel_builds_all_components(self, mock_temp: Mock, mock_recorder: Mock, mock_builder: Mock, *mocks: Any) -> None:
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        main()
+        self.assertNotEqual(mock_builder.return_value.build.call_count, 0)
+        self.assertEqual(mock_builder.return_value.build.call_count, mock_builder.return_value.export_artifacts.call_count)
+        mock_recorder.return_value.write_manifest.assert_called()
+
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "-p", "linux", "--parallel", "2"])
+    @patch("run_build.Builders.builder_from", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.TemporaryDirectory")
+    def test_main_parallel_with_custom_workers(self, mock_temp: Mock, mock_recorder: Mock, mock_builder: Mock, *mocks: Any) -> None:
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        main()
+        self.assertNotEqual(mock_builder.return_value.build.call_count, 0)
+        self.assertEqual(mock_builder.return_value.build.call_count, mock_builder.return_value.export_artifacts.call_count)
+        mock_recorder.return_value.write_manifest.assert_called()
+
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST_3_x, "-p", "linux", "--parallel"])
+    @patch("run_build.Builders.builder_from", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.TemporaryDirectory")
+    def test_main_parallel_3x_manifest(self, mock_temp: Mock, mock_recorder: Mock, mock_builder: Mock, *mocks: Any) -> None:
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        main()
+        self.assertNotEqual(mock_builder.return_value.build.call_count, 0)
+        self.assertEqual(mock_builder.return_value.build.call_count, mock_builder.return_value.export_artifacts.call_count)
+        mock_recorder.return_value.write_manifest.assert_called()
+
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "-p", "linux", "--parallel", "--continue-on-error"])
+    @patch("run_build.Builders.builder_from", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.TemporaryDirectory")
+    @patch("run_build.logging.error")
+    def test_main_parallel_continue_on_error_plugin_failure(self, mock_logging_error: Mock, mock_temp: Mock, mock_recorder: Mock, mock_builder_from: Mock, *mocks: Any) -> None:
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+
+        def side_effect_build(*args: Any, **kwargs: Any) -> None:
+            component = mock_builder_from.call_args[0][0]
+            if component.name == "custom-codecs":
+                raise Exception("custom-codecs build failed")
+
+        mock_builder = MagicMock()
+        mock_builder.build.side_effect = side_effect_build
+        mock_builder_from.return_value = mock_builder
+
+        main()
+        mock_recorder.return_value.write_manifest.assert_called()
+
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "-p", "linux", "--parallel"])
+    @patch("run_build.Builders.builder_from", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.TemporaryDirectory")
+    def test_main_parallel_core_builds_first(self, mock_temp: Mock, mock_recorder: Mock, mock_builder_from: Mock, *mocks: Any) -> None:
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+
+        build_order: list = []
+
+        def track_builder(component: Any, target: Any) -> MagicMock:
+            builder = MagicMock()
+
+            def track_build(*args: Any, **kwargs: Any) -> None:
+                build_order.append(component.name)
+            builder.build.side_effect = track_build
+            return builder
+
+        mock_builder_from.side_effect = track_builder
+        main()
+
+        self.assertEqual(build_order[0], "OpenSearch")
+
+    @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "-p", "linux", "--parallel"])
+    @patch("run_build.Builders.builder_from", return_value=MagicMock())
+    @patch("run_build.BuildRecorder", return_value=MagicMock())
+    @patch("run_build.TemporaryDirectory")
+    def test_main_parallel_raises_on_core_failure(self, mock_temp: Mock, mock_recorder: Mock, mock_builder_from: Mock, *mocks: Any) -> None:
+        mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
+
+        def fail_core(component: Any, target: Any) -> MagicMock:
+            builder = MagicMock()
+            if component.name == "OpenSearch":
+                builder.build.side_effect = Exception("OpenSearch build failed")
+            return builder
+
+        mock_builder_from.side_effect = fail_core
+
+        with self.assertRaises(Exception) as ctx:
+            main()
+        self.assertIn("OpenSearch build failed", str(ctx.exception))

--- a/tests/tests_build_workflow/test_build_args.py
+++ b/tests/tests_build_workflow/test_build_args.py
@@ -137,3 +137,15 @@ class TestBuildArgs(unittest.TestCase):
     @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--skip-artifact-check"])
     def test_skip_artifact_check_true(self) -> None:
         self.assertTrue(BuildArgs().skip_artifact_check)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST])
+    def test_parallel_default(self) -> None:
+        self.assertIsNone(BuildArgs().parallel)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--parallel"])
+    def test_parallel_default_workers(self) -> None:
+        self.assertEqual(BuildArgs().parallel, 4)
+
+    @patch("argparse._sys.argv", [BUILD_PY, OPENSEARCH_MANIFEST, "--parallel", "8"])
+    def test_parallel_custom_workers(self) -> None:
+        self.assertEqual(BuildArgs().parallel, 8)

--- a/tests/tests_build_workflow/test_build_graph.py
+++ b/tests/tests_build_workflow/test_build_graph.py
@@ -47,7 +47,7 @@ class TestBuildGraph(unittest.TestCase):
         graph.add_component("job-scheduler")
 
         build_fn = MagicMock()
-        failed = graph.execute_parallel(build_fn, critical_components=[], continue_on_error=False)
+        failed = graph.execute_parallel(build_fn, required_components=[], continue_on_error=False)
 
         self.assertEqual(failed, [])
         build_fn.assert_has_calls([call("common-utils"), call("job-scheduler")], any_order=True)
@@ -59,7 +59,7 @@ class TestBuildGraph(unittest.TestCase):
 
         build_fn = MagicMock(side_effect=lambda name: (_ for _ in ()).throw(Exception("fail")) if name == "custom-codecs" else None)
 
-        failed = graph.execute_parallel(build_fn, critical_components=[], continue_on_error=True)
+        failed = graph.execute_parallel(build_fn, required_components=[], continue_on_error=True)
 
         self.assertIn("custom-codecs", failed)
         self.assertNotIn("common-utils", failed)
@@ -72,13 +72,13 @@ class TestBuildGraph(unittest.TestCase):
 
         build_fn = MagicMock(side_effect=lambda name: (_ for _ in ()).throw(Exception("fail")) if name == "common-utils" else None)
 
-        failed = graph.execute_parallel(build_fn, critical_components=[], continue_on_error=True)
+        failed = graph.execute_parallel(build_fn, required_components=[], continue_on_error=True)
 
         self.assertIn("common-utils", failed)
         self.assertIn("k-NN", failed)
         self.assertIn("neural-search", failed)
 
-    def test_execute_parallel_raises_on_critical_failure(self) -> None:
+    def test_execute_parallel_raises_on_required_component_failure(self) -> None:
         graph = BuildGraph(max_workers=4)
         graph.add_component("common-utils")
         graph.add_component("security")
@@ -86,19 +86,50 @@ class TestBuildGraph(unittest.TestCase):
         build_fn = MagicMock(side_effect=lambda name: (_ for _ in ()).throw(Exception("common-utils failed")) if name == "common-utils" else None)
 
         with self.assertRaises(Exception) as ctx:
-            graph.execute_parallel(build_fn, critical_components=["common-utils"], continue_on_error=False)
+            graph.execute_parallel(build_fn, required_components=["common-utils"], continue_on_error=False)
         self.assertIn("common-utils failed", str(ctx.exception))
 
-    def test_execute_parallel_does_not_raise_non_critical_failure(self) -> None:
+    def test_execute_parallel_does_not_raise_non_required_component_failure(self) -> None:
         graph = BuildGraph(max_workers=4)
         graph.add_component("common-utils")
         graph.add_component("custom-codecs")
 
         build_fn = MagicMock(side_effect=lambda name: (_ for _ in ()).throw(Exception("fail")) if name == "custom-codecs" else None)
 
-        failed = graph.execute_parallel(build_fn, critical_components=["common-utils"], continue_on_error=True)
+        failed = graph.execute_parallel(build_fn, required_components=["common-utils"], continue_on_error=True)
         self.assertIn("custom-codecs", failed)
         self.assertNotIn("common-utils", failed)
+
+    def test_execute_parallel_required_component_failure_raises_with_continue_on_error(self) -> None:
+        graph = BuildGraph(max_workers=4)
+        graph.add_component("common-utils")
+        graph.add_component("job-scheduler")
+        graph.add_component("security")
+
+        build_fn = MagicMock(side_effect=lambda name: (_ for _ in ()).throw(Exception("common-utils failed")) if name == "common-utils" else None)
+
+        with self.assertRaises(Exception) as ctx:
+            graph.execute_parallel(build_fn, required_components=["common-utils", "job-scheduler"], continue_on_error=True)
+        self.assertIn("common-utils failed", str(ctx.exception))
+
+    def test_execute_parallel_non_required_component_failure_continues_with_continue_on_error(self) -> None:
+        graph = BuildGraph(max_workers=4)
+        graph.add_component("common-utils")
+        graph.add_component("job-scheduler")
+        graph.add_component("custom-codecs")
+        graph.add_component("security")
+
+        build_fn = MagicMock(side_effect=lambda name: (_ for _ in ()).throw(Exception("fail")) if name == "custom-codecs" else None)
+
+        failed = graph.execute_parallel(build_fn, required_components=["common-utils", "job-scheduler"], continue_on_error=True)
+
+        self.assertIn("custom-codecs", failed)
+        self.assertNotIn("common-utils", failed)
+        self.assertNotIn("job-scheduler", failed)
+        self.assertNotIn("security", failed)
+        build_fn.assert_any_call("common-utils")
+        build_fn.assert_any_call("job-scheduler")
+        build_fn.assert_any_call("security")
 
     def test_execute_parallel_respects_max_workers(self) -> None:
         graph = BuildGraph(max_workers=2)
@@ -108,6 +139,6 @@ class TestBuildGraph(unittest.TestCase):
         graph.add_component("custom-codecs")
 
         build_fn = MagicMock()
-        graph.execute_parallel(build_fn, critical_components=[], continue_on_error=False)
+        graph.execute_parallel(build_fn, required_components=[], continue_on_error=False)
 
         self.assertEqual(build_fn.call_count, 4)

--- a/tests/tests_build_workflow/test_build_graph.py
+++ b/tests/tests_build_workflow/test_build_graph.py
@@ -1,0 +1,113 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+import unittest
+from unittest.mock import MagicMock, call
+
+from build_workflow.build_graph import BuildGraph
+
+
+class TestBuildGraph(unittest.TestCase):
+
+    def test_add_component_no_deps(self) -> None:
+        graph = BuildGraph()
+        graph.add_component("common-utils")
+        graph.add_component("job-scheduler")
+        self.assertEqual(graph.components, ["common-utils", "job-scheduler"])
+        self.assertEqual(graph.dependencies["common-utils"], set())
+        self.assertEqual(graph.dependencies["job-scheduler"], set())
+
+    def test_add_component_with_deps(self) -> None:
+        graph = BuildGraph()
+        graph.add_component("common-utils")
+        graph.add_component("security")
+        graph.add_component("k-NN", ["common-utils", "security"])
+        self.assertEqual(graph.dependencies["k-NN"], {"common-utils", "security"})
+        self.assertEqual(graph.dependents["common-utils"], {"k-NN"})
+        self.assertEqual(graph.dependents["security"], {"k-NN"})
+
+    def test_add_component_ignores_deps_not_in_graph(self) -> None:
+        graph = BuildGraph()
+        graph.add_component("k-NN", ["common-utils", "security"])
+        self.assertEqual(graph.dependencies["k-NN"], set())
+
+    def test_add_component_partial_deps_in_graph(self) -> None:
+        graph = BuildGraph()
+        graph.add_component("common-utils")
+        graph.add_component("k-NN", ["common-utils", "security"])
+        self.assertEqual(graph.dependencies["k-NN"], {"common-utils"})
+
+    def test_execute_parallel_returns_empty_on_success(self) -> None:
+        graph = BuildGraph(max_workers=4)
+        graph.add_component("common-utils")
+        graph.add_component("job-scheduler")
+
+        build_fn = MagicMock()
+        failed = graph.execute_parallel(build_fn, critical_components=[], continue_on_error=False)
+
+        self.assertEqual(failed, [])
+        build_fn.assert_has_calls([call("common-utils"), call("job-scheduler")], any_order=True)
+
+    def test_execute_parallel_returns_failed_components(self) -> None:
+        graph = BuildGraph(max_workers=4)
+        graph.add_component("common-utils")
+        graph.add_component("custom-codecs")
+
+        build_fn = MagicMock(side_effect=lambda name: (_ for _ in ()).throw(Exception("fail")) if name == "custom-codecs" else None)
+
+        failed = graph.execute_parallel(build_fn, critical_components=[], continue_on_error=True)
+
+        self.assertIn("custom-codecs", failed)
+        self.assertNotIn("common-utils", failed)
+
+    def test_execute_parallel_skips_dependents_on_failure(self) -> None:
+        graph = BuildGraph(max_workers=4)
+        graph.add_component("common-utils")
+        graph.add_component("k-NN", ["common-utils"])
+        graph.add_component("neural-search", ["k-NN"])
+
+        build_fn = MagicMock(side_effect=lambda name: (_ for _ in ()).throw(Exception("fail")) if name == "common-utils" else None)
+
+        failed = graph.execute_parallel(build_fn, critical_components=[], continue_on_error=True)
+
+        self.assertIn("common-utils", failed)
+        self.assertIn("k-NN", failed)
+        self.assertIn("neural-search", failed)
+
+    def test_execute_parallel_raises_on_critical_failure(self) -> None:
+        graph = BuildGraph(max_workers=4)
+        graph.add_component("common-utils")
+        graph.add_component("security")
+
+        build_fn = MagicMock(side_effect=lambda name: (_ for _ in ()).throw(Exception("common-utils failed")) if name == "common-utils" else None)
+
+        with self.assertRaises(Exception) as ctx:
+            graph.execute_parallel(build_fn, critical_components=["common-utils"], continue_on_error=False)
+        self.assertIn("common-utils failed", str(ctx.exception))
+
+    def test_execute_parallel_does_not_raise_non_critical_failure(self) -> None:
+        graph = BuildGraph(max_workers=4)
+        graph.add_component("common-utils")
+        graph.add_component("custom-codecs")
+
+        build_fn = MagicMock(side_effect=lambda name: (_ for _ in ()).throw(Exception("fail")) if name == "custom-codecs" else None)
+
+        failed = graph.execute_parallel(build_fn, critical_components=["common-utils"], continue_on_error=True)
+        self.assertIn("custom-codecs", failed)
+        self.assertNotIn("common-utils", failed)
+
+    def test_execute_parallel_respects_max_workers(self) -> None:
+        graph = BuildGraph(max_workers=2)
+        graph.add_component("common-utils")
+        graph.add_component("job-scheduler")
+        graph.add_component("security")
+        graph.add_component("custom-codecs")
+
+        build_fn = MagicMock()
+        graph.execute_parallel(build_fn, critical_components=[], continue_on_error=False)
+
+        self.assertEqual(build_fn.call_count, 4)


### PR DESCRIPTION
### Description
As of today, all components are build sequentially on jenkins for OpenSearch which takes approximately 2hours. [Ref](https://build.ci.opensearch.org/view/Build/job/distribution-build-opensearch/11832/)

The `depends_on` in the manifest ([example](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/3.6.0/opensearch-3.6.0.yml#L192-L194)) is only utilized during incremental builds and NOT during regular builds.

This PR refactors the building logic to utilize the depends_on to build a dependency graph (DAG) and run builds in parallel using multiple threads controlled by `--parallel`

```mermaid
graph TD
    OpenSearch[/"OpenSearch"/]:::core

    %% Level 1 - No dependencies
    common-utils:::level1
    opensearch-learning-to-rank-base:::level1
    opensearch-remote-metadata-sdk:::level1
    job-scheduler:::level1
    security:::level1
    custom-codecs:::level1
    performance-analyzer:::level1
    query-insights:::level1
    opensearch-system-templates:::level1
    user-behavior-insights:::level1

    %% Level 2
    k-NN:::level2
    geospatial:::level2
    cross-cluster-replication:::level2
    ml-commons:::level2
    notifications-core:::level2
    notifications:::level2
    opensearch-observability:::level2
    opensearch-reports:::level2
    asynchronous-search:::level2
    anomaly-detection:::level2
    alerting:::level2
    index-management:::level2

    %% Level 3
    neural-search:::level3
    sql:::level3
    security-analytics:::level3

    %% Level 4
    flow-framework:::level4
    skills:::level4
    search-relevance:::level4

    %% Implicit deps from core
    OpenSearch -.-> common-utils
    OpenSearch -.-> opensearch-learning-to-rank-base
    OpenSearch -.-> opensearch-remote-metadata-sdk
    OpenSearch -.-> job-scheduler
    OpenSearch -.-> security
    OpenSearch -.-> custom-codecs
    OpenSearch -.-> performance-analyzer
    OpenSearch -.-> query-insights
    OpenSearch -.-> opensearch-system-templates
    OpenSearch -.-> user-behavior-insights

    %% Explicit dependencies
    common-utils --> k-NN
    security --> k-NN
    custom-codecs --> k-NN

    job-scheduler --> geospatial

    common-utils --> cross-cluster-replication

    common-utils --> ml-commons
    job-scheduler --> ml-commons
    opensearch-remote-metadata-sdk --> ml-commons
    security --> ml-commons

    ml-commons --> neural-search
    k-NN --> neural-search

    common-utils --> notifications-core
    common-utils --> notifications
    common-utils --> opensearch-observability

    common-utils --> opensearch-reports
    job-scheduler --> opensearch-reports

    ml-commons --> sql
    geospatial --> sql
    job-scheduler --> sql

    common-utils --> asynchronous-search

    common-utils --> anomaly-detection
    job-scheduler --> anomaly-detection

    common-utils --> alerting

    common-utils --> security-analytics
    alerting --> security-analytics
    job-scheduler --> security-analytics

    common-utils --> index-management
    job-scheduler --> index-management

    common-utils --> flow-framework
    opensearch-remote-metadata-sdk --> flow-framework
    ml-commons --> flow-framework
    k-NN --> flow-framework
    neural-search --> flow-framework

    job-scheduler --> skills
    anomaly-detection --> skills
    sql --> skills
    ml-commons --> skills

    job-scheduler --> search-relevance
    neural-search --> search-relevance
    k-NN --> search-relevance
    ml-commons --> search-relevance
    user-behavior-insights --> search-relevance

    %% Styles
    classDef core fill:#FFD700,stroke:#333,font-weight:bold
    classDef level1 fill:#90EE90,stroke:#333
    classDef level2 fill:#87CEEB,stroke:#333
    classDef level3 fill:#DDA0DD,stroke:#333
    classDef level4 fill:#FFA07A,stroke:#333
```


Defaults to 4 parallel threads to start with and adding parallel is optional in the build process for now.
Below are the "build" stats for 3.6.0 builds when ran using sequential build, parallel builds with 4 threads and parallel builds with 8 threads on jenkins. 

<img width="2002" height="578" alt="image" src="https://github.com/user-attachments/assets/b76aec82-0349-4dea-8751-3a2fa86929de" />


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
