### PR TITLE
Update docker copy legacy to use latest 13.8.3

### DIFF
--- a/jenkins/legacy/build.ci.backups/docker/docker-copy.jenkinsfile
+++ b/jenkins/legacy/build.ci.backups/docker/docker-copy.jenkinsfile
@@ -10,7 +10,7 @@
 // @job-name: docker-copy
 // @description: Copies Docker images from one registry to another.
 
-lib = library(identifier: 'jenkins@13.7.1', retriever: modernSCM([
+lib = library(identifier: 'jenkins@13.8.3', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))


### PR DESCRIPTION
### Description
Update docker copy legacy to use latest 13.8.3

### Issues Resolved
https://github.com/opensearch-project/opensearch-build-libraries/pull/923

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
