### PR TITLE
sysctl: set vm.max_map_count to `1048576` instead of `262144`

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,7 +16,7 @@ This is a script to deploy a single node OpenSearch + OpenSearch-Dashboards clus
 * If you are using LINUX host to run dockerd, provision container based on the dockerfile, and execute integTest:
   * You must run these commands on the LINUX host for OpenSearch process to run:
     ```
-    sudo sysctl -w vm.max_map_count=262144
+    sudo sysctl -w vm.max_map_count=1048576
     ulimit -n 65535
     ```
 

--- a/scripts/pkg/service_templates/opensearch/etc/sysconfig/opensearch
+++ b/scripts/pkg/service_templates/opensearch/etc/sysconfig/opensearch
@@ -53,4 +53,4 @@ OPENSEARCH_SD_NOTIFY=true
 # Maximum number of VMA (Virtual Memory Areas) a process can own
 # When using Systemd, this setting is ignored and the 'vm.max_map_count'
 # property is set at boot time in /usr/lib/sysctl.d/opensearch.conf
-#MAX_MAP_COUNT=262144
+#MAX_MAP_COUNT=1048576


### PR DESCRIPTION
This change is dependent on
https://github.com/opensearch-project/OpenSearch/pull/21606 being merged.

Please see that change for more context.

### Description
 set vm.max_map_count to 1048576 instead of 262144 . Aligns with changed proposed in https://github.com/opensearch-project/OpenSearch/pull/21606 

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/21604

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
