### PR TITLE
Add args to jenkins for parallel builds & enable it by default

### DIFF
--- a/jenkins/check-for-build.jenkinsfile
+++ b/jenkins/check-for-build.jenkinsfile
@@ -26,7 +26,6 @@ pipeline {
     }
     triggers {
         parameterizedCron '''
-            H 1 * * * %INPUT_MANIFEST=3.6.1/opensearch-3.6.1.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip
             H 1 * * * %INPUT_MANIFEST=3.7.0/opensearch-dashboards-3.7.0.yml;TARGET_JOB_NAME=distribution-build-opensearch-dashboards;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=3.7.0/opensearch-dashboards-3.7.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
             H 1 * * * %INPUT_MANIFEST=3.7.0/opensearch-3.7.0.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=3.7.0/opensearch-3.7.0-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar
             H 1 * * * %INPUT_MANIFEST=2.19.6/opensearch-2.19.6.yml;TARGET_JOB_NAME=distribution-build-opensearch;BUILD_PLATFORM=linux windows;BUILD_DISTRIBUTION=tar rpm deb zip;TEST_MANIFEST=2.19.6/opensearch-2.19.6-test.yml;TEST_PLATFORM=linux;TEST_DISTRIBUTION=tar

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -10,7 +10,7 @@
 // @job-name: distribution-build-opensearch
 // @description: Build OpenSearch distribution based on the input manifest and provided parameters.
 
-lib = library(identifier: 'jenkins@11.6.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@11.6.3', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -95,6 +95,12 @@ pipeline {
             name: 'BUILD_DOCKER',
             description: '<Optional> Build docker image or not with options. Defaults to build_docker.',
             choices: ['build_docker', 'build_docker_with_build_number_tag', 'do_not_build_docker'],
+        )
+        string(
+            name: 'PARALLEL',
+            description: '<Optional> Number of parallel workers for component builds. Set to 0 or empty to disable. Default is 4.',
+            defaultValue: '4',
+            trim: true
         )
         booleanParam(
             name: 'UPDATE_LATEST_URL',


### PR DESCRIPTION
### Description
Add args to jenkins for parallel builds & enable it by default.
Also remove 3.6.1 cron builds as we are approaching 3.7.0 release window

### Issues Resolved
Related PR https://github.com/opensearch-project/opensearch-build/pull/6190

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
