### PR TITLE
Add backport-pr re-usable workflow to replace old backport action

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -27,9 +27,11 @@ jobs:
           echo "PR labels: $labels"
           branches="[]"
           for label in $labels; do
-            if [[ "$label" =~ ^backport\ [^\ ]+$ ]]; then
+            if [[ "$label" =~ ^backport\ [a-zA-Z0-9._/\-]+$ ]]; then
               branch="${label#backport }"
               branches=$(echo "$branches" | jq --arg b "$branch" '. + [$b]')
+            elif [[ "$label" == backport* ]]; then
+              echo "::warning::Invalid backport label format: '$label'. Expected 'backport <branch>' with alphanumeric, dot, slash, dash, or underscore characters."
             fi
           done
           echo "branches=$branches" >> $GITHUB_OUTPUT
@@ -56,32 +58,39 @@ jobs:
         run: |
           git config user.name "opensearch-ci-bot"
           git config user.email "opensearch-infra@amazon.com"
-          BACKPORT_BRANCH="backport/backport-${{ github.event.pull_request.number }}-to-${{ matrix.branch }}"
+          BACKPORT_BRANCH="backport/backport-${PR_NUMBER}-to-${BASE_BRANCH}"
           git checkout -b "$BACKPORT_BRANCH"
-          PARENT_COUNT=$(git cat-file -p ${{ github.event.pull_request.merge_commit_sha }} | grep -c '^parent')
+          PARENT_COUNT=$(git cat-file -p "$MERGE_COMMIT_SHA" | grep -c '^parent')
           if [ "$PARENT_COUNT" -gt 1 ]; then
-            echo "::error::PR #${{ github.event.pull_request.number }} was not squash-merged (merge commit has $PARENT_COUNT parents). Automatic backport is only supported for squash merges."
+            echo "::error::PR #${PR_NUMBER} was not squash-merged (merge commit has $PARENT_COUNT parents). Automatic backport is only supported for squash merges."
             exit 1
           fi
-          git cherry-pick -x --signoff ${{ github.event.pull_request.merge_commit_sha }}
-          git remote add fork "https://x-access-token:${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}@github.com/opensearch-ci-bot/${{ github.event.repository.name }}.git"
+          git cherry-pick -x --signoff "$MERGE_COMMIT_SHA"
+          git remote add fork "https://x-access-token:${GH_TOKEN}@github.com/opensearch-ci-bot/${REPO_NAME}.git"
           git push fork "$BACKPORT_BRANCH"
           gh pr create \
             --repo "${{ github.repository }}" \
-            --base "${{ matrix.branch }}" \
+            --base "$BASE_BRANCH" \
             --head "opensearch-ci-bot:${BACKPORT_BRANCH}" \
-            --title "[Backport ${{ matrix.branch }}] ${{ github.event.pull_request.title }}" \
-            --body "Backport ${{ github.event.pull_request.merge_commit_sha }} from #${{ github.event.pull_request.number }}."
+            --title "[Backport ${BASE_BRANCH}] ${PR_TITLE}" \
+            --body "Backport ${MERGE_COMMIT_SHA} from #${PR_NUMBER}."
         env:
           GH_TOKEN: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          BASE_BRANCH: ${{ matrix.branch }}
+          REPO_NAME: ${{ github.event.repository.name }}
 
       - name: Comment on failure
         if: failure()
         run: |
-          gh issue comment ${{ github.event.pull_request.number }} \
+          gh issue comment "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
-            --body "The backport to \`${{ matrix.branch }}\` failed. Please backport manually.
+            --body "The backport to \`${BASE_BRANCH}\` failed. Please backport manually.
 
           See failed workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           GH_TOKEN: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_BRANCH: ${{ matrix.branch }}

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -26,6 +26,7 @@ jobs:
   Get-Backport-Branches:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
+    timeout-minutes: 5
     outputs:
       branches: ${{ steps.parse.outputs.branches }}
     steps:
