### PR TITLE
Add arrow-base plugin to feature-datafusion build

### DIFF
--- a/scripts/components/core-plugins-sandbox/build.sh
+++ b/scripts/components/core-plugins-sandbox/build.sh
@@ -81,13 +81,13 @@ DIR="$(dirname "$0")"
 echo $DIR
 cd $DIR
 cp -v ../../../tar/builds/opensearch/core-plugins/arrow-base-$VERSION.zip \
-    "${OUTPUT_REAL}"/plugins/0-arrow-base-$VERSION.zip || \
+    "${OUTPUT_REAL}"/plugins/0-1-arrow-base-$VERSION.zip || \
 cp -v ../../../zip/builds/opensearch/core-plugins/arrow-base-$VERSION.zip \
-    "${OUTPUT_REAL}"/plugins/0-arrow-base-$VERSION.zip
+    "${OUTPUT_REAL}"/plugins/0-1-arrow-base-$VERSION.zip
 cp -v ../../../tar/builds/opensearch/core-plugins/arrow-flight-rpc-$VERSION.zip \
-    "${OUTPUT_REAL}"/plugins/0-arrow-flight-rpc-$VERSION.zip || \
+    "${OUTPUT_REAL}"/plugins/0-2-arrow-flight-rpc-$VERSION.zip || \
 cp -v ../../../zip/builds/opensearch/core-plugins/arrow-flight-rpc-$VERSION.zip \
-    "${OUTPUT_REAL}"/plugins/0-arrow-flight-rpc-$VERSION.zip
+    "${OUTPUT_REAL}"/plugins/0-2-arrow-flight-rpc-$VERSION.zip
 
 cd -
 

--- a/scripts/components/core-plugins-sandbox/build.sh
+++ b/scripts/components/core-plugins-sandbox/build.sh
@@ -76,10 +76,14 @@ echo OUTPUT_REAL $OUTPUT_REAL
 mkdir -p "${OUTPUT_REAL}"/plugins
 mkdir -p "${OUTPUT_REAL}"/dist/
 
-# Copy arrow as it is needed before analytics-engine
+# Copy arrow plugins as they are needed before analytics-engine
 DIR="$(dirname "$0")"
 echo $DIR
 cd $DIR
+cp -v ../../../tar/builds/opensearch/core-plugins/arrow-base-$VERSION.zip \
+    "${OUTPUT_REAL}"/plugins/0-arrow-base-$VERSION.zip || \
+cp -v ../../../zip/builds/opensearch/core-plugins/arrow-base-$VERSION.zip \
+    "${OUTPUT_REAL}"/plugins/0-arrow-base-$VERSION.zip
 cp -v ../../../tar/builds/opensearch/core-plugins/arrow-flight-rpc-$VERSION.zip \
     "${OUTPUT_REAL}"/plugins/0-arrow-flight-rpc-$VERSION.zip || \
 cp -v ../../../zip/builds/opensearch/core-plugins/arrow-flight-rpc-$VERSION.zip \


### PR DESCRIPTION
## Summary

- Add `arrow-base` plugin copy to `core-plugins-sandbox/build.sh` with `0-` install-order prefix
- `arrow-base` (from `plugins/arrow-base/`) provides the shared Arrow classloader that `arrow-flight-rpc`, `analytics-engine`, and `parquet-data-format` depend on via `extendedPlugins`
- Install order: `arrow-base` → `arrow-flight-rpc` → `analytics-engine` → rest

## Context

Depends on https://github.com/opensearch-project/OpenSearch/pull/21465 merging first (adds `plugins/arrow-base/` to OpenSearch).

## Test plan

- [x] Full feature-datafusion build + assemble on build instance using `bowenlan-amzn:experiment/arrow-base-plugin` branch
- [x] Verified install ordering: `arrow-base` installed first, all downstream plugins resolve `extendedPlugins` correctly
- [x] Final tarball produced successfully with all plugins: `arrow-base, arrow-flight-rpc, analytics-engine, analytics-backend-datafusion, analytics-backend-lucene, composite-engine, parquet-data-format`

Signed-off-by: Bowen Lan <bowenlan@amazon.com>