### PR TITLE
Fetch seed node ip from cluster and establish bidirectional CCR remote connection

### DIFF
--- a/src/test_workflow/benchmark_test/benchmark_create_cluster.py
+++ b/src/test_workflow/benchmark_test/benchmark_create_cluster.py
@@ -25,10 +25,11 @@ from test_workflow.integ_test.utils import get_password
 
 
 class BenchmarkCreateCluster(BenchmarkTestCluster):
-    # Aliases used to wire up the cross-cluster-replication relationship on the follower. The remote
-    # alias doubles as the 'cluster.remote.<alias>.seeds' key that points at the leader's seed node.
-    REMOTE_ALIAS = "leader"
-    LOCAL_ALIAS = "local-cluster"
+    # Cross-cluster-replication aliases, shared by both clusters. The primary (leader) is 'cluster-1'
+    # and the secondary (follower) is 'cluster-2'. Each alias doubles as the 'cluster.remote.<alias>.seeds'
+    # key pointing at that cluster's seed node, so the two clusters must agree on them.
+    PRIMARY_ALIAS = "cluster-1"
+    SECONDARY_ALIAS = "cluster-2"
     REPLICATION_RELATIONSHIP = "my-relationship"
     # 'node.name' that opensearch-cluster-cdk assigns to the seed node of a multi-node cluster.
     SEED_NODE_NAME = "seed"
@@ -158,9 +159,9 @@ class BenchmarkCreateCluster(BenchmarkTestCluster):
 
     def apply_follower_settings(self, leader_seed_node_ip: str) -> None:
         """
-        Apply cross-cluster-replication settings on the follower cluster, using the leader's seed
-        node ip to establish the remote leader connection, then register the follower as the
-        SECONDARY end of a remote replication relationship with that leader.
+        Apply cross-cluster-replication settings on the follower (secondary) cluster: connect to the
+        leader's seed node under the primary alias, then register this cluster as the SECONDARY end
+        of a remote replication relationship with that leader.
         TODO: Add the arrow streaming settings here once finalized.
         """
         if not leader_seed_node_ip:
@@ -169,22 +170,40 @@ class BenchmarkCreateCluster(BenchmarkTestCluster):
         logging.info(f"Applying follower (CCR) settings on cluster {self.stack_name} "
                      f"pointing to leader seed node {'*' * len(leader_seed_node_ip)}")
 
-        self.put(
-            "/_cluster/settings",
-            {
-                "persistent": {
-                    f"cluster.remote.{self.REMOTE_ALIAS}.seeds": [f"{leader_seed_node_ip}:9300"]
-                }
-            }
-        )
+        self.connect_remote_cluster(self.PRIMARY_ALIAS, leader_seed_node_ip)
 
         # The remote connection above has to exist before the relationship can reference it by alias.
         self.put(
             f"/_remote_replication/cluster/{self.REPLICATION_RELATIONSHIP}",
             {
                 "role": "SECONDARY",
-                "local_alias": self.LOCAL_ALIAS,
-                "remote_alias": self.REMOTE_ALIAS
+                "local_alias": self.SECONDARY_ALIAS,
+                "remote_alias": self.PRIMARY_ALIAS
+            }
+        )
+
+    def apply_leader_reverse_settings(self, follower_seed_node_ip: str) -> None:
+        """
+        Point the leader (primary) cluster back at the follower's seed node under the secondary alias.
+        Both clusters knowing each other's seed node is what makes a later switchover possible; this is
+        applied after the follower is up so its seed node ip is known.
+        """
+        if not follower_seed_node_ip:
+            raise RuntimeError("Unable to apply leader reverse CCR settings, follower seed node ip is missing")
+
+        logging.info(f"Applying leader reverse (CCR) settings on cluster {self.stack_name} "
+                     f"pointing to follower seed node {'*' * len(follower_seed_node_ip)}")
+
+        self.connect_remote_cluster(self.SECONDARY_ALIAS, follower_seed_node_ip)
+
+    def connect_remote_cluster(self, alias: str, seed_node_ip: str) -> None:
+        """Register a remote cluster connection under 'alias', seeded from seed_node_ip's transport port."""
+        self.put(
+            "/_cluster/settings",
+            {
+                "persistent": {
+                    f"cluster.remote.{alias}.seeds": [f"{seed_node_ip}:9300"]
+                }
             }
         )
 

--- a/src/test_workflow/benchmark_test/benchmark_test_runner_opensearch.py
+++ b/src/test_workflow/benchmark_test/benchmark_test_runner_opensearch.py
@@ -68,6 +68,9 @@ class BenchmarkTestRunnerOpenSearch(BenchmarkTestRunner):
             leader_cluster.apply_leader_settings()
             with BenchmarkCreateCluster.create(self.args, self.test_manifest, config, current_workspace, "follower") as follower_cluster:
                 follower_cluster.apply_follower_settings(leader_cluster.seed_node_ip)
