### PR TITLE
Update OpenSearch OpenAPI spec URL to api-spec.opensearch.org (opensearch-build)

### DIFF
--- a/src/test_workflow/smoke_test/smoke_test_runner_opensearch.py
+++ b/src/test_workflow/smoke_test/smoke_test_runner_opensearch.py
@@ -33,7 +33,7 @@ class SmokeTestRunnerOpenSearch(SmokeTestRunner):
         logging.info("Entering Smoke test for OpenSearch Bundle.")
 
         # Below URL is for the pre-release latest. In the future may consider use formal released spec when available.
-        self.spec_url = "https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml"
+        self.spec_url = "https://api-spec.opensearch.org/opensearch-openapi.yaml"
         self.spec_local_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "smoke_tests_spec", "opensearch-openapi-local.yaml")
         self.spec_download_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "smoke_tests_spec", "opensearch-openapi.yaml")
         self.spec_path = self.download_spec(self.spec_url, self.spec_local_path, self.spec_download_path)

--- a/tests/tests_test_workflow/test_smoke_workflow/smoke_test/test_smoke_test_runner_opensearch.py
+++ b/tests/tests_test_workflow/test_smoke_workflow/smoke_test/test_smoke_test_runner_opensearch.py
@@ -110,7 +110,7 @@ class TestSmokeTestRunnerOpenSearch(unittest.TestCase):
         runner = SmokeTestRunnerOpenSearch(MagicMock(), MagicMock())
 
         mock_get.assert_called_once_with(
-            "https://github.com/opensearch-project/opensearch-api-specification/releases/download/main-latest/opensearch-openapi.yaml",
+            "https://api-spec.opensearch.org/opensearch-openapi.yaml",
             timeout=10
         )
 


### PR DESCRIPTION
### Description
Update the smoke test OpenSearch OpenAPI spec download URL to the stable `https://api-spec.opensearch.org/opensearch-openapi.yaml` endpoint.

### Issues Resolved
https://github.com/opensearch-project/.github/issues/618

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
