### PR TITLE
Ensure 3.7.0 is using chromium on cypress 13.17.0 now

### DIFF
--- a/manifests/3.7.0/opensearch-dashboards-3.7.0-test.yml
+++ b/manifests/3.7.0/opensearch-dashboards-3.7.0-test.yml
@@ -6,15 +6,15 @@ ci:
     linux:
       tar:
         name: opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-dashboards-integtest-v2
-        args: -u 1000 --cpus 4 -m 16g -e BROWSER_PATH=electron
+        args: -u 1000 --cpus 4 -m 16g
       deb:
         name: opensearchstaging/ci-runner:ci-runner-ubuntu2404-systemd-base-integtest-v2
         args: --entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw
-          --cgroupns=host --cpus 4 -m 16g -e BROWSER_PATH=electron
+          --cgroupns=host --cpus 4 -m 16g
       rpm:
         name: opensearchstaging/ci-runner:ci-runner-almalinux8-systemd-base-integtest-v2
         args: --entrypoint=/usr/lib/systemd/systemd -u root --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:rw
-          --cgroupns=host --cpus 4 -m 16g -e BROWSER_PATH=electron
+          --cgroupns=host --cpus 4 -m 16g
     windows:
       zip:
         name: opensearchstaging/ci-runner:ci-runner-windows2019-opensearch-build-v1


### PR DESCRIPTION
### Description
Ensure 3.7.0 is using chromium on cypress 13.17.0 now

### Issues Resolved
https://github.com/cypress-io/cypress/issues/30988
https://github.com/cypress-io/cypress/issues/27415
https://github.com/opensearch-project/opensearch-build/issues/6062

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
