### PR TITLE
Fix parallel arg passing for distribution builds

### DIFF
--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -265,7 +265,8 @@ pipeline {
                                 continueOnError: params.CONTINUE_ON_ERROR,
                                 skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                 incremental: params.INCREMENTAL,
-                                previousBuildId: params.PREVIOUS_BUILD_ID
+                                previousBuildId: params.PREVIOUS_BUILD_ID,
+                                parallel: params.PARALLEL
                             )
                             String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
                             String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
@@ -351,6 +352,7 @@ pipeline {
                                         skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
+                                        parallel: params.PARALLEL,
                                         stashName: "build-archive-linux-x64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -469,6 +471,7 @@ pipeline {
                                         skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
+                                        parallel: params.PARALLEL,
                                         stashName: "build-archive-linux-x64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -583,7 +586,8 @@ pipeline {
                                 continueOnError: params.CONTINUE_ON_ERROR,
                                 skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                 incremental: params.INCREMENTAL,
-                                previousBuildId: params.PREVIOUS_BUILD_ID
+                                previousBuildId: params.PREVIOUS_BUILD_ID,
+                                parallel: params.PARALLEL
                             )
                             String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
                             String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)
@@ -666,6 +670,7 @@ pipeline {
                                         skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
+                                        parallel: params.PARALLEL,
                                         stashName: "build-archive-linux-arm64-rpm-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -785,6 +790,7 @@ pipeline {
                                         skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                         incremental: params.INCREMENTAL,
                                         previousBuildId: params.PREVIOUS_BUILD_ID,
+                                        parallel: params.PARALLEL,
                                         stashName: "build-archive-linux-arm64-deb-${JOB_NAME}-${BUILD_NUMBER}"
                                     )
                                 }
@@ -904,7 +910,8 @@ pipeline {
                                     continueOnError: params.CONTINUE_ON_ERROR,
                                     skipArtifactCheck: params.SKIP_ARTIFACT_CHECK,
                                     incremental: params.INCREMENTAL,
-                                    previousBuildId: params.PREVIOUS_BUILD_ID
+                                    previousBuildId: params.PREVIOUS_BUILD_ID,
+                                    parallel: params.PARALLEL
                                 )
                                 String buildManifestUrl = buildManifestObj.getUrl(JOB_NAME, BUILD_NUMBER)
                                 String artifactUrl = buildManifestObj.getArtifactUrl(JOB_NAME, BUILD_NUMBER)


### PR DESCRIPTION
### Description
Previous PR https://github.com/opensearch-project/opensearch-build/pull/6198 was half-baked. This PR fixes the arg passing from parameter to child build-libraries call

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
