### PR TITLE
Enable PPL rest command endpoints for sql 3.8.0 integ-test cluster

### DIFF
--- a/manifests/3.8.0/opensearch-3.8.0-test.yml
+++ b/manifests/3.8.0/opensearch-3.8.0-test.yml
@@ -170,6 +170,20 @@ components:
       additional-cluster-configs:
         script.context.field.max_compilations_rate: 1000/1m
         plugins.query.datasources.encryption.masterkey: 4fc8fee6a3fd7d6ca01772e5
+        # The PPL `rest` command is disabled by default (empty allow-list) and the setting is
+        # node-scoped, so it must be set at cluster startup. Opt into the same endpoints the sql
+        # repo's own integ-test clusters enable so the rest integration tests exercise the enabled
+        # path instead of failing with "the rest command is disabled on this cluster".
+        plugins.ppl.rest.allowed_endpoints:
+          - /_cluster/health
+          - /_cluster/state
+          - /_cluster/settings
+          - /_cat/indices
+          - /_cat/nodes
+          - /_cat/cluster_manager
+          - /_cat/plugins
+          - /_cat/shards
+          - /_resolve/index
     bwc-test:
       test-configs:
         - with-security


### PR DESCRIPTION
### Description

The PPL `rest` command (opensearch-project/sql#5599) is **disabled by default**: it is gated behind `plugins.ppl.rest.allowed_endpoints`, a node-scoped setting whose default is an empty allow-list. Because the setting is `NodeScope` (non-dynamic), it must be provided at cluster startup.

The sql repo's own `integ-test/build.gradle` opts its test clusters into the registered endpoints, which is why the tests pass in the sql repo's CI. But the 3.8.0 distribution **test** manifest was never updated to match, so the release integ-test cluster boots with the command disabled.

As a result, every `| rest ...` integration test fails on the distribution cluster with `the rest command is disabled on this cluster` — across both `with-security` and `without-security`, on every platform/arch/dist. Affected classes:

- `org.opensearch.sql.calcite.remote.CalcitePPLRestIT`
- `org.opensearch.sql.calcite.remote.CalciteExplainIT` (`explainRestCommand`)
- `org.opensearch.sql.calcite.remote.CalciteNewAddedCommandsIT` (`testRest`)
- `org.opensearch.sql.calcite.CalciteNoPushdownIT` (suite runner aggregating the above)

This adds the same endpoint allow-list the sql repo enables so the release integ-test cluster exercises the enabled path. The value is rendered into `opensearch.yml` as a native YAML list (matching how `plugins.destination.host.deny_list` and `path.repo` are already configured for other components in this manifest), which is the correct representation for an OpenSearch `listSetting`.

Only the `3.8.0` manifest is affected — the `rest` command first ships in 3.8.0, so earlier release trains (3.7.x, 3.6.x) do not have the feature and need no change.

### Issues Resolved

Fixes the current failure mode in opensearch-project/sql#5620 (build 12088).

### Testing

- Manifest validated through the repo's `TestManifest` loader (Cerberus schema): loads and validates OK.
- Confirmed `yaml.dump` of the config renders `plugins.ppl.rest.allowed_endpoints` as a native YAML list in the generated `opensearch.yml`.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
