### PR TITLE
Move inactive maintainers to emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @peterzhuamazon @gaiksaya @rishabh6788 @zelinh @prudhvigodithi @Divyaasm @tianleh
+* @peterzhuamazon @gaiksaya @rishabh6788 @prudhvigodithi @Divyaasm

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,10 +20,8 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Peter Zhu       | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon      |
 | Sayali Gaikawad | [gaiksaya](https://github.com/gaiksaya)             | Amazon      |
 | Rishab Singh    | [rishabh6788](https://github.com/rishabh6788)       | Amazon      |
-| Zelin Hao       | [zelinh](https://github.com/zelinh)                 | Amazon      |
 | Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon      |
 | Divya Madala    | [Divyaasm](https://github.com/Divyaasm)             | Amazon      |
-| Tianle Huang    | [tianleh](https://github.com/tianleh)               | Amazon      |
 
 ## Emeritus Maintainers
 
@@ -36,6 +34,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Peter Nied               | [peternied](https://github.com/peternied)           | Amazon      |
 | Jeff Lu                  | [jordarlu](https://github.com/jordarlu)             | Amazon      |
 | Barani Bikshandi         | [bbarani](https://github.com/bbarani)               | Amazon      |
+| Zelin Hao                | [zelinh](https://github.com/zelinh)                 | Amazon      |
+| Tianle Huang             | [tianleh](https://github.com/tianleh)               | Amazon      |
+
 
 ## Release Owner
 


### PR DESCRIPTION
### Description
Moving inactive maintainers to emeritus
@zelinh @tianleh please reach out if you still wish to maintain this repository. Please be aware that you do need to be a maintainer to continue to contribute to the project.

Thank you for all your contributions so far.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
