### PR TITLE
Fix logging for parallel builds

### DIFF
--- a/src/run_build.py
+++ b/src/run_build.py
@@ -152,10 +152,15 @@ def _build_parallel(manifest: InputManifest, target: BuildTarget, build_recorder
         logging.info(f"Building {component.name}")
 
         builder = Builders.builder_from(component, target)
-        builder.checkout(work_dir)
-        builder.build(build_recorder)
-        builder.export_artifacts(build_recorder)
-        logging.info(f"Successfully built {component.name}")
+        try:
+            builder.checkout(work_dir)
+            builder.build(build_recorder)
+            builder.export_artifacts(build_recorder)
+            logging.info(f"Successfully built {component.name}")
+        except Exception as e:
+            logging.error(f"ERROR: {e}")
+            logging.error(f"Error building {component.name}, retry with: {args.component_command(component.name)}")
+            raise
 
     failed = graph.execute_parallel(
         build_fn=build_component,

--- a/tests/test_run_build.py
+++ b/tests/test_run_build.py
@@ -496,20 +496,26 @@ class TestRunBuild(unittest.TestCase):
     @patch("run_build.BuildRecorder", return_value=MagicMock())
     @patch("run_build.TemporaryDirectory")
     @patch("run_build.logging.error")
-    def test_main_parallel_continue_on_error_plugin_failure(self, mock_logging_error: Mock, mock_temp: Mock, mock_recorder: Mock, mock_builder_from: Mock, *mocks: Any) -> None:
+    @patch("run_build.logging.info")
+    def test_main_parallel_continue_on_error_plugin_failure(
+            self, mock_logging_info: Mock, mock_logging_error: Mock,
+            mock_temp: Mock, mock_recorder: Mock, mock_builder_from: Mock, *mocks: Any) -> None:
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
 
-        def side_effect_build(*args: Any, **kwargs: Any) -> None:
-            component = mock_builder_from.call_args[0][0]
-            if component.name == "custom-codecs":
-                raise Exception("custom-codecs build failed")
+        def builder_side_effect(component: Any, target: Any) -> MagicMock:
+            builder = MagicMock()
+            if component.name == "geospatial":
+                def fail_build(*a: Any, **kw: Any) -> None:
+                    raise Exception("geospatial build failed")
+                builder.build.side_effect = fail_build
+            return builder
 
-        mock_builder = MagicMock()
-        mock_builder.build.side_effect = side_effect_build
-        mock_builder_from.return_value = mock_builder
+        mock_builder_from.side_effect = builder_side_effect
 
         main()
         mock_recorder.return_value.write_manifest.assert_called()
+        mock_logging_error.assert_any_call(f"Error building geospatial, retry with: run_build.py {self.OPENSEARCH_MANIFEST} --component geospatial")
+        mock_logging_info.assert_any_call("Successfully built OpenSearch")
 
     @patch("argparse._sys.argv", ["run_build.py", OPENSEARCH_MANIFEST, "-p", "linux", "--parallel"])
     @patch("run_build.Builders.builder_from", return_value=MagicMock())
@@ -537,7 +543,8 @@ class TestRunBuild(unittest.TestCase):
     @patch("run_build.Builders.builder_from", return_value=MagicMock())
     @patch("run_build.BuildRecorder", return_value=MagicMock())
     @patch("run_build.TemporaryDirectory")
-    def test_main_parallel_raises_on_core_failure(self, mock_temp: Mock, mock_recorder: Mock, mock_builder_from: Mock, *mocks: Any) -> None:
+    @patch("run_build.logging.error")
+    def test_main_parallel_raises_on_core_failure(self, mock_logging_error: Mock, mock_temp: Mock, mock_recorder: Mock, mock_builder_from: Mock, *mocks: Any) -> None:
         mock_temp.return_value.__enter__.return_value.name = tempfile.gettempdir()
 
         def fail_core(component: Any, target: Any) -> MagicMock:
@@ -551,3 +558,4 @@ class TestRunBuild(unittest.TestCase):
         with self.assertRaises(Exception) as ctx:
             main()
         self.assertIn("OpenSearch build failed", str(ctx.exception))
+        mock_logging_error.assert_any_call(f"Error building OpenSearch, retry with: run_build.py {self.OPENSEARCH_MANIFEST} --component OpenSearch")


### PR DESCRIPTION
### Description
The publishDistributionBuildResults Jenkins library searches console logs for "Error building" and "Successfully built" messages to index build results. After enabling parallel builds (--parallel), the _build_parallel path in run_build.py never logged these messages on failure — exceptions were caught silently by build_graph.py
This PR adds try/except in build_component to emit the same log messages as the sequential path before re-raising

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
