### PR TITLE
[3.8] Enable Dashboard Variables feature by default in distribution config

### DIFF
--- a/config/opensearch_dashboards-3.x.yml
+++ b/config/opensearch_dashboards-3.x.yml
@@ -232,12 +232,11 @@
 # investigation.agenticFeaturesEnabled: false
 
 # 3.8 New Dashboards Variable Feature
-# Enable the Dashboard Variables feature (disabled by default). When off, the `variablesJSON`
-# field is never added to the dashboard mapping or written on save.
-# Turning it on triggers a one-time saved object index migration.
-# Warning: before turning it back off, remove `variablesJSON` from all dashboard documents,
-# otherwise the index migration fails with strict_dynamic_mapping_exception on every startup.
-# dashboard.variables.enabled: false
+# Enable the Dashboard Variables feature. The code default is `false`, but this distribution
+# enables it below for backward compatibility with 3.7. 3.7 shipped without this flag and
+# always wrote the variablesJSON field, so existing dashboards rely on it.
+# Keeping it enabled here preserves that behavior across the 3.7 -> 3.8 upgrade.
+dashboard.variables.enabled: true
 
 opensearch.hosts: [https://localhost:9200]
 opensearch.ssl.verificationMode: none
@@ -250,8 +249,3 @@ opensearch_security.multitenancy.tenants.preferred: [Private, Global]
 opensearch_security.readonly_mode.roles: [kibana_read_only]
 # Use this setting if you are running opensearch-dashboards without https
 opensearch_security.cookie.secure: false
-
-# Enable the Dashboard Variables feature by default in distributions.
-# 3.7 shipped without this flag and always wrote the variablesJSON field, so existing dashboards
-# rely on it. Keeping it enabled here preserves that behavior across the 3.7 -> 3.8 upgrade.
-dashboard.variables.enabled: true

--- a/config/opensearch_dashboards-3.x.yml
+++ b/config/opensearch_dashboards-3.x.yml
@@ -231,6 +231,14 @@
 # Default to false, set true to enable the agentic features in investigation dashboards
 # investigation.agenticFeaturesEnabled: false
 
+# 3.8 New Dashboards Variable Feature
+# Enable the Dashboard Variables feature (disabled by default). When off, the `variablesJSON`
+# field is never added to the dashboard mapping or written on save.
+# Turning it on triggers a one-time saved object index migration.
+# Warning: before turning it back off, remove `variablesJSON` from all dashboard documents,
+# otherwise the index migration fails with strict_dynamic_mapping_exception on every startup.
+# dashboard.variables.enabled: false
+
 opensearch.hosts: [https://localhost:9200]
 opensearch.ssl.verificationMode: none
 opensearch.username: kibanaserver
@@ -242,3 +250,8 @@ opensearch_security.multitenancy.tenants.preferred: [Private, Global]
 opensearch_security.readonly_mode.roles: [kibana_read_only]
 # Use this setting if you are running opensearch-dashboards without https
 opensearch_security.cookie.secure: false
+
+# Enable the Dashboard Variables feature by default in distributions.
+# 3.7 shipped without this flag and always wrote the variablesJSON field, so existing dashboards
+# rely on it. Keeping it enabled here preserves that behavior across the 3.7 -> 3.8 upgrade.
+dashboard.variables.enabled: true


### PR DESCRIPTION
### Description
OpenSearch Dashboards 3.8 introduces a `dashboard.variables.enabled` feature flag that controls the Dashboard Variables feature and its `variablesJSON` saved object field. The flag defaults to false in code.

However, 3.7 shipped without this flag and always registered/wrote the `variablesJSON` field. As a result, every 3.7 deployment that saved a dashboard already has `variablesJSON` in both the dashboard mapping and the saved object documents.

If 3.8 distributions ran with the flag defaulting to false, the saved object index migration on upgrade would try to reindex those existing documents into an index whose mapping no longer declares `variablesJSON` (the index is dynamic: strict), failing with `strict_dynamic_mapping_exception` on every startup.

This change sets `dashboard.variables.enabled: true` in the distribution config so the 3.7 → 3.8 upgrade preserves existing behavior and does not break startup.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
