### PR TITLE
Add setup OpenSearch Dashboards action

### DIFF
--- a/.github/actions/setup-opensearch-dashboards/README.md
+++ b/.github/actions/setup-opensearch-dashboards/README.md
@@ -1,0 +1,39 @@
+# Set Up OpenSearch Dashboards
+
+Composite GitHub Action for checking out OpenSearch Dashboards, checking out a Dashboards plugin into the plugin directory, configuring Node.js and Yarn, bootstrapping OpenSearch Dashboards, and optionally building and installing the plugin into a downloaded OpenSearch Dashboards distribution.
+
+Consumers should pin this action to a full `opensearch-build` commit SHA:
+
+```yaml
+- name: Set up OpenSearch Dashboards
+  uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@<opensearch-build-commit-sha>
+  with:
+    plugin_name: security-dashboards-plugin
+    opensearch_dashboards_yml: opensearch_dashboards.yml
+```
+
+For binary install testing, set `install_zip` and provide the built plugin naming inputs:
+
+```yaml
+- name: Set up OpenSearch Dashboards
+  uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@<opensearch-build-commit-sha>
+  with:
+    plugin_name: security-dashboards-plugin
+    built_plugin_name: securityDashboards
+    install_zip: true
+    snapshot: true
+    opensearch_dashboards_yml: opensearch_dashboards.yml
+```
+
+Set `snapshot: false` to download the OpenSearch Dashboards artifact from `ci.opensearch.org` release artifacts instead of `artifacts.opensearch.org` snapshots.
+
+To check out a plugin from a different repository or branch, provide `plugin_repo` and/or `plugin_branch`:
+
+```yaml
+- name: Set up OpenSearch Dashboards
+  uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@<opensearch-build-commit-sha>
+  with:
+    plugin_name: security-dashboards-plugin
+    plugin_repo: opensearch-project/security-dashboards-plugin
+    plugin_branch: main
+```

