### PR TITLE
Update numDirectArenas override to 32

### DIFF
--- a/scripts/components/OpenSearch-DataFusion/jvmopts.txt
+++ b/scripts/components/OpenSearch-DataFusion/jvmopts.txt
@@ -1,5 +1,6 @@
 
 # DataFusion JVM Opts
+-Dio.netty.allocator.numDirectArenas=32
 -Dio.netty.noUnsafe=false
 -Dio.netty.tryUnsafe=true
 -Dio.netty.tryReflectionSetAccessible=true

--- a/scripts/components/OpenSearch-DataFusion/jvmopts.txt
+++ b/scripts/components/OpenSearch-DataFusion/jvmopts.txt
@@ -1,6 +1,5 @@
 
 # DataFusion JVM Opts
--Dio.netty.allocator.numDirectArenas=1
 -Dio.netty.noUnsafe=false
 -Dio.netty.tryUnsafe=true
 -Dio.netty.tryReflectionSetAccessible=true


### PR DESCRIPTION
### Description
Update numDirectArenas override to 32 for datafusion builds. . 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