@@ -127,6 +128,7 @@ jobs:
 
   Delete-Backport-Branch:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: |
       inputs.delete_branch &&
       github.event.action == 'closed' &&

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -1,0 +1,87 @@
+---
+name: Backport PR
+on:
+  workflow_call:
+    secrets:
+      OPENSEARCH_CI_BOT_TOKEN:
+        required: true
+
+jobs:
+  Get-Backport-Branches:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    outputs:
+      branches: ${{ steps.parse.outputs.branches }}
+    steps:
+      - name: Verify event
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request_target" ]]; then
+            echo "::error::This workflow only supports pull_request_target events, got '${{ github.event_name }}'"
+            exit 1
+          fi
+
+      - name: Parse backport labels
+        id: parse
+        run: |
+          labels=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
+          echo "PR labels: $labels"
+          branches="[]"
+          for label in $labels; do
+            if [[ "$label" =~ ^backport\ [^\ ]+$ ]]; then
+              branch="${label#backport }"
+              branches=$(echo "$branches" | jq --arg b "$branch" '. + [$b]')
+            fi
+          done
+          echo "branches=$branches" >> $GITHUB_OUTPUT
+          echo "Backport target branches: $branches"
+
+  Backport:
+    needs: Get-Backport-Branches
+    if: needs.Get-Backport-Branches.outputs.branches != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ${{ fromJSON(needs.Get-Backport-Branches.outputs.branches) }}
+    timeout-minutes: 10
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ matrix.branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Cherry-pick and create backport PR
+        run: |
+          git config user.name "opensearch-ci-bot"
+          git config user.email "opensearch-infra@amazon.com"
+          BACKPORT_BRANCH="backport/backport-${{ github.event.pull_request.number }}-to-${{ matrix.branch }}"
+          git checkout -b "$BACKPORT_BRANCH"
+          PARENT_COUNT=$(git cat-file -p ${{ github.event.pull_request.merge_commit_sha }} | grep -c '^parent')
+          if [ "$PARENT_COUNT" -gt 1 ]; then
+            echo "::error::PR #${{ github.event.pull_request.number }} was not squash-merged (merge commit has $PARENT_COUNT parents). Automatic backport is only supported for squash merges."
+            exit 1
+          fi
+          git cherry-pick -x --signoff ${{ github.event.pull_request.merge_commit_sha }}
+          git remote add fork "https://x-access-token:${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}@github.com/opensearch-ci-bot/${{ github.event.repository.name }}.git"
+          git push fork "$BACKPORT_BRANCH"
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --base "${{ matrix.branch }}" \
+            --head "opensearch-ci-bot:${BACKPORT_BRANCH}" \
+            --title "[Backport ${{ matrix.branch }}] ${{ github.event.pull_request.title }}" \
+            --body "Backport ${{ github.event.pull_request.merge_commit_sha }} from #${{ github.event.pull_request.number }}."
+        env:
+          GH_TOKEN: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
+
+      - name: Comment on failure
+        if: failure()
+        run: |
+          gh issue comment ${{ github.event.pull_request.number }} \
+            --repo "${{ github.repository }}" \
+            --body "The backport to \`${{ matrix.branch }}\` failed. Please backport manually.
+
+          See failed workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -60,7 +60,7 @@ jobs:
           git config user.name "opensearch-ci-bot"
           git config user.email "opensearch-infra@amazon.com"
           BACKPORT_BRANCH="backport/backport-${PR_NUMBER}-to-${BASE_BRANCH}"
-          if gh pr list --repo "$GITHUB_REPO" --head "opensearch-ci-bot:${BACKPORT_BRANCH}" --state open --json number --jq '.[0].number' | grep -q .; then
+          if gh pr list --repo "$GITHUB_REPO" --head "${BACKPORT_BRANCH}" --state open --json number,headRepositoryOwner --jq '.[] | select(.headRepositoryOwner.login=="opensearch-ci-bot") | .number' | grep -q .; then
             echo "Backport PR for ${BACKPORT_BRANCH} already exists, skipping."
             exit 0
           fi
