### PR TITLE
Fix DataFusion install.sh rustlib copy failing on windows-zip (internal builds)

### DIFF
--- a/scripts/components/OpenSearch-DataFusion/install.sh
+++ b/scripts/components/OpenSearch-DataFusion/install.sh
@@ -117,12 +117,22 @@ elif [ "$DISTRIBUTION" = "zip" ] && [ "$PLATFORM" = "windows" ]; then
     cp -v ../../../scripts/startup/zip/windows/opensearch-windows-install-datafusion.bat "$OUTPUT/"
 fi
 
-## Major 3 rustlib, since 3.7 version
+## Major 3, since 3.7 version
 if [ "$MAJOR_VERSION" -ge "3" ]; then
-  echo "Setting datafusion rustlib..."
-  mkdir -p "$OUTPUT/lib/rust"
-  cp -v ../../../$DISTRIBUTION/builds/opensearch/dist/libopensearch_native.* "$OUTPUT/lib/rust"
-  ls "$OUTPUT/lib/rust"
+  # Append datafusion JVM options first. arrow-base requires io.netty.noUnsafe=false /
+  # io.netty.allocator.numDirectArenas=1 / io.netty.tryUnsafe=true / io.netty.tryReflectionSetAccessible=true
+  # at node startup or its Netty allocation manager fails clinit. Do this before the rustlib copy
+  # so a rustlib failure cannot leave the bundle without these flags.
   echo "Updating jvmopts settings..."
   cat ./jvmopts.txt >> "$OUTPUT/config/jvm.options"
+
+  echo "Setting datafusion rustlib..."
+  mkdir -p "$OUTPUT/lib/rust"
+  # Cargo cdylib naming: libopensearch_native.{so,dylib} on linux/darwin, opensearch_native.dll on windows.
+  if [ "$DISTRIBUTION" = "zip" ] && [ "$PLATFORM" = "windows" ]; then
+    cp -v ../../../$DISTRIBUTION/builds/opensearch/dist/opensearch_native.dll "$OUTPUT/lib/rust"
+  else
+    cp -v ../../../$DISTRIBUTION/builds/opensearch/dist/libopensearch_native.* "$OUTPUT/lib/rust"
+  fi
+  ls "$OUTPUT/lib/rust"
 fi


### PR DESCRIPTION
## Scope

**This PR fixes only the internal feature-datafusion windows build path.** It does **not** unblock the 3.7 production windows-zip release crash. Production windows-zip is built without `OpenSearch-DataFusion/install.sh` and started via `scripts/startup/zip/windows/opensearch-windows-install.bat`; the production arrow-base crash will need a separate fix (OpenSearch core, see "Notes" below).

I'm submitting this anyway because the bug is real, the change is local, and the moment someone runs the feature-datafusion build for windows-zip — even internally — it will fail.

**This is not a bug in `arrow-base` or `arrow-flight-rpc`.** It's a packaging-script bug in `scripts/components/OpenSearch-DataFusion/install.sh`. The arrow plugins are correctly documented (see `plugins/arrow-flight-rpc/README.md`) to require four `-Dio.netty.*` flags at node startup; `jvmopts.txt` in this same directory exists to set them. Today, those flags never reach a windows-zip DataFusion bundle's `jvm.options` because the install script aborts on a different line before getting there.

## Root cause

`scripts/components/OpenSearch-DataFusion/install.sh:124` copies the Rust cdylib using the glob:

```bash
cp -v ../../../$DISTRIBUTION/builds/opensearch/dist/libopensearch_native.* "$OUTPUT/lib/rust"
```

Cargo's cdylib naming differs by platform:
- linux: `libopensearch_native.so`
- darwin: `libopensearch_native.dylib`
- **windows: `opensearch_native.dll` (no `lib` prefix)**

This is a hard Cargo convention. It is mirrored in `OpenSearch/sandbox/libs/dataformat-native/build.gradle:56`:

```groovy
def libPrefix = osName.contains('windows') ? '' : 'lib'
```

On windows-zip, the glob matches nothing. Because `install.sh` runs under `set -ex` (line 10), the failed `cp` aborts the script and the next line — `cat ./jvmopts.txt >> "$OUTPUT/config/jvm.options"` — never executes.

