### PR TITLE
Remove wretry from setup OpenSearch Dashboards action

### DIFF
--- a/.github/actions/setup-opensearch-dashboards/action.yml
+++ b/.github/actions/setup-opensearch-dashboards/action.yml
@@ -126,16 +126,28 @@ runs:
         registry-url: 'https://registry.npmjs.org'
 
     - name: Set up OpenSearch Dashboards
-      uses: Wandalen/wretry.action@e94c43bf2e865e7dbbd90b0c1061053f5888932a # master
-      with:
-        attempts: 3
-        command: |
-          npm uninstall -g yarn
-          echo "Installing yarn ${{ steps.tool-versions.outputs.yarn_version }}"
-          npm i -g yarn@${{ steps.tool-versions.outputs.yarn_version }}
-          yarn cache clean
-          yarn add sha.js
-        current_path: OpenSearch-Dashboards
+      run: |
+        for attempt in {1..3}; do
+          echo "Setting up OpenSearch Dashboards attempt ${attempt}/3."
+          if (
+            cd OpenSearch-Dashboards
+            npm uninstall -g yarn
+            echo "Installing yarn ${{ steps.tool-versions.outputs.yarn_version }}"
+            npm i -g yarn@${{ steps.tool-versions.outputs.yarn_version }}
+            yarn cache clean
+            yarn add sha.js
+          ); then
+            exit 0
+          fi
+
+          if [ "${attempt}" -eq 3 ]; then
+            echo "Failed to set up OpenSearch Dashboards after ${attempt} attempts."
+            exit 1
+          fi
+
+          sleep 2
+        done
+      shell: bash
 
     - name: Bootstrap OpenSearch Dashboards
       uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2


### PR DESCRIPTION
## Description

Removes `Wandalen/wretry.action` from the shared `setup-opensearch-dashboards` composite action and replaces it with a local bash retry loop.

The current action references `Wandalen/wretry.action` by commit SHA, but that commit is a composite wrapper which internally references `Wandalen/wretry.action@v3.8.0_js_action`. Repositories enforcing full SHA pinning reject the nested tag-based action reference even when the outer action is pinned.

This surfaced in `security-dashboards-plugin` after switching to the OpenSearch-owned setup action:

https://productionresultssa4.blob.core.windows.net/actions-results/22a3979c-2992-4a4a-aeca-15669b53ac60/workflow-job-run-2dcf166c-9c9c-5b48-9743-a3d3ba13be31/logs/job/job-logs.txt

The local retry loop preserves the same behavior for the yarn setup step:

- retry up to 3 attempts
- run from the `OpenSearch-Dashboards` directory
- fail the action after the final unsuccessful attempt

## Testing

- Parsed `.github/actions/setup-opensearch-dashboards/action.yml` with Ruby's YAML parser.
- Confirmed the setup action has no `Wandalen/wretry.action` references.
- Confirmed the setup action has no non-local `uses:` references that are missing a 40-character commit SHA.