### PR TITLE
Add cross-cluster-replication benchmark test workflow

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_args.py
+++ b/src/test_workflow/benchmark_test/benchmark_args.py
@@ -59,6 +59,7 @@ class BenchmarkArgs:
     command: str
     enable_instance_storage: bool
     preserve_cluster: bool
+    ccr_enabled: bool
 
     def __init__(self) -> None:
         parser = argparse.ArgumentParser(description="Test an OpenSearch Bundle or compare two tests")
@@ -156,6 +157,9 @@ class BenchmarkArgs:
                                          help="Use instance based SSD storage instead of EBS for data nodes", default=False)
         execute_test_parser.add_argument("--preserve-cluster", dest="preserve_cluster", action="store_true",
                                          help="Do not destroy the CDK cluster after the test completes", default=False)
+        execute_test_parser.add_argument("--ccr-enabled", dest="ccr_enabled", action="store_true",
+                                         help="Run cross-cluster-replication test by spinning up a leader and a follower cluster "
+                                              "and applying CCR settings on the follower.", default=False)
 
         # command to run comparison
         compare_parser = subparsers.add_parser("compare", parents=[parent_parser],
@@ -203,6 +207,7 @@ class BenchmarkArgs:
             self.ml_node_storage = args.ml_node_storage if args.ml_node_storage else None
             self.enable_instance_storage = args.enable_instance_storage
             self.preserve_cluster = args.preserve_cluster
+            self.ccr_enabled = args.ccr_enabled
             self.enable_remote_store = args.enable_remote_store
             self.data_instance_type = args.data_instance_type if args.data_instance_type else None
             self.workload = args.workload

--- a/src/test_workflow/benchmark_test/benchmark_create_cluster.py
+++ b/src/test_workflow/benchmark_test/benchmark_create_cluster.py
@@ -11,7 +11,12 @@ import logging
 import os
 import subprocess
 from contextlib import contextmanager
-from typing import Any, Generator, Union
+from typing import Any, Dict, Generator, Union
+
+import boto3
+import requests
+from requests.auth import HTTPBasicAuth
+from retry.api import retry_call  # type: ignore
 
 from manifests.build_manifest import BuildManifest
 from manifests.bundle_manifest import BundleManifest
@@ -28,6 +33,9 @@ class BenchmarkCreateCluster(BenchmarkTestCluster):
     params: str
     is_endpoint_public: bool
     cluster_endpoint: str
+    cluster_role: str
+    stack_suffix: str
+    seed_node_ip: str
 
     """
     Represents a performance test cluster. This class deploys the opensearch bundle with CDK. Supports both single
@@ -39,12 +47,19 @@ class BenchmarkCreateCluster(BenchmarkTestCluster):
             args: BenchmarkArgs,
             bundle_manifest: Union[BundleManifest, BuildManifest],
             config: dict,
-            current_workspace: str
+            current_workspace: str,
+            cluster_role: str = None
     ) -> None:
         super().__init__(args)
         self.manifest = bundle_manifest
         self.current_workspace = current_workspace
-        self.output_file = "output.json"
+        # Role of the cluster in a cross-cluster-replication run, either 'leader' or 'follower'.
+        # It is appended to the stack suffix/name to differentiate the two cluster stacks.
+        self.cluster_role = cluster_role
+        self.output_file = f"output-{cluster_role}.json" if cluster_role else "output.json"
+        # Append the cluster role (leader/follower) to the stack suffix so that the two CCR
+        # cluster stacks get unique, differentiable names. Does not mutate the shared args.
+        self.stack_suffix = f"{self.args.stack_suffix}-{cluster_role}" if cluster_role else self.args.stack_suffix
         role = config["Constants"]["Role"]
         params_dict = self.setup_cdk_params(config)
         params_list = []
@@ -66,7 +81,10 @@ class BenchmarkCreateCluster(BenchmarkTestCluster):
         self.params = "".join(params_list) + role_params
         self.password = None if self.args.insecure else get_password(self.args.distribution_version)
         self.is_endpoint_public = False
-        self.stack_name = f"opensearch-infra-stack-{self.args.stack_suffix}"
+        # Private IP of the seed node (single-node ip for a single node cluster), resolved once
+        # the cluster is up. Required to apply cross-cluster-replication settings on the follower.
+        self.seed_node_ip = None
+        self.stack_name = f"opensearch-infra-stack-{self.stack_suffix}"
         if self.manifest:
             self.stack_name += f"-{self.manifest.build.id}-{self.manifest.build.architecture}"
 
@@ -87,6 +105,77 @@ class BenchmarkCreateCluster(BenchmarkTestCluster):
             raise RuntimeError("Unable to fetch the cluster endpoint from cdk output")
         self.cluster_endpoint = load_balancer_url
         self.cluster_endpoint_with_port = "".join([load_balancer_url, ":", str(self.port)])
+        if self.args.ccr_enabled:
+            self.seed_node_ip = self.fetch_seed_node_ip(cdk_output)
+
+    def fetch_seed_node_ip(self, cdk_output: dict) -> str:
+        """
+        Resolve the private IP of the seed node, which is needed to apply cross-cluster-replication
+        settings. For a single-node cluster the IP is exposed directly in the cdk output ('privateip').
+        For a multi-node cluster the seed node sits behind an autoscaling group, so it is looked up via
+        the unique 'Name' tag (<stack_name>/seedNodeLt) that opensearch-cluster-cdk applies per stack.
+        """
+        if self.args.single_node:
+            private_ip = cdk_output[self.stack_name].get('privateip', None)
+            if private_ip is None:
+                raise RuntimeError("Unable to fetch the single-node private ip from cdk output")
+            return str(private_ip)
+
+        return self.fetch_seed_node_ip_by_tag(f"{self.stack_name}/seedNodeLt")
+
+    def fetch_seed_node_ip_by_tag(self, seed_node_tag: str) -> str:
+        region = self.args.region if getattr(self.args, "region", None) else "us-east-1"
+        ec2_client = boto3.client("ec2", region_name=region)
+        response = ec2_client.describe_instances(
+            Filters=[
+                {"Name": "tag:Name", "Values": [seed_node_tag]},
+                {"Name": "instance-state-name", "Values": ["running"]},
+            ]
+        )
+        for reservation in response.get("Reservations", []):
+            for instance in reservation.get("Instances", []):
+                private_ip = instance.get("PrivateIpAddress")
+                if private_ip:
+                    return str(private_ip)
+        raise RuntimeError(f"Unable to find a running seed node with tag Name={seed_node_tag}")
+
+    def apply_leader_settings(self) -> None:
+        """
+        Placeholder to apply arrow streaming settings on the leader cluster.
+        TODO: Fill in the exact arrow streaming settings once finalized.
+        """
+        logging.info(f"Applying leader (arrow streaming) settings on cluster {self.stack_name}")
+
+    def apply_follower_settings(self, leader_seed_node_ip: str) -> None:
+        """
+        Apply cross-cluster-replication settings on the follower cluster, using the leader's seed
+        node ip to establish the remote leader connection.
+        TODO: Add the arrow streaming settings here once finalized.
+        """
+        if not leader_seed_node_ip:
+            raise RuntimeError("Unable to apply follower CCR settings, leader seed node ip is missing")
+
+        logging.info(f"Applying follower (CCR) settings on cluster {self.stack_name} "
+                     f"pointing to leader seed node {'*' * len(leader_seed_node_ip)}")
+
+        settings = {
+            "persistent": {
+                "cluster.remote.leader.seeds": [f"{leader_seed_node_ip}:9300"]
+            }
+        }
+
+        protocol = "http://" if self.args.insecure else "https://"
+        url = "".join([protocol, self.endpoint, "/_cluster/settings"])
+        request_args: Dict[str, Any] = {"url": url, "json": settings}
+        if not self.args.insecure:
+            request_args["auth"] = HTTPBasicAuth(self.args.username, self.password)
+            request_args["verify"] = False
+
+        def _put_settings() -> None:
+            response = requests.put(**request_args)
+            response.raise_for_status()
+
+        retry_call(_put_settings, tries=3, delay=15, backoff=2)
 
     def terminate(self) -> None:
         command = f"cdk destroy {self.stack_name} {self.params} --force"
@@ -96,12 +185,12 @@ class BenchmarkCreateCluster(BenchmarkTestCluster):
 
     def setup_cdk_params(self, config: dict) -> dict:
         suffix = ''
-        if self.args.stack_suffix and self.manifest:
-            suffix = self.args.stack_suffix + '-' + self.manifest.build.id + '-' + self.manifest.build.architecture
+        if self.stack_suffix and self.manifest:
+            suffix = self.stack_suffix + '-' + self.manifest.build.id + '-' + self.manifest.build.architecture
         elif self.manifest:
             suffix = self.manifest.build.id + '-' + self.manifest.build.architecture
-        elif self.args.stack_suffix:
-            suffix = self.args.stack_suffix
+        elif self.stack_suffix:
+            suffix = self.stack_suffix
 
         if self.manifest:
             self.args.distribution_version = self.manifest.build.version

--- a/src/test_workflow/benchmark_test/benchmark_test_cluster.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_cluster.py
@@ -68,7 +68,7 @@ class BenchmarkTestCluster:
     def fetch_password(self) -> str:
         return self.password
 
-    def wait_for_processing(self, tries: int = 3, delay: int = 15, backoff: int = 2) -> None:
+    def wait_for_processing(self, tries: int = 10, delay: int = 30, backoff: int = 1) -> None:
         logging.info("Waiting for domain ******* to be up")
         protocol = "http://" if self.args.insecure else "https://"
         url = "".join([protocol, self.endpoint, "/_cluster/health"])

--- a/src/test_workflow/benchmark_test/benchmark_test_runner_opensearch.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_runner_opensearch.py
@@ -51,6 +51,23 @@ class BenchmarkTestRunnerOpenSearch(BenchmarkTestRunner):
                 current_workspace = os.path.join(work_dir.name, "opensearch-cluster-cdk")
                 with GitRepository(self.get_cluster_repo_url(), self.get_git_ref(), current_workspace):
                     with WorkingDirectory(current_workspace):
-                        with BenchmarkCreateCluster.create(self.args, self.test_manifest, config, current_workspace) as test_cluster:
-                            benchmark_test_suite = BenchmarkTestSuiteRunners.from_args(self.args, test_cluster.endpoint_with_port, self.security, test_cluster.fetch_password())
-                            retry_call(benchmark_test_suite.execute, tries=3, delay=60, backoff=2)
+                        if self.args.ccr_enabled:
+                            self.run_ccr_tests(config, current_workspace)
+                        else:
+                            with BenchmarkCreateCluster.create(self.args, self.test_manifest, config, current_workspace) as test_cluster:
+                                benchmark_test_suite = BenchmarkTestSuiteRunners.from_args(self.args, test_cluster.endpoint_with_port, self.security, test_cluster.fetch_password())
+                                retry_call(benchmark_test_suite.execute, tries=3, delay=60, backoff=2)
+
+    def run_ccr_tests(self, config: dict, current_workspace: str) -> None:
+        """
+        Cross-cluster-replication flow: bring up the leader cluster first, then the follower cluster.
+        Once both are up, apply arrow streaming settings on the leader and arrow streaming + CCR
+        settings on the follower (pointing at the leader's seed node), then run the benchmark suite.
+        """
+        with BenchmarkCreateCluster.create(self.args, self.test_manifest, config, current_workspace, "leader") as leader_cluster:
+            leader_cluster.apply_leader_settings()
+            with BenchmarkCreateCluster.create(self.args, self.test_manifest, config, current_workspace, "follower") as follower_cluster:
+                follower_cluster.apply_follower_settings(leader_cluster.seed_node_ip)
+                benchmark_test_suite = BenchmarkTestSuiteRunners.from_args(
+                    self.args, follower_cluster.endpoint_with_port, self.security, follower_cluster.fetch_password())
+                retry_call(benchmark_test_suite.execute, tries=3, delay=60, backoff=2)

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_create_cluster.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_create_cluster.py
@@ -29,6 +29,7 @@ class TestBenchmarkCreateCluster(unittest.TestCase):
             self.args.single_node = True
             self.args.min_distribution = False
             self.args.enable_instance_storage = False
+            self.args.ccr_enabled = False
         self.manifest = BundleManifest.from_path(self.BUNDLE_MANIFEST) if use_manifest else None
         self.stack_name = "stack"
         self.security = True
@@ -104,6 +105,71 @@ class TestBenchmarkCreateCluster(unittest.TestCase):
         self.assertTrue("singleNodeCluster=false" in self.benchmark_create_cluster.params)
         self.assertTrue("enableRemoteStore=true" in self.benchmark_create_cluster.params)
         self.assertTrue("pluginUrl=https://example.com/plugin.zip" in self.benchmark_create_cluster.params)
+
+    @patch("test_workflow.benchmark_test.benchmark_create_cluster.BenchmarkCreateCluster.wait_for_processing")
+    def test_create_ccr_leader_stack_suffix_and_seed_ip_single_node(self, mock_wait_for_processing: Optional[Mock]) -> None:
+        self.args.ccr_enabled = True
+        self.args.single_node = True
+        TestBenchmarkCreateCluster.setUp(self, self.args)
+        cluster = BenchmarkCreateCluster(bundle_manifest=self.manifest, config=self.config, args=self.args,
+                                         current_workspace="current_workspace", cluster_role="leader")
+        self.assertEqual(cluster.cluster_role, "leader")
+        self.assertEqual(cluster.output_file, "output-leader.json")
+        self.assertTrue("test-suffix-leader" in cluster.stack_name)
+        self.assertTrue("suffix=test-suffix-leader" in cluster.params)
+        mock_file = MagicMock(side_effect=[{cluster.stack_name: {"loadbalancerurl": "www.example.com", "privateip": "10.0.0.5"}}])
+        with patch("subprocess.check_call"):
+            with patch("builtins.open", MagicMock()):
+                with patch("json.load", mock_file):
+                    cluster.start()
+        self.assertEqual(cluster.seed_node_ip, "10.0.0.5")
+
+    @patch("test_workflow.benchmark_test.benchmark_create_cluster.boto3")
+    @patch("test_workflow.benchmark_test.benchmark_create_cluster.BenchmarkCreateCluster.wait_for_processing")
+    def test_create_ccr_follower_seed_ip_multi_node(self, mock_wait_for_processing: Optional[Mock], mock_boto3: Mock) -> None:
+        self.args.ccr_enabled = True
+        self.args.single_node = False
+        self.args.region = "us-west-2"
+        TestBenchmarkCreateCluster.setUp(self, self.args)
+        mock_boto3.client.return_value.describe_instances.return_value = {
+            "Reservations": [{"Instances": [{"PrivateIpAddress": "10.0.1.9"}]}]
+        }
+        cluster = BenchmarkCreateCluster(bundle_manifest=self.manifest, config=self.config, args=self.args,
+                                         current_workspace="current_workspace", cluster_role="follower")
+        self.assertTrue("test-suffix-follower" in cluster.stack_name)
+        mock_file = MagicMock(side_effect=[{cluster.stack_name: {"loadbalancerurl": "www.example.com"}}])
+        with patch("subprocess.check_call"):
+            with patch("builtins.open", MagicMock()):
+                with patch("json.load", mock_file):
+                    cluster.start()
+        self.assertEqual(cluster.seed_node_ip, "10.0.1.9")
+        mock_boto3.client.return_value.describe_instances.assert_called_once()
+
+    @patch("test_workflow.benchmark_test.benchmark_create_cluster.requests.put")
+    def test_apply_follower_settings(self, mock_put: Mock) -> None:
+        self.args.ccr_enabled = True
+        self.args.insecure = False
+        self.args.username = "admin"
+        TestBenchmarkCreateCluster.setUp(self, self.args)
+        cluster = BenchmarkCreateCluster(bundle_manifest=self.manifest, config=self.config, args=self.args,
+                                         current_workspace="current_workspace", cluster_role="follower")
+        cluster.cluster_endpoint = "follower.example.com"
+        cluster.apply_follower_settings("10.0.0.5")
+
+        mock_put.assert_called_once()
+        _, kwargs = mock_put.call_args
+        self.assertEqual(kwargs["url"], "https://follower.example.com/_cluster/settings")
+        self.assertEqual(kwargs["json"]["persistent"]["cluster.remote.leader.seeds"], ["10.0.0.5:9300"])
+        self.assertEqual(kwargs["verify"], False)
+        mock_put.return_value.raise_for_status.assert_called_once()
+
+    def test_apply_follower_settings_missing_seed_ip(self) -> None:
+        self.args.ccr_enabled = True
+        TestBenchmarkCreateCluster.setUp(self, self.args)
+        cluster = BenchmarkCreateCluster(bundle_manifest=self.manifest, config=self.config, args=self.args,
+                                         current_workspace="current_workspace", cluster_role="follower")
+        with self.assertRaises(RuntimeError):
+            cluster.apply_follower_settings("")
 
     @patch("test_workflow.benchmark_test.benchmark_create_cluster.BenchmarkCreateCluster.wait_for_processing")
     def test_create_multi_node_without_manifest(self, mock_wait_for_processing: Optional[Mock]) -> None:

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_cluster_min.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_cluster_min.py
@@ -26,6 +26,7 @@ class TestBenchmarkCreateClusterMin(unittest.TestCase):
         self.args.insecure = True
         self.args.single_node = False
         self.args.min_distribution = True
+        self.args.ccr_enabled = False
         self.manifest = BuildManifest.from_path(self.MIN_MANIFEST)
         self.stack_name = "stack"
         self.security = True

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_runner_opensearch.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_runner_opensearch.py
@@ -77,6 +77,40 @@ class TestBenchmarkTestRunnerOpenSearch(unittest.TestCase):
         self.assertEqual(mock_git.call_count, 1)
         self.assertEqual(mock_temp_directory.call_count, 1)
 
+    @patch("argparse._sys.argv", ["run_benchmark_test.py",
+                                  "execute-test",
+                                  "--distribution-url",
+                                  "https://artifacts.opensearch.org/2.10.0/opensearch.tar.gz",
+                                  "--distribution-version",
+                                  "2.3.0",
+                                  "--config", os.path.join(os.path.dirname(__file__), "data", "test-config.yml"),
+                                  "--workload", "test",
+                                  "--suffix", "test",
+                                  "--ccr-enabled"])
+    @patch("os.chdir")
+    @patch("test_workflow.benchmark_test.benchmark_test_runner_opensearch.TemporaryDirectory")
+    @patch("test_workflow.benchmark_test.benchmark_test_runner_opensearch.GitRepository")
+    @patch("test_workflow.benchmark_test.benchmark_test_runner_opensearch.retry_call")
+    @patch("test_workflow.benchmark_test.benchmark_test_runner_opensearch.BenchmarkCreateCluster.create")
+    @patch("test_workflow.benchmark_test.benchmark_test_runner_opensearch.BenchmarkTestSuiteRunners.from_args")
+    def test_run_ccr_enabled(self, mock_suite: Mock, mock_cluster: Mock, mock_retry_call: Mock, mock_git: Mock,
+                             mock_temp_directory: Mock, *mocks: Any) -> None:
+        mock_temp_directory.return_value.__enter__.return_value.name = tempfile.gettempdir()
+        leader_cluster = MagicMock(seed_node_ip="10.0.0.5")
+        follower_cluster = MagicMock()
+        mock_cluster.return_value.__enter__.side_effect = [leader_cluster, follower_cluster]
+
+        benchmark_args = BenchmarkArgs()
+        runner = BenchmarkTestRunners.from_args(benchmark_args)
+        runner.run()
+
+        # A leader and a follower cluster should be created.
+        self.assertEqual(mock_cluster.call_count, 2)
+        leader_cluster.apply_leader_settings.assert_called_once()
+        follower_cluster.apply_follower_settings.assert_called_once_with("10.0.0.5")
+        self.assertEqual(mock_suite.call_count, 1)
+        mock_retry_call.assert_called_once_with(mock_suite.return_value.execute, tries=3, delay=60, backoff=2)
+
     @patch("test_workflow.benchmark_test.benchmark_test_runner_opensearch.BenchmarkTestCluster.start")
     @patch("test_workflow.benchmark_test.benchmark_test_runner_opensearch.BenchmarkTestSuiteRunners.from_args")
     @patch('test_workflow.benchmark_test.benchmark_test_runner_opensearch.retry_call')


### PR DESCRIPTION
### Description
Adds a `--ccr-enabled` flag to the benchmark test workflow to run cross-cluster-replication (CCR) benchmarks by spinning up a **leader** and a **follower** cluster.

**Flow** (`run_ccr_tests`):
1. Bring up the leader cluster (blocks until up + healthy).
2. Apply leader settings (arrow streaming — placeholder for now).
3. Bring up the follower cluster (blocks until up + healthy).
4. Apply follower settings — sets `cluster.remote.leader.seeds` to `<leader-seed-node-ip>:9300` via `PUT /_cluster/settings` (arrow streaming — placeholder).
5. Run the benchmark suite against the follower.
6. Teardown unwinds follower-first, then leader (both honor `--preserve-cluster`).

**Seed node IP resolution:**
- Single-node: read `privateip` from the CDK output.
- Multi-node: looked up via boto3 using the unique seed-node EC2 tag `<stack_name>/seedNodeLt`.

**Stack naming:** the leader/follower role is appended to the stack suffix so the two stacks stay distinct, without mutating the shared `args`. Non-CCR runs produce identical stack names to before.

### Notes
- Arrow streaming settings on both leader and follower are left as `TODO` placeholders.
- No Jenkinsfile / `test.sh` changes yet.

### Issues Resolved
N/A

### Check List
- [x] Unit tests added for the CCR flow, seed-ip resolution, and follower settings.
- [x] Full test suite passes (1111 passed); flake8, isort, mypy clean.
- [x] Commits are signed per the DCO.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.