### PR TITLE
Upgrade nick-fields/retry to v4 for Node.js 24 compatibility

### DIFF
--- a/.github/actions/setup-opensearch-dashboards/action.yml
+++ b/.github/actions/setup-opensearch-dashboards/action.yml
@@ -150,7 +150,7 @@ runs:
       shell: bash
 
     - name: Bootstrap OpenSearch Dashboards
-      uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
       with:
         timeout_minutes: 20
         max_attempts: 2


### PR DESCRIPTION
### Description
Addresses: `Warning: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 targets Node.js 20 (deprecated)`

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
