### PR TITLE
Fix manifest lock workflow by forking and then creating PRs

### DIFF
--- a/jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile
+++ b/jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile
@@ -223,18 +223,22 @@ pipeline {
                     withSecrets(secrets: secret_github_bot){
                         try {
                             sh """
-                                git remote set-url origin "https://opensearch-ci:${GITHUB_TOKEN}@github.com/opensearch-project/opensearch-build"
-                                git config user.email "opensearch-infra@amazon.com"
-                                git config user.name "opensearch-ci"
+                                gh repo fork "opensearch-project/opensearch-build" --clone=false
+                                git remote add fork "https://opensearch-ci:${GITHUB_TOKEN}@github.com/opensearch-ci/opensearch-build"
                                 git checkout -b manifest-lock
                             """
                             def status = sh(returnStdout: true, script: 'git status --porcelain')
                             if (status) {
                                 sh """
                                     git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
-                                    git commit -sm "Manifest Commit Lock for Release ${params.RELEASE_VERSION}"
-                                    git push origin manifest-lock --force
-                                    gh pr create --title '[${params.RELEASE_VERSION}] Manifest Commit Lock with action ${params.MANIFEST_LOCK_ACTION}' --body 'Manifest Commit Lock for Release ${params.RELEASE_VERSION} ' -H manifest-lock -B main
+                                    git -c user.email="opensearch-infra@amazon.com" -c user.name="opensearch-ci" commit -sm "Manifest Commit Lock for Release ${params.RELEASE_VERSION}"
+                                    git push fork manifest-lock --force
+                                    EXISTING_PR=\$(gh pr list --repo "opensearch-project/opensearch-build" --head "opensearch-ci:manifest-lock" --state open --json number --jq '.[0].number')
+                                    if [ -n "\$EXISTING_PR" ]; then
+                                        gh pr edit "\$EXISTING_PR" --repo "opensearch-project/opensearch-build" --body "Manifest Commit Lock for Release ${params.RELEASE_VERSION}"
+                                    else
+                                        gh pr create --repo "opensearch-project/opensearch-build" --title '[${params.RELEASE_VERSION}] Manifest Commit Lock with action ${params.MANIFEST_LOCK_ACTION}' --body 'Manifest Commit Lock for Release ${params.RELEASE_VERSION} ' -H "opensearch-ci:manifest-lock" -B main
+                                    fi
                                 """
                             } else {
                                 println 'Nothing to commit!'

--- a/tests/jenkins/TestReleaseManifestCommitLock.groovy
+++ b/tests/jenkins/TestReleaseManifestCommitLock.groovy
@@ -106,8 +106,9 @@ class TestReleaseManifestCommitLock extends BuildPipelineTest {
         addParam('OPENSEARCH_DASHBOARDS_RELEASE_CANDIDATE', '3050')
         super.testPipeline('jenkins/release-workflows/release-manifest-commit-lock.jenkinsfile',
                 'tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_createPullRequest')
-        assertThat(getShellCommands('git'), hasItem("\n                                git remote set-url origin \"https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build\"\n                                git config user.email \"opensearch-infra@amazon.com\"\n                                git config user.name \"opensearch-ci\"\n                                git checkout -b manifest-lock\n                            "))
-        assertThat(getShellCommands('git'), hasItem("\n                                    git status --porcelain | grep '^ M' | cut -d \" \" -f3 | xargs git add\n                                    git commit -sm \"Manifest Commit Lock for Release 2.0.0\"\n                                    git push origin manifest-lock --force\n                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action MATCH_BUILD_MANIFEST' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main\n                                "))
+        assertCallStack().contains('release-manifest-commit-lock.sh(\n                                gh repo fork \"opensearch-project/opensearch-build\" --clone=false\n                                git remote add fork \"https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-ci/opensearch-build\"\n                                git checkout -b manifest-lock\n                            )')
+        assertCallStack().contains('git push fork manifest-lock --force')
+        assertCallStack().contains('gh pr create --repo \"opensearch-project/opensearch-build\"')
     }
 
     @Test

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_createPullRequest.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_createPullRequest.txt
@@ -33,17 +33,21 @@ ccc})
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   release-manifest-commit-lock.sh(
-                                git remote set-url origin "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build"
-                                git config user.email "opensearch-infra@amazon.com"
-                                git config user.name "opensearch-ci"
+                                gh repo fork "opensearch-project/opensearch-build" --clone=false
+                                git remote add fork "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-ci/opensearch-build"
                                 git checkout -b manifest-lock
                             )
                   release-manifest-commit-lock.sh({returnStdout=true, script=git status --porcelain})
                   release-manifest-commit-lock.sh(
                                     git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
-                                    git commit -sm "Manifest Commit Lock for Release 2.0.0"
-                                    git push origin manifest-lock --force
-                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action MATCH_BUILD_MANIFEST' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
+                                    git -c user.email="opensearch-infra@amazon.com" -c user.name="opensearch-ci" commit -sm "Manifest Commit Lock for Release 2.0.0"
+                                    git push fork manifest-lock --force
+                                    EXISTING_PR=$(gh pr list --repo "opensearch-project/opensearch-build" --head "opensearch-ci:manifest-lock" --state open --json number --jq '.[0].number')
+                                    if [ -n "$EXISTING_PR" ]; then
+                                        gh pr edit "$EXISTING_PR" --repo "opensearch-project/opensearch-build" --body "Manifest Commit Lock for Release 2.0.0"
+                                    else
+                                        gh pr create --repo "opensearch-project/opensearch-build" --title '[2.0.0] Manifest Commit Lock with action MATCH_BUILD_MANIFEST' --body 'Manifest Commit Lock for Release 2.0.0 ' -H "opensearch-ci:manifest-lock" -B main
+                                    fi
                                 )
          release-manifest-commit-lock.script(groovy.lang.Closure)
             release-manifest-commit-lock.postCleanup()

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_matchBuildManifest.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_matchBuildManifest.txt
@@ -33,17 +33,21 @@ ccc})
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   release-manifest-commit-lock.sh(
-                                git remote set-url origin "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build"
-                                git config user.email "opensearch-infra@amazon.com"
-                                git config user.name "opensearch-ci"
+                                gh repo fork "opensearch-project/opensearch-build" --clone=false
+                                git remote add fork "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-ci/opensearch-build"
                                 git checkout -b manifest-lock
                             )
                   release-manifest-commit-lock.sh({returnStdout=true, script=git status --porcelain})
                   release-manifest-commit-lock.sh(
                                     git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
-                                    git commit -sm "Manifest Commit Lock for Release 2.0.0"
-                                    git push origin manifest-lock --force
-                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action MATCH_BUILD_MANIFEST' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
+                                    git -c user.email="opensearch-infra@amazon.com" -c user.name="opensearch-ci" commit -sm "Manifest Commit Lock for Release 2.0.0"
+                                    git push fork manifest-lock --force
+                                    EXISTING_PR=$(gh pr list --repo "opensearch-project/opensearch-build" --head "opensearch-ci:manifest-lock" --state open --json number --jq '.[0].number')
+                                    if [ -n "$EXISTING_PR" ]; then
+                                        gh pr edit "$EXISTING_PR" --repo "opensearch-project/opensearch-build" --body "Manifest Commit Lock for Release 2.0.0"
+                                    else
+                                        gh pr create --repo "opensearch-project/opensearch-build" --title '[2.0.0] Manifest Commit Lock with action MATCH_BUILD_MANIFEST' --body 'Manifest Commit Lock for Release 2.0.0 ' -H "opensearch-ci:manifest-lock" -B main
+                                    fi
                                 )
          release-manifest-commit-lock.script(groovy.lang.Closure)
             release-manifest-commit-lock.postCleanup()

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_updateToRecentCommits.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_updateToRecentCommits.txt
@@ -31,17 +31,21 @@ ccc, repository=https://github.com/opensearch-project/OpenSearch.git, checks=[gr
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   release-manifest-commit-lock.sh(
-                                git remote set-url origin "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build"
-                                git config user.email "opensearch-infra@amazon.com"
-                                git config user.name "opensearch-ci"
+                                gh repo fork "opensearch-project/opensearch-build" --clone=false
+                                git remote add fork "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-ci/opensearch-build"
                                 git checkout -b manifest-lock
                             )
                   release-manifest-commit-lock.sh({returnStdout=true, script=git status --porcelain})
                   release-manifest-commit-lock.sh(
                                     git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
-                                    git commit -sm "Manifest Commit Lock for Release 2.0.0"
-                                    git push origin manifest-lock --force
-                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_RECENT_COMMITS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
+                                    git -c user.email="opensearch-infra@amazon.com" -c user.name="opensearch-ci" commit -sm "Manifest Commit Lock for Release 2.0.0"
+                                    git push fork manifest-lock --force
+                                    EXISTING_PR=$(gh pr list --repo "opensearch-project/opensearch-build" --head "opensearch-ci:manifest-lock" --state open --json number --jq '.[0].number')
+                                    if [ -n "$EXISTING_PR" ]; then
+                                        gh pr edit "$EXISTING_PR" --repo "opensearch-project/opensearch-build" --body "Manifest Commit Lock for Release 2.0.0"
+                                    else
+                                        gh pr create --repo "opensearch-project/opensearch-build" --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_RECENT_COMMITS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H "opensearch-ci:manifest-lock" -B main
+                                    fi
                                 )
          release-manifest-commit-lock.script(groovy.lang.Closure)
             release-manifest-commit-lock.postCleanup()

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_updateToTags.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/testManifestCommitLock_updateToTags.txt
@@ -27,17 +27,21 @@
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   release-manifest-commit-lock.sh(
-                                git remote set-url origin "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build"
-                                git config user.email "opensearch-infra@amazon.com"
-                                git config user.name "opensearch-ci"
+                                gh repo fork "opensearch-project/opensearch-build" --clone=false
+                                git remote add fork "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-ci/opensearch-build"
                                 git checkout -b manifest-lock
                             )
                   release-manifest-commit-lock.sh({returnStdout=true, script=git status --porcelain})
                   release-manifest-commit-lock.sh(
                                     git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
-                                    git commit -sm "Manifest Commit Lock for Release 2.0.0"
-                                    git push origin manifest-lock --force
-                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_TAGS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
+                                    git -c user.email="opensearch-infra@amazon.com" -c user.name="opensearch-ci" commit -sm "Manifest Commit Lock for Release 2.0.0"
+                                    git push fork manifest-lock --force
+                                    EXISTING_PR=$(gh pr list --repo "opensearch-project/opensearch-build" --head "opensearch-ci:manifest-lock" --state open --json number --jq '.[0].number')
+                                    if [ -n "$EXISTING_PR" ]; then
+                                        gh pr edit "$EXISTING_PR" --repo "opensearch-project/opensearch-build" --body "Manifest Commit Lock for Release 2.0.0"
+                                    else
+                                        gh pr create --repo "opensearch-project/opensearch-build" --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_TAGS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H "opensearch-ci:manifest-lock" -B main
+                                    fi
                                 )
          release-manifest-commit-lock.script(groovy.lang.Closure)
             release-manifest-commit-lock.postCleanup()

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/testMatchBuildManifest.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/testMatchBuildManifest.txt
@@ -33,17 +33,21 @@ ccc})
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   release-manifest-commit-lock.sh(
-                                git remote set-url origin "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build"
-                                git config user.email "opensearch-infra@amazon.com"
-                                git config user.name "opensearch-ci"
+                                gh repo fork "opensearch-project/opensearch-build" --clone=false
+                                git remote add fork "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-ci/opensearch-build"
                                 git checkout -b manifest-lock
                             )
                   release-manifest-commit-lock.sh({returnStdout=true, script=git status --porcelain})
                   release-manifest-commit-lock.sh(
                                     git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
-                                    git commit -sm "Manifest Commit Lock for Release 2.0.0"
-                                    git push origin manifest-lock --force
-                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action MATCH_BUILD_MANIFEST' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
+                                    git -c user.email="opensearch-infra@amazon.com" -c user.name="opensearch-ci" commit -sm "Manifest Commit Lock for Release 2.0.0"
+                                    git push fork manifest-lock --force
+                                    EXISTING_PR=$(gh pr list --repo "opensearch-project/opensearch-build" --head "opensearch-ci:manifest-lock" --state open --json number --jq '.[0].number')
+                                    if [ -n "$EXISTING_PR" ]; then
+                                        gh pr edit "$EXISTING_PR" --repo "opensearch-project/opensearch-build" --body "Manifest Commit Lock for Release 2.0.0"
+                                    else
+                                        gh pr create --repo "opensearch-project/opensearch-build" --title '[2.0.0] Manifest Commit Lock with action MATCH_BUILD_MANIFEST' --body 'Manifest Commit Lock for Release 2.0.0 ' -H "opensearch-ci:manifest-lock" -B main
+                                    fi
                                 )
          release-manifest-commit-lock.script(groovy.lang.Closure)
             release-manifest-commit-lock.postCleanup()

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/testUpdateToRecentCommit.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/testUpdateToRecentCommit.txt
@@ -31,17 +31,21 @@ ccc, repository=https://github.com/opensearch-project/OpenSearch.git, checks=[gr
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   release-manifest-commit-lock.sh(
-                                git remote set-url origin "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build"
-                                git config user.email "opensearch-infra@amazon.com"
-                                git config user.name "opensearch-ci"
+                                gh repo fork "opensearch-project/opensearch-build" --clone=false
+                                git remote add fork "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-ci/opensearch-build"
                                 git checkout -b manifest-lock
                             )
                   release-manifest-commit-lock.sh({returnStdout=true, script=git status --porcelain})
                   release-manifest-commit-lock.sh(
                                     git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
-                                    git commit -sm "Manifest Commit Lock for Release 2.0.0"
-                                    git push origin manifest-lock --force
-                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_RECENT_COMMITS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
+                                    git -c user.email="opensearch-infra@amazon.com" -c user.name="opensearch-ci" commit -sm "Manifest Commit Lock for Release 2.0.0"
+                                    git push fork manifest-lock --force
+                                    EXISTING_PR=$(gh pr list --repo "opensearch-project/opensearch-build" --head "opensearch-ci:manifest-lock" --state open --json number --jq '.[0].number')
+                                    if [ -n "$EXISTING_PR" ]; then
+                                        gh pr edit "$EXISTING_PR" --repo "opensearch-project/opensearch-build" --body "Manifest Commit Lock for Release 2.0.0"
+                                    else
+                                        gh pr create --repo "opensearch-project/opensearch-build" --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_RECENT_COMMITS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H "opensearch-ci:manifest-lock" -B main
+                                    fi
                                 )
          release-manifest-commit-lock.script(groovy.lang.Closure)
             release-manifest-commit-lock.postCleanup()

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/testUpdateToRecentCommit_excludeFTRepo.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/testUpdateToRecentCommit_excludeFTRepo.txt
@@ -27,17 +27,21 @@
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   release-manifest-commit-lock.sh(
-                                git remote set-url origin "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build"
-                                git config user.email "opensearch-infra@amazon.com"
-                                git config user.name "opensearch-ci"
+                                gh repo fork "opensearch-project/opensearch-build" --clone=false
+                                git remote add fork "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-ci/opensearch-build"
                                 git checkout -b manifest-lock
                             )
                   release-manifest-commit-lock.sh({returnStdout=true, script=git status --porcelain})
                   release-manifest-commit-lock.sh(
                                     git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
-                                    git commit -sm "Manifest Commit Lock for Release 2.0.0"
-                                    git push origin manifest-lock --force
-                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_RECENT_COMMITS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
+                                    git -c user.email="opensearch-infra@amazon.com" -c user.name="opensearch-ci" commit -sm "Manifest Commit Lock for Release 2.0.0"
+                                    git push fork manifest-lock --force
+                                    EXISTING_PR=$(gh pr list --repo "opensearch-project/opensearch-build" --head "opensearch-ci:manifest-lock" --state open --json number --jq '.[0].number')
+                                    if [ -n "$EXISTING_PR" ]; then
+                                        gh pr edit "$EXISTING_PR" --repo "opensearch-project/opensearch-build" --body "Manifest Commit Lock for Release 2.0.0"
+                                    else
+                                        gh pr create --repo "opensearch-project/opensearch-build" --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_RECENT_COMMITS' --body 'Manifest Commit Lock for Release 2.0.0 ' -H "opensearch-ci:manifest-lock" -B main
+                                    fi
                                 )
          release-manifest-commit-lock.script(groovy.lang.Closure)
             release-manifest-commit-lock.postCleanup()

