### PR TITLE
Fix OSD min download URL in setup-opensearch-dashboards action

### DIFF
--- a/.github/actions/setup-opensearch-dashboards/action.yml
+++ b/.github/actions/setup-opensearch-dashboards/action.yml
@@ -160,9 +160,9 @@ runs:
       if: ${{ inputs.install_zip == 'true' && runner.os == 'Linux' }}
       run: |
         if [ "${{ inputs.snapshot }}" = "false" ]; then
-          url="https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ steps.osd-version.outputs.plugin-version }}/latest/linux/x64/tar/builds/opensearch-dashboards/dist/opensearch-dashboards-min-${{ steps.osd-version.outputs.plugin-version }}-linux-x64.tar.gz"
+          url="https://artifacts.opensearch.org/releases/core/opensearch-dashboards/${{ steps.osd-version.outputs.plugin-version }}/opensearch-dashboards-min-${{ steps.osd-version.outputs.plugin-version }}-linux-x64.tar.gz"
         else
-          url="https://artifacts.opensearch.org/snapshots/core/opensearch-dashboards/${{ steps.osd-version.outputs.plugin-version }}-SNAPSHOT/opensearch-dashboards-min-${{ steps.osd-version.outputs.plugin-version }}-SNAPSHOT-linux-x64-latest.tar.gz"
+          url="https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ steps.osd-version.outputs.plugin-version }}/latest/linux/x64/tar/builds/opensearch-dashboards/dist/opensearch-dashboards-min-${{ steps.osd-version.outputs.plugin-version }}-linux-x64.tar.gz"
         fi
         curl -L -o opensearch-dashboards.tar.gz "$url"
       shell: bash


### PR DESCRIPTION
### Description

Fix the OSD min artifact download URL in the `setup-opensearch-dashboards` composite action.

The `snapshot: true` path was pointing to `artifacts.opensearch.org/snapshots/core/opensearch-dashboards/` which does not have OSD min artifacts published (returns 403 for all versions). The actual latest CI builds live at `ci.opensearch.org`.

### Verified URLs

| Path | Status |
|---|---|
| `artifacts.opensearch.org/snapshots/core/opensearch-dashboards/3.7.0-SNAPSHOT/...` | ❌ 403 |
| `ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/3.7.0/latest/...` | ✅ 302 |
| `artifacts.opensearch.org/releases/core/opensearch-dashboards/3.7.0/...` | ✅ 200 |

### Changes

- `snapshot: true` (default) → downloads from `ci.opensearch.org` (latest CI build)
- `snapshot: false` → downloads from `artifacts.opensearch.org/releases/` (official releases)

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.