### PR TITLE
Upgrade dotnet to 10.0.300 to meet .NET client 2.0.0 requirements

### DIFF
--- a/docker/ci/dockerfiles/current/release.almalinux8.clients.x64.arm64.dockerfile
+++ b/docker/ci/dockerfiles/current/release.almalinux8.clients.x64.arm64.dockerfile
@@ -32,9 +32,16 @@ RUN dnf install -y @development zlib-devel bzip2 bzip2-devel readline-devel sqli
 # Add Yarn dependencies
 RUN dnf groupinstall -y "Development Tools" && dnf clean all && rm -rf /var/cache/dnf/*
 
-# Installing dotnet
+# Installing dotnet (almalinux8 10.0 == 10.0.109 < 10.0.300)
 ARG DOT_NET_LIST="10.0"
 RUN for dotnet_version in $DOT_NET_LIST; do dnf install -y dotnet-sdk-$dotnet_version; done
+# Specifically to upgrade version from 10.0.109 to 10.0.300, keep above to install all the dependencies
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh && chmod +x dotnet-install.sh && \
+    ./dotnet-install.sh --version 10.0.300 --install-dir /usr/share/dotnet
+
+# ENV DOTNET
+ENV DOTNET_ROOT=/usr/share/dotnet
+ENV PATH=$DOTNET_ROOT:$PATH
 
 # Tools setup
 COPY --chown=0:0 config/jdk-setup.sh config/yq-setup.sh config/gh-setup.sh config/op-setup.sh /tmp/


### PR DESCRIPTION
### Description
Upgrade dotnet to 10.0.300 to meet .NET client 2.0.0 requirements

### Issues Resolved
https://github.com/opensearch-project/.github/issues/570

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
