### PR TITLE
Add jenkinks job to index release state

### DIFF
--- a/jenkins/release-workflows/release-state.jenkinsfile
+++ b/jenkins/release-workflows/release-state.jenkinsfile
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+// @job-name: release-state
+// @description: Scheduled job that computes per-criterion release readiness for every active release
+// and indexes it into the opensearch_release_state metrics index. Runs every 6 hours so OSCAR always
+// reads a current view; this job only records state (Jenkins is the hands, OSCAR is the brain).
+
+lib = library(identifier: 'jenkins@13.8.0', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+pipeline {
+    options {
+        timeout(time: 1, unit: 'HOURS')
+        buildDiscarder(logRotator(daysToKeepStr: '30'))
+    }
+    agent {
+        docker {
+            label 'Jenkins-Agent-AL2023-X64-M54xlarge-Docker-Host'
+            image 'opensearchstaging/ci-runner:ci-runner-almalinux8-opensearch-build-v1'
+            registryUrl 'https://public.ecr.aws/'
+            alwaysPull true
+        }
+    }
+    triggers {
+        cron('H */6 * * *')
+    }
+    parameters {
+        string(
+            name: 'VERSION',
+            description: 'Restrict indexing to a single release version, e.g. 3.8.0. Leave empty to index all active releases.',
+            defaultValue: '',
+            trim: true
+        )
+    }
+    stages {
+        stage('Index Release State') {
+            steps {
+                script {
+                    if (params.VERSION?.trim()) {
+                        indexReleaseState(version: params.VERSION.trim())
+                    } else {
+                        indexReleaseState()
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                postCleanup()
+            }
+        }
+    }
+}

--- a/tests/jenkins/TestReleaseState.groovy
+++ b/tests/jenkins/TestReleaseState.groovy
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import jenkins.tests.BuildPipelineTest
+import org.junit.Before
+import org.junit.Test
+import static com.lesfurets.jenkins.unit.MethodCall.callArgsToString
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.containsString
+import static org.hamcrest.MatcherAssert.assertThat
+import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
+import static com.lesfurets.jenkins.unit.global.lib.GitSource.gitSource
+
+class TestReleaseState extends BuildPipelineTest {
+
+    @Override
+    @Before
+    void setUp() {
+        // TODO: point back at the upstream library tag once it is cut; using the fork branch (matching
+        // release-state.jenkinsfile) because indexReleaseState is not yet released upstream.
+        helper.registerSharedLibrary(
+            library().name('jenkins')
+                .defaultVersion('13.8.0')
+                .allowOverride(true)
+                .implicit(true)
+                .targetPath('vars')
+                .retriever(gitSource('https://github.com/opensearch-project/opensearch-build-libraries.git'))
+                .build()
+            )
+        helper.registerAllowedMethod("withAWS", [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        helper.registerAllowedMethod("withSecrets", [Map, Closure], { args, closure ->
+            closure.delegate = delegate
+            return helper.callClosure(closure)
+        })
+        helper.registerAllowedMethod('writeFile', [Map])
+        binding.setVariable('METRICS_HOST_ACCOUNT', 'METRICS_HOST_ACCOUNT')
+        binding.setVariable('env', [
+                'METRICS_HOST_URL'     : 'sample.url',
+                'AWS_ACCESS_KEY_ID'    : 'abc',
+                'AWS_SECRET_ACCESS_KEY': 'xyz',
+                'AWS_SESSION_TOKEN'    : 'sampleToken',
+                'JOB_NAME'             : 'release-state',
+                'BUILD_NUMBER'         : '7'
+        ])
+        super.setUp()
+        // Schedule search returns one active release; writes return 201; other metrics searches return
+        // no hits; gh (and everything else) returns empty so chores read them as "nothing found".
+        helper.registerAllowedMethod('sh', [Map.class], { Map args ->
+            String script = args.script
+            if (script.contains('opensearch_release_schedule')) {
+                return '{"hits":{"hits":[{"_source":{"version":"3.8.0","release_date":"2026-08-15","status":"active"}}]}}'
+            }
+            if (script.contains('-XPOST') || script.contains('-XPUT')) {
+                return '201'
+            }
+            if (script.contains('_search')) {
+                return '{"hits":{"hits":[]}}'
+            }
+            return ''
+        })
+    }
+
+    @Test
+    void testIndexesActiveReleaseWhenNoVersionGiven() {
+        runScript('jenkins/release-workflows/release-state.jenkinsfile')
+        assertThat(getCommandExecutions('echo', 'Indexing release state'),
+                hasItem(containsString('Indexing release state for version 3.8.0.')))
+    }
+
+    @Test
+    void testRestrictsToRequestedVersion() {
+        addParam('VERSION', '3.8.0')
+        runScript('jenkins/release-workflows/release-state.jenkinsfile')
+        assertThat(getCommandExecutions('echo', 'Indexing release state'),
+                hasItem(containsString('Indexing release state for version 3.8.0.')))
+    }
+
+    @Test
+    void testSkipsWhenRequestedVersionIsNotActive() {
+        addParam('VERSION', '9.9.9')
+        runScript('jenkins/release-workflows/release-state.jenkinsfile')
+        assertThat(getCommandExecutions('echo', 'No active releases'),
+                hasItem(containsString('No active releases to index state for.')))
+    }
+
+    def getCommandExecutions(methodName, command) {
+        def commands = helper.callStack.findAll {
+            call ->
+                call.methodName == methodName
+        }.
+        collect {
+            call ->
+                callArgsToString(call)
+        }.findAll {
+            output ->
+                output.contains(command)
+        }
+        return commands
+    }
+}


### PR DESCRIPTION
### Description
Adds a jenkins job that indexes active release state into metrics cluster. Executes https://github.com/opensearch-project/opensearch-build-libraries/pull/899 library in this workflow

### Issues Resolved
closes https://github.com/opensearch-project/oscar-ai-bot/issues/170

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
