### PR TITLE
Update release client docker image to upgrade dotnet to 10

### DIFF
--- a/docker/ci/dockerfiles/current/release.almalinux8.clients.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/release.almalinux8.clients.x64.arm64.dockerfile
@@ -33,7 +33,7 @@ RUN dnf install -y @development zlib-devel bzip2 bzip2-devel readline-devel sqli
 RUN dnf groupinstall -y "Development Tools" && dnf clean all && rm -rf /var/cache/dnf/*
 
 # Installing dotnet
-ARG DOT_NET_LIST="8.0"
+ARG DOT_NET_LIST="10.0"
 RUN for dotnet_version in $DOT_NET_LIST; do dnf install -y dotnet-sdk-$dotnet_version; done
 
 # Tools setup


### PR DESCRIPTION
### Description
Update release client docker image to upgrade dotnet to 10

### Issues Resolved
https://github.com/opensearch-project/.github/issues/570

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
