### PR TITLE
Warm Spotless Eclipse formatter cache in version increment workflow

### DIFF
--- a/.github/workflows/os-increment-plugin-versions.yml
+++ b/.github/workflows/os-increment-plugin-versions.yml
@@ -3,7 +3,7 @@ name: Increment OpenSearch Plugins Version
 
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0,8,16 * * *
   workflow_dispatch:
     inputs:
       logLevel:
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         entry:
-          # Adding the core repo OpenSearch for the label creation automation
+          # Adding the core repo OpenSearch to warm the Spotless Eclipse formatter cache
           - {repo: OpenSearch}
           - {repo: alerting}
           - {repo: anomaly-detection}
@@ -95,6 +95,10 @@ jobs:
           repository: opensearch-project/${{ matrix.entry.repo }}
           ref: ${{ matrix.branch }}
           persist-credentials: false
+
+      - name: Warm Spotless Eclipse formatter cache
+        continue-on-error: true
+        run: ./gradlew spotlessJavaCheck --no-daemon || true
 
       - name: Increment Version in ${{ matrix.entry.repo }}
         if: ${{ matrix.entry.repo != 'OpenSearch' }}


### PR DESCRIPTION
### Description
Warm Spotless Eclipse formatter cache in version increment workflow

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