@@ -69,6 +69,7 @@ jobs:
             echo "::error::merge_commit_sha is empty for PR #${PR_NUMBER}; cannot backport."
             exit 1
           fi
+          git fetch origin "$MERGE_COMMIT_SHA"
           PARENT_COUNT=$(git cat-file -p "$MERGE_COMMIT_SHA" | grep -c '^parent')
           if [ "$PARENT_COUNT" -gt 1 ]; then
             echo "::error::PR #${PR_NUMBER} was not squash-merged (merge commit has $PARENT_COUNT parents). Automatic backport is only supported for squash merges."
@@ -76,7 +77,8 @@ jobs:
           fi
           git cherry-pick -x --signoff "$MERGE_COMMIT_SHA"
           git remote add fork "https://github.com/opensearch-ci-bot/${REPO_NAME}.git"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)" push --force fork "$BACKPORT_BRANCH"
+          gh auth setup-git
+          git push --force fork "$BACKPORT_BRANCH"
           gh pr create \
             --repo "$GITHUB_REPO" \
             --base "$BASE_BRANCH" \

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -53,8 +53,10 @@ jobs:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
           persist-credentials: false
+          path: backport-repo
 
       - name: Cherry-pick and create backport PR
+        working-directory: backport-repo
         run: |
           git config user.name "opensearch-ci-bot"
           git config user.email "opensearch-infra@amazon.com"
@@ -81,6 +83,10 @@ jobs:
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           BASE_BRANCH: ${{ matrix.branch }}
           REPO_NAME: ${{ github.event.repository.name }}
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf backport-repo
 
       - name: Comment on failure
         if: failure()

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -3,6 +3,16 @@ name: Backport PR
 on:
   workflow_call:
     inputs:
+      backport_user_name:
+        description: 'GitHub user/org that owns the fork to push backport branches to'
+        type: string
+        default: 'opensearch-ci-bot'
+        required: false
+      backport_user_email:
+        description: 'Email address used for git commit identity'
+        type: string
+        default: 'opensearch-infra@amazon.com'
+        required: false
       delete_branch:
         description: 'Delete the backport branch on the fork after the backport PR is merged'
         type: boolean
@@ -63,13 +73,9 @@ jobs:
       - name: Cherry-pick and create backport PR
         working-directory: backport-repo
         run: |
-          git config user.name "opensearch-ci-bot"
-          git config user.email "opensearch-infra@amazon.com"
+          git config user.name "$BACKPORT_USER_NAME"
+          git config user.email "$BACKPORT_USER_EMAIL"
           BACKPORT_BRANCH="backport/backport-${PR_NUMBER}-to-${BASE_BRANCH}"
-          if gh pr list --repo "$GITHUB_REPO" --head "${BACKPORT_BRANCH}" --state open --json number,headRepositoryOwner --jq '.[] | select(.headRepositoryOwner.login=="opensearch-ci-bot") | .number' | grep -q .; then
-            echo "Backport PR for ${BACKPORT_BRANCH} already exists, skipping."
-            exit 0
-          fi
           git checkout -b "$BACKPORT_BRANCH"
           if [ -z "$MERGE_COMMIT_SHA" ]; then
             echo "::error::merge_commit_sha is empty for PR #${PR_NUMBER}; cannot backport."
@@ -82,13 +88,13 @@ jobs:
             exit 1
           fi
           git cherry-pick -x --signoff "$MERGE_COMMIT_SHA"
-          git remote add fork "https://github.com/opensearch-ci-bot/${REPO_NAME}.git"
+          git remote add fork "https://github.com/${BACKPORT_USER_NAME}/${REPO_NAME}.git"
           gh auth setup-git
           git push --force fork "$BACKPORT_BRANCH"
           gh pr create \
             --repo "$GITHUB_REPO" \
             --base "$BASE_BRANCH" \
