### PR TITLE
SQL use main and move dsl-query-executor to dist now

### DIFF
--- a/feature-manifests/feature-datafusion/opensearch-3.7.0.yml
+++ b/feature-manifests/feature-datafusion/opensearch-3.7.0.yml
@@ -64,7 +64,7 @@ components:
       - security
   - name: sql
     repository: https://github.com/opensearch-project/sql.git
-    ref: 'feature/mustang-ppl-integration'
+    ref: 'main'
     platforms:
       - linux
       - windows

--- a/scripts/components/core-plugins-sandbox/build.sh
+++ b/scripts/components/core-plugins-sandbox/build.sh
@@ -106,7 +106,13 @@ for plugin in ./*; do
         PLUGIN_NAME=$INSTALL_ORDER-$PLUGIN_NAME
         INSTALL_ORDER=$((INSTALL_ORDER + 1))
       fi
-      cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT_REAL}"/plugins/"$PLUGIN_NAME-$VERSION.zip"
+
+      if [ "$PLUGIN_NAME" = "dsl-query-executor" ]; then  # temp put dsl plugin to dist to build but avoid installation
+        cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT_REAL}"/dist/"$PLUGIN_NAME-$VERSION.zip"
+      else
+        cp -v "$plugin"/build/distributions/"$PLUGIN_ARTIFACT_BUILD_NAME" "${OUTPUT_REAL}"/plugins/"$PLUGIN_NAME-$VERSION.zip"
+      fi
+
     else
       echo "Ignore $PLUGIN_NAME as it is not in the required list"
     fi


### PR DESCRIPTION
### Description
SQL use main and move dsl-query-executor to dist now

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5810

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
