### PR TITLE
Upgrade release scheduler to 13.5.0

### DIFF
--- a/jenkins/release-workflows/release-schedule.jenkinsfile
+++ b/jenkins/release-workflows/release-schedule.jenkinsfile
@@ -12,7 +12,7 @@
 // and registers each upcoming release into the opensearch_release_schedule metrics index. Re-running
 // keeps the derived status (inactive/active) current as each release's RC date approaches.
 
-lib = library(identifier: 'jenkins@13.4.0', retriever: modernSCM([
+lib = library(identifier: 'jenkins@13.5.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))

--- a/tests/jenkins/TestReleaseSchedule.groovy
+++ b/tests/jenkins/TestReleaseSchedule.groovy
@@ -32,7 +32,7 @@ class TestReleaseSchedule extends BuildPipelineTest {
     void setUp() {
         helper.registerSharedLibrary(
             library().name('jenkins')
-                .defaultVersion('13.4.0')
+                .defaultVersion('13.5.0')
                 .allowOverride(true)
                 .implicit(true)
                 .targetPath('vars')


### PR DESCRIPTION
### Description
Contains fixes for failing workflow of register scheduler

### Issues Resolved
https://github.com/opensearch-project/oscar-ai-bot/issues/170

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