-            --head "opensearch-ci-bot:${BACKPORT_BRANCH}" \
+            --head "${BACKPORT_USER_NAME}:${BACKPORT_BRANCH}" \
             --title "[Backport ${BASE_BRANCH}] ${PR_TITLE}" \
             --body "Backport ${MERGE_COMMIT_SHA} from #${PR_NUMBER}."
         env:
@@ -99,6 +105,8 @@ jobs:
           BASE_BRANCH: ${{ matrix.branch }}
           REPO_NAME: ${{ github.event.repository.name }}
           GITHUB_REPO: ${{ github.repository }}
+          BACKPORT_USER_NAME: ${{ inputs.backport_user_name }}
+          BACKPORT_USER_EMAIL: ${{ inputs.backport_user_email }}
 
       - name: Cleanup
         if: always()
@@ -124,11 +132,12 @@ jobs:
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'backport/') &&
-      github.event.pull_request.head.repo.owner.login == 'opensearch-ci-bot'
+      github.event.pull_request.head.repo.owner.login == inputs.backport_user_name
     steps:
       - name: Delete branch on fork
-        run: gh api -X DELETE "repos/opensearch-ci-bot/${REPO_NAME}/git/refs/heads/${BRANCH_NAME}"
+        run: gh api -X DELETE "repos/${BACKPORT_USER_NAME}/${REPO_NAME}/git/refs/heads/${BRANCH_NAME}"
         env:
           GH_TOKEN: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
           REPO_NAME: ${{ github.event.repository.name }}
           BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+          BACKPORT_USER_NAME: ${{ inputs.backport_user_name }}

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -23,19 +23,16 @@ jobs:
       - name: Parse backport labels
         id: parse
         run: |
-          labels=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | jq -r '.[]')
-          echo "PR labels: $labels"
-          branches="[]"
-          for label in $labels; do
-            if [[ "$label" =~ ^backport\ [a-zA-Z0-9._/\-]+$ ]]; then
-              branch="${label#backport }"
-              branches=$(echo "$branches" | jq --arg b "$branch" '. + [$b]')
-            elif [[ "$label" == backport* ]]; then
-              echo "::warning::Invalid backport label format: '$label'. Expected 'backport <branch>' with alphanumeric, dot, slash, dash, or underscore characters."
-            fi
-          done
+          echo "PR labels: $LABELS"
+          branches=$(echo "$LABELS" | jq -c '[.[] | select(test("^backport [a-zA-Z0-9._/\\-]+$")) | sub("^backport "; "")]')
           echo "branches=$branches" >> $GITHUB_OUTPUT
           echo "Backport target branches: $branches"
