### PR TITLE
Replace issue-finder with GH script and enable workflows

### DIFF
--- a/.github/workflows/create-release-issues.yml
+++ b/.github/workflows/create-release-issues.yml
@@ -1,111 +1,96 @@
-# ---
-# name: create-release-issues
-#
-# on:
-#   workflow_dispatch:
-#     inputs:
-#       version:
-#         required: true
-#         description: 'Release version'
-#         type: string
-#       repos:
-#         required: true
-#         description: 'List of components repositories'
-#         type: string
-#   workflow_call:
-#     inputs:
-#       version:
-#         required: true
-#         description: 'Release version'
-#         type: string
-#       repos:
-#         required: true
-#         description: 'List of components repositories'
-#         type: string
-#
-# jobs:
-#   build-repo-issue-check:
-#     outputs:
-#       build_repo_issue_exists: ${{ steps.check_if_build_repo_issue_exists.outputs.issues }}
-#       build_repo_issue_number: ${{ steps.get_build_repo_issue_number.outputs.issue_number }}
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: GitHub App token
-#         id: github_app_token
-#         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-#         with:
-#           app_id: ${{ secrets.APP_ID }}
-#           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-#           installation_id: 22958780
-#       - name: Checkout Build repo
-#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-#       - name: Check if build repo release issue exists
-#         id: check_if_build_repo_issue_exists
-#       # WARNING: actions-cool/issues-helper repo is blocked by GitHub for TOS violation (since 2026-05-19).
-#       # This action should be replaced before re-enabling this workflow.
-#         uses: actions-cool/issues-helper@v3
-#         with:
-#           actions: 'find-issues'
-#           repo: opensearch-project/opensearch-build
-#           token: ${{ steps.github_app_token.outputs.token }}
-#           issue-state: 'open'
-#           title-includes: '[RELEASE] Release version ${{ inputs.version }}'
-#       - name: Build repo issue number
-#         id: get_build_repo_issue_number
-#         if: steps.check_if_build_repo_issue_exists.outputs.issues != '[]'
-#         run: |
-#           issues=$(cat <<EOF
-#           ${{ steps.check_if_build_repo_issue_exists.outputs.issues }}
-#           EOF
-#           )
-#           echo "issue_number=$(echo $issues | jq -r '.[0].number')" >> $GITHUB_OUTPUT
-#
-#
-#   component-release-issue:
-#     needs: build-repo-issue-check
-#     if: needs.build-repo-issue-check.outputs.build_repo_issue_exists != '[]'
-#     runs-on: ubuntu-latest
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         repos: ${{ fromJson(inputs.repos) }}
-#     steps:
-#       - name: GitHub App token
-#         id: github_app_token
-#         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-#         with:
-#           app_id: ${{ secrets.APP_ID }}
-#           private_key: ${{ secrets.APP_PRIVATE_KEY }}
-#           installation_id: 22958780
-#       - name: Check if plugin repo release issue exists
-#         id: check_if_plugin_repo_issue_exists
-#       # WARNING: actions-cool/issues-helper repo is blocked by GitHub for TOS violation (since 2026-05-19).
-#       # This action should be replaced before re-enabling this workflow.
-#         uses: actions-cool/issues-helper@v3
-#         with:
-#           actions: 'find-issues'
-#           repo: opensearch-project/${{ matrix.repos }}
-#           token: ${{ steps.github_app_token.outputs.token }}
-#           title-includes: '[RELEASE] Release version ${{ inputs.version }}'
-#       - name: Checkout Build repo
-#         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-#       - name: Replace Placeholders
-#         if: steps.check_if_plugin_repo_issue_exists.outputs.issues == '[]'
-#         run: |
-#           # Read the file contents and replace the placeholders
-#           file_path=".github/ISSUE_TEMPLATE/component_release_template.md"
-#           RELEASE_VERSION="${{ inputs.version }}"
-#           RELEASE_BRANCH=$(echo ${{ inputs.version }} | cut -d. -f1-2)
-#           RELEASE_ISSUE_NUMBER=${{needs.build-repo-issue-check.outputs.build_repo_issue_number}}
-#           RELEASE_ISSUE="https://github.com/opensearch-project/opensearch-build/issues/${RELEASE_ISSUE_NUMBER}"
-#           RELEASE_VERSION_X=$(echo "${{ inputs.version }}" | awk -F'.' '{print $1}').x
-#           sed -e "s|{{RELEASE_VERSION}}|${RELEASE_VERSION}|g" -e "s|{{RELEASE_ISSUE}}|${RELEASE_ISSUE}|g" -e "s|{{RELEASE_BRANCH}}|${RELEASE_BRANCH}|g" -e "s|{{RELEASE_VERSION_X}}|${RELEASE_VERSION_X}|g" "$file_path" > "$file_path.tmp" && mv "$file_path.tmp" "$file_path"
-#       - name: Create component release issue from file
-#         if: steps.check_if_plugin_repo_issue_exists.outputs.issues == '[]'
-#         uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f # v4
-#         with:
-#           title: '[RELEASE] Release version ${{ inputs.version }}'
-#           content-filepath: ../opensearch-build/.github/ISSUE_TEMPLATE/component_release_template.md
-#           labels: v${{ inputs.version }}
-#           token: ${{ steps.github_app_token.outputs.token }}
-#           repository: opensearch-project/${{ matrix.repos }}
+---
+name: create-release-issues
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: 'Release version'
+        type: string
+      repos:
+        required: true
+        description: 'List of components repositories'
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        description: 'Release version'
+        type: string
+      repos:
+        required: true
+        description: 'List of components repositories'
+        type: string
+
+jobs:
+  build-repo-issue-check:
+    outputs:
+      build_repo_issue_exists: ${{ steps.check_if_build_repo_issue_exists.outputs.issues }}
+      build_repo_issue_number: ${{ steps.get_build_repo_issue_number.outputs.issue_number }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Build repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Check if build repo release issue exists
+        id: check_if_build_repo_issue_exists
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
+          script: |
+            const result = await github.rest.search.issuesAndPullRequests({
+              q: 'repo:opensearch-project/opensearch-build "[RELEASE] Release version ${{ inputs.version }}" in:title is:issue is:open'
+            });
+            core.setOutput('issues', JSON.stringify(result.data.items));
+      - name: Build repo issue number
+        id: get_build_repo_issue_number
+        if: steps.check_if_build_repo_issue_exists.outputs.issues != '[]'
+        run: |
+          issues=$(cat <<EOF
+          ${{ steps.check_if_build_repo_issue_exists.outputs.issues }}
+          EOF
+          )
+          echo "issue_number=$(echo $issues | jq -r '.[0].number')" >> $GITHUB_OUTPUT
+
+
+  component-release-issue:
+    needs: build-repo-issue-check
+    if: needs.build-repo-issue-check.outputs.build_repo_issue_exists != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repos: ${{ fromJson(inputs.repos) }}
+    steps:
+      - name: Check if plugin repo release issue exists
+        id: check_if_plugin_repo_issue_exists
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
+          script: |
+            const result = await github.rest.search.issuesAndPullRequests({
+              q: 'repo:opensearch-project/${{ matrix.repos }} "[RELEASE] Release version ${{ inputs.version }}" in:title is:issue'
+            });
+            core.setOutput('issues', JSON.stringify(result.data.items));
+      - name: Checkout Build repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Replace Placeholders
+        if: steps.check_if_plugin_repo_issue_exists.outputs.issues == '[]'
+        run: |
+          # Read the file contents and replace the placeholders
+          file_path=".github/ISSUE_TEMPLATE/component_release_template.md"
+          RELEASE_VERSION="${{ inputs.version }}"
+          RELEASE_BRANCH=$(echo ${{ inputs.version }} | cut -d. -f1-2)
+          RELEASE_ISSUE_NUMBER=${{needs.build-repo-issue-check.outputs.build_repo_issue_number}}
+          RELEASE_ISSUE="https://github.com/opensearch-project/opensearch-build/issues/${RELEASE_ISSUE_NUMBER}"
+          RELEASE_VERSION_X=$(echo "${{ inputs.version }}" | awk -F'.' '{print $1}').x
+          sed -e "s|{{RELEASE_VERSION}}|${RELEASE_VERSION}|g" -e "s|{{RELEASE_ISSUE}}|${RELEASE_ISSUE}|g" -e "s|{{RELEASE_BRANCH}}|${RELEASE_BRANCH}|g" -e "s|{{RELEASE_VERSION_X}}|${RELEASE_VERSION_X}|g" "$file_path" > "$file_path.tmp" && mv "$file_path.tmp" "$file_path"
+      - name: Create component release issue from file
+        if: steps.check_if_plugin_repo_issue_exists.outputs.issues == '[]'
+        uses: peter-evans/create-issue-from-file@433e51abf769039ee20ba1293a088ca19d573b7f # v4
+        with:
+          title: '[RELEASE] Release version ${{ inputs.version }}'
+          content-filepath: ../opensearch-build/.github/ISSUE_TEMPLATE/component_release_template.md
+          labels: v${{ inputs.version }}
+          token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
+          repository: opensearch-project/${{ matrix.repos }}

--- a/.github/workflows/create-release-issues.yml
+++ b/.github/workflows/create-release-issues.yml
@@ -35,11 +35,13 @@ jobs:
       - name: Check if build repo release issue exists
         id: check_if_build_repo_issue_exists
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         with:
           github-token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
           script: |
             const result = await github.rest.search.issuesAndPullRequests({
-              q: 'repo:opensearch-project/opensearch-build "[RELEASE] Release version ${{ inputs.version }}" in:title is:issue is:open'
+              q: `repo:opensearch-project/opensearch-build "[RELEASE] Release version ${process.env.RELEASE_VERSION}" in:title is:issue is:open`
             });
             core.setOutput('issues', JSON.stringify(result.data.items));
       - name: Build repo issue number

--- a/.github/workflows/create-release-issues.yml
+++ b/.github/workflows/create-release-issues.yml
@@ -67,11 +67,14 @@ jobs:
       - name: Check if plugin repo release issue exists
         id: check_if_plugin_repo_issue_exists
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          COMPONENT_REPO: ${{ matrix.repos }}
         with:
           github-token: ${{ secrets.OPENSEARCH_CI_BOT_TOKEN }}
           script: |
             const result = await github.rest.search.issuesAndPullRequests({
-              q: 'repo:opensearch-project/${{ matrix.repos }} "[RELEASE] Release version ${{ inputs.version }}" in:title is:issue'
+              q: `repo:opensearch-project/${process.env.COMPONENT_REPO} "[RELEASE] Release version ${process.env.RELEASE_VERSION}" in:title is:issue`
             });
             core.setOutput('issues', JSON.stringify(result.data.items));
       - name: Checkout Build repo


### PR DESCRIPTION
### Description
  - Removed both tibdex/github-app-token steps (and the APP_ID, APP_PRIVATE_KEY, installation_id dependencies) from both jobs
  - Replaced both actions-cool/issues-helper usages with actions/github-script@v7.0.1 using the GitHub Search API
  - Switched all token references to secrets.OPENSEARCH_CI_BOT_TOKEN

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