--- a/.github/actions/setup-opensearch-dashboards/action.yml
+++ b/.github/actions/setup-opensearch-dashboards/action.yml
@@ -1,0 +1,198 @@
+---
+name: 'Set up OpenSearch Dashboards with a plugin'
+description: 'Configures OpenSearch Dashboards with a plugin for test workflows'
+
+inputs:
+  plugin_name:
+    description: 'The name of the plugin to use, such as security-dashboards-plugin'
+    required: true
+
+  built_plugin_name:
+    description: 'The name of the plugin after building, if doing zip install'
+    required: false
+
+  built_plugin_suffix:
+    description: 'The suffix of the plugin after building, if doing zip install. Leave empty to indicate default OSD build behavior'
+    required: false
+
+  install_zip:
+    description: 'Whether setup should use the install plugin flow. Leave empty to indicate dev setup. Only applicable for Linux for now'
+    required: false
+
+  plugin_repo:
+    description: 'The repo of the plugin to use. Leave empty to indicate the repo running this action'
+    required: false
+
+  opensearch_dashboards_yml:
+    description: 'The file to replace opensearch_dashboards.yml. Leave empty to use the default'
+    required: false
+
+  plugin_branch:
+    description: 'The branch of the plugin repo to use. Leave empty to indicate the branch running this action'
+    required: false
+
+  snapshot:
+    description: 'Whether to download a snapshot build. Set to false to download from ci.opensearch.org release artifacts.'
+    required: false
+    default: 'true'
+
+outputs:
+  dashboards-directory:
+    description: 'The directory where OpenSearch Dashboards has been configured'
+    value: ${{ steps.determine-dashboards-directory.outputs.dashboards-directory }}
+
+  dashboards-binary-directory:
+    description: 'The directory of the OpenSearch Dashboards binary that was configured'
+    value: ${{ steps.determine-dashboards-directory-zip-install.outputs.dashboards-directory }}
+
+  plugin-directory:
+    description: 'The directory where the plugin has been configured'
+    value: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: determine-dashboards-directory
+      if: ${{ inputs.install_zip != 'true' }}
+      run: echo "dashboards-directory=OpenSearch-Dashboards" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - id: determine-plugin-directory
+      run: echo "plugin-directory=./OpenSearch-Dashboards/plugins/${{ inputs.plugin_name }}" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Check out OpenSearch Dashboards
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        path: OpenSearch-Dashboards
+        repository: opensearch-project/OpenSearch-Dashboards
+        ref: main
+        fetch-depth: 0
+
+    - name: Check out plugin from current repository
+      if: ${{ inputs.plugin_repo == '' && inputs.plugin_branch == '' }}
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        path: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
+
+    - name: Check out plugin branch from current repository
+      if: ${{ inputs.plugin_repo == '' && inputs.plugin_branch != '' }}
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        path: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
+        ref: ${{ inputs.plugin_branch }}
+
+    - name: Check out plugin from external repository
+      if: ${{ inputs.plugin_repo != '' && inputs.plugin_branch == '' }}
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        path: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
+        repository: ${{ inputs.plugin_repo }}
+
+    - name: Check out plugin branch from external repository
+      if: ${{ inputs.plugin_repo != '' && inputs.plugin_branch != '' }}
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        path: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
+        repository: ${{ inputs.plugin_repo }}
+        ref: ${{ inputs.plugin_branch }}
+
+    - id: osd-version
+      run: |
+        echo "osd-version=$(jq -r '.opensearchDashboards.version | split(".") | .[:2] | join(".")' package.json)" >> "$GITHUB_OUTPUT"
+        echo "osd-x-version=$(jq -r '.opensearchDashboards.version | split(".") | .[0]' package.json).x" >> "$GITHUB_OUTPUT"
+        echo "plugin-version=$(jq -r '.opensearchDashboardsVersion' opensearch_dashboards.json)" >> "$GITHUB_OUTPUT"
+      working-directory: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
+      shell: bash
+
+    - id: branch-switch-if-possible
+      continue-on-error: true
+      if: ${{ steps.osd-version.outputs.osd-version }}
+      run: git checkout ${{ steps.osd-version.outputs.osd-version }} || git checkout ${{ steps.osd-version.outputs.osd-x-version }}
+      working-directory: ./OpenSearch-Dashboards
+      shell: bash
+
+    - id: tool-versions
+      run: |
+        echo "node_version=$(cat .node-version)" >> "$GITHUB_OUTPUT"
+        echo "yarn_version=$(jq -r '.engines.yarn' package.json)" >> "$GITHUB_OUTPUT"
+      working-directory: OpenSearch-Dashboards
+      shell: bash
+
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      with:
+        node-version: ${{ steps.tool-versions.outputs.node_version }}
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Set up OpenSearch Dashboards
+      uses: Wandalen/wretry.action@e94c43bf2e865e7dbbd90b0c1061053f5888932a # master
+      with:
+        attempts: 3
+        command: |
+          npm uninstall -g yarn
+          echo "Installing yarn ${{ steps.tool-versions.outputs.yarn_version }}"
+          npm i -g yarn@${{ steps.tool-versions.outputs.yarn_version }}
+          yarn cache clean
+          yarn add sha.js
+        current_path: OpenSearch-Dashboards
+
+    - name: Bootstrap OpenSearch Dashboards
+      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2
+      with:
+        timeout_minutes: 20
+        max_attempts: 2
+        command: yarn --cwd OpenSearch-Dashboards osd bootstrap --oss --single-version=loose
+
+    - name: Download OpenSearch Dashboards for Linux
+      if: ${{ inputs.install_zip == 'true' && runner.os == 'Linux' }}
+      run: |
+        if [ "${{ inputs.snapshot }}" = "false" ]; then
+          url="https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ steps.osd-version.outputs.plugin-version }}/latest/linux/x64/tar/builds/opensearch-dashboards/dist/opensearch-dashboards-min-${{ steps.osd-version.outputs.plugin-version }}-linux-x64.tar.gz"
+        else
+          url="https://artifacts.opensearch.org/snapshots/core/opensearch-dashboards/${{ steps.osd-version.outputs.plugin-version }}-SNAPSHOT/opensearch-dashboards-min-${{ steps.osd-version.outputs.plugin-version }}-SNAPSHOT-linux-x64-latest.tar.gz"
+        fi
+        curl -L -o opensearch-dashboards.tar.gz "$url"
+      shell: bash
+
+    - name: Extract downloaded tar
+      if: ${{ inputs.install_zip == 'true' && runner.os == 'Linux' }}
+      run: |
+        tar -xzf opensearch-dashboards.tar.gz
+        rm -f opensearch-dashboards.tar.gz
+      shell: bash
+
+    - id: determine-dashboards-directory-zip-install
+      if: ${{ inputs.install_zip == 'true' }}
+      run: echo "dashboards-directory=opensearch-dashboards-${{ steps.osd-version.outputs.plugin-version }}-linux-x64" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Build the plugin
+      if: ${{ inputs.install_zip == 'true' }}
+      run: yarn build
+      working-directory: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
+      shell: bash
+
+    - name: Install the plugin zip with default suffix
+      if: ${{ inputs.install_zip == 'true' && inputs.built_plugin_suffix == '' }}
+      run: |
+        ${{ steps.determine-dashboards-directory-zip-install.outputs.dashboards-directory }}/bin/opensearch-dashboards-plugin install file:$(pwd)/OpenSearch-Dashboards/plugins/${{ inputs.plugin_name }}/build/${{ inputs.built_plugin_name }}-${{ env.PLUGIN_VERSION }}.zip
+      shell: bash
+
+    - name: Install the plugin zip with custom suffix
+      if: ${{ inputs.install_zip == 'true' && inputs.built_plugin_suffix != '' }}
+      run: |
+        ${{ steps.determine-dashboards-directory-zip-install.outputs.dashboards-directory }}/bin/opensearch-dashboards-plugin install file:$(pwd)/OpenSearch-Dashboards/plugins/${{ inputs.plugin_name }}/build/${{ inputs.built_plugin_name }}-${{ inputs.built_plugin_suffix }}.zip
+      shell: bash
+
+    - name: Replace opensearch_dashboards.yml for binary install
+      if: ${{ inputs.opensearch_dashboards_yml != '' && inputs.install_zip == 'true' }}
+      run: |
+        mv ${{ inputs.opensearch_dashboards_yml }} ${{ steps.determine-dashboards-directory-zip-install.outputs.dashboards-directory }}/config/opensearch_dashboards.yml
+      shell: bash
+
+    - name: Replace opensearch_dashboards.yml for dev install
+      if: ${{ inputs.opensearch_dashboards_yml != '' && inputs.install_zip != 'true' }}
+      run: |
+        mv ${{ inputs.opensearch_dashboards_yml }} ./OpenSearch-Dashboards/config/opensearch_dashboards.yml
+      shell: bash


