### PR TITLE
Remove 3.7.1 cron from opensearch snapshots

### DIFF
--- a/docs/Testing-the-Distribution.md
+++ b/docs/Testing-the-Distribution.md
@@ -28,7 +28,7 @@ Additional arguments:
 | -v, --verbose          | Show more verbose output.                                               |
 
 ### Integration Tests
-In order to run the tests in your local, you can avoid installing the packages with right version by using a docker image. Each test manifest consist of the docker image to run tests on. Check the [test manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/2.19.0/opensearch-2.19.0.yml#L8) or [jenkins file](https://github.com/opensearch-project/opensearch-build/blob/main/jenkins/opensearch/integ-test.jenkinsfile#L15-L20) to retrieve the docker images.
+In order to run the tests in your local, you can avoid installing the packages with right version by using a docker image. Each test manifest consist of the docker image to run tests on. Check the [test manifest](https://github.com/opensearch-project/opensearch-build/blob/main/manifests/3.9.0/opensearch-3.9.0-test.yml#L4-L23) to retrieve the docker images.
 
 ```
   docker run -u root -it opensearchstaging/ci-runner:ci-runner-centos7-opensearch-build-v3 /bin/bash

--- a/jenkins/opensearch/publish-min-snapshots.jenkinsfile
+++ b/jenkins/opensearch/publish-min-snapshots.jenkinsfile
@@ -33,7 +33,6 @@ pipeline {
             H */4 * * * %INPUT_MANIFEST=3.9.0/opensearch-3.9.0.yml
             H */4 * * * %INPUT_MANIFEST=3.8.1/opensearch-3.8.1.yml
             H */4 * * * %INPUT_MANIFEST=3.8.0/opensearch-3.8.0.yml
-            H */4 * * * %INPUT_MANIFEST=3.7.1/opensearch-3.7.1.yml
             H */4 * * * %INPUT_MANIFEST=2.19.6/opensearch-2.19.6.yml
         '''
     }


### PR DESCRIPTION
### Description
Remove 3.7.1 cron from opensearch snapshots

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
