### PR TITLE
Default to all for indexing release state

### DIFF
--- a/jenkins/release-workflows/release-state.jenkinsfile
+++ b/jenkins/release-workflows/release-state.jenkinsfile
@@ -43,12 +43,13 @@ pipeline {
         activeChoice(
             name: 'CRITERIA',
             choiceType: 'PT_CHECKBOX',
-            description: 'Restrict indexing to the checked criteria. Leave all unchecked to index every criterion.',
+            description: 'Restrict indexing to the checked criteria. Check "all" to index every criterion.',
             filterable: false,
             randomName: 'choice-parameter-release-state-criteria',
             script: groovyScript(
                 fallbackScript: [classpath: [], oldScript: '', sandbox: true, script: 'return ["Unknown criteria"]'],
                 script: [classpath: [], oldScript: '', sandbox: true, script: '''return [
+                    "all",
                     "release_owners_assigned",
                     "documentation_draft_prs_up",
                     "code_coverage_not_decreased",
@@ -73,8 +74,9 @@ pipeline {
                     if (params.VERSION?.trim()) {
                         indexArgs.version = params.VERSION.trim()
                     }
-                    if (params.CRITERIA?.trim()) {
-                        indexArgs.criteria = params.CRITERIA.trim()
+                    List criteria = params.CRITERIA?.tokenize(',')*.trim()?.findAll { it && it != 'all' } ?: []
+                    if (criteria) {
+                        indexArgs.criteria = criteria.join(',')
                     }
                     def indexedReleases = indexReleaseState(indexArgs)
                     writeJSON file: 'indexed-releases.json', json: indexedReleases

--- a/tests/jenkins/TestReleaseState.groovy
+++ b/tests/jenkins/TestReleaseState.groovy
@@ -113,6 +113,23 @@ class TestReleaseState extends BuildPipelineTest {
     }
 
     @Test
+    void testIndexesAllCriteriaWhenAllSentinelIsSelected() {
+        // Timer and API builds cannot submit checkbox state, so Active Choices falls back to the first
+        // choice, 'all', which must not restrict the run to a single criterion.
+        addParam('CRITERIA', 'all')
+        runScript('jenkins/release-workflows/release-state.jenkinsfile')
+        assert getCommandExecutions('echo', 'Restricting to criteria').isEmpty()
+    }
+
+    @Test
+    void testDropsAllSentinelWhenCombinedWithNamedCriteria() {
+        addParam('CRITERIA', 'all,code_coverage_not_decreased')
+        runScript('jenkins/release-workflows/release-state.jenkinsfile')
+        assertThat(getCommandExecutions('echo', 'Restricting to criteria'),
+                hasItem(containsString('Restricting to criteria: code_coverage_not_decreased.')))
+    }
+
+    @Test
     void testUpdateReleaseIssuesStageIsPresent() {
         runScript('jenkins/release-workflows/release-state.jenkinsfile')
         assertThat(getCommandExecutions('echo', 'Update Release Issues'),


### PR DESCRIPTION
### Description
The active choice plugin defaults the first arg to default value in PT_CHECKBOX. This PR adds the option to trigger all. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