### PR DESCRIPTION
## Description
Ports the [`derek-ho/setup-opensearch-dashboards` composite action](https://github.com/derek-ho/setup-opensearch-dashboards) into [`opensearch-build`](https://github.com/opensearch-project/opensearch-build) as:

[`.github/actions/setup-opensearch-dashboards`](https://github.com/opensearch-project/opensearch-build/tree/main/.github/actions/setup-opensearch-dashboards)

This follows the same build-owned action pattern added for [`.github/actions/start-opensearch`](https://github.com/opensearch-project/opensearch-build/pull/6254).

The action keeps the same primary workflow shape used by existing consumers: it checks out [OpenSearch Dashboards](https://github.com/opensearch-project/OpenSearch-Dashboards), checks out the plugin into `OpenSearch-Dashboards/plugins/<plugin_name>`, configures Node/Yarn, bootstraps OpenSearch Dashboards, and optionally builds and installs the plugin into a downloaded OpenSearch Dashboards distribution.

Changes made while porting:

- Replaced tag/branch-based action references with full commit SHAs.
- Replaced deprecated [`::set-output`](https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/) calls with ``.
- Kept the existing public inputs/outputs for compatibility.
- Wired `plugin_repo` and `plugin_branch` so those documented inputs are functional.
- Added `snapshot`, defaulting to `true`, so binary install tests can choose between [snapshot artifacts](https://artifacts.opensearch.org/snapshots/core/opensearch-dashboards/) and [ci.opensearch.org release artifacts](https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/) with `snapshot: false`.
- Replaced the previous download helper action with shell `curl`, matching the nested-action policy hardening from the start OpenSearch action.
- Removed the old checkout `filter` value because it was a no-op with the original checkout action and is not a valid partial clone filter for modern [`actions/checkout`](https://github.com/actions/checkout).

## Testing
- Parsed all `.github/actions/*/action.yml` files with Ruby's YAML parser.
- Confirmed the new action has no `::set-output` usage.
- Confirmed the new action has no tag/branch-based `uses:` action references.
- Confirmed the previous `peternied/download-file` helper action is no longer used by the new action.