+                # Point the leader back at the follower's seed node so both clusters know each other,
+                # which a later replication switchover requires. Done here since the follower is now up.
+                leader_cluster.apply_leader_reverse_settings(follower_cluster.seed_node_ip)
                 # OpenSearch Benchmark addresses the leader cluster as 'default' and the follower
                 # cluster as 'follower' in a multi-cluster (cross-cluster-replication) run.
                 endpoints = {

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_create_cluster.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_create_cluster.py
@@ -182,12 +182,12 @@ class TestBenchmarkCreateCluster(unittest.TestCase):
         self.assertEqual(mock_put.call_count, 2)
         settings_kwargs = mock_put.call_args_list[0].kwargs
         self.assertEqual(settings_kwargs["url"], "https://follower.example.com/_cluster/settings")
-        self.assertEqual(settings_kwargs["json"]["persistent"]["cluster.remote.leader.seeds"], ["10.0.0.5:9300"])
+        self.assertEqual(settings_kwargs["json"]["persistent"]["cluster.remote.cluster-1.seeds"], ["10.0.0.5:9300"])
         self.assertEqual(settings_kwargs["verify"], False)
 
         relationship_kwargs = mock_put.call_args_list[1].kwargs
         self.assertEqual(relationship_kwargs["url"], "https://follower.example.com/_remote_replication/cluster/my-relationship")
-        self.assertEqual(relationship_kwargs["json"], {"role": "SECONDARY", "local_alias": "local-cluster", "remote_alias": "leader"})
+        self.assertEqual(relationship_kwargs["json"], {"role": "SECONDARY", "local_alias": "cluster-2", "remote_alias": "cluster-1"})
         self.assertEqual(relationship_kwargs["verify"], False)
         self.assertEqual(mock_put.return_value.raise_for_status.call_count, 2)
 
@@ -214,6 +214,32 @@ class TestBenchmarkCreateCluster(unittest.TestCase):
                                          current_workspace="current_workspace", cluster_role="follower")
         with self.assertRaises(RuntimeError):
             cluster.apply_follower_settings("")
+
+    @patch("test_workflow.benchmark_test.benchmark_create_cluster.requests.put")
+    def test_apply_leader_reverse_settings(self, mock_put: Mock) -> None:
+        self.args.ccr_enabled = True
+        self.args.insecure = False
+        self.args.username = "admin"
+        TestBenchmarkCreateCluster.setUp(self, self.args)
+        cluster = BenchmarkCreateCluster(bundle_manifest=self.manifest, config=self.config, args=self.args,
+                                         current_workspace="current_workspace", cluster_role="leader")
+        cluster.cluster_endpoint = "leader.example.com"
+        cluster.apply_leader_reverse_settings("10.0.1.9")
+
+        # Only the reverse remote connection is applied on the leader, pointing at the follower seed node.
+        self.assertEqual(mock_put.call_count, 1)
+        settings_kwargs = mock_put.call_args_list[0].kwargs
+        self.assertEqual(settings_kwargs["url"], "https://leader.example.com/_cluster/settings")
+        self.assertEqual(settings_kwargs["json"]["persistent"]["cluster.remote.cluster-2.seeds"], ["10.0.1.9:9300"])
+        self.assertEqual(settings_kwargs["verify"], False)
+
+    def test_apply_leader_reverse_settings_missing_seed_ip(self) -> None:
+        self.args.ccr_enabled = True
+        TestBenchmarkCreateCluster.setUp(self, self.args)
+        cluster = BenchmarkCreateCluster(bundle_manifest=self.manifest, config=self.config, args=self.args,
+                                         current_workspace="current_workspace", cluster_role="leader")
+        with self.assertRaises(RuntimeError):
+            cluster.apply_leader_reverse_settings("")
 
     @patch("test_workflow.benchmark_test.benchmark_create_cluster.BenchmarkCreateCluster.wait_for_processing")
     def test_create_multi_node_without_manifest(self, mock_wait_for_processing: Optional[Mock]) -> None:

--- a/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_runner_opensearch.py
+++ b/tests/tests_test_workflow/test_benchmark_workflow/benchmark_test/test_benchmark_test_runner_opensearch.py
@@ -97,7 +97,7 @@ class TestBenchmarkTestRunnerOpenSearch(unittest.TestCase):
                              mock_temp_directory: Mock, *mocks: Any) -> None:
         mock_temp_directory.return_value.__enter__.return_value.name = tempfile.gettempdir()
         leader_cluster = MagicMock(seed_node_ip="10.0.0.5")
-        follower_cluster = MagicMock()
+        follower_cluster = MagicMock(seed_node_ip="10.0.1.9")
         mock_cluster.return_value.__enter__.side_effect = [leader_cluster, follower_cluster]
 
         benchmark_args = BenchmarkArgs()
@@ -108,6 +108,8 @@ class TestBenchmarkTestRunnerOpenSearch(unittest.TestCase):
         self.assertEqual(mock_cluster.call_count, 2)
         leader_cluster.apply_leader_settings.assert_called_once()
         follower_cluster.apply_follower_settings.assert_called_once_with("10.0.0.5")
+        # The leader is then pointed back at the follower's seed node for a bidirectional connection.
+        leader_cluster.apply_leader_reverse_settings.assert_called_once_with("10.0.1.9")
         self.assertEqual(mock_suite.call_count, 1)
         mock_retry_call.assert_called_once_with(mock_suite.return_value.execute, tries=3, delay=60, backoff=2)
 


### PR DESCRIPTION
Fetch seed node ip from cluster and establish bidirectional CCR remote connection. 

- Resolve the multi-node seed node ip by querying the cluster's _cat/nodes over the load balancer (node named 'seed') instead of a boto3 EC2 lookup, which required permissions in the cluster's AWS account that the host lacks.
- Move seed ip resolution to after wait_for_processing so the cluster is up first.
- Rename CCR aliases to cluster-1 (primary) and cluster-2 (secondary).
- Point the leader back at the follower's seed node after the follower is up, so both clusters know each other for a later replication switchover.

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
