### PR TITLE
Add -Drepos.mavenLocal=true to GRADLE_OPTS to resolve dependencies from mavenLocal 1st

### DIFF
--- a/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
+++ b/jenkins/gradle/gradle-check-flaky-test-issue-creation.jenkinsfile
@@ -15,7 +15,6 @@ lib = library(identifier: 'jenkins@12.0.0', retriever: modernSCM([
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
 
-
 pipeline {
     agent {
         docker {
@@ -24,6 +23,9 @@ pipeline {
             registryUrl 'https://public.ecr.aws/'
             alwaysPull true
         }
+    }
+    environment {
+        GRADLE_OPTS = '-Drepos.mavenLocal=true'
     }
     options {
         timeout(time: 1, unit: 'HOURS')

--- a/jenkins/opensearch/bwc-test.jenkinsfile
+++ b/jenkins/opensearch/bwc-test.jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
     }
     agent none
     environment {
+        GRADLE_OPTS = '-Drepos.mavenLocal=true'
         BUILD_MANIFEST = "build-manifest.yml"
         DEFAULT_BUILD_JOB_NAME = "distribution-build-opensearch"
     }

--- a/jenkins/opensearch/distribution-build.jenkinsfile
+++ b/jenkins/opensearch/distribution-build.jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
     }
     agent none
     environment {
+        GRADLE_OPTS = '-Drepos.mavenLocal=true'
         AGENT_LINUX_X64 = 'Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host'
         AGENT_LINUX_ARM64 = 'Jenkins-Agent-AL2023-Arm64-M6g4xlarge-Docker-Host'
         AGENT_WINDOWS_X64 = 'Jenkins-Agent-Windows2019-X64-M54xlarge-Docker-Host'

--- a/jenkins/opensearch/feature-build.jenkinsfile
+++ b/jenkins/opensearch/feature-build.jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
     }
     agent none
     environment {
+        GRADLE_OPTS = '-Drepos.mavenLocal=true'
         AGENT_LINUX_X64 = 'Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host'
         AGENT_LINUX_ARM64 = 'Jenkins-Agent-AL2023-Arm64-M6g4xlarge-Docker-Host'
     }

--- a/jenkins/opensearch/integ-test.jenkinsfile
+++ b/jenkins/opensearch/integ-test.jenkinsfile
@@ -32,6 +32,7 @@ pipeline {
     }
     agent none
     environment {
+        GRADLE_OPTS = '-Drepos.mavenLocal=true'
         BUILD_MANIFEST = 'build-manifest.yml'
         BUILD_JOB_NAME = 'distribution-build-opensearch'
     }

--- a/jenkins/opensearch/publish-min-snapshots.jenkinsfile
+++ b/jenkins/opensearch/publish-min-snapshots.jenkinsfile
@@ -21,6 +21,7 @@ pipeline {
     }
     agent none
     environment {
+        GRADLE_OPTS = '-Drepos.mavenLocal=true'
         AGENT_LINUX_X64 = 'Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host'
         AGENT_LINUX_ARM64 = 'Jenkins-Agent-AL2023-Arm64-M6g4xlarge-Docker-Host'
         AGENT_MACOS_X64 = 'Jenkins-Agent-MacOS14-X64-Mac1-Multi-Host'

--- a/jenkins/opensearch/smoke-test.jenkinsfile
+++ b/jenkins/opensearch/smoke-test.jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
     }
     agent none
     environment {
+        GRADLE_OPTS = '-Drepos.mavenLocal=true'
         BUILD_MANIFEST = 'build-manifest.yml'
         BUILD_JOB_NAME = 'distribution-build-opensearch'
     }


### PR DESCRIPTION
### Description
RepositoriesSetupPlugin in OpenSearch build-tools only adds mavenLocal() to the repository list when gradle parameter `-Drepos.mavenLocal=true` is set. Without it, Gradle skips mavenLocal for project dependencies and goes straight to remote repos (/m2/ → redirects to Maven Central → HTTP 429). Setting this flag ensures Gradle checks mavenLocal first, resolving pre-installed artifacts locally without hitting remote repos.

See https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/src/main/java/org/opensearch/gradle/RepositoriesSetupPlugin.java#L76-L81

Before:

1. /maven2/ (ci.opensearch.org cache)
2. /m2/ (ci.opensearch.org plugin mirror → redirects to repo.maven.apache.org → 429)
3. mavenCentral()
4. lucene-snapshots (if applicable)
5. Repo level 
6. ......

After:

1. mavenLocal() ← resolves here, stops
2. /maven2/
3. /m2/
4. mavenCentral()
5. lucene-snapshots (if applicable)
7. Repo level 



### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803