### PR TITLE
Add backport-pr reusable workflow v2

### DIFF
--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -42,16 +42,23 @@ jobs:
       - name: Parse backport labels
         id: parse
         run: |
-          echo "PR labels: $LABELS"
-          branches=$(echo "$LABELS" | jq -c '[.[] | select(test("^backport [a-zA-Z0-9._/\\-]+$")) | sub("^backport "; "")]')
+          if [ "$EVENT_ACTION" = "labeled" ]; then
+            PARSE_LABELS=$(jq -nc --arg l "$SINGLE_LABEL" '[$l]')
+          else
+            PARSE_LABELS="$LABELS"
+          fi
+          echo "PR labels to process: $PARSE_LABELS"
+          branches=$(echo "$PARSE_LABELS" | jq -c '[.[] | select(test("^backport [a-zA-Z0-9._/\\-]+$")) | sub("^backport "; "")]')
           echo "branches=$branches" >> $GITHUB_OUTPUT
           echo "Backport target branches: $branches"
-          invalid=$(echo "$LABELS" | jq -r '.[] | select(startswith("backport ")) | select(test("^backport [a-zA-Z0-9._/\\-]+$") | not)')
+          invalid=$(echo "$PARSE_LABELS" | jq -r '.[] | select(startswith("backport ")) | select(test("^backport [a-zA-Z0-9._/\\-]+$") | not)')
           if [ -n "$invalid" ]; then
             echo "::warning::Invalid backport labels found: $invalid"
           fi
         env:
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          SINGLE_LABEL: ${{ github.event.label.name }}
+          EVENT_ACTION: ${{ github.event.action }}
 
   Backport:
     needs: Get-Backport-Branches

--- a/.github/workflows/backport-pr.yml
+++ b/.github/workflows/backport-pr.yml
@@ -43,6 +43,10 @@ jobs:
         id: parse
         run: |
           if [ "$EVENT_ACTION" = "labeled" ]; then
+            if [ -z "$SINGLE_LABEL" ]; then
+              echo "::error::Labeled event received but label name is empty"
+              exit 1
+            fi
             PARSE_LABELS=$(jq -nc --arg l "$SINGLE_LABEL" '[$l]')
           else
             PARSE_LABELS="$LABELS"


### PR DESCRIPTION
### Description
Add backport-pr reusable workflow v2 with single-label optimization for labeled events to avoid duplicate backport runs.

Changes from v1:
- On `labeled` events, only process the newly added label (not all labels)
- Safely construct JSON via `jq` for single label parsing

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6270

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
