### PR TITLE
Disable audit logging in without-security integ-test clusters

### DIFF
--- a/src/test_workflow/integ_test/service_opensearch.py
+++ b/src/test_workflow/integ_test/service_opensearch.py
@@ -50,6 +50,14 @@ class ServiceOpenSearch(Service):
         self.security_plugin_dir = os.path.join(self.install_dir, "plugins", "opensearch-security")
 
         if not self.security_enabled and os.path.isdir(self.security_plugin_dir):
+            # Disable the security plugin, and remove any configured audit sink so audit logging
+            # stays fully off. In disabled mode the plugin still initializes standalone audit
+            # whenever plugins.security.audit.type is set (the distribution's demo config sets it
+            # to internal_opensearch), which asynchronously writes to security-auditlog-* indices;
+            # those writes can linger past a test and break teardown task-wait checks. Stripping
+            # audit.type leaves it unset, so the plugin uses a NullAuditLog and registers no audit
+            # filter/interceptor at all.
+            self.__remove_plugin_specific_config("plugins.security.audit.type")
             self.__add_plugin_specific_config({"plugins.security.disabled": "true"})
 
         if self.additional_config:
@@ -72,6 +80,14 @@ class ServiceOpenSearch(Service):
     def __add_plugin_specific_config(self, additional_config: dict) -> None:
         with open(self.opensearch_yml_path, "a") as yamlfile:
             yamlfile.write(yaml.dump(additional_config))
+
+    def __remove_plugin_specific_config(self, key: str) -> None:
+        if not os.path.isfile(self.opensearch_yml_path):
+            return
+        with open(self.opensearch_yml_path, "r") as yamlfile:
+            lines = yamlfile.readlines()
+        with open(self.opensearch_yml_path, "w") as yamlfile:
+            yamlfile.writelines(line for line in lines if not line.lstrip().startswith(key))
 
     def port(self) -> int:
         return self.cluster_port


### PR DESCRIPTION
### Description

When a distribution integ-test runs a security-**installed** cluster in `without-security` mode, `ServiceOpenSearch.start()` only appends `plugins.security.disabled: true` to `opensearch.yml`. The bundled distribution's demo config also sets `plugins.security.audit.type: internal_opensearch`.

On OpenSearch 3.8+, the security plugin initializes **standalone audit logging in disabled mode** whenever `plugins.security.audit.type` is set (see opensearch-project/security#6304 + its fast-follow #6321). It builds a real `AuditLogImpl` and registers the REST audit filter / transport interceptor, which asynchronously write `REQUEST_AUDIT` events to `security-auditlog-*` indices on every request. Those bulk-write tasks can still be in flight at test teardown, so `waitForRunningTasks` (via `wipeAllIndices`) sees lingering `indices:data/write/bulk` tasks against `security-auditlog-*` and fails with a spurious "There are still tasks running" error — unrelated to the test under test.

This surfaced as flaky failures in downstream integ-tests (e.g. index-management `RestStartSnapshotManagementIT`) and is behind the corresponding AUTOCUT reports.

### Fix

In the `without-security` path, remove any configured `plugins.security.audit.type` so it stays **unset**, alongside `plugins.security.disabled: true`.

`plugins.security.audit.type` is registered with no default (`Setting.simpleString(...)`), so when the key is absent `initStandaloneAuditIfEnabled` takes the `else` branch and uses a `NullAuditLog` — no audit filter or interceptor is registered, and nothing is written to `security-auditlog-*`. (Setting the type to `noop` would **not** work: `auditType != null` would still be true, so a real `AuditLogImpl` and its filters are still created — events would merely be routed to a discarding sink. Stripping the key is the correct disable.)

Because the demo config already writes `audit.type`, a small `__remove_plugin_specific_config` helper strips the existing line first (the config is written in append mode, so re-adding the key would otherwise produce a duplicate YAML key).

### Why other `plugins.security.disabled` sites are intentionally not changed

`plugins.security.disabled: true` is set in several other places in this repo; none of them need this treatment:

- **Docker entrypoints** (`docker/release/config/opensearch/opensearch-docker-entrypoint-*.sh`): disabling security and running the demo config are **mutually exclusive** (`if DISABLE_SECURITY_PLUGIN … else install_demo_configuration.sh`). When security is disabled, demo config never runs, so `audit.type` is never set and standalone audit never initializes. Not reachable — nothing to fix.

- **Package post-install** (`scripts/pkg/build_templates/{current,2.x}/opensearch/{deb,rpm}/…`, `scripts/opensearch-onetime-setup.sh`): these are real user installs. Demo config and disable are independent, user-controlled options (`DISABLE_INSTALL_DEMO_CONFIG` vs `DISABLE_SECURITY_PLUGIN`), so a user *can* end up with disabled + `audit.type` set — but that is **intended product behavior**: standalone audit logging in disabled mode is exactly the feature #6304 added (an audit trail without access control). Silently stripping `audit.type` there would be an unrequested behavior change for operators who deliberately want it.

- **`scripts/deploy_single_tar_cluster.sh`**: a deploy helper, same reasoning as the package installers.

Only the integ-test framework wants security *and* audit fully off (tests don't exercise audit, and the async writes break teardown), so the change is scoped to `service_opensearch.py`.

If the broader question — "should disabled mode auto-enable audit purely from a leftover demo `audit.type`?" — is worth revisiting, that belongs in the security plugin (e.g. an explicit opt-in), not in these build scripts.

### Testing

- `tests/tests_test_workflow/test_integ_workflow/integ_test/test_service_opensearch.py` passes (17/17), including the disabled-mode cases.
- `mypy` clean on the changed file.

### Check List
- [x] Commits are signed per the DCO using `--signoff`.