+          invalid=$(echo "$LABELS" | jq -r '.[] | select(startswith("backport")) | select(test("^backport [a-zA-Z0-9._/\\-]+$") | not)')
+          if [ -n "$invalid" ]; then
+            echo "::warning::Invalid backport labels found: $invalid"
+          fi
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
 
   Backport:
     needs: Get-Backport-Branches

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: ${{ fromJSON(needs.Get-Backport-Branches.outputs.branches) }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Check out repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -46,7 +46,7 @@ jobs:
           branches=$(echo "$LABELS" | jq -c '[.[] | select(test("^backport [a-zA-Z0-9._/\\-]+$")) | sub("^backport "; "")]')
           echo "branches=$branches" >> $GITHUB_OUTPUT
           echo "Backport target branches: $branches"
-          invalid=$(echo "$LABELS" | jq -r '.[] | select(startswith("backport")) | select(test("^backport [a-zA-Z0-9._/\\-]+$") | not)')
+          invalid=$(echo "$LABELS" | jq -r '.[] | select(startswith("backport ")) | select(test("^backport [a-zA-Z0-9._/\\-]+$") | not)')
           if [ -n "$invalid" ]; then
             echo "::warning::Invalid backport labels found: $invalid"
           fi

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -67,7 +67,7 @@ jobs:
           fi
           git cherry-pick -x --signoff "$MERGE_COMMIT_SHA"
           git remote add fork "https://x-access-token:${GH_TOKEN}@github.com/opensearch-ci-bot/${REPO_NAME}.git"
-          git push fork "$BACKPORT_BRANCH"
+          git push --force fork "$BACKPORT_BRANCH"
           gh pr create \
             --repo "${{ github.repository }}" \
             --base "$BASE_BRANCH" \

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -103,11 +103,10 @@ jobs:
         run: |
           gh issue comment "$PR_NUMBER" \
             --repo "$GITHUB_REPO" \
-            --body "The backport to \`${BASE_BRANCH}\` failed. Please backport manually.
-
-          See failed workflow run: https://github.com/${GITHUB_REPO}/actions/runs/${{ github.run_id }}"
+            --body "The backport to \`${BASE_BRANCH}\` failed. Please backport manually. See failed workflow run: https://github.com/${GITHUB_REPO}/actions/runs/${GITHUB_RUN_ID}"
         env:
           GH_TOKEN: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_BRANCH: ${{ matrix.branch }}
           GITHUB_REPO: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -60,7 +60,15 @@ jobs:
           git config user.name "opensearch-ci-bot"
           git config user.email "opensearch-infra@amazon.com"
           BACKPORT_BRANCH="backport/backport-${PR_NUMBER}-to-${BASE_BRANCH}"
+          if gh pr list --repo "$GITHUB_REPO" --head "opensearch-ci-bot:${BACKPORT_BRANCH}" --state open --json number --jq '.[0].number' | grep -q .; then
+            echo "Backport PR for ${BACKPORT_BRANCH} already exists, skipping."
+            exit 0
+          fi
           git checkout -b "$BACKPORT_BRANCH"
+          if [ -z "$MERGE_COMMIT_SHA" ]; then
+            echo "::error::merge_commit_sha is empty for PR #${PR_NUMBER}; cannot backport."
+            exit 1
+          fi
           PARENT_COUNT=$(git cat-file -p "$MERGE_COMMIT_SHA" | grep -c '^parent')
           if [ "$PARENT_COUNT" -gt 1 ]; then
             echo "::error::PR #${PR_NUMBER} was not squash-merged (merge commit has $PARENT_COUNT parents). Automatic backport is only supported for squash merges."
@@ -68,17 +76,13 @@ jobs:
           fi
           git cherry-pick -x --signoff "$MERGE_COMMIT_SHA"
           git remote add fork "https://github.com/opensearch-ci-bot/${REPO_NAME}.git"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64)" push --force fork "$BACKPORT_BRANCH"
-          if gh pr list --repo "${{ github.repository }}" --head "opensearch-ci-bot:${BACKPORT_BRANCH}" --state open --json number --jq '.[0].number' | grep -q .; then
-            echo "Backport PR for ${BACKPORT_BRANCH} already exists, skipping creation."
-          else
-            gh pr create \
-              --repo "${{ github.repository }}" \
-              --base "$BASE_BRANCH" \
-              --head "opensearch-ci-bot:${BACKPORT_BRANCH}" \
-              --title "[Backport ${BASE_BRANCH}] ${PR_TITLE}" \
-              --body "Backport ${MERGE_COMMIT_SHA} from #${PR_NUMBER}."
-          fi
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)" push --force fork "$BACKPORT_BRANCH"
+          gh pr create \
+            --repo "$GITHUB_REPO" \
+            --base "$BASE_BRANCH" \
+            --head "opensearch-ci-bot:${BACKPORT_BRANCH}" \
+            --title "[Backport ${BASE_BRANCH}] ${PR_TITLE}" \
+            --body "Backport ${MERGE_COMMIT_SHA} from #${PR_NUMBER}."
         env:
           GH_TOKEN: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -86,6 +90,7 @@ jobs:
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           BASE_BRANCH: ${{ matrix.branch }}
           REPO_NAME: ${{ github.event.repository.name }}