--- a/tests/jenkins/jenkinsjob-regression-files/release-workflows/testUpdateToReleaseBranch.txt
+++ b/tests/jenkins/jenkinsjob-regression-files/release-workflows/testUpdateToReleaseBranch.txt
@@ -27,17 +27,21 @@
             release-manifest-commit-lock.script(groovy.lang.Closure)
                release-manifest-commit-lock.withSecrets({secrets=[{envVar=GITHUB_USER, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-username}, {envVar=GITHUB_TOKEN, secretRef=op://opensearch-release-secrets/github-bot/ci-bot-token}]}, groovy.lang.Closure)
                   release-manifest-commit-lock.sh(
-                                git remote set-url origin "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-project/opensearch-build"
-                                git config user.email "opensearch-infra@amazon.com"
-                                git config user.name "opensearch-ci"
+                                gh repo fork "opensearch-project/opensearch-build" --clone=false
+                                git remote add fork "https://opensearch-ci:GITHUB_TOKEN@github.com/opensearch-ci/opensearch-build"
                                 git checkout -b manifest-lock
                             )
                   release-manifest-commit-lock.sh({returnStdout=true, script=git status --porcelain})
                   release-manifest-commit-lock.sh(
                                     git status --porcelain | grep '^ M' | cut -d " " -f3 | xargs git add
-                                    git commit -sm "Manifest Commit Lock for Release 2.0.0"
-                                    git push origin manifest-lock --force
-                                    gh pr create --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_RELEASE_BRANCH' --body 'Manifest Commit Lock for Release 2.0.0 ' -H manifest-lock -B main
+                                    git -c user.email="opensearch-infra@amazon.com" -c user.name="opensearch-ci" commit -sm "Manifest Commit Lock for Release 2.0.0"
+                                    git push fork manifest-lock --force
+                                    EXISTING_PR=$(gh pr list --repo "opensearch-project/opensearch-build" --head "opensearch-ci:manifest-lock" --state open --json number --jq '.[0].number')
+                                    if [ -n "$EXISTING_PR" ]; then
+                                        gh pr edit "$EXISTING_PR" --repo "opensearch-project/opensearch-build" --body "Manifest Commit Lock for Release 2.0.0"
+                                    else
+                                        gh pr create --repo "opensearch-project/opensearch-build" --title '[2.0.0] Manifest Commit Lock with action UPDATE_TO_RELEASE_BRANCH' --body 'Manifest Commit Lock for Release 2.0.0 ' -H "opensearch-ci:manifest-lock" -B main
+                                    fi
                                 )
          release-manifest-commit-lock.script(groovy.lang.Closure)
             release-manifest-commit-lock.postCleanup()


### PR DESCRIPTION
### Description
Fix manifest lock workflow by forking and then creating PRs

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6062

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
