### PR TITLE
Use polyfill-glibc to patch cypress addon-native.node to be compatible with glibc2.28

### DIFF
--- a/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.opensearch-dashboards.x64.arm64.dockerfile
@@ -67,6 +67,11 @@ RUN npm install -g yarn@`/tmp/yarn-version.sh main`
 # Update to 13.17.0 per https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/1996
 RUN for cypress_version in $CYPRESS_VERSION_LIST; do npm install -g cypress@$cypress_version && npm cache verify; done
 
+# Patch for glibc 2.28 version specifically
+RUN if [ `uname -m` = "aarch64" ]; then curl -SfL https://ci.opensearch.org/ci/dbc/tools/polyfill-glibc/polyfill-glibc-dd59051-arm64 -o ./polyfill-glibc && \
+    chmod u+x ./polyfill-glibc && ./polyfill-glibc --target-glibc=2.28 /home/ci-runner/.cache/Cypress/$CYPRESS_VERSION/Cypress/resources/app/packages/server/lib/modes/addon/addon-native.node && \
+    rm -v ./polyfill-glibc; fi
+
 # Need root to get pass the build due to chrome sandbox needs to own by the root
 USER 0
 

--- a/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/test.almalinux8.systemd-base.x64.arm64.dockerfile
@@ -75,6 +75,11 @@ RUN npm install -g yarn@`/tmp/yarn-version.sh main`
 # Update to 13.17.0 per https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/1996
 RUN for cypress_version in $CYPRESS_VERSION_LIST; do npm install -g cypress@$cypress_version && npm cache verify; done
 
+# Patch for glibc 2.28 version specifically
+RUN if [ `uname -m` = "aarch64" ]; then curl -SfL https://ci.opensearch.org/ci/dbc/tools/polyfill-glibc/polyfill-glibc-dd59051-arm64 -o ./polyfill-glibc && \
+    chmod u+x ./polyfill-glibc && ./polyfill-glibc --target-glibc=2.28 /home/ci-runner/.cache/Cypress/$CYPRESS_VERSION/Cypress/resources/app/packages/server/lib/modes/addon/addon-native.node && \
+    rm -v ./polyfill-glibc; fi
+
 # Need root to get pass the build due to chrome sandbox needs to own by the root
 USER 0
 


### PR DESCRIPTION


### Description
Use polyfill-glibc to patch cypress addon-native.node to be compatible with glibc2.28

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-build/issues/6234

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