+          GITHUB_REPO: ${{ github.repository }}
 
       - name: Cleanup
         if: always()
@@ -95,11 +100,12 @@ jobs:
         if: failure()
         run: |
           gh issue comment "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
+            --repo "$GITHUB_REPO" \
             --body "The backport to \`${BASE_BRANCH}\` failed. Please backport manually.
 
-          See failed workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          See failed workflow run: https://github.com/${GITHUB_REPO}/actions/runs/${{ github.run_id }}"
         env:
           GH_TOKEN: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_BRANCH: ${{ matrix.branch }}
+          GITHUB_REPO: ${{ github.repository }}

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -15,10 +15,12 @@ jobs:
     steps:
       - name: Verify event
         run: |
-          if [[ "${{ github.event_name }}" != "pull_request_target" ]]; then
-            echo "::error::This workflow only supports pull_request_target events, got '${{ github.event_name }}'"
+          if [[ "$EVENT_NAME" != "pull_request_target" ]]; then
+            echo "::error::This workflow only supports pull_request_target events, got '$EVENT_NAME'"
             exit 1
           fi
+        env:
+          EVENT_NAME: ${{ github.event_name }}
 
       - name: Parse backport labels
         id: parse
@@ -65,14 +67,18 @@ jobs:
             exit 1
           fi
           git cherry-pick -x --signoff "$MERGE_COMMIT_SHA"
-          git remote add fork "https://x-access-token:${GH_TOKEN}@github.com/opensearch-ci-bot/${REPO_NAME}.git"
-          git push --force fork "$BACKPORT_BRANCH"
-          gh pr create \
-            --repo "${{ github.repository }}" \
-            --base "$BASE_BRANCH" \
-            --head "opensearch-ci-bot:${BACKPORT_BRANCH}" \
-            --title "[Backport ${BASE_BRANCH}] ${PR_TITLE}" \
-            --body "Backport ${MERGE_COMMIT_SHA} from #${PR_NUMBER}."
+          git remote add fork "https://github.com/opensearch-ci-bot/${REPO_NAME}.git"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64)" push --force fork "$BACKPORT_BRANCH"
+          if gh pr list --repo "${{ github.repository }}" --head "opensearch-ci-bot:${BACKPORT_BRANCH}" --state open --json number --jq '.[0].number' | grep -q .; then
+            echo "Backport PR for ${BACKPORT_BRANCH} already exists, skipping creation."
+          else
+            gh pr create \
+              --repo "${{ github.repository }}" \
+              --base "$BASE_BRANCH" \
+              --head "opensearch-ci-bot:${BACKPORT_BRANCH}" \
+              --title "[Backport ${BASE_BRANCH}] ${PR_TITLE}" \
+              --body "Backport ${MERGE_COMMIT_SHA} from #${PR_NUMBER}."
+          fi
         env:
           GH_TOKEN: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -2,6 +2,12 @@
 name: Backport PR
 on:
   workflow_call:
+    inputs:
+      delete_branch:
+        description: 'Delete the backport branch on the fork after the backport PR is merged'
+        type: boolean
+        default: true
+        required: false
     secrets:
       OPENSEARCH_CI_BOT_TOKEN:
         required: true
@@ -110,3 +116,19 @@ jobs:
           BASE_BRANCH: ${{ matrix.branch }}
           GITHUB_REPO: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+
+  Delete-Backport-Branch:
+    runs-on: ubuntu-latest
+    if: |
+      inputs.delete_branch &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'backport/') &&
+      github.event.pull_request.head.repo.owner.login == 'opensearch-ci-bot'
+    steps:
+      - name: Delete branch on fork
+        run: gh api -X DELETE "repos/opensearch-ci-bot/${REPO_NAME}/git/refs/heads/${BRANCH_NAME}"
+        env:
+          GH_TOKEN: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
### Description
Add backport-pr re-usable workflow to replace old backport action

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6270

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
