### PR TITLE
Revert "Enable PPL rest command endpoints for sql 3.8.0 integ-test cluster"

### DIFF
--- a/manifests/3.8.0/opensearch-3.8.0-test.yml
+++ b/manifests/3.8.0/opensearch-3.8.0-test.yml
@@ -170,20 +170,6 @@ components:
       additional-cluster-configs:
         script.context.field.max_compilations_rate: 1000/1m
         plugins.query.datasources.encryption.masterkey: 4fc8fee6a3fd7d6ca01772e5
-        # The PPL `rest` command is disabled by default (empty allow-list) and the setting is
-        # node-scoped, so it must be set at cluster startup. Opt into the same endpoints the sql
-        # repo's own integ-test clusters enable so the rest integration tests exercise the enabled
-        # path instead of failing with "the rest command is disabled on this cluster".
-        plugins.ppl.rest.allowed_endpoints:
-          - /_cluster/health
-          - /_cluster/state
-          - /_cluster/settings
-          - /_cat/indices
-          - /_cat/nodes
-          - /_cat/cluster_manager
-          - /_cat/plugins
-          - /_cat/shards
-          - /_resolve/index
     bwc-test:
       test-configs:
         - with-security


### PR DESCRIPTION
### Description

PR #6299 added `plugins.ppl.rest.allowed_endpoints` to the SQL 3.8.0 distribution integration-test cluster so the PPL `rest` tests could run. However, the SQL `rest` feature had already been reverted by opensearch-project/sql#5635 before #6299 merged:

- opensearch-project/sql#5635 merged at 2026-07-17 20:12 UTC and removed the command, its integration tests, and registration of both `plugins.ppl.rest.*` node settings.
- #6299 merged at 2026-07-17 22:25 UTC and continued injecting `plugins.ppl.rest.allowed_endpoints` into `opensearch.yml`.

The 3.8.0 distribution manifest tracks SQL `main`, so current SQL artifacts no longer recognize this setting. OpenSearch rejects the unknown setting during bootstrap, and the integration-test launcher eventually reports `Cluster is not available after 10 attempts` before any SQL test can run.

This removes the stale setting from the SQL test-cluster configuration. The existing list-valued YAML handling is valid and does not need a Python change; the failure is specifically the cross-repository setting mismatch. If the PPL `rest` feature is reintroduced, its cluster configuration should be restored together with the feature.

### Issues Resolved

Follow-up to #6299 and opensearch-project/sql#5620.

### Testing

- `PYTHONPATH=src python src/run_ci.py manifests/3.8.0/opensearch-3.8.0-test.yml --snapshot`
- `yamllint -c .yamllint.yml manifests/3.8.0/opensearch-3.8.0-test.yml`
- Focused manifest and integration-workflow pytest suites: 77 passed
- `git diff --check`

### Check List

- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.