The DataFusion bundle is then shipped without the four flags `arrow-base` needs at startup:

```
-Dio.netty.allocator.numDirectArenas=1
-Dio.netty.noUnsafe=false
-Dio.netty.tryUnsafe=true
-Dio.netty.tryReflectionSetAccessible=true
```

When the cluster starts, the launcher's `SystemJvmOptions` defaults (`-Dio.netty.noUnsafe=true`, `-Dio.netty.allocator.numDirectArenas=0`) win and the arrow-base plugin fails clinit:

```
java.lang.ExceptionInInitializerError
  at org.apache.arrow.memory.netty.DefaultAllocationManagerFactory.<clinit>
  ...
  at org.opensearch.arrow.allocator.ArrowBasePlugin.createComponents
  at org.opensearch.node.Node.<init>
Caused by: java.lang.UnsupportedOperationException
  at io.netty.buffer.EmptyByteBuf.memoryAddress
  at io.netty.buffer.UnsafeDirectLittleEndian.<init>
  at io.netty.buffer.PooledByteBufAllocatorL.<init>
  at org.apache.arrow.memory.netty.NettyAllocationManager.<clinit>
```

The crash signature points at arrow-base, but the underlying defect is in this script. linux-tar / darwin-tar are unaffected only because their cdylib filenames happen to match the `lib*` glob, so install.sh proceeds to the `cat` line and the bundle ships with the correct `jvm.options`.

## Changes

- Branch the rustlib `cp` by platform: use `opensearch_native.dll` on windows-zip, keep `libopensearch_native.*` elsewhere.
- Move the `cat ./jvmopts.txt >> ...` append above the rustlib copy. The append is independent of whether the Rust library shipped on this platform; arrow-base needs those flags at node startup either way. Reordering means a future rustlib failure (still fatal under `set -ex`) cannot leave the bundle without the JVM options.

## Verification

Reproduced the original failure on macOS by mimicking the windows-zip layout (`opensearch_native.dll` in the dist dir) and running the original `install.sh` block: `cp` failed, `set -ex` aborted, `jvm.options` was untouched.

Re-ran the same harness against the edited script for three layouts — windows-zip, linux-tar, darwin-tar — using the matching cdylib filename for each. All three exit 0; `lib/rust` contains the correct platform-specific filename; `jvm.options` contains all six lines from `jvmopts.txt`.

## Test plan

- [ ] Trigger a feature-datafusion build for windows-zip (manual/Jenkins) and confirm the assembly stage no longer aborts in `OpenSearch-DataFusion` install step.
- [ ] Inspect the produced bundle's `config/jvm.options` and verify it contains the DataFusion JVM opts.
- [ ] Start the produced bundle on Windows and confirm arrow-base + arrow-flight-rpc load without the `BaseAllocator.<clinit>` crash.
- [ ] Confirm linux-tar / darwin-tar feature-datafusion builds still pass unchanged.

## Notes — production windows-zip release crash is a separate issue

The 3.7 production windows-zip is built and started without going through `OpenSearch-DataFusion/install.sh`, so this PR will not unblock that release. The crash there is reproduced when validate-artifacts' core-plugin-check (`src/validation_workflow/validation.py::install_native_plugin`) installs every plugin under OpenSearch's `plugins/` directory — which now includes `arrow-base` — onto the release zip and starts the cluster. The release zip's `jvm.options` does not contain the netty unsafe / direct-arena flags, so arrow-base hits the same `BaseAllocator.<clinit>` crash.

The right fix for that lives in the OpenSearch repo: have `arrow-base` ship its own `config/jvm.options.d/arrow-base.options` and teach `plugin-cli`'s `InstallPluginCommand` to route a plugin's `config/jvm.options.d/*.options` to `<OPENSEARCH_HOME>/config/jvm.options.d/` (with cleanup in `RemovePluginCommand`). That way any installation path — validator, user manual install, internal builds — picks up the flags automatically. Tracking that separately.

Signed-off-by: Rishabh Maurya <rishabhmaurya@amazon.